### PR TITLE
chore: restore dryrun badge

### DIFF
--- a/badges/dryrun.json
+++ b/badges/dryrun.json
@@ -1,0 +1,6 @@
+{
+  "schemaVersion": 1,
+  "label": "Dry Run Updated",
+  "message": "2025-12-03",
+  "color": "blue"
+}


### PR DESCRIPTION
- add missing badges/dryrun.json endpoint so README shields render correctly