### PR TITLE
ci: stop pip cache from filling runner disk

### DIFF
--- a/.github/workflows/daily-trading.yml
+++ b/.github/workflows/daily-trading.yml
@@ -118,9 +118,11 @@ jobs:
           key: backtest-cache-${{ hashFiles('config/backtest_scenarios.yaml') }}
 
       - name: Install dependencies
+        env:
+          PIP_CACHE_DIR: /tmp/pipcache
         run: |
           python3 -m pip install --upgrade pip
-          python3 -m pip install -r requirements.txt
+          python3 -m pip install --no-cache-dir -r requirements.txt
 
       - name: Run backtest scenario matrix
         timeout-minutes: 20
@@ -189,9 +191,11 @@ jobs:
 
       - name: Install dependencies
         timeout-minutes: 12
+        env:
+          PIP_CACHE_DIR: /tmp/pipcache
         run: |
           python3 -m pip install --upgrade pip
-          python3 -m pip install -r requirements.txt
+          python3 -m pip install --no-cache-dir -r requirements.txt
 
       - name: Set up Go for ADK orchestrator
         uses: actions/setup-go@v5


### PR DESCRIPTION
- set PIP_CACHE_DIR and install with --no-cache-dir in daily-trading to avoid /tmp disk exhaustion