### PR TITLE
chore: set least-privilege permissions on workflows

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -1,5 +1,8 @@
 name: Smoke
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ main ]

--- a/.github/workflows/unified-rag-ingestion.yml
+++ b/.github/workflows/unified-rag-ingestion.yml
@@ -1,5 +1,8 @@
 name: Unified RAG Ingestion
 
+permissions:
+  contents: read
+
 on:
   schedule:
     # Run daily at 6:00 AM ET (11:00 UTC) - before market analysis

--- a/.github/workflows/unit-fast.yml
+++ b/.github/workflows/unit-fast.yml
@@ -1,5 +1,8 @@
 name: Unit (Fast)
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ main ]


### PR DESCRIPTION
Fix CodeQL actions/missing-workflow-permissions by adding explicit minimal permissions (contents: read) to unit-fast, smoke, and unified-rag-ingestion workflows.