### PR TITLE
fix(deps): Resolve dependency conflicts in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,18 +1,17 @@
 # Trading System - Minimal Production Dependencies
 # Optimized for fast CI/CD installation (<2 minutes)
-# Last updated: 2025-11-24
+# Last updated: 2025-12-02
 #
-# Python Version Requirement: >=3.9,<3.15
-# pandas 2.3.3 is compatible with Python 3.9-3.14
-# Python 3.15+ will require pandas upgrade when released
+# Python Version Requirement: >=3.9,<3.14
+# Note: Python 3.14+ has limited wheel availability; use 3.12 for best compatibility
 
 # Trading APIs
 alpaca-py==0.43.2  # Modern SDK (replaces deprecated alpaca-trade-api) - websockets>=10.4
-openai==1.109.1
+openai>=1.40.0,<2.0.0  # Flexible range for better compatibility
 
 # Data Processing
-pandas==2.3.3
-numpy>=1.26.4,<2.0.0  # pandas 2.3.3 requires numpy>=1.26.0; <2.0 for langchain compatibility
+pandas>=2.0.0,<3.0.0  # Flexible for numpy compatibility
+numpy>=1.26.4,<2.0.0  # <2.0 for langchain/torch compatibility
 yfinance==0.2.58  # Stable version without websocket conflicts (Issue #65)
 alpha-vantage==2.3.1
 
@@ -52,7 +51,7 @@ pytz==2023.3
 loguru==0.7.2
 httpx>=0.27.0,<0.28.0  # Pin to avoid 'proxies' arg removal in 0.28+
 anthropic>=0.73.0,<1.0.0
-google-generativeai>=0.8.0,<1.0.0  # Required for gemini_agent and gemini3_langgraph_agent
+google-generativeai>=0.8.0,<0.9.0  # Required for gemini_agent - pin for protobuf compat
 
 # Deep Learning (Phase 1: Elite AI Trader)
 torch>=2.0.0,<3.0.0  # PyTorch for LSTM-PPO ensemble (primary framework)
@@ -61,15 +60,15 @@ scikit-learn>=1.3.0,<2.0.0  # Feature engineering and preprocessing
 
 # RL Fine-Tuning
 gymnasium==0.29.1
-stable-baselines3==2.3.0
+stable-baselines3==2.3.2  # 2.3.0 yanked due to PyTorch 1.13 loading issue
 
-# DeepAgents Integration (pinned to 0.3.x for numpy<2 compatibility - Issue #65)
-langchain>=0.3.0,<1.0.0
-langchain-core>=0.3.0,<1.0.0
-langchain-anthropic>=0.3.0,<1.0.0
+# DeepAgents Integration (pinned for numpy<2 and protobuf compatibility - Issue #65)
+langchain>=0.3.0,<0.4.0
+langchain-core>=0.3.0,<0.4.0
+langchain-anthropic>=0.3.0,<0.4.0
 langchain-community>=0.3.0,<0.4.0
-langgraph>=0.2.0,<1.0.0
-langsmith>=0.1.0  # LangSmith monitoring for RL training
+langgraph>=0.2.0,<0.3.0
+langsmith>=0.1.0,<0.2.0  # LangSmith monitoring for RL training
 
 # Dashboard
 streamlit>=1.29.0


### PR DESCRIPTION
## Summary
- Pin langchain ecosystem to 0.3.x to prevent resolver backtracking
- Pin google-generativeai to <0.9.0 for protobuf compatibility  
- Upgrade stable-baselines3 to 2.3.2 (2.3.0 was yanked)
- Relax pandas/openai versions for better compatibility

## Test plan
- [x] `pip install --dry-run -r requirements.txt` passes with no conflicts
- [x] No yanked packages in dependencies
- [x] Pre-commit hooks pass

Closes #65

🤖 Generated with [Claude Code](https://claude.com/claude-code)