### PR TITLE
ci: avoid direct pushes from trading job

### DIFF
--- a/.github/workflows/daily-trading.yml
+++ b/.github/workflows/daily-trading.yml
@@ -484,7 +484,9 @@ jobs:
           fi
 
       - name: Commit system state updates
-        if: steps.check_execution.outputs.skip != 'true' && steps.check_state_changes.outputs.state_changed == 'true'
+        if: steps.check_execution.outputs.skip != 'true' && steps.check_state_changes.outputs.state_changed == 'true' && env.ALLOW_STATE_PUSH == '1'
+        env:
+          ALLOW_STATE_PUSH: ${{ secrets.ALLOW_STATE_PUSH || '0' }}
         run: |
           echo "💾 Committing system_state.json updates..."
 


### PR DESCRIPTION
- gate the system_state commit/push behind an ALLOW_STATE_PUSH secret so repo rules (PR-only) don't fail the workflow