### PR TITLE
ci: PR-based state updates

### DIFF
--- a/.github/workflows/daily-trading.yml
+++ b/.github/workflows/daily-trading.yml
@@ -492,51 +492,31 @@ jobs:
           FAILING_STEP: ""
           ERROR_MESSAGE: ""
 
-      - name: Commit system state updates
+      - name: Open PR with system state updates
         if: steps.check_execution.outputs.skip != 'true' && steps.check_state_changes.outputs.state_changed == 'true' && env.ALLOW_STATE_PUSH == '1'
         env:
           ALLOW_STATE_PUSH: ${{ secrets.ALLOW_STATE_PUSH || '0' }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          echo "💾 Committing system_state.json updates..."
+          echo "💾 Preparing PR for system_state.json updates..."
 
           git config user.name "GitHub Actions Bot"
           git config user.email "actions@github.com"
 
-          # Stage system_state.json first, then rebase with autostash to avoid
-          # "unstaged changes" errors from the runner checkout.
+          BRANCH="state-update-${{ github.run_id }}"
+          git checkout -b "$BRANCH"
+
           git add data/system_state.json
+          git commit -m "chore: update system state after trading run ${{ github.run_id }}"
+          git push origin "$BRANCH"
 
-          git pull --rebase --autostash origin main || {
-            echo "⚠️  Merge conflict detected - keeping workflow-generated state"
-            git rebase --abort || true
-          }
+          gh pr create \
+            --title "chore: update system state after trading run ${{ github.run_id }}" \
+            --body "Automated state update from daily-trading run ${{ github.run_id }}." \
+            --base main \
+            --head "$BRANCH"
 
-          # Create commit with trading execution details
-          git commit -m "$(cat <<'EOF'
-          chore: Update system state after trading execution
-
-          Daily trading execution completed and system state updated.
-
-          Execution details:
-          - Date: $(date -u +'%Y-%m-%d %H:%M:%S UTC')
-          - Workflow: daily-trading.yml
-          - Run ID: ${{ github.run_id }}
-
-          Changes:
-          - Updated account balances
-          - Recorded trade execution results
-          - Updated performance metrics
-
-          🤖 Generated with [Claude Code](https://claude.com/claude-code)
-
-          Co-Authored-By: Claude <noreply@anthropic.com>
-          EOF
-          )"
-
-          # Push changes
-          git push origin main
-
-          echo "✅ System state changes committed and pushed"
+          echo "✅ Opened PR for state update"
 
       - name: Stop ADK service
         if: always()


### PR DESCRIPTION
- replace direct push of system_state.json with an auto-created PR on each trading run when state changes
- keeps repo PR-only rules intact