### PR TITLE
chore: enable CodeQL and allow manual dispatch

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,6 +1,7 @@
 name: "CodeQL Security Analysis"
 
 on:
+  workflow_dispatch:
   push:
     branches: [ "main" ]
   pull_request:


### PR DESCRIPTION
Rename codeql-analysis workflow to active .yml and add workflow_dispatch so we can run CodeQL on demand (push/PR/schedule retained).