### PR TITLE
ci: allow GH_TOKEN to open state update PRs

### DIFF
--- a/.github/workflows/daily-trading.yml
+++ b/.github/workflows/daily-trading.yml
@@ -25,6 +25,7 @@ on:
 
 permissions:
   contents: write
+  pull-requests: write
   pages: write
 
 # Prevent multiple concurrent trading runs


### PR DESCRIPTION
Grant pull-request write so the daily trading workflow can open the automated state-update PR after a run.