### PR TITLE
feat: surface trading failures on dashboard

### DIFF
--- a/.github/workflows/daily-trading.yml
+++ b/.github/workflows/daily-trading.yml
@@ -483,6 +483,15 @@ jobs:
             git diff --stat data/system_state.json
           fi
 
+      - name: Record trading run result
+        if: always()
+        run: |
+          python3 scripts/log_trading_run.py
+        env:
+          JOB_STATUS: ${{ job.status }}
+          FAILING_STEP: ""
+          ERROR_MESSAGE: ""
+
       - name: Commit system state updates
         if: steps.check_execution.outputs.skip != 'true' && steps.check_state_changes.outputs.state_changed == 'true' && env.ALLOW_STATE_PUSH == '1'
         env:

--- a/scripts/log_trading_run.py
+++ b/scripts/log_trading_run.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+"""
+Append a trading run record to data/trading_runs.jsonl.
+
+Intended to be called from GitHub Actions. Keeps only the most recent
+MAX_RECORDS entries to prevent unbounded growth.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+MAX_RECORDS = 200
+RUN_LOG = Path("data/trading_runs.jsonl")
+
+
+def load_runs() -> list[dict[str, Any]]:
+    if not RUN_LOG.exists():
+        return []
+    try:
+        return [json.loads(line) for line in RUN_LOG.read_text().splitlines() if line.strip()]
+    except Exception:
+        # Corrupted file? Start fresh but keep a backup for debugging.
+        RUN_LOG.rename(RUN_LOG.with_suffix(".jsonl.bak"))
+        return []
+
+
+def main() -> None:
+    run_id = os.getenv("GITHUB_RUN_ID")
+    run_number = os.getenv("GITHUB_RUN_NUMBER")
+    sha = os.getenv("GITHUB_SHA")
+    repo = os.getenv("GITHUB_REPOSITORY")
+    job_status = os.getenv("JOB_STATUS", "unknown")
+    failing_step = os.getenv("FAILING_STEP") or None
+    error_message = os.getenv("ERROR_MESSAGE") or None
+
+    now = datetime.now(timezone.utc)
+
+    record = {
+        "ts": now.isoformat(),
+        "status": job_status.lower(),
+        "run_id": run_id,
+        "run_number": run_number,
+        "sha": sha,
+        "repo": repo,
+        "failing_step": failing_step,
+        "error": error_message,
+        "actions_url": f"https://github.com/{repo}/actions/runs/{run_id}"
+        if repo and run_id
+        else None,
+    }
+
+    runs = load_runs()
+    runs.append(record)
+    runs = runs[-MAX_RECORDS:]
+
+    RUN_LOG.parent.mkdir(parents=True, exist_ok=True)
+    with RUN_LOG.open("w", encoding="utf-8") as f:
+        for row in runs:
+            f.write(json.dumps(row, ensure_ascii=False) + "\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_trading_runs_dashboard.py
+++ b/tests/test_trading_runs_dashboard.py
@@ -1,0 +1,39 @@
+import json
+from datetime import datetime
+
+import scripts.generate_progress_dashboard as g
+
+
+def test_format_recent_runs_empty():
+    assert "—" in g.format_recent_runs([])
+
+
+def test_format_recent_runs_formats_link():
+    runs = [
+        {
+            "ts": datetime.utcnow().isoformat() + "Z",
+            "status": "failure",
+            "failing_step": "Install dependencies",
+            "error": "pip timeout",
+            "run_number": "123",
+            "actions_url": "https://example.com/run/123",
+        }
+    ]
+    out = g.format_recent_runs(runs)
+    assert "FAILURE" in out
+    assert "[#123](https://example.com/run/123)" in out
+    assert "Install dependencies" in out
+
+
+def test_load_run_log_reads_and_orders(tmp_path, monkeypatch):
+    log = tmp_path / "trading_runs.jsonl"
+    entries = [
+        {"ts": "2025-12-03T00:00:00Z", "status": "success"},
+        {"ts": "2025-12-04T00:00:00Z", "status": "failure"},
+    ]
+    log.write_text("\n".join(json.dumps(e) for e in entries))
+    monkeypatch.setattr(g, "RUN_LOG", log)
+    runs = g.load_run_log(max_items=5)
+    assert len(runs) == 2
+    # newest first
+    assert runs[0]["status"] == "failure"


### PR DESCRIPTION
- log every trading run to data/trading_runs.jsonl (capped) via a dedicated script
- add 'Recent Trading Runs' section and failure banner to the Progress Dashboard
- extend execute-trading workflow to record runs (no pushes unless ALLOW_STATE_PUSH=1)
- tests to cover run log formatting