### PR TITLE
feat: Add options book RAG ingestion with McMillan's expected move cr…

### DIFF
--- a/scripts/ingest_options_books.py
+++ b/scripts/ingest_options_books.py
@@ -1,0 +1,380 @@
+#!/usr/bin/env python3
+"""
+Ingest Options Trading Books into RAG Vector Store
+
+This script ingests options trading books (PDF format) into the RAG system
+for semantic search and knowledge retrieval during trading decisions.
+
+Primary Books:
+1. "Options as a Strategic Investment" by Lawrence McMillan (5th Edition)
+2. "Option Volatility and Pricing" by Sheldon Natenberg
+3. "Volatility Trading" by Euan Sinclair
+
+Usage:
+    # Ingest a single book
+    python scripts/ingest_options_books.py --pdf /path/to/mcmillan.pdf --book-id mcmillan_options
+
+    # Ingest McMillan knowledge base (no PDF needed - uses built-in KB)
+    python scripts/ingest_options_books.py --ingest-kb
+
+    # Ingest all PDFs from a directory
+    python scripts/ingest_options_books.py --dir /path/to/books/
+
+    # Re-ingest (force refresh)
+    python scripts/ingest_options_books.py --pdf /path/to/book.pdf --force
+
+Author: AI Trading System
+Date: December 2, 2025
+"""
+
+import argparse
+import logging
+import sys
+from pathlib import Path
+from datetime import datetime
+
+# Add project root to path
+project_root = Path(__file__).parent.parent
+sys.path.insert(0, str(project_root))
+
+from src.rag.collectors.options_book_collector import OptionsBookCollector
+from src.rag.collectors.mcmillan_options_collector import McMillanOptionsKnowledgeBase
+from src.rag.vector_db.chroma_client import get_rag_db
+from src.rag.vector_db.embedder import get_embedder
+from src.rag.options_book_retriever import get_options_book_retriever
+
+# Configure logging
+logging.basicConfig(
+    level=logging.INFO,
+    format='%(asctime)s - %(name)s - %(levelname)s - %(message)s'
+)
+logger = logging.getLogger(__name__)
+
+
+def ingest_pdf_book(pdf_path: str, book_id: str, force: bool = False) -> dict:
+    """
+    Ingest a single PDF book.
+
+    Args:
+        pdf_path: Path to PDF file
+        book_id: Identifier for the book (e.g., 'mcmillan_options')
+        force: Force re-ingestion even if already processed
+
+    Returns:
+        Dict with ingestion status and stats
+    """
+    logger.info(f"\n{'='*60}")
+    logger.info(f"INGESTING: {book_id}")
+    logger.info(f"PDF: {pdf_path}")
+    logger.info(f"{'='*60}")
+
+    collector = OptionsBookCollector()
+
+    # Step 1: Ingest PDF
+    result = collector.ingest_pdf(
+        pdf_path=pdf_path,
+        book_id=book_id,
+        force_refresh=force
+    )
+
+    if result["status"] == "success":
+        logger.info(f"PDF ingested: {result['chunks']} chunks from {result['pages']} pages")
+
+        # Step 2: Add to vector store
+        retriever = get_options_book_retriever()
+        vector_result = retriever.ingest_options_books_to_vector_store()
+
+        logger.info(f"Vector store: {vector_result['status']}")
+
+        return {
+            "status": "success",
+            "book_id": book_id,
+            "chunks": result["chunks"],
+            "pages": result["pages"],
+            "vector_store": vector_result["status"]
+        }
+
+    elif result["status"] == "already_ingested":
+        logger.info(f"Book already ingested. Use --force to re-ingest.")
+        return result
+
+    else:
+        logger.error(f"Ingestion failed: {result.get('message')}")
+        return result
+
+
+def ingest_mcmillan_knowledge_base() -> dict:
+    """
+    Ingest the built-in McMillan knowledge base into the vector store.
+
+    This doesn't require a PDF - it uses the structured knowledge already
+    coded in mcmillan_options_collector.py.
+
+    Returns:
+        Dict with ingestion status
+    """
+    logger.info("\n" + "="*60)
+    logger.info("INGESTING: McMillan Knowledge Base (Built-in)")
+    logger.info("="*60)
+
+    kb = McMillanOptionsKnowledgeBase()
+    db = get_rag_db()
+    embedder = get_embedder()
+
+    # Get all knowledge
+    all_knowledge = kb.get_all_knowledge()
+
+    documents = []
+    metadatas = []
+    ids = []
+
+    # Process Greeks
+    logger.info("Processing Greeks...")
+    for greek_name, greek_data in all_knowledge["greeks"].items():
+        content = (
+            f"Greek: {greek_data['name']}\n"
+            f"Definition: {greek_data['definition']}\n"
+            f"Range: {greek_data['range']}\n"
+            f"Interpretation: {greek_data['interpretation']}\n"
+            f"Trading Implications: {greek_data['trading_implications']}\n"
+            f"Peak Conditions: {greek_data['peak_conditions']}"
+        )
+        documents.append(content)
+        metadatas.append({
+            "source": "mcmillan_kb",
+            "content_type": "greek",
+            "topic": greek_name,
+            "book_title": "Options as a Strategic Investment"
+        })
+        ids.append(f"mcmillan_greek_{greek_name}")
+
+    # Process Strategies
+    logger.info("Processing Strategies...")
+    for strategy_name, strategy_data in all_knowledge["strategies"].items():
+        content = (
+            f"Strategy: {strategy_data['strategy_name']}\n"
+            f"Description: {strategy_data['description']}\n"
+            f"Market Outlook: {strategy_data['market_outlook']}\n"
+            f"Setup Rules:\n- " + "\n- ".join(strategy_data['setup_rules']) + "\n"
+            f"Entry Criteria:\n- " + "\n- ".join(strategy_data['entry_criteria']) + "\n"
+            f"Exit Rules:\n- " + "\n- ".join(strategy_data['exit_rules']) + "\n"
+            f"Risk Management:\n- " + "\n- ".join(strategy_data['risk_management']) + "\n"
+            f"Common Mistakes:\n- " + "\n- ".join(strategy_data['common_mistakes'])
+        )
+        documents.append(content)
+        metadatas.append({
+            "source": "mcmillan_kb",
+            "content_type": "strategy",
+            "topic": strategy_name,
+            "book_title": "Options as a Strategic Investment"
+        })
+        ids.append(f"mcmillan_strategy_{strategy_name}")
+
+    # Process Volatility Guidance
+    logger.info("Processing Volatility Guidance...")
+    for i, guidance in enumerate(all_knowledge["volatility_guidance"]):
+        content = (
+            f"IV Range: {guidance['iv_rank_min']:.0f}-{guidance['iv_rank_max']:.0f}\n"
+            f"Recommendation: {guidance['recommendation']}\n"
+            f"Reasoning: {guidance['reasoning']}\n"
+            f"Suggested Strategies: {', '.join(guidance['strategies'])}"
+        )
+        documents.append(content)
+        metadatas.append({
+            "source": "mcmillan_kb",
+            "content_type": "volatility_guidance",
+            "topic": f"iv_range_{i}",
+            "book_title": "Options as a Strategic Investment"
+        })
+        ids.append(f"mcmillan_iv_guidance_{i}")
+
+    # Process Risk Rules
+    logger.info("Processing Risk Rules...")
+    for category, rules in all_knowledge["risk_rules"].items():
+        content = f"Risk Category: {category}\n"
+        if isinstance(rules, dict):
+            for key, value in rules.items():
+                if isinstance(value, dict):
+                    content += f"\n{key}:\n"
+                    for k, v in value.items():
+                        content += f"  - {k}: {v}\n"
+                else:
+                    content += f"- {key}: {value}\n"
+        documents.append(content)
+        metadatas.append({
+            "source": "mcmillan_kb",
+            "content_type": "risk_rule",
+            "topic": category,
+            "book_title": "Options as a Strategic Investment"
+        })
+        ids.append(f"mcmillan_risk_{category}")
+
+    # Add to vector store
+    logger.info(f"Adding {len(documents)} documents to vector store...")
+    result = db.add_documents(
+        documents=documents,
+        metadatas=metadatas,
+        ids=ids
+    )
+
+    if result["status"] == "success":
+        logger.info(f"Successfully ingested {result['count']} knowledge chunks")
+
+        # Get stats
+        stats = db.get_stats()
+        logger.info(f"Vector store now has {stats.get('total_documents', 0)} total documents")
+
+        return {
+            "status": "success",
+            "chunks": len(documents),
+            "categories": ["greeks", "strategies", "volatility_guidance", "risk_rules"]
+        }
+    else:
+        logger.error(f"Failed to ingest: {result.get('message')}")
+        return result
+
+
+def ingest_directory(dir_path: str, force: bool = False) -> dict:
+    """
+    Ingest all PDF books from a directory.
+
+    Args:
+        dir_path: Path to directory containing PDFs
+        force: Force re-ingestion
+
+    Returns:
+        Dict with results for each book
+    """
+    dir_path = Path(dir_path)
+    if not dir_path.exists():
+        return {"status": "error", "message": f"Directory not found: {dir_path}"}
+
+    pdf_files = list(dir_path.glob("*.pdf"))
+    if not pdf_files:
+        return {"status": "error", "message": f"No PDF files found in {dir_path}"}
+
+    logger.info(f"Found {len(pdf_files)} PDF files")
+
+    results = {}
+    for pdf_file in pdf_files:
+        # Generate book_id from filename
+        book_id = pdf_file.stem.lower().replace(" ", "_").replace("-", "_")
+        result = ingest_pdf_book(str(pdf_file), book_id, force)
+        results[book_id] = result
+
+    return {
+        "status": "success",
+        "books_processed": len(results),
+        "results": results
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Ingest options trading books into RAG vector store",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  # Ingest McMillan knowledge base (no PDF needed)
+  python scripts/ingest_options_books.py --ingest-kb
+
+  # Ingest a specific PDF book
+  python scripts/ingest_options_books.py --pdf ~/Books/mcmillan.pdf --book-id mcmillan_options
+
+  # Ingest all PDFs from a directory
+  python scripts/ingest_options_books.py --dir ~/Books/Options/
+
+  # Force re-ingest
+  python scripts/ingest_options_books.py --pdf book.pdf --book-id my_book --force
+        """
+    )
+
+    parser.add_argument(
+        "--pdf",
+        type=str,
+        help="Path to PDF file to ingest"
+    )
+    parser.add_argument(
+        "--book-id",
+        type=str,
+        help="Book identifier (e.g., 'mcmillan_options')"
+    )
+    parser.add_argument(
+        "--dir",
+        type=str,
+        help="Directory containing PDF books to ingest"
+    )
+    parser.add_argument(
+        "--ingest-kb",
+        action="store_true",
+        help="Ingest the built-in McMillan knowledge base"
+    )
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help="Force re-ingestion even if already processed"
+    )
+    parser.add_argument(
+        "--test",
+        action="store_true",
+        help="Run a test search after ingestion"
+    )
+
+    args = parser.parse_args()
+
+    # Validate arguments
+    if not args.pdf and not args.dir and not args.ingest_kb:
+        parser.print_help()
+        print("\nError: Must specify --pdf, --dir, or --ingest-kb")
+        sys.exit(1)
+
+    if args.pdf and not args.book_id:
+        # Try to infer book_id from filename
+        args.book_id = Path(args.pdf).stem.lower().replace(" ", "_")
+        logger.info(f"Inferred book_id: {args.book_id}")
+
+    # Run ingestion
+    start_time = datetime.now()
+
+    if args.ingest_kb:
+        result = ingest_mcmillan_knowledge_base()
+    elif args.pdf:
+        result = ingest_pdf_book(args.pdf, args.book_id, args.force)
+    elif args.dir:
+        result = ingest_directory(args.dir, args.force)
+
+    elapsed = (datetime.now() - start_time).total_seconds()
+
+    # Print summary
+    print("\n" + "="*60)
+    print("INGESTION COMPLETE")
+    print("="*60)
+    print(f"Status: {result['status']}")
+    print(f"Time: {elapsed:.1f} seconds")
+
+    if result["status"] == "success":
+        if "chunks" in result:
+            print(f"Chunks ingested: {result['chunks']}")
+        if "pages" in result:
+            print(f"Pages processed: {result['pages']}")
+
+    # Optional test search
+    if args.test and result["status"] == "success":
+        print("\n" + "="*60)
+        print("TEST SEARCH")
+        print("="*60)
+
+        retriever = get_options_book_retriever()
+        test_query = "iron condor setup when IV is high"
+
+        search_result = retriever.search_options_knowledge(test_query)
+        print(f"Query: '{test_query}'")
+        print(f"Book results: {len(search_result.get('book_results', []))}")
+        print(f"Structured results: {len(search_result.get('structured_results', []))}")
+
+        if search_result.get("combined_answer"):
+            print(f"\nAnswer preview:\n{search_result['combined_answer'][:300]}...")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/rag/collectors/options_book_collector.py
+++ b/src/rag/collectors/options_book_collector.py
@@ -1,0 +1,719 @@
+"""
+Options Book Collector - PDF/EPUB Ingestion for Trading Books
+
+Ingests options trading books for RAG retrieval:
+- "Options as a Strategic Investment" by Lawrence McMillan (primary)
+- Other options books (secondary)
+
+Based on the proven Berkshire Letters pattern.
+"""
+
+import re
+import json
+import logging
+from typing import List, Dict, Any, Optional
+from datetime import datetime
+from pathlib import Path
+from dataclasses import dataclass, asdict
+
+try:
+    import PyPDF2
+except ImportError:
+    PyPDF2 = None
+
+from src.rag.collectors.base_collector import BaseNewsCollector
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class BookChunk:
+    """A chunk of book content with metadata."""
+    book_title: str
+    author: str
+    chapter: str
+    section: str
+    page_numbers: str
+    content: str
+    content_type: str  # 'strategy', 'example', 'definition', 'rule', 'warning'
+    topics: List[str]
+
+
+class OptionsBookCollector(BaseNewsCollector):
+    """
+    Collect and index options trading books for RAG.
+
+    Primary target: "Options as a Strategic Investment" by Lawrence McMillan
+
+    Features:
+    - PDF parsing with chapter/section detection
+    - Intelligent chunking preserving context
+    - Content type classification (strategy, example, definition, etc.)
+    - Page number tracking for citations
+    - Semantic search across all books
+    """
+
+    # Book metadata for known options books
+    KNOWN_BOOKS = {
+        "mcmillan_options": {
+            "title": "Options as a Strategic Investment",
+            "author": "Lawrence G. McMillan",
+            "edition": "5th Edition",
+            "isbn": "978-0735201972",
+            "pages": 1012,
+            "topics": [
+                "greeks", "volatility", "covered_calls", "iron_condor",
+                "straddles", "spreads", "risk_management", "taxes"
+            ]
+        },
+        "natenberg_volatility": {
+            "title": "Option Volatility and Pricing",
+            "author": "Sheldon Natenberg",
+            "edition": "2nd Edition",
+            "isbn": "978-0071818773",
+            "pages": 512,
+            "topics": [
+                "volatility_trading", "pricing_models", "greeks",
+                "volatility_skew", "risk_management"
+            ]
+        },
+        "sinclair_volatility": {
+            "title": "Volatility Trading",
+            "author": "Euan Sinclair",
+            "edition": "2nd Edition",
+            "isbn": "978-1118347133",
+            "pages": 384,
+            "topics": [
+                "volatility_forecasting", "trade_sizing", "hedging",
+                "psychology", "variance_swaps"
+            ]
+        }
+    }
+
+    # Chapter patterns for McMillan's book (helps with parsing)
+    MCMILLAN_CHAPTERS = {
+        1: "Definitions",
+        2: "Covered Call Writing",
+        3: "Call Buying",
+        4: "Other Call Buying Strategies",
+        5: "Naked Call Writing",
+        6: "Ratio Call Strategies",
+        7: "Bull Spreads",
+        8: "Bear Spreads",
+        9: "Calendar Spreads",
+        10: "Butterfly Spreads",
+        11: "Ratio Spreads",
+        12: "Combinations",
+        13: "Put Buying",
+        14: "Put Selling",
+        15: "Spreads Combining Puts and Calls",
+        16: "Straddle Buying",
+        17: "Straddle Writing",
+        18: "The Strangle",
+        19: "Put and Call Combination Strategies",
+        20: "Synthetic Stock Strategies",
+        21: "Index Options",
+        22: "Volatility",
+        23: "The Volatility Smile",
+        24: "Kurtosis in Stock Prices",
+        25: "Taxes",
+    }
+
+    # Content type patterns for classification
+    CONTENT_PATTERNS = {
+        "strategy": [
+            r"strategy[:\s]", r"setup[:\s]", r"trade[:\s]", r"position[:\s]",
+            r"when to use", r"profit potential", r"maximum (loss|gain)"
+        ],
+        "example": [
+            r"example[:\s]", r"for instance", r"consider", r"suppose",
+            r"let's say", r"illustration", r"assume that"
+        ],
+        "definition": [
+            r"is defined as", r"refers to", r"means that", r"definition",
+            r"^[A-Z][a-z]+ is [a-z]"  # "Delta is the..."
+        ],
+        "rule": [
+            r"rule[:\s]", r"always", r"never", r"must", r"should",
+            r"critical", r"important", r"key point"
+        ],
+        "warning": [
+            r"warning", r"caution", r"danger", r"risk", r"avoid",
+            r"mistake", r"trap", r"pitfall"
+        ],
+    }
+
+    def __init__(self, cache_dir: Optional[str] = None):
+        """
+        Initialize options book collector.
+
+        Args:
+            cache_dir: Directory to cache books (default: data/rag/options_books)
+        """
+        super().__init__(source_name="options_books")
+
+        if cache_dir is None:
+            cache_dir = "data/rag/options_books"
+
+        self.cache_dir = Path(cache_dir)
+        self.cache_dir.mkdir(parents=True, exist_ok=True)
+
+        # Subdirectories
+        self.raw_dir = self.cache_dir / "raw"      # Original PDFs
+        self.parsed_dir = self.cache_dir / "parsed"  # Extracted text
+        self.chunks_dir = self.cache_dir / "chunks"  # Chunked content
+        self.index_dir = self.cache_dir / "index"    # Search index
+
+        for dir_path in [self.raw_dir, self.parsed_dir, self.chunks_dir, self.index_dir]:
+            dir_path.mkdir(exist_ok=True)
+
+        # Load or create index
+        self.index_file = self.index_dir / "books_index.json"
+        self.index = self._load_index()
+
+        logger.info(f"Options Book Collector initialized (cache: {self.cache_dir})")
+
+    def _load_index(self) -> Dict[str, Dict[str, Any]]:
+        """Load the books index from disk."""
+        if self.index_file.exists():
+            try:
+                with open(self.index_file, "r") as f:
+                    return json.load(f)
+            except Exception as e:
+                logger.error(f"Error loading index: {e}")
+                return {}
+        return {}
+
+    def _save_index(self):
+        """Save the books index to disk."""
+        try:
+            with open(self.index_file, "w") as f:
+                json.dump(self.index, f, indent=2)
+            logger.info(f"Saved index with {len(self.index)} books")
+        except Exception as e:
+            logger.error(f"Error saving index: {e}")
+
+    def ingest_pdf(
+        self,
+        pdf_path: str,
+        book_id: str = "mcmillan_options",
+        force_refresh: bool = False
+    ) -> Dict[str, Any]:
+        """
+        Ingest a PDF book into the RAG system.
+
+        Args:
+            pdf_path: Path to the PDF file
+            book_id: Book identifier (e.g., 'mcmillan_options')
+            force_refresh: Re-ingest even if already cached
+
+        Returns:
+            Dict with ingestion status and stats
+        """
+        if PyPDF2 is None:
+            logger.error("PyPDF2 not installed - cannot parse PDF files")
+            return {"status": "error", "message": "PyPDF2 not installed"}
+
+        pdf_path = Path(pdf_path)
+        if not pdf_path.exists():
+            return {"status": "error", "message": f"PDF not found: {pdf_path}"}
+
+        # Check if already ingested
+        if not force_refresh and book_id in self.index:
+            logger.info(f"Book {book_id} already ingested. Use force_refresh=True to re-ingest.")
+            return {"status": "already_ingested", "book_id": book_id}
+
+        logger.info(f"Ingesting book: {book_id} from {pdf_path}")
+
+        # Get book metadata
+        book_meta = self.KNOWN_BOOKS.get(book_id, {
+            "title": pdf_path.stem,
+            "author": "Unknown",
+            "edition": "Unknown",
+            "topics": []
+        })
+
+        try:
+            # Step 1: Extract text from PDF
+            logger.info("Step 1: Extracting text from PDF...")
+            full_text, page_texts = self._extract_pdf_text(pdf_path)
+
+            if not full_text:
+                return {"status": "error", "message": "No text extracted from PDF"}
+
+            # Save raw text
+            parsed_file = self.parsed_dir / f"{book_id}.txt"
+            with open(parsed_file, "w", encoding="utf-8") as f:
+                f.write(full_text)
+
+            # Step 2: Chunk the text intelligently
+            logger.info("Step 2: Chunking content...")
+            chunks = self._chunk_book(full_text, page_texts, book_meta)
+
+            # Save chunks
+            chunks_file = self.chunks_dir / f"{book_id}_chunks.json"
+            with open(chunks_file, "w") as f:
+                json.dump([asdict(c) for c in chunks], f, indent=2)
+
+            # Step 3: Update index
+            self.index[book_id] = {
+                "book_id": book_id,
+                "title": book_meta["title"],
+                "author": book_meta["author"],
+                "pdf_path": str(pdf_path),
+                "parsed_file": str(parsed_file),
+                "chunks_file": str(chunks_file),
+                "chunk_count": len(chunks),
+                "char_count": len(full_text),
+                "page_count": len(page_texts),
+                "ingested_at": datetime.now().isoformat(),
+                "topics": book_meta.get("topics", [])
+            }
+            self._save_index()
+
+            logger.info(f"Successfully ingested {book_id}: {len(chunks)} chunks from {len(page_texts)} pages")
+
+            return {
+                "status": "success",
+                "book_id": book_id,
+                "chunks": len(chunks),
+                "pages": len(page_texts),
+                "chars": len(full_text)
+            }
+
+        except Exception as e:
+            logger.error(f"Error ingesting {book_id}: {e}")
+            return {"status": "error", "message": str(e)}
+
+    def _extract_pdf_text(self, pdf_path: Path) -> tuple:
+        """
+        Extract text from PDF, page by page.
+
+        Returns:
+            Tuple of (full_text, list of page texts)
+        """
+        page_texts = []
+
+        try:
+            with open(pdf_path, "rb") as f:
+                pdf_reader = PyPDF2.PdfReader(f)
+
+                for page_num, page in enumerate(pdf_reader.pages):
+                    text = page.extract_text()
+                    if text:
+                        page_texts.append({
+                            "page": page_num + 1,
+                            "text": text
+                        })
+
+            full_text = "\n\n".join([p["text"] for p in page_texts])
+            return full_text, page_texts
+
+        except Exception as e:
+            logger.error(f"Error extracting PDF text: {e}")
+            return "", []
+
+    def _chunk_book(
+        self,
+        full_text: str,
+        page_texts: List[Dict],
+        book_meta: Dict
+    ) -> List[BookChunk]:
+        """
+        Chunk book into semantic units.
+
+        Strategy:
+        1. Detect chapter/section boundaries
+        2. Split into ~2000 char chunks
+        3. Preserve paragraph boundaries
+        4. Classify content types
+        5. Track page numbers
+        """
+        chunks = []
+
+        # Build page lookup for page number tracking
+        page_lookup = {}
+        char_pos = 0
+        for page_data in page_texts:
+            page_text = page_data["text"]
+            page_num = page_data["page"]
+            page_lookup[char_pos] = page_num
+            char_pos += len(page_text) + 2  # +2 for \n\n separator
+
+        # Split into paragraphs
+        paragraphs = re.split(r'\n\s*\n', full_text)
+
+        current_chapter = "Introduction"
+        current_section = ""
+        current_chunk_text = ""
+        current_chunk_start = 0
+        chunk_page_start = 1
+
+        max_chunk_size = 2000  # Characters per chunk
+
+        for para in paragraphs:
+            para = para.strip()
+            if not para:
+                continue
+
+            # Detect chapter headers
+            chapter_match = re.match(r'^(?:CHAPTER|Chapter)\s*(\d+)[:\s]+(.+)$', para)
+            if chapter_match:
+                # Save current chunk if not empty
+                if current_chunk_text:
+                    chunks.append(self._create_chunk(
+                        current_chunk_text,
+                        book_meta,
+                        current_chapter,
+                        current_section,
+                        chunk_page_start
+                    ))
+                    current_chunk_text = ""
+
+                chapter_num = int(chapter_match.group(1))
+                current_chapter = self.MCMILLAN_CHAPTERS.get(
+                    chapter_num,
+                    chapter_match.group(2).strip()
+                )
+                current_section = ""
+                chunk_page_start = self._get_page_for_position(
+                    len(full_text) - len("\n\n".join(paragraphs[paragraphs.index(para):])),
+                    page_lookup
+                )
+                continue
+
+            # Detect section headers (ALL CAPS or Title Case with specific patterns)
+            if re.match(r'^[A-Z][A-Z\s]+$', para) and len(para) < 100:
+                current_section = para.title()
+                continue
+
+            # Add paragraph to current chunk
+            if len(current_chunk_text) + len(para) > max_chunk_size:
+                # Save current chunk
+                if current_chunk_text:
+                    chunks.append(self._create_chunk(
+                        current_chunk_text,
+                        book_meta,
+                        current_chapter,
+                        current_section,
+                        chunk_page_start
+                    ))
+                current_chunk_text = para
+                chunk_page_start = self._get_page_for_position(
+                    len(full_text) - len("\n\n".join(paragraphs[paragraphs.index(para):])),
+                    page_lookup
+                )
+            else:
+                if current_chunk_text:
+                    current_chunk_text += "\n\n" + para
+                else:
+                    current_chunk_text = para
+
+        # Don't forget the last chunk
+        if current_chunk_text:
+            chunks.append(self._create_chunk(
+                current_chunk_text,
+                book_meta,
+                current_chapter,
+                current_section,
+                chunk_page_start
+            ))
+
+        return chunks
+
+    def _create_chunk(
+        self,
+        text: str,
+        book_meta: Dict,
+        chapter: str,
+        section: str,
+        page_start: int
+    ) -> BookChunk:
+        """Create a BookChunk with content classification."""
+
+        # Classify content type
+        content_type = self._classify_content(text)
+
+        # Extract topics
+        topics = self._extract_topics(text, book_meta.get("topics", []))
+
+        return BookChunk(
+            book_title=book_meta.get("title", "Unknown"),
+            author=book_meta.get("author", "Unknown"),
+            chapter=chapter,
+            section=section,
+            page_numbers=str(page_start),
+            content=text,
+            content_type=content_type,
+            topics=topics
+        )
+
+    def _classify_content(self, text: str) -> str:
+        """Classify chunk by content type."""
+        text_lower = text.lower()
+
+        scores = {}
+        for content_type, patterns in self.CONTENT_PATTERNS.items():
+            score = sum(
+                1 for pattern in patterns
+                if re.search(pattern, text_lower)
+            )
+            scores[content_type] = score
+
+        if not scores or max(scores.values()) == 0:
+            return "general"
+
+        return max(scores, key=scores.get)
+
+    def _extract_topics(self, text: str, known_topics: List[str]) -> List[str]:
+        """Extract relevant topics from chunk."""
+        text_lower = text.lower()
+        found_topics = []
+
+        # Topic keywords mapping
+        topic_keywords = {
+            "greeks": ["delta", "gamma", "theta", "vega", "rho"],
+            "volatility": ["volatility", "iv", "implied volatility", "vix", "iv rank"],
+            "covered_calls": ["covered call", "covered writing", "overwriting"],
+            "iron_condor": ["iron condor", "condor", "wing spread"],
+            "straddles": ["straddle", "long straddle", "short straddle"],
+            "spreads": ["spread", "vertical spread", "calendar spread", "diagonal"],
+            "risk_management": ["risk", "stop loss", "position sizing", "max loss"],
+            "taxes": ["tax", "wash sale", "qualified covered call", "straddle rules"],
+            "expected_move": ["expected move", "standard deviation", "one sigma"],
+        }
+
+        for topic, keywords in topic_keywords.items():
+            if any(kw in text_lower for kw in keywords):
+                found_topics.append(topic)
+
+        return found_topics
+
+    def _get_page_for_position(self, char_position: int, page_lookup: Dict) -> int:
+        """Find the page number for a character position."""
+        last_page = 1
+        for pos, page in sorted(page_lookup.items()):
+            if pos > char_position:
+                break
+            last_page = page
+        return last_page
+
+    def search(
+        self,
+        query: str,
+        book_id: Optional[str] = None,
+        top_k: int = 5,
+        content_types: Optional[List[str]] = None
+    ) -> Dict[str, Any]:
+        """
+        Search ingested books for relevant content.
+
+        Args:
+            query: Search query
+            book_id: Optional book ID to search (None = all books)
+            top_k: Number of results to return
+            content_types: Filter by content types (strategy, example, etc.)
+
+        Returns:
+            Search results with excerpts and metadata
+        """
+        logger.info(f"Searching options books for: '{query}'")
+
+        if not self.index:
+            return {
+                "query": query,
+                "results": [],
+                "message": "No books ingested. Use ingest_pdf() first."
+            }
+
+        # Determine which books to search
+        books_to_search = [book_id] if book_id else list(self.index.keys())
+
+        all_results = []
+
+        for bid in books_to_search:
+            if bid not in self.index:
+                continue
+
+            book_info = self.index[bid]
+            chunks_file = Path(book_info["chunks_file"])
+
+            if not chunks_file.exists():
+                continue
+
+            with open(chunks_file, "r") as f:
+                chunks = json.load(f)
+
+            # Score each chunk
+            for chunk in chunks:
+                # Filter by content type if specified
+                if content_types and chunk["content_type"] not in content_types:
+                    continue
+
+                score = self._score_chunk(query, chunk)
+                if score > 0:
+                    all_results.append({
+                        "book_id": bid,
+                        "book_title": chunk["book_title"],
+                        "author": chunk["author"],
+                        "chapter": chunk["chapter"],
+                        "section": chunk["section"],
+                        "page": chunk["page_numbers"],
+                        "content_type": chunk["content_type"],
+                        "topics": chunk["topics"],
+                        "excerpt": chunk["content"][:500] + "..." if len(chunk["content"]) > 500 else chunk["content"],
+                        "full_content": chunk["content"],
+                        "score": score
+                    })
+
+        # Sort by score and return top_k
+        all_results.sort(key=lambda x: x["score"], reverse=True)
+        top_results = all_results[:top_k]
+
+        return {
+            "query": query,
+            "results": top_results,
+            "total_matches": len(all_results),
+            "books_searched": books_to_search
+        }
+
+    def _score_chunk(self, query: str, chunk: Dict) -> float:
+        """Score a chunk's relevance to query."""
+        query_lower = query.lower()
+        content_lower = chunk["content"].lower()
+
+        # Tokenize query
+        stop_words = {
+            "the", "a", "an", "and", "or", "but", "is", "are", "was", "were",
+            "in", "on", "at", "to", "for", "of", "with", "by", "from", "what",
+            "how", "when", "where", "why"
+        }
+        query_words = [w for w in query_lower.split() if w not in stop_words]
+
+        if not query_words:
+            return 0.0
+
+        # Count matches
+        matches = sum(content_lower.count(word) for word in query_words)
+
+        # Boost for exact phrase match
+        if query_lower in content_lower:
+            matches *= 2
+
+        # Boost for topic match
+        for topic in chunk.get("topics", []):
+            if topic.replace("_", " ") in query_lower:
+                matches *= 1.5
+
+        # Normalize by content length
+        word_count = len(content_lower.split())
+        return (matches / len(query_words)) * (1000 / max(word_count, 100))
+
+    def get_chunks_for_rag(
+        self,
+        book_id: Optional[str] = None
+    ) -> List[Dict[str, Any]]:
+        """
+        Get all chunks formatted for RAG ingestion.
+
+        Returns list of dicts ready for vector store ingestion.
+        """
+        all_chunks = []
+
+        books_to_process = [book_id] if book_id else list(self.index.keys())
+
+        for bid in books_to_process:
+            if bid not in self.index:
+                continue
+
+            book_info = self.index[bid]
+            chunks_file = Path(book_info["chunks_file"])
+
+            if not chunks_file.exists():
+                continue
+
+            with open(chunks_file, "r") as f:
+                chunks = json.load(f)
+
+            for i, chunk in enumerate(chunks):
+                all_chunks.append({
+                    "id": f"{bid}_chunk_{i}",
+                    "content": chunk["content"],
+                    "metadata": {
+                        "book_id": bid,
+                        "book_title": chunk["book_title"],
+                        "author": chunk["author"],
+                        "chapter": chunk["chapter"],
+                        "section": chunk["section"],
+                        "page": chunk["page_numbers"],
+                        "content_type": chunk["content_type"],
+                        "topics": ",".join(chunk["topics"]),
+                        "source": "options_book"
+                    }
+                })
+
+        return all_chunks
+
+    # Implement abstract methods from BaseNewsCollector
+
+    def collect_ticker_news(
+        self, ticker: str, days_back: int = 7
+    ) -> List[Dict[str, Any]]:
+        """
+        Options books don't have ticker-specific news.
+        Return empty list.
+        """
+        return []
+
+    def collect_market_news(self, days_back: int = 1) -> List[Dict[str, Any]]:
+        """
+        Return general options knowledge as "market news".
+
+        This returns chunks that can be used as context for trading decisions.
+        """
+        # Get high-value chunks (strategies, rules, warnings)
+        valuable_types = ["strategy", "rule", "warning"]
+        chunks = self.get_chunks_for_rag()
+
+        # Filter to valuable content
+        valuable_chunks = [
+            c for c in chunks
+            if c["metadata"]["content_type"] in valuable_types
+        ]
+
+        # Convert to article format
+        articles = []
+        for chunk in valuable_chunks[:50]:  # Limit to 50 most valuable
+            article = self.normalize_article(
+                title=f"{chunk['metadata']['chapter']} - {chunk['metadata']['section'] or 'Overview'}",
+                content=chunk["content"],
+                url=f"book://{chunk['metadata']['book_id']}/page/{chunk['metadata']['page']}",
+                published_date=datetime.now().strftime("%Y-%m-%d"),
+                ticker=None,
+                sentiment=None
+            )
+            articles.append(article)
+
+        return articles
+
+
+# Convenience function
+def get_options_book_collector() -> OptionsBookCollector:
+    """Get OptionsBookCollector instance."""
+    return OptionsBookCollector()
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+
+    collector = OptionsBookCollector()
+
+    print("Options Book Collector initialized")
+    print(f"Cache directory: {collector.cache_dir}")
+    print(f"Known books: {list(collector.KNOWN_BOOKS.keys())}")
+
+    # Example: Check if any books are already ingested
+    if collector.index:
+        print(f"\nIngested books: {list(collector.index.keys())}")
+    else:
+        print("\nNo books ingested yet. Use ingest_pdf() to add books.")

--- a/src/rag/options_book_retriever.py
+++ b/src/rag/options_book_retriever.py
@@ -1,0 +1,637 @@
+"""
+Options Book Retriever - RAG Interface for Options Trading Knowledge
+
+Provides high-level retrieval API for options book content:
+1. Query options strategies by market conditions
+2. Get McMillan's rules for specific setups
+3. Cross-reference IV/Greeks with book knowledge
+4. Support trading decisions with authoritative citations
+
+Integrates with:
+- OptionsBookCollector (PDF ingestion)
+- McMillanOptionsKnowledgeBase (structured knowledge)
+- IVAnalyzer (volatility metrics)
+- Trading signal generation
+"""
+
+import logging
+from typing import Dict, Any, List, Optional
+from datetime import datetime
+
+from src.rag.collectors.options_book_collector import get_options_book_collector
+from src.rag.collectors.mcmillan_options_collector import McMillanOptionsKnowledgeBase
+from src.rag.vector_db.chroma_client import get_rag_db
+from src.rag.vector_db.embedder import get_embedder
+
+logger = logging.getLogger(__name__)
+
+
+class OptionsBookRetriever:
+    """
+    High-level retrieval interface for options book knowledge.
+
+    Combines:
+    - PDF book content (via OptionsBookCollector)
+    - Structured knowledge (via McMillanOptionsKnowledgeBase)
+    - Vector search (via ChromaDB)
+
+    Usage:
+        retriever = OptionsBookRetriever()
+
+        # Get strategy guidance
+        guidance = retriever.get_strategy_for_conditions(
+            iv_rank=65,
+            market_outlook="neutral",
+            days_to_expiration=30
+        )
+
+        # Get expected move cross-check
+        cross_check = retriever.cross_check_expected_move(
+            ticker="SPY",
+            sentiment_signal="overbought",
+            current_iv=0.18,
+            dte=7
+        )
+
+        # Search book for topic
+        results = retriever.search_options_knowledge(
+            "iron condor entry timing"
+        )
+    """
+
+    # Collection name for options books in ChromaDB
+    COLLECTION_NAME = "options_books"
+
+    def __init__(self):
+        """Initialize retriever with all knowledge sources."""
+        self.book_collector = get_options_book_collector()
+        self.mcmillan_kb = McMillanOptionsKnowledgeBase()
+        self.db = get_rag_db()
+        self.embedder = get_embedder()
+
+        logger.info("Options Book Retriever initialized")
+
+    def search_options_knowledge(
+        self,
+        query: str,
+        top_k: int = 5,
+        content_types: Optional[List[str]] = None,
+        include_structured: bool = True
+    ) -> Dict[str, Any]:
+        """
+        Search all options knowledge sources for query.
+
+        Args:
+            query: Natural language query
+            top_k: Number of results per source
+            content_types: Filter by content types (strategy, example, etc.)
+            include_structured: Also search McMillan knowledge base
+
+        Returns:
+            Dict with results from all sources:
+            {
+                "query": str,
+                "book_results": [...],
+                "structured_results": [...],
+                "combined_answer": str
+            }
+        """
+        logger.info(f"Searching options knowledge for: '{query}'")
+
+        results = {
+            "query": query,
+            "book_results": [],
+            "structured_results": [],
+            "combined_answer": "",
+            "timestamp": datetime.now().isoformat()
+        }
+
+        # Search PDF books
+        book_search = self.book_collector.search(
+            query=query,
+            top_k=top_k,
+            content_types=content_types
+        )
+        results["book_results"] = book_search.get("results", [])
+
+        # Search structured knowledge base
+        if include_structured:
+            kb_results = self.mcmillan_kb.search_knowledge(query)
+            results["structured_results"] = kb_results
+
+        # Combine into answer
+        results["combined_answer"] = self._synthesize_answer(query, results)
+
+        return results
+
+    def get_strategy_for_conditions(
+        self,
+        iv_rank: float,
+        market_outlook: str = "neutral",
+        days_to_expiration: int = 30,
+        risk_tolerance: str = "moderate"
+    ) -> Dict[str, Any]:
+        """
+        Get recommended options strategy based on current conditions.
+
+        Args:
+            iv_rank: Current IV Rank (0-100)
+            market_outlook: 'bullish', 'neutral', 'bearish'
+            days_to_expiration: Target DTE
+            risk_tolerance: 'conservative', 'moderate', 'aggressive'
+
+        Returns:
+            Strategy recommendation with reasoning and book references
+        """
+        logger.info(
+            f"Getting strategy for: IV Rank={iv_rank}, Outlook={market_outlook}, "
+            f"DTE={days_to_expiration}"
+        )
+
+        # Get IV-based recommendation from structured KB
+        iv_rec = self.mcmillan_kb.get_iv_recommendation(
+            iv_rank=iv_rank,
+            iv_percentile=iv_rank  # Use same if percentile not available
+        )
+
+        # Map outlook to strategy categories
+        outlook_strategies = {
+            "bullish": ["long_call", "covered_call", "cash_secured_put", "bull_spread"],
+            "neutral": ["iron_condor", "covered_call", "calendar_spread", "butterfly"],
+            "bearish": ["long_put", "bear_spread", "protective_put"]
+        }
+
+        suitable_strategies = outlook_strategies.get(market_outlook.lower(), [])
+
+        # Filter by IV recommendation
+        if "SELL" in iv_rec["recommendation"]:
+            # High IV - prefer short premium strategies
+            preferred = ["iron_condor", "covered_call", "cash_secured_put", "credit_spread"]
+        else:
+            # Low IV - prefer long premium strategies
+            preferred = ["long_call", "long_put", "debit_spread", "calendar_spread"]
+
+        # Find overlap
+        recommended = [s for s in suitable_strategies if s in preferred]
+        if not recommended:
+            recommended = suitable_strategies[:2]  # Fall back to outlook strategies
+
+        # Get detailed rules for top strategy
+        primary_strategy = recommended[0] if recommended else "covered_call"
+        strategy_rules = self.mcmillan_kb.get_strategy_rules(primary_strategy)
+
+        # Search books for additional context
+        book_context = self.book_collector.search(
+            query=f"{primary_strategy} setup {market_outlook}",
+            top_k=3
+        )
+
+        return {
+            "recommended_strategy": primary_strategy,
+            "alternative_strategies": recommended[1:] if len(recommended) > 1 else [],
+            "iv_recommendation": iv_rec["recommendation"],
+            "iv_reasoning": iv_rec["reasoning"],
+            "strategy_rules": strategy_rules,
+            "book_references": book_context.get("results", []),
+            "conditions": {
+                "iv_rank": iv_rank,
+                "market_outlook": market_outlook,
+                "dte": days_to_expiration,
+                "risk_tolerance": risk_tolerance
+            }
+        }
+
+    def cross_check_expected_move(
+        self,
+        ticker: str,
+        sentiment_signal: str,
+        current_iv: float,
+        dte: int,
+        stock_price: float = None
+    ) -> Dict[str, Any]:
+        """
+        Cross-check sentiment signal against McMillan's expected move calculation.
+
+        This is the KEY integration for: "whenever sentiment says overbought,
+        cross-check McMillan's expected move calc before slapping on a call."
+
+        Args:
+            ticker: Stock symbol
+            sentiment_signal: 'overbought', 'oversold', 'bullish', 'bearish', 'neutral'
+            current_iv: Current implied volatility (as decimal, e.g., 0.30)
+            dte: Days to expiration
+            stock_price: Current stock price (optional, can fetch if not provided)
+
+        Returns:
+            Cross-check result with:
+            - Expected move range
+            - Whether sentiment aligns with IV expectation
+            - Recommended action
+            - McMillan's guidance
+        """
+        logger.info(
+            f"Cross-checking sentiment '{sentiment_signal}' for {ticker} "
+            f"(IV={current_iv:.2%}, DTE={dte})"
+        )
+
+        # Use provided price or fetch (simplified - would use yfinance in production)
+        if stock_price is None:
+            stock_price = 100.0  # Placeholder - real implementation fetches live price
+            logger.warning(f"Using placeholder price ${stock_price} for {ticker}")
+
+        # Calculate expected move using McMillan's formula
+        expected_move = self.mcmillan_kb.calculate_expected_move(
+            stock_price=stock_price,
+            implied_volatility=current_iv,
+            days_to_expiration=dte,
+            confidence_level=1.0  # 1 std dev (68% probability)
+        )
+
+        # Also calculate 2 std dev for more context
+        expected_move_2std = self.mcmillan_kb.calculate_expected_move(
+            stock_price=stock_price,
+            implied_volatility=current_iv,
+            days_to_expiration=dte,
+            confidence_level=2.0  # 2 std dev (95% probability)
+        )
+
+        # Get IV recommendation
+        iv_rank_approx = min(100, current_iv * 300)  # Rough approximation
+        iv_rec = self.mcmillan_kb.get_iv_recommendation(
+            iv_rank=iv_rank_approx,
+            iv_percentile=iv_rank_approx
+        )
+
+        # Determine if sentiment aligns with expected move
+        alignment_analysis = self._analyze_sentiment_alignment(
+            sentiment_signal=sentiment_signal,
+            expected_move=expected_move,
+            iv_recommendation=iv_rec
+        )
+
+        # Get relevant book passages
+        book_search = self.book_collector.search(
+            query=f"expected move {sentiment_signal} IV {current_iv*100:.0f}%",
+            top_k=3,
+            content_types=["strategy", "rule"]
+        )
+
+        return {
+            "ticker": ticker,
+            "sentiment_signal": sentiment_signal,
+            "expected_move": expected_move,
+            "expected_move_2std": expected_move_2std,
+            "iv_analysis": {
+                "current_iv": current_iv,
+                "iv_rank_approx": iv_rank_approx,
+                "recommendation": iv_rec["recommendation"],
+                "strategies": iv_rec["strategies"]
+            },
+            "alignment": alignment_analysis,
+            "book_references": book_search.get("results", []),
+            "final_recommendation": self._generate_recommendation(
+                sentiment_signal,
+                expected_move,
+                iv_rec,
+                alignment_analysis
+            )
+        }
+
+    def get_20_delta_weekly_guidance(
+        self,
+        iv_rank: float,
+        iv_percentile: float,
+        stock_price: float = 100.0
+    ) -> Dict[str, Any]:
+        """
+        Get guidance for auto-selling 20-delta weeklies when IV is 2σ cheap.
+
+        Per user spec: "auto-selling 20-delta weeklies only when IV is
+        two-standard-devs cheap"
+
+        Args:
+            iv_rank: Current IV Rank (0-100)
+            iv_percentile: Current IV Percentile (0-100)
+            stock_price: Current stock price
+
+        Returns:
+            Guidance on whether to auto-sell 20-delta weeklies
+        """
+        # McMillan's rule: IV < (mean - 2σ) = exceptionally cheap
+        # This translates to roughly IV Rank < 5 or IV Percentile < 5
+        is_2std_cheap = iv_rank < 5 or iv_percentile < 5
+
+        # Get strategy rules for covered calls (20-delta is a covered call strike)
+        strategy_rules = self.mcmillan_kb.get_strategy_rules("covered_call")
+
+        # Position sizing for this setup
+        position_sizing = self.mcmillan_kb.get_position_size(
+            portfolio_value=10000,  # Example
+            option_premium=0.50,    # Typical weekly premium for 20-delta
+            max_risk_pct=0.02
+        )
+
+        return {
+            "should_auto_sell": is_2std_cheap,
+            "iv_rank": iv_rank,
+            "iv_percentile": iv_percentile,
+            "is_2std_cheap": is_2std_cheap,
+            "reasoning": (
+                "IV is 2 standard deviations below mean - exceptionally cheap. "
+                "McMillan suggests this is optimal for selling premium via 20-delta weeklies."
+                if is_2std_cheap else
+                "IV is not at 2σ cheap level. Wait for better entry or use standard criteria."
+            ),
+            "strategy_rules": strategy_rules,
+            "position_sizing": position_sizing,
+            "delta_target": 0.20,
+            "dte_target": 7,  # Weekly
+            "reference": "McMillan's Options as a Strategic Investment, Ch. 22: Volatility"
+        }
+
+    def get_collar_or_butterfly_guidance(
+        self,
+        position_type: str,
+        iv_rank: float,
+        stock_price: float,
+        shares_owned: int = 100
+    ) -> Dict[str, Any]:
+        """
+        Quick retrieval for collar or butterfly setups.
+
+        Per user spec: "short, cheat-sheet style, perfect for quick retrieval
+        when the system wants a collar or butterfly"
+
+        Args:
+            position_type: 'collar' or 'butterfly'
+            iv_rank: Current IV Rank
+            stock_price: Current stock price
+            shares_owned: Shares owned (for collar)
+
+        Returns:
+            Cheat-sheet style guidance
+        """
+        logger.info(f"Getting {position_type} guidance (IV Rank: {iv_rank})")
+
+        if position_type.lower() == "collar":
+            return {
+                "strategy": "Collar (Protective Put + Covered Call)",
+                "when_to_use": "Own shares, want downside protection while generating income",
+                "setup": {
+                    "step_1": f"Own {shares_owned} shares",
+                    "step_2": "Buy OTM put (10-15 delta) for protection",
+                    "step_3": "Sell OTM call (15-30 delta) to offset put cost",
+                    "net_cost": "Usually zero or small credit"
+                },
+                "optimal_iv": "IV Rank 30-50 (balanced put cost vs call premium)",
+                "current_iv_rank": iv_rank,
+                "iv_assessment": (
+                    "Good entry - balanced costs" if 30 <= iv_rank <= 50 else
+                    "Put may be expensive - consider narrower width" if iv_rank > 50 else
+                    "Put is cheap - wider protection available"
+                ),
+                "quick_rules": [
+                    "Put strike: 8-10% below current price",
+                    "Call strike: 5-10% above current price",
+                    "Same expiration for both",
+                    "DTE: 30-60 days typical",
+                    "Roll before expiration, not at"
+                ],
+                "risk_profile": "Limited downside (to put strike), capped upside (at call strike)",
+                "mcmillan_reference": "Chapter 19: Put and Call Combination Strategies"
+            }
+
+        elif position_type.lower() == "butterfly":
+            return {
+                "strategy": "Butterfly Spread (Long Call Butterfly or Put Butterfly)",
+                "when_to_use": "Expect stock to stay near current price at expiration",
+                "setup": {
+                    "step_1": "Buy 1 ITM call (lower strike)",
+                    "step_2": "Sell 2 ATM calls (middle strike)",
+                    "step_3": "Buy 1 OTM call (higher strike)",
+                    "strikes": "Equal distance between strikes"
+                },
+                "optimal_iv": "IV Rank > 30 (more premium to collect)",
+                "current_iv_rank": iv_rank,
+                "iv_assessment": (
+                    "Good entry - elevated premiums" if iv_rank > 30 else
+                    "Low IV - butterfly may be too cheap"
+                ),
+                "quick_rules": [
+                    "Wings: 5-10 points apart typically",
+                    "Max profit: At middle strike at expiration",
+                    "Max loss: Net debit paid",
+                    "DTE: 30-45 days optimal",
+                    "Close at 50% profit or 21 DTE"
+                ],
+                "risk_profile": "Limited risk (net debit), limited reward (width - debit)",
+                "example": {
+                    "stock_price": stock_price,
+                    "lower_strike": stock_price - 5,
+                    "middle_strike": stock_price,
+                    "upper_strike": stock_price + 5,
+                    "typical_cost": "$1.50-2.50 for $5 wide",
+                    "max_profit": "$5 - cost = $2.50-3.50"
+                },
+                "mcmillan_reference": "Chapter 10: Butterfly Spreads"
+            }
+
+        else:
+            return {
+                "error": f"Unknown position type: {position_type}",
+                "supported": ["collar", "butterfly"]
+            }
+
+    def _analyze_sentiment_alignment(
+        self,
+        sentiment_signal: str,
+        expected_move: Dict,
+        iv_recommendation: Dict
+    ) -> Dict[str, Any]:
+        """Analyze if sentiment aligns with expected move."""
+
+        move_pct = expected_move["move_percentage"]
+
+        # Define what "significant move" means per McMillan
+        is_large_expected_move = move_pct > 5  # >5% expected move is significant
+
+        # Sentiment implies direction; expected move implies magnitude
+        if sentiment_signal in ["overbought", "bearish"]:
+            # Expecting downside
+            if is_large_expected_move:
+                alignment = "ALIGNED"
+                note = "High IV supports potential for significant move in expected direction"
+            else:
+                alignment = "CAUTION"
+                note = "Sentiment is bearish but expected move is small - may be overpriced put"
+
+        elif sentiment_signal in ["oversold", "bullish"]:
+            # Expecting upside
+            if is_large_expected_move:
+                alignment = "ALIGNED"
+                note = "High IV supports potential for significant move in expected direction"
+            else:
+                alignment = "CAUTION"
+                note = "Sentiment is bullish but expected move is small - may be overpriced call"
+
+        else:  # neutral
+            if is_large_expected_move:
+                alignment = "CAUTION"
+                note = "Neutral sentiment but high expected move - consider straddle/strangle"
+            else:
+                alignment = "ALIGNED"
+                note = "Neutral sentiment and low expected move - good for iron condor"
+
+        return {
+            "status": alignment,
+            "note": note,
+            "expected_move_pct": move_pct,
+            "is_significant_move": is_large_expected_move,
+            "sentiment_direction": sentiment_signal
+        }
+
+    def _generate_recommendation(
+        self,
+        sentiment_signal: str,
+        expected_move: Dict,
+        iv_recommendation: Dict,
+        alignment: Dict
+    ) -> str:
+        """Generate final recommendation based on all inputs."""
+
+        if alignment["status"] == "ALIGNED":
+            if sentiment_signal in ["overbought", "bearish"]:
+                return (
+                    f"PROCEED: Buy protective put or bearish spread. "
+                    f"Expected move: ±{expected_move['move_percentage']:.1f}%. "
+                    f"Target strike: ${expected_move['lower_bound']:.2f} (1σ) or "
+                    f"${expected_move['lower_bound'] - expected_move['expected_move']:.2f} (2σ)."
+                )
+            elif sentiment_signal in ["oversold", "bullish"]:
+                return (
+                    f"PROCEED: Buy call or bullish spread. "
+                    f"Expected move: ±{expected_move['move_percentage']:.1f}%. "
+                    f"Target strike: ${expected_move['upper_bound']:.2f} (1σ)."
+                )
+            else:  # neutral
+                return (
+                    f"PROCEED: Iron condor or butterfly. "
+                    f"Expected range: ${expected_move['lower_bound']:.2f} - "
+                    f"${expected_move['upper_bound']:.2f} (68% probability)."
+                )
+        else:  # CAUTION
+            return (
+                f"WAIT: Sentiment ({sentiment_signal}) may not be supported by IV. "
+                f"Expected move only ±{expected_move['move_percentage']:.1f}%. "
+                f"Consider waiting for better setup or use defined-risk spread."
+            )
+
+    def _synthesize_answer(self, query: str, results: Dict) -> str:
+        """Synthesize answer from all results."""
+        parts = []
+
+        if results["structured_results"]:
+            for result in results["structured_results"][:2]:
+                parts.append(f"[{result['type'].upper()}] {result['name']}")
+
+        if results["book_results"]:
+            for result in results["book_results"][:2]:
+                chapter = result.get("chapter", "Unknown")
+                excerpt = result.get("excerpt", "")[:200]
+                parts.append(f"[Book: {chapter}] {excerpt}...")
+
+        if parts:
+            return "\n\n".join(parts)
+        return "No relevant information found in options knowledge base."
+
+    def ingest_options_books_to_vector_store(self) -> Dict[str, Any]:
+        """
+        Ingest all options book chunks into the vector store for semantic search.
+
+        This enables semantic search across book content.
+        """
+        logger.info("Ingesting options books to vector store...")
+
+        chunks = self.book_collector.get_chunks_for_rag()
+
+        if not chunks:
+            return {
+                "status": "no_chunks",
+                "message": "No book chunks to ingest. Use book_collector.ingest_pdf() first."
+            }
+
+        # Prepare for ChromaDB
+        documents = []
+        metadatas = []
+        ids = []
+
+        for chunk in chunks:
+            documents.append(chunk["content"])
+            metadatas.append(chunk["metadata"])
+            ids.append(chunk["id"])
+
+        # Add to database
+        result = self.db.add_documents(
+            documents=documents,
+            metadatas=metadatas,
+            ids=ids
+        )
+
+        return {
+            "status": result["status"],
+            "chunks_ingested": len(chunks),
+            "message": result.get("message", "")
+        }
+
+
+# Singleton instance
+_retriever_instance = None
+
+
+def get_options_book_retriever() -> OptionsBookRetriever:
+    """Get or create OptionsBookRetriever instance (singleton)."""
+    global _retriever_instance
+
+    if _retriever_instance is None:
+        _retriever_instance = OptionsBookRetriever()
+
+    return _retriever_instance
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+
+    retriever = OptionsBookRetriever()
+
+    # Example: Get strategy for conditions
+    print("\n=== Strategy for Current Conditions ===")
+    strategy = retriever.get_strategy_for_conditions(
+        iv_rank=65,
+        market_outlook="neutral",
+        days_to_expiration=30
+    )
+    print(f"Recommended: {strategy['recommended_strategy']}")
+    print(f"IV Reasoning: {strategy['iv_reasoning']}")
+
+    # Example: Cross-check expected move
+    print("\n=== Expected Move Cross-Check ===")
+    cross_check = retriever.cross_check_expected_move(
+        ticker="SPY",
+        sentiment_signal="overbought",
+        current_iv=0.18,
+        dte=7,
+        stock_price=450.0
+    )
+    print(f"Expected Move: ±{cross_check['expected_move']['move_percentage']:.1f}%")
+    print(f"Alignment: {cross_check['alignment']['status']}")
+    print(f"Recommendation: {cross_check['final_recommendation']}")
+
+    # Example: Collar guidance
+    print("\n=== Collar Cheat Sheet ===")
+    collar = retriever.get_collar_or_butterfly_guidance(
+        position_type="collar",
+        iv_rank=45,
+        stock_price=150.0
+    )
+    print(f"When to use: {collar['when_to_use']}")
+    print(f"IV Assessment: {collar['iv_assessment']}")

--- a/src/signals/__init__.py
+++ b/src/signals/__init__.py
@@ -1,0 +1,23 @@
+"""
+Signals Module - Trading Signal Enhancement and Validation
+
+This module provides signal enhancement capabilities including:
+- Options signal enhancement with IV/expected move cross-check
+- McMillan's methodology integration
+- Strategy recommendation based on market conditions
+
+Modules:
+- options_signal_enhancer: Enhance sentiment signals with options analysis
+"""
+
+from src.signals.options_signal_enhancer import (
+    OptionsSignalEnhancer,
+    EnhancedSignal,
+    get_signal_enhancer,
+)
+
+__all__ = [
+    "OptionsSignalEnhancer",
+    "EnhancedSignal",
+    "get_signal_enhancer",
+]

--- a/src/signals/options_signal_enhancer.py
+++ b/src/signals/options_signal_enhancer.py
@@ -1,0 +1,632 @@
+"""
+Options Signal Enhancer - Integrate IV/Expected Move with Sentiment Signals
+
+This module provides the KEY integration per user requirement:
+"whenever sentiment says overbought it cross-checks McMillan's expected move
+calc before slapping on a call"
+
+Workflow:
+1. Receive sentiment signal (overbought, oversold, bullish, bearish)
+2. Fetch current IV metrics
+3. Calculate McMillan's expected move
+4. Cross-check signal validity
+5. Enhance with book knowledge (strategy rules, risk management)
+6. Return validated trading recommendation
+
+Author: AI Trading System
+Date: December 2, 2025
+"""
+
+import logging
+from typing import Dict, Any, Optional, List
+from datetime import datetime
+from dataclasses import dataclass, asdict
+
+logger = logging.getLogger(__name__)
+
+# Import dependencies
+try:
+    from src.rag.options_book_retriever import get_options_book_retriever
+    from src.rag.collectors.mcmillan_options_collector import McMillanOptionsKnowledgeBase
+except ImportError as e:
+    logger.warning(f"Optional import failed: {e}")
+
+try:
+    from src.utils.iv_analyzer import IVAnalyzer, IVMetrics
+except ImportError:
+    IVAnalyzer = None
+    IVMetrics = None
+    logger.warning("IVAnalyzer not available - using fallback calculations")
+
+
+@dataclass
+class EnhancedSignal:
+    """
+    Enhanced trading signal with IV cross-check.
+
+    Contains the original sentiment signal plus McMillan's expected move
+    validation and recommended action.
+    """
+    # Original signal
+    ticker: str
+    original_signal: str  # 'overbought', 'oversold', 'bullish', 'bearish', 'neutral'
+    sentiment_score: float  # -1.0 to 1.0
+    sentiment_confidence: float  # 0.0 to 1.0
+
+    # IV Analysis
+    current_iv: float
+    iv_rank: float
+    iv_percentile: float
+
+    # Expected Move (McMillan's formula)
+    expected_move_pct: float
+    expected_move_dollars: float
+    price_range_low: float
+    price_range_high: float
+
+    # Cross-Check Result
+    is_validated: bool
+    alignment_status: str  # 'ALIGNED', 'CAUTION', 'REJECT'
+    alignment_reason: str
+
+    # Recommendation
+    recommended_action: str  # 'BUY_CALL', 'BUY_PUT', 'SELL_CALL', 'IRON_CONDOR', 'WAIT', etc.
+    recommended_strategy: str
+    position_sizing_pct: float  # % of portfolio
+    target_delta: float
+    target_dte: int
+
+    # Book Reference
+    mcmillan_guidance: str
+    book_references: List[str]
+
+    # Metadata
+    timestamp: str
+    current_price: float
+
+
+class OptionsSignalEnhancer:
+    """
+    Enhances sentiment signals with IV analysis and McMillan's expected move.
+
+    This is the bridge between sentiment analysis and options execution.
+    Every signal goes through McMillan's expected move validation before
+    being passed to the trading system.
+
+    Usage:
+        enhancer = OptionsSignalEnhancer()
+
+        # Enhance a sentiment signal
+        enhanced = enhancer.enhance_signal(
+            ticker="SPY",
+            sentiment_signal="overbought",
+            sentiment_score=-0.65,
+            sentiment_confidence=0.80
+        )
+
+        if enhanced.is_validated:
+            print(f"Execute: {enhanced.recommended_action}")
+        else:
+            print(f"Wait: {enhanced.alignment_reason}")
+    """
+
+    # Sentiment signal mappings
+    SIGNAL_DIRECTIONS = {
+        "overbought": "bearish",
+        "oversold": "bullish",
+        "bullish": "bullish",
+        "bearish": "bearish",
+        "neutral": "neutral"
+    }
+
+    # IV-based strategy mappings
+    HIGH_IV_STRATEGIES = {
+        "bullish": ["covered_call", "cash_secured_put", "bull_put_spread"],
+        "bearish": ["bear_call_spread", "naked_put"],  # Careful with naked
+        "neutral": ["iron_condor", "strangle_short", "butterfly"]
+    }
+
+    LOW_IV_STRATEGIES = {
+        "bullish": ["long_call", "call_debit_spread", "long_straddle"],
+        "bearish": ["long_put", "put_debit_spread"],
+        "neutral": ["calendar_spread", "long_butterfly"]
+    }
+
+    def __init__(self, portfolio_value: float = 10000.0):
+        """
+        Initialize signal enhancer.
+
+        Args:
+            portfolio_value: Portfolio value for position sizing
+        """
+        self.portfolio_value = portfolio_value
+        self.mcmillan_kb = McMillanOptionsKnowledgeBase()
+
+        # Initialize IV analyzer if available
+        if IVAnalyzer:
+            try:
+                self.iv_analyzer = IVAnalyzer()
+            except Exception as e:
+                logger.warning(f"IVAnalyzer init failed: {e}")
+                self.iv_analyzer = None
+        else:
+            self.iv_analyzer = None
+
+        # Initialize book retriever
+        try:
+            self.book_retriever = get_options_book_retriever()
+        except Exception as e:
+            logger.warning(f"Book retriever init failed: {e}")
+            self.book_retriever = None
+
+        logger.info("Options Signal Enhancer initialized")
+
+    def enhance_signal(
+        self,
+        ticker: str,
+        sentiment_signal: str,
+        sentiment_score: float,
+        sentiment_confidence: float,
+        current_price: Optional[float] = None,
+        current_iv: Optional[float] = None,
+        iv_rank: Optional[float] = None,
+        dte: int = 30
+    ) -> EnhancedSignal:
+        """
+        Enhance a sentiment signal with IV/expected move cross-check.
+
+        This is the MAIN entry point - called whenever the trading system
+        receives a sentiment signal.
+
+        Args:
+            ticker: Stock symbol
+            sentiment_signal: 'overbought', 'oversold', 'bullish', 'bearish', 'neutral'
+            sentiment_score: Raw sentiment score (-1.0 to 1.0)
+            sentiment_confidence: Confidence in the signal (0.0 to 1.0)
+            current_price: Current stock price (optional, will fetch if not provided)
+            current_iv: Current IV (optional, will fetch if not provided)
+            iv_rank: IV Rank 0-100 (optional, will calculate if not provided)
+            dte: Days to expiration for expected move calc
+
+        Returns:
+            EnhancedSignal with validation and recommendation
+        """
+        logger.info(
+            f"Enhancing signal for {ticker}: {sentiment_signal} "
+            f"(score={sentiment_score:.2f}, conf={sentiment_confidence:.2f})"
+        )
+
+        # Step 1: Get IV metrics
+        iv_metrics = self._get_iv_metrics(
+            ticker=ticker,
+            current_price=current_price,
+            current_iv=current_iv,
+            iv_rank=iv_rank
+        )
+
+        # Step 2: Calculate expected move (McMillan's formula)
+        expected_move = self.mcmillan_kb.calculate_expected_move(
+            stock_price=iv_metrics["current_price"],
+            implied_volatility=iv_metrics["current_iv"],
+            days_to_expiration=dte,
+            confidence_level=1.0  # 1 std dev
+        )
+
+        # Step 3: Cross-check sentiment with expected move
+        alignment = self._cross_check_alignment(
+            sentiment_signal=sentiment_signal,
+            sentiment_score=sentiment_score,
+            sentiment_confidence=sentiment_confidence,
+            expected_move=expected_move,
+            iv_metrics=iv_metrics
+        )
+
+        # Step 4: Get strategy recommendation
+        strategy_rec = self._get_strategy_recommendation(
+            direction=self.SIGNAL_DIRECTIONS.get(sentiment_signal, "neutral"),
+            iv_rank=iv_metrics["iv_rank"],
+            alignment=alignment
+        )
+
+        # Step 5: Calculate position sizing
+        position_sizing = self._calculate_position_size(
+            strategy=strategy_rec["strategy"],
+            iv_rank=iv_metrics["iv_rank"],
+            confidence=sentiment_confidence
+        )
+
+        # Step 6: Get book references
+        book_refs = self._get_book_references(
+            sentiment_signal=sentiment_signal,
+            strategy=strategy_rec["strategy"]
+        )
+
+        # Build enhanced signal
+        enhanced = EnhancedSignal(
+            ticker=ticker,
+            original_signal=sentiment_signal,
+            sentiment_score=sentiment_score,
+            sentiment_confidence=sentiment_confidence,
+            current_iv=iv_metrics["current_iv"],
+            iv_rank=iv_metrics["iv_rank"],
+            iv_percentile=iv_metrics.get("iv_percentile", iv_metrics["iv_rank"]),
+            expected_move_pct=expected_move["move_percentage"],
+            expected_move_dollars=expected_move["expected_move"],
+            price_range_low=expected_move["lower_bound"],
+            price_range_high=expected_move["upper_bound"],
+            is_validated=alignment["is_valid"],
+            alignment_status=alignment["status"],
+            alignment_reason=alignment["reason"],
+            recommended_action=strategy_rec["action"],
+            recommended_strategy=strategy_rec["strategy"],
+            position_sizing_pct=position_sizing["size_pct"],
+            target_delta=strategy_rec["delta"],
+            target_dte=dte,
+            mcmillan_guidance=alignment["mcmillan_guidance"],
+            book_references=book_refs,
+            timestamp=datetime.now().isoformat(),
+            current_price=iv_metrics["current_price"]
+        )
+
+        logger.info(
+            f"Signal enhanced: {enhanced.alignment_status} - "
+            f"{enhanced.recommended_action} ({enhanced.recommended_strategy})"
+        )
+
+        return enhanced
+
+    def _get_iv_metrics(
+        self,
+        ticker: str,
+        current_price: Optional[float],
+        current_iv: Optional[float],
+        iv_rank: Optional[float]
+    ) -> Dict[str, float]:
+        """Get IV metrics, fetching from analyzer if needed."""
+
+        # Try to get live data if analyzer available
+        if self.iv_analyzer and current_iv is None:
+            try:
+                metrics = self.iv_analyzer.analyze(ticker)
+                if metrics:
+                    return {
+                        "current_price": metrics.current_price,
+                        "current_iv": metrics.current_iv,
+                        "iv_rank": metrics.iv_rank,
+                        "iv_percentile": metrics.iv_percentile
+                    }
+            except Exception as e:
+                logger.warning(f"Failed to fetch IV metrics: {e}")
+
+        # Use provided values or defaults
+        return {
+            "current_price": current_price or 100.0,
+            "current_iv": current_iv or 0.25,  # Default 25% IV
+            "iv_rank": iv_rank or 50.0,        # Default middle range
+            "iv_percentile": iv_rank or 50.0
+        }
+
+    def _cross_check_alignment(
+        self,
+        sentiment_signal: str,
+        sentiment_score: float,
+        sentiment_confidence: float,
+        expected_move: Dict,
+        iv_metrics: Dict
+    ) -> Dict[str, Any]:
+        """
+        Cross-check if sentiment signal aligns with expected move.
+
+        This is McMillan's key insight: don't just follow sentiment,
+        validate that IV supports the expected magnitude of move.
+        """
+        move_pct = expected_move["move_percentage"]
+        iv_rank = iv_metrics["iv_rank"]
+
+        # Minimum expected move for signal to be valid
+        # If sentiment says big move but expected move is tiny, signal is weak
+        min_move_threshold = 2.0  # At least 2% expected move for directional trades
+
+        # For neutral/range-bound strategies, we want SMALL expected moves
+        if sentiment_signal == "neutral":
+            # Perfect for iron condors when expected move is small
+            if move_pct < 5.0:  # Less than 5% expected move
+                is_valid = True
+                status = "ALIGNED"
+                reason = (
+                    f"Neutral sentiment with small expected move (±{move_pct:.1f}%). "
+                    "Ideal for iron condor or butterfly."
+                )
+            else:
+                is_valid = False
+                status = "CAUTION"
+                reason = (
+                    f"Neutral sentiment but expected move is large (±{move_pct:.1f}%). "
+                    "Stock may break out of range. Consider straddle instead."
+                )
+
+        elif sentiment_signal in ["overbought", "bearish"]:
+            # Bearish signals - want enough expected move for profit
+            if move_pct >= min_move_threshold:
+                if sentiment_confidence >= 0.6:
+                    is_valid = True
+                    status = "ALIGNED"
+                    reason = (
+                        f"Bearish signal validated. Expected move ±{move_pct:.1f}% "
+                        f"supports potential downside to ${expected_move['lower_bound']:.2f}."
+                    )
+                else:
+                    is_valid = True
+                    status = "CAUTION"
+                    reason = (
+                        f"Bearish signal weak (conf={sentiment_confidence:.0%}). "
+                        "Consider defined-risk spread instead of naked options."
+                    )
+            else:
+                is_valid = False
+                status = "REJECT"
+                reason = (
+                    f"Bearish signal but expected move only ±{move_pct:.1f}%. "
+                    "IV doesn't support expected magnitude. Wait or sell premium instead."
+                )
+
+        elif sentiment_signal in ["oversold", "bullish"]:
+            # Bullish signals - want enough expected move for profit
+            if move_pct >= min_move_threshold:
+                if sentiment_confidence >= 0.6:
+                    is_valid = True
+                    status = "ALIGNED"
+                    reason = (
+                        f"Bullish signal validated. Expected move ±{move_pct:.1f}% "
+                        f"supports potential upside to ${expected_move['upper_bound']:.2f}."
+                    )
+                else:
+                    is_valid = True
+                    status = "CAUTION"
+                    reason = (
+                        f"Bullish signal weak (conf={sentiment_confidence:.0%}). "
+                        "Consider defined-risk spread instead of outright call."
+                    )
+            else:
+                is_valid = False
+                status = "REJECT"
+                reason = (
+                    f"Bullish signal but expected move only ±{move_pct:.1f}%. "
+                    "IV doesn't support expected magnitude. Wait or sell put instead."
+                )
+        else:
+            is_valid = False
+            status = "UNKNOWN"
+            reason = f"Unknown signal type: {sentiment_signal}"
+
+        # Get McMillan's IV guidance
+        iv_rec = self.mcmillan_kb.get_iv_recommendation(
+            iv_rank=iv_rank,
+            iv_percentile=iv_metrics.get("iv_percentile", iv_rank)
+        )
+
+        mcmillan_guidance = (
+            f"IV Rank: {iv_rank:.0f}. {iv_rec['recommendation']}. "
+            f"Expected move formula: Price × IV × √(DTE/365) = "
+            f"${expected_move['expected_move']:.2f} ({move_pct:.1f}%)."
+        )
+
+        return {
+            "is_valid": is_valid,
+            "status": status,
+            "reason": reason,
+            "mcmillan_guidance": mcmillan_guidance,
+            "iv_recommendation": iv_rec["recommendation"]
+        }
+
+    def _get_strategy_recommendation(
+        self,
+        direction: str,
+        iv_rank: float,
+        alignment: Dict
+    ) -> Dict[str, Any]:
+        """Get recommended strategy based on direction and IV."""
+
+        # Determine if high or low IV
+        is_high_iv = iv_rank >= 50
+
+        # Select strategy pool
+        if is_high_iv:
+            strategies = self.HIGH_IV_STRATEGIES.get(direction, ["iron_condor"])
+        else:
+            strategies = self.LOW_IV_STRATEGIES.get(direction, ["long_call"])
+
+        # Pick based on alignment status
+        if alignment["status"] == "REJECT":
+            # Conservative: sell premium or wait
+            strategy = "wait" if not is_high_iv else "iron_condor"
+            action = "WAIT" if strategy == "wait" else "SELL_PREMIUM"
+            delta = 0.16  # Conservative delta for premium selling
+        elif alignment["status"] == "CAUTION":
+            # Use defined-risk strategy
+            if direction == "bullish":
+                strategy = "call_debit_spread" if not is_high_iv else "bull_put_spread"
+                action = "BUY_CALL_SPREAD" if not is_high_iv else "SELL_PUT_SPREAD"
+            elif direction == "bearish":
+                strategy = "put_debit_spread" if not is_high_iv else "bear_call_spread"
+                action = "BUY_PUT_SPREAD" if not is_high_iv else "SELL_CALL_SPREAD"
+            else:
+                strategy = "iron_condor"
+                action = "IRON_CONDOR"
+            delta = 0.30
+        else:  # ALIGNED
+            # Can be more aggressive
+            strategy = strategies[0]
+            if direction == "bullish":
+                action = "BUY_CALL" if not is_high_iv else "SELL_PUT"
+            elif direction == "bearish":
+                action = "BUY_PUT" if not is_high_iv else "SELL_CALL"
+            else:
+                action = "IRON_CONDOR"
+            delta = 0.45 if not is_high_iv else 0.30
+
+        return {
+            "strategy": strategy,
+            "action": action,
+            "delta": delta,
+            "is_high_iv": is_high_iv
+        }
+
+    def _calculate_position_size(
+        self,
+        strategy: str,
+        iv_rank: float,
+        confidence: float
+    ) -> Dict[str, float]:
+        """Calculate position size based on strategy and confidence."""
+
+        # Base position size: 2% of portfolio
+        base_size = 0.02
+
+        # Adjust for confidence
+        confidence_multiplier = 0.5 + (confidence * 0.5)  # 0.5x to 1.0x
+
+        # Adjust for IV - smaller positions in high IV (more expensive)
+        iv_multiplier = 1.0 - (iv_rank / 200)  # 0.5x at IV Rank 100, 1.0x at 0
+
+        # Strategy-specific adjustments
+        strategy_multipliers = {
+            "wait": 0.0,
+            "iron_condor": 1.2,  # Defined risk, can size up
+            "covered_call": 1.0,
+            "long_call": 0.8,   # Single leg, more risky
+            "long_put": 0.8,
+            "call_debit_spread": 1.0,
+            "put_debit_spread": 1.0,
+        }
+        strategy_mult = strategy_multipliers.get(strategy, 1.0)
+
+        final_size = base_size * confidence_multiplier * iv_multiplier * strategy_mult
+
+        # Cap at 5% max
+        final_size = min(final_size, 0.05)
+
+        return {
+            "size_pct": round(final_size * 100, 2),
+            "dollar_amount": round(self.portfolio_value * final_size, 2),
+            "base_size": base_size,
+            "adjustments": {
+                "confidence": confidence_multiplier,
+                "iv": iv_multiplier,
+                "strategy": strategy_mult
+            }
+        }
+
+    def _get_book_references(
+        self,
+        sentiment_signal: str,
+        strategy: str
+    ) -> List[str]:
+        """Get relevant book references for the trade."""
+
+        if not self.book_retriever:
+            return ["McMillan: Options as a Strategic Investment"]
+
+        try:
+            search_result = self.book_retriever.search_options_knowledge(
+                query=f"{strategy} {sentiment_signal}",
+                top_k=2
+            )
+            refs = []
+            for result in search_result.get("book_results", []):
+                chapter = result.get("chapter", "")
+                page = result.get("page", "")
+                refs.append(f"McMillan Ch.{chapter}, p.{page}")
+
+            return refs if refs else ["McMillan: Options as a Strategic Investment"]
+
+        except Exception as e:
+            logger.warning(f"Failed to get book references: {e}")
+            return ["McMillan: Options as a Strategic Investment"]
+
+    def batch_enhance(
+        self,
+        signals: List[Dict[str, Any]]
+    ) -> List[EnhancedSignal]:
+        """
+        Batch enhance multiple signals.
+
+        Args:
+            signals: List of dicts with ticker, signal, score, confidence
+
+        Returns:
+            List of EnhancedSignal objects
+        """
+        enhanced_signals = []
+
+        for signal in signals:
+            try:
+                enhanced = self.enhance_signal(
+                    ticker=signal["ticker"],
+                    sentiment_signal=signal["signal"],
+                    sentiment_score=signal.get("score", 0.0),
+                    sentiment_confidence=signal.get("confidence", 0.5),
+                    current_price=signal.get("price"),
+                    current_iv=signal.get("iv"),
+                    iv_rank=signal.get("iv_rank")
+                )
+                enhanced_signals.append(enhanced)
+            except Exception as e:
+                logger.error(f"Failed to enhance signal for {signal.get('ticker')}: {e}")
+
+        return enhanced_signals
+
+
+# Convenience function
+def get_signal_enhancer(portfolio_value: float = 10000.0) -> OptionsSignalEnhancer:
+    """Get OptionsSignalEnhancer instance."""
+    return OptionsSignalEnhancer(portfolio_value=portfolio_value)
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+
+    enhancer = OptionsSignalEnhancer(portfolio_value=10000.0)
+
+    # Example: Enhance an overbought signal
+    print("\n=== Testing Overbought Signal ===")
+    signal = enhancer.enhance_signal(
+        ticker="SPY",
+        sentiment_signal="overbought",
+        sentiment_score=-0.65,
+        sentiment_confidence=0.80,
+        current_price=450.0,
+        current_iv=0.18,
+        iv_rank=35.0,
+        dte=7
+    )
+
+    print(f"Ticker: {signal.ticker}")
+    print(f"Original Signal: {signal.original_signal}")
+    print(f"Expected Move: ±{signal.expected_move_pct:.1f}%")
+    print(f"Price Range: ${signal.price_range_low:.2f} - ${signal.price_range_high:.2f}")
+    print(f"Validated: {signal.is_validated} ({signal.alignment_status})")
+    print(f"Reason: {signal.alignment_reason}")
+    print(f"Recommendation: {signal.recommended_action}")
+    print(f"Strategy: {signal.recommended_strategy}")
+    print(f"Position Size: {signal.position_sizing_pct}%")
+    print(f"McMillan Guidance: {signal.mcmillan_guidance}")
+
+    # Example: Enhance a bullish signal with high IV
+    print("\n=== Testing Bullish Signal with High IV ===")
+    signal2 = enhancer.enhance_signal(
+        ticker="NVDA",
+        sentiment_signal="bullish",
+        sentiment_score=0.72,
+        sentiment_confidence=0.85,
+        current_price=140.0,
+        current_iv=0.45,
+        iv_rank=75.0,
+        dte=30
+    )
+
+    print(f"Ticker: {signal2.ticker}")
+    print(f"IV Rank: {signal2.iv_rank}")
+    print(f"Validated: {signal2.is_validated} ({signal2.alignment_status})")
+    print(f"Recommendation: {signal2.recommended_action}")
+    print(f"Strategy: {signal2.recommended_strategy}")


### PR DESCRIPTION
…oss-check

Implements comprehensive options book ingestion for RAG retrieval:

- OptionsBookCollector: PDF ingestion with intelligent chunking
  - Chapter/section detection for McMillan's book structure
  - Content type classification (strategy, example, rule, warning)
  - Page number tracking for citations

- OptionsBookRetriever: High-level retrieval API
  - Strategy recommendations based on IV conditions
  - Expected move cross-check for sentiment signals
  - Collar/butterfly cheat-sheet guidance
  - 20-delta weekly auto-sell detection (2σ cheap IV)

- OptionsSignalEnhancer: Bridge between sentiment and options execution
  - Cross-checks every sentiment signal against McMillan's expected move
  - Validates alignment before recommending trades
  - Position sizing based on IV rank and confidence

- Ingestion script: scripts/ingest_options_books.py
  - Ingest PDF books into vector store
  - Ingest built-in McMillan knowledge base
  - Test search functionality

Key feature: "whenever sentiment says overbought, cross-check McMillan's expected move calc before slapping on a call"