### PR TITLE
fix: import error for VolatilityAuditor

### DIFF
--- a/src/agent_framework/auditor.py
+++ b/src/agent_framework/auditor.py
@@ -197,3 +197,10 @@ class AdaptiveTradeAuditor:
                 handle.write(json.dumps(report, default=str) + "\n")
         except Exception as exc:
             logger.warning("Failed to append audit report: %s", exc)
+
+
+# Backwards compatibility: older modules import VolatilityAuditor
+class VolatilityAuditor(AdaptiveTradeAuditor):
+    """Alias for AdaptiveTradeAuditor used in legacy code paths."""
+
+    pass


### PR DESCRIPTION
- add back the VolatilityAuditor alias so autonomous_trader imports succeed
- keeps legacy modules compatible while we keep AdaptiveTradeAuditor as the implementation