### PR TITLE
fix: disable weekend proxy and remove weekend schedule

### DIFF
--- a/.github/workflows/daily-trading.yml
+++ b/.github/workflows/daily-trading.yml
@@ -9,8 +9,6 @@ on:
     # Run: python3 scripts/get_utc_time.py 9 35 1-5
     # NOTE: On market holidays, the script automatically switches to crypto trading mode
     - cron: '35 13,14 * * 1-5'   # 9:35 AM Eastern (covers both EST and EDT)
-    # Weekend proxy trading window (BITO/RWCR) - same time slot for consistency
-    - cron: '35 13,14 * * 6,0'
   workflow_dispatch:
     inputs:
       force_trade:
@@ -162,7 +160,7 @@ jobs:
     if: needs.validate-and-test.outputs.secrets_valid == 'true'
     env:
       PYTHONPATH: ${{ github.workspace }}
-      ENABLE_WEEKEND_PROXY: 'true'
+      ENABLE_WEEKEND_PROXY: 'false'
       ALLOW_PROMOTION_OVERRIDE: '1'  # Temporary override to allow trading while metrics are repaired
 
     steps:


### PR DESCRIPTION
Disables the weekend proxy mode in daily-trading.yml and removes the Saturday/Sunday cron schedule. This prevents the daily workflow from attempting to trade equity ETFs on weekends, avoiding failures when triggered by other events (like YouTube analysis). Weekend execution is now handled exclusively by weekend-crypto-trading.yml.