### PR TITLE
ci: allow longer dependency install

### DIFF
--- a/.github/workflows/daily-trading.yml
+++ b/.github/workflows/daily-trading.yml
@@ -188,7 +188,7 @@ jobs:
           cache: 'pip'
 
       - name: Install dependencies
-        timeout-minutes: 3
+        timeout-minutes: 12
         run: |
           python3 -m pip install --upgrade pip
           python3 -m pip install -r requirements.txt


### PR DESCRIPTION
- bump execute-trading dependency install timeout to 12 minutes to keep heavy torch/langchain install from being killed