### PR TITLE
ci: extend trading install timeout

### DIFF
--- a/.github/workflows/daily-trading.yml
+++ b/.github/workflows/daily-trading.yml
@@ -54,6 +54,7 @@ jobs:
           python-version: '3.11'
 
       - name: Install dependencies
+        timeout-minutes: 10
         run: |
           python3 -m pip install --upgrade pip
           python3 -m pip install -r requirements.txt


### PR DESCRIPTION
- give execute-trading dependency install 10 minutes so pip can finish heavy torch/langchain downloads