### PR TITLE
ci: temporarily allow promotion override

### DIFF
--- a/.github/workflows/daily-trading.yml
+++ b/.github/workflows/daily-trading.yml
@@ -160,6 +160,7 @@ jobs:
     env:
       PYTHONPATH: ${{ github.workspace }}
       ENABLE_WEEKEND_PROXY: 'true'
+      ALLOW_PROMOTION_OVERRIDE: '1'  # Temporary override to allow trading while metrics are repaired
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
Allow promotion override during execute-trading so runs proceed while we repair metrics. Added ALLOW_PROMOTION_OVERRIDE=1 env in execute-trading job.