### PR TITLE
feat: Alpaca Health Monitor + Position Reconciliation

### DIFF
--- a/scripts/reconcile_positions.py
+++ b/scripts/reconcile_positions.py
@@ -1,0 +1,449 @@
+#!/usr/bin/env python3
+"""
+Daily Position Reconciliation - Alpaca <-> Local State Sync
+
+Ensures our local system_state.json matches Alpaca's ground truth.
+Run daily to detect and fix discrepancies.
+
+Checks:
+1. Position quantities match
+2. P/L calculations are accurate
+3. No phantom positions (in local but not Alpaca)
+4. No missing positions (in Alpaca but not local)
+5. Account equity matches
+
+Critical gap addressed:
+- "Did Alpaca fuck us?" - CEO concern Dec 8, 2025
+- Local state showed $17.49 P/L but hook showed $5.5
+- No reconciliation between systems
+
+Usage:
+    python scripts/reconcile_positions.py
+    python scripts/reconcile_positions.py --fix  # Auto-fix discrepancies
+    python scripts/reconcile_positions.py --report-only  # Just report, no changes
+
+Author: Trading System CTO
+Created: 2025-12-08
+"""
+
+import argparse
+import json
+import logging
+import os
+import sys
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+
+# Add parent directory to path
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from dotenv import load_dotenv
+
+load_dotenv()
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s - %(levelname)s - %(message)s",
+)
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class PositionDiff:
+    """Difference between local and Alpaca position."""
+    symbol: str
+    local_qty: float
+    alpaca_qty: float
+    local_value: float
+    alpaca_value: float
+    qty_diff: float
+    value_diff: float
+    status: str  # 'match', 'mismatch', 'missing_local', 'missing_alpaca'
+
+
+@dataclass
+class ReconciliationReport:
+    """Full reconciliation report."""
+    timestamp: datetime
+    local_equity: float
+    alpaca_equity: float
+    equity_diff: float
+    local_pl: float
+    alpaca_pl: float
+    pl_diff: float
+    position_diffs: list[PositionDiff]
+    discrepancies: list[str]
+    fixes_applied: list[str]
+    is_reconciled: bool
+
+
+class PositionReconciler:
+    """
+    Reconcile positions between local state and Alpaca.
+    """
+
+    # Tolerance for floating point comparisons
+    QTY_TOLERANCE = 0.0001
+    VALUE_TOLERANCE = 0.01
+
+    def __init__(
+        self,
+        state_path: Path = Path("data/system_state.json"),
+        auto_fix: bool = False,
+    ):
+        """
+        Initialize reconciler.
+
+        Args:
+            state_path: Path to local system state
+            auto_fix: Whether to automatically fix discrepancies
+        """
+        self.state_path = state_path
+        self.auto_fix = auto_fix
+        self.client = None
+
+        # Initialize Alpaca client
+        self._init_alpaca()
+
+    def _init_alpaca(self) -> None:
+        """Initialize Alpaca client."""
+        try:
+            from alpaca.trading.client import TradingClient
+
+            api_key = os.getenv("ALPACA_API_KEY")
+            api_secret = os.getenv("ALPACA_SECRET_KEY")
+
+            if not api_key or not api_secret:
+                raise ValueError("ALPACA_API_KEY and ALPACA_SECRET_KEY required")
+
+            self.client = TradingClient(api_key, api_secret, paper=True)
+            logger.info("Alpaca client initialized")
+        except Exception as e:
+            logger.error(f"Failed to initialize Alpaca client: {e}")
+            raise
+
+    def reconcile(self) -> ReconciliationReport:
+        """
+        Perform full reconciliation.
+
+        Returns:
+            ReconciliationReport with all findings
+        """
+        logger.info("=" * 70)
+        logger.info("POSITION RECONCILIATION")
+        logger.info("=" * 70)
+
+        discrepancies = []
+        fixes_applied = []
+
+        # Get Alpaca data (ground truth)
+        alpaca_account = self.client.get_account()
+        alpaca_positions = self.client.get_all_positions()
+
+        alpaca_equity = float(alpaca_account.equity)
+        alpaca_cash = float(alpaca_account.cash)
+        starting_balance = 100000.0  # Known starting balance
+        alpaca_pl = alpaca_equity - starting_balance
+
+        logger.info(f"Alpaca Equity: ${alpaca_equity:,.2f}")
+        logger.info(f"Alpaca P/L: ${alpaca_pl:,.2f}")
+        logger.info(f"Alpaca Positions: {len(alpaca_positions)}")
+
+        # Get local data
+        local_state = self._load_local_state()
+        local_equity = local_state.get("account", {}).get("current_equity", 0)
+        local_pl = local_state.get("account", {}).get("total_pl", 0)
+        local_positions = local_state.get("performance", {}).get("open_positions", [])
+
+        logger.info(f"Local Equity: ${local_equity:,.2f}")
+        logger.info(f"Local P/L: ${local_pl:,.2f}")
+        logger.info(f"Local Positions: {len(local_positions)}")
+
+        # Compare equity
+        equity_diff = abs(alpaca_equity - local_equity)
+        if equity_diff > self.VALUE_TOLERANCE:
+            discrepancies.append(
+                f"Equity mismatch: Local ${local_equity:,.2f} vs Alpaca ${alpaca_equity:,.2f} "
+                f"(diff: ${equity_diff:,.2f})"
+            )
+
+        # Compare P/L
+        pl_diff = abs(alpaca_pl - local_pl)
+        if pl_diff > self.VALUE_TOLERANCE:
+            discrepancies.append(
+                f"P/L mismatch: Local ${local_pl:,.2f} vs Alpaca ${alpaca_pl:,.2f} "
+                f"(diff: ${pl_diff:,.2f})"
+            )
+
+        # Compare positions
+        position_diffs = self._compare_positions(local_positions, alpaca_positions)
+
+        for diff in position_diffs:
+            if diff.status != "match":
+                discrepancies.append(
+                    f"Position {diff.symbol}: {diff.status} - "
+                    f"Local qty={diff.local_qty:.6f} vs Alpaca qty={diff.alpaca_qty:.6f}"
+                )
+
+        # Apply fixes if enabled
+        if self.auto_fix and discrepancies:
+            fixes_applied = self._apply_fixes(
+                alpaca_equity=alpaca_equity,
+                alpaca_pl=alpaca_pl,
+                alpaca_positions=alpaca_positions,
+                local_state=local_state,
+            )
+
+        # Create report
+        is_reconciled = len(discrepancies) == 0 or (self.auto_fix and len(fixes_applied) > 0)
+
+        report = ReconciliationReport(
+            timestamp=datetime.now(),
+            local_equity=local_equity,
+            alpaca_equity=alpaca_equity,
+            equity_diff=equity_diff,
+            local_pl=local_pl,
+            alpaca_pl=alpaca_pl,
+            pl_diff=pl_diff,
+            position_diffs=position_diffs,
+            discrepancies=discrepancies,
+            fixes_applied=fixes_applied,
+            is_reconciled=is_reconciled,
+        )
+
+        self._log_report(report)
+        self._save_report(report)
+
+        return report
+
+    def _load_local_state(self) -> dict:
+        """Load local system state."""
+        if not self.state_path.exists():
+            logger.warning(f"Local state not found: {self.state_path}")
+            return {}
+
+        with open(self.state_path) as f:
+            return json.load(f)
+
+    def _compare_positions(
+        self,
+        local_positions: list[dict],
+        alpaca_positions: list,
+    ) -> list[PositionDiff]:
+        """Compare positions between local and Alpaca."""
+        diffs = []
+
+        # Build lookup maps
+        local_by_symbol = {p.get("symbol"): p for p in local_positions}
+        alpaca_by_symbol = {p.symbol: p for p in alpaca_positions}
+
+        all_symbols = set(local_by_symbol.keys()) | set(alpaca_by_symbol.keys())
+
+        for symbol in all_symbols:
+            local_pos = local_by_symbol.get(symbol)
+            alpaca_pos = alpaca_by_symbol.get(symbol)
+
+            if local_pos and alpaca_pos:
+                # Both have position - compare
+                local_qty = float(local_pos.get("quantity", 0))
+                alpaca_qty = float(alpaca_pos.qty)
+                local_value = float(local_pos.get("amount", 0))
+                alpaca_value = float(alpaca_pos.market_value)
+
+                qty_diff = abs(local_qty - alpaca_qty)
+                value_diff = abs(local_value - alpaca_value)
+
+                if qty_diff > self.QTY_TOLERANCE or value_diff > self.VALUE_TOLERANCE:
+                    status = "mismatch"
+                else:
+                    status = "match"
+
+                diffs.append(PositionDiff(
+                    symbol=symbol,
+                    local_qty=local_qty,
+                    alpaca_qty=alpaca_qty,
+                    local_value=local_value,
+                    alpaca_value=alpaca_value,
+                    qty_diff=qty_diff,
+                    value_diff=value_diff,
+                    status=status,
+                ))
+
+            elif local_pos and not alpaca_pos:
+                # Local has position but Alpaca doesn't (phantom)
+                diffs.append(PositionDiff(
+                    symbol=symbol,
+                    local_qty=float(local_pos.get("quantity", 0)),
+                    alpaca_qty=0,
+                    local_value=float(local_pos.get("amount", 0)),
+                    alpaca_value=0,
+                    qty_diff=float(local_pos.get("quantity", 0)),
+                    value_diff=float(local_pos.get("amount", 0)),
+                    status="missing_alpaca",
+                ))
+
+            elif alpaca_pos and not local_pos:
+                # Alpaca has position but local doesn't (missing)
+                diffs.append(PositionDiff(
+                    symbol=symbol,
+                    local_qty=0,
+                    alpaca_qty=float(alpaca_pos.qty),
+                    local_value=0,
+                    alpaca_value=float(alpaca_pos.market_value),
+                    qty_diff=float(alpaca_pos.qty),
+                    value_diff=float(alpaca_pos.market_value),
+                    status="missing_local",
+                ))
+
+        return diffs
+
+    def _apply_fixes(
+        self,
+        alpaca_equity: float,
+        alpaca_pl: float,
+        alpaca_positions: list,
+        local_state: dict,
+    ) -> list[str]:
+        """Apply fixes to sync local state with Alpaca."""
+        fixes = []
+
+        logger.info("Applying fixes to sync with Alpaca...")
+
+        # Update account info
+        local_state["account"]["current_equity"] = alpaca_equity
+        local_state["account"]["total_pl"] = alpaca_pl
+        local_state["account"]["total_pl_pct"] = (alpaca_pl / 100000.0) * 100
+
+        fixes.append(f"Updated equity to ${alpaca_equity:,.2f}")
+        fixes.append(f"Updated P/L to ${alpaca_pl:,.2f}")
+
+        # Rebuild positions from Alpaca
+        new_positions = []
+        for pos in alpaca_positions:
+            new_positions.append({
+                "symbol": pos.symbol,
+                "tier": "unknown",
+                "amount": float(pos.market_value),
+                "order_id": None,
+                "entry_date": datetime.now().isoformat(),
+                "entry_price": float(pos.avg_entry_price),
+                "current_price": float(pos.current_price),
+                "quantity": float(pos.qty),
+                "unrealized_pl": float(pos.unrealized_pl),
+                "unrealized_pl_pct": float(pos.unrealized_plpc) * 100,
+                "last_updated": datetime.now().isoformat(),
+            })
+
+        local_state["performance"]["open_positions"] = new_positions
+        fixes.append(f"Synced {len(new_positions)} positions from Alpaca")
+
+        # Update positions value
+        positions_value = sum(float(pos.market_value) for pos in alpaca_positions)
+        local_state["account"]["positions_value"] = positions_value
+
+        # Update timestamp
+        local_state["meta"]["last_updated"] = datetime.now().isoformat()
+        local_state["meta"]["last_reconciliation"] = datetime.now().isoformat()
+
+        # Save updated state
+        with open(self.state_path, "w") as f:
+            json.dump(local_state, f, indent=2)
+
+        logger.info(f"Applied {len(fixes)} fixes")
+        return fixes
+
+    def _log_report(self, report: ReconciliationReport) -> None:
+        """Log reconciliation report."""
+        logger.info("=" * 70)
+        logger.info("RECONCILIATION REPORT")
+        logger.info("=" * 70)
+
+        if report.is_reconciled:
+            logger.info("STATUS: RECONCILED")
+        else:
+            logger.warning(f"STATUS: {len(report.discrepancies)} DISCREPANCIES FOUND")
+
+        logger.info(f"Equity Diff: ${report.equity_diff:,.2f}")
+        logger.info(f"P/L Diff: ${report.pl_diff:,.2f}")
+
+        if report.discrepancies:
+            logger.warning("Discrepancies:")
+            for d in report.discrepancies:
+                logger.warning(f"  - {d}")
+
+        if report.fixes_applied:
+            logger.info("Fixes Applied:")
+            for f in report.fixes_applied:
+                logger.info(f"  - {f}")
+
+        logger.info("=" * 70)
+
+    def _save_report(self, report: ReconciliationReport) -> None:
+        """Save reconciliation report to file."""
+        report_dir = Path("data/reconciliation")
+        report_dir.mkdir(parents=True, exist_ok=True)
+
+        report_file = report_dir / f"reconciliation_{report.timestamp.strftime('%Y%m%d_%H%M%S')}.json"
+
+        report_data = {
+            "timestamp": report.timestamp.isoformat(),
+            "local_equity": report.local_equity,
+            "alpaca_equity": report.alpaca_equity,
+            "equity_diff": report.equity_diff,
+            "local_pl": report.local_pl,
+            "alpaca_pl": report.alpaca_pl,
+            "pl_diff": report.pl_diff,
+            "position_diffs": [
+                {
+                    "symbol": d.symbol,
+                    "local_qty": d.local_qty,
+                    "alpaca_qty": d.alpaca_qty,
+                    "status": d.status,
+                }
+                for d in report.position_diffs
+            ],
+            "discrepancies": report.discrepancies,
+            "fixes_applied": report.fixes_applied,
+            "is_reconciled": report.is_reconciled,
+        }
+
+        with open(report_file, "w") as f:
+            json.dump(report_data, f, indent=2)
+
+        logger.info(f"Report saved: {report_file}")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Reconcile positions with Alpaca")
+    parser.add_argument(
+        "--fix",
+        action="store_true",
+        help="Auto-fix discrepancies by syncing with Alpaca",
+    )
+    parser.add_argument(
+        "--report-only",
+        action="store_true",
+        help="Only generate report, don't modify anything",
+    )
+    args = parser.parse_args()
+
+    try:
+        reconciler = PositionReconciler(auto_fix=args.fix and not args.report_only)
+        report = reconciler.reconcile()
+
+        # Exit with error if discrepancies found and not fixed
+        if not report.is_reconciled:
+            logger.error("Reconciliation found discrepancies!")
+            sys.exit(1)
+        else:
+            logger.info("Reconciliation complete - all positions match")
+            sys.exit(0)
+
+    except Exception as e:
+        logger.error(f"Reconciliation failed: {e}", exc_info=True)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/risk/alpaca_health_monitor.py
+++ b/src/risk/alpaca_health_monitor.py
@@ -1,0 +1,527 @@
+"""
+Alpaca Health Monitor - API Failover and Alert System
+
+Provides redundancy against Alpaca failures:
+1. Real-time API health checks with retry logic
+2. Exponential backoff on failures (2s, 4s, 8s, 16s)
+3. Alert system (logs, webhook, email-ready)
+4. Circuit breaker pattern - stop trading if API unstable
+5. Order queue for failed orders (retry later)
+
+Critical gap addressed:
+- "If Alpaca decides to fuck us" - CEO concern Dec 8, 2025
+- No alerts if API fails
+- No retry logic
+- No order queue for failed trades
+
+Author: Trading System CTO
+Created: 2025-12-08
+"""
+
+import json
+import logging
+import os
+import time
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta
+from enum import Enum
+from pathlib import Path
+from typing import Any, Callable
+
+logger = logging.getLogger(__name__)
+
+
+class HealthStatus(Enum):
+    """API health status levels."""
+    HEALTHY = "healthy"           # All systems go
+    DEGRADED = "degraded"         # Slow but working
+    UNHEALTHY = "unhealthy"       # Failing, retrying
+    CRITICAL = "critical"         # Multiple failures, stop trading
+    UNKNOWN = "unknown"           # Not yet checked
+
+
+@dataclass
+class HealthCheckResult:
+    """Result of a health check."""
+    status: HealthStatus
+    latency_ms: float
+    error: str | None
+    timestamp: datetime
+    consecutive_failures: int
+    details: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict:
+        return {
+            "status": self.status.value,
+            "latency_ms": round(self.latency_ms, 2),
+            "error": self.error,
+            "timestamp": self.timestamp.isoformat(),
+            "consecutive_failures": self.consecutive_failures,
+            "details": self.details,
+        }
+
+
+@dataclass
+class QueuedOrder:
+    """Order queued for retry after API failure."""
+    symbol: str
+    amount_usd: float
+    side: str
+    tier: str
+    created_at: datetime
+    retry_count: int = 0
+    max_retries: int = 3
+    last_error: str | None = None
+
+
+class AlpacaHealthMonitor:
+    """
+    Monitor Alpaca API health and provide failover capabilities.
+
+    Features:
+    - Periodic health checks
+    - Retry with exponential backoff
+    - Circuit breaker (stop trading after N failures)
+    - Order queue for failed trades
+    - Alert system integration
+    """
+
+    # Thresholds
+    LATENCY_WARNING_MS = 2000      # Warn if API > 2 seconds
+    LATENCY_CRITICAL_MS = 5000     # Critical if API > 5 seconds
+    MAX_CONSECUTIVE_FAILURES = 3   # Trip circuit breaker after 3 failures
+    CIRCUIT_BREAKER_RESET_MINUTES = 5  # Reset circuit breaker after 5 min
+
+    # Retry settings
+    MAX_RETRIES = 4
+    BASE_RETRY_DELAY_SECONDS = 2   # 2s, 4s, 8s, 16s
+
+    def __init__(
+        self,
+        alpaca_client=None,
+        alert_webhook_url: str | None = None,
+        order_queue_path: Path = Path("data/failed_orders_queue.json"),
+    ):
+        """
+        Initialize the health monitor.
+
+        Args:
+            alpaca_client: Alpaca TradingClient instance
+            alert_webhook_url: Webhook URL for alerts (Slack, Discord, etc.)
+            order_queue_path: Path to persist failed orders
+        """
+        self.client = alpaca_client
+        self.alert_webhook_url = alert_webhook_url or os.getenv("ALERT_WEBHOOK_URL")
+        self.order_queue_path = order_queue_path
+
+        # State
+        self.consecutive_failures = 0
+        self.last_successful_check: datetime | None = None
+        self.circuit_breaker_tripped = False
+        self.circuit_breaker_tripped_at: datetime | None = None
+        self.order_queue: list[QueuedOrder] = []
+
+        # Load persisted order queue
+        self._load_order_queue()
+
+        logger.info("AlpacaHealthMonitor initialized")
+
+    def check_health(self) -> HealthCheckResult:
+        """
+        Perform a health check on Alpaca API.
+
+        Returns:
+            HealthCheckResult with status, latency, and any errors
+        """
+        start_time = time.time()
+        error = None
+        status = HealthStatus.UNKNOWN
+        details = {}
+
+        try:
+            if not self.client:
+                # Try to create client if not provided
+                from alpaca.trading.client import TradingClient
+                api_key = os.getenv("ALPACA_API_KEY")
+                api_secret = os.getenv("ALPACA_SECRET_KEY")
+
+                if not api_key or not api_secret:
+                    raise ValueError("ALPACA_API_KEY and ALPACA_SECRET_KEY not set")
+
+                self.client = TradingClient(api_key, api_secret, paper=True)
+
+            # Check account (lightweight API call)
+            account = self.client.get_account()
+
+            latency_ms = (time.time() - start_time) * 1000
+
+            # Determine status based on latency
+            if latency_ms < self.LATENCY_WARNING_MS:
+                status = HealthStatus.HEALTHY
+                self.consecutive_failures = 0
+                self.last_successful_check = datetime.now()
+            elif latency_ms < self.LATENCY_CRITICAL_MS:
+                status = HealthStatus.DEGRADED
+                logger.warning(f"Alpaca API degraded: {latency_ms:.0f}ms latency")
+            else:
+                status = HealthStatus.DEGRADED
+                logger.warning(f"Alpaca API slow: {latency_ms:.0f}ms latency")
+
+            # Collect account details
+            details = {
+                "equity": float(account.equity),
+                "buying_power": float(account.buying_power),
+                "trading_blocked": account.trading_blocked,
+                "account_blocked": account.account_blocked,
+            }
+
+            # Check if trading is blocked
+            if account.trading_blocked or account.account_blocked:
+                status = HealthStatus.CRITICAL
+                error = "Trading or account is blocked by Alpaca"
+                self._send_alert(f"CRITICAL: {error}", details)
+
+            # Reset circuit breaker if healthy
+            if status == HealthStatus.HEALTHY:
+                self._reset_circuit_breaker()
+
+        except Exception as e:
+            latency_ms = (time.time() - start_time) * 1000
+            error = str(e)
+            self.consecutive_failures += 1
+
+            if self.consecutive_failures >= self.MAX_CONSECUTIVE_FAILURES:
+                status = HealthStatus.CRITICAL
+                self._trip_circuit_breaker(error)
+            else:
+                status = HealthStatus.UNHEALTHY
+
+            logger.error(f"Alpaca health check failed ({self.consecutive_failures}x): {error}")
+
+        return HealthCheckResult(
+            status=status,
+            latency_ms=latency_ms,
+            error=error,
+            timestamp=datetime.now(),
+            consecutive_failures=self.consecutive_failures,
+            details=details,
+        )
+
+    def execute_with_retry(
+        self,
+        operation: Callable[[], Any],
+        operation_name: str = "API call",
+    ) -> tuple[bool, Any, str | None]:
+        """
+        Execute an operation with retry logic and exponential backoff.
+
+        Args:
+            operation: Callable to execute
+            operation_name: Name for logging
+
+        Returns:
+            Tuple of (success, result, error_message)
+        """
+        if self.circuit_breaker_tripped:
+            if not self._should_reset_circuit_breaker():
+                logger.warning(f"Circuit breaker tripped - skipping {operation_name}")
+                return False, None, "Circuit breaker tripped - API unstable"
+
+        last_error = None
+
+        for attempt in range(self.MAX_RETRIES):
+            try:
+                result = operation()
+
+                # Success - reset failure count
+                self.consecutive_failures = 0
+                self.last_successful_check = datetime.now()
+
+                if attempt > 0:
+                    logger.info(f"{operation_name} succeeded on attempt {attempt + 1}")
+
+                return True, result, None
+
+            except Exception as e:
+                last_error = str(e)
+                self.consecutive_failures += 1
+
+                if attempt < self.MAX_RETRIES - 1:
+                    delay = self.BASE_RETRY_DELAY_SECONDS * (2 ** attempt)
+                    logger.warning(
+                        f"{operation_name} failed (attempt {attempt + 1}/{self.MAX_RETRIES}): {e}. "
+                        f"Retrying in {delay}s..."
+                    )
+                    time.sleep(delay)
+                else:
+                    logger.error(f"{operation_name} failed after {self.MAX_RETRIES} attempts: {e}")
+
+        # All retries failed
+        if self.consecutive_failures >= self.MAX_CONSECUTIVE_FAILURES:
+            self._trip_circuit_breaker(last_error)
+
+        return False, None, last_error
+
+    def queue_failed_order(
+        self,
+        symbol: str,
+        amount_usd: float,
+        side: str,
+        tier: str,
+        error: str,
+    ) -> None:
+        """
+        Queue a failed order for later retry.
+
+        Args:
+            symbol: Trading symbol
+            amount_usd: Order amount
+            side: 'buy' or 'sell'
+            tier: Trading tier
+            error: Error that caused the failure
+        """
+        order = QueuedOrder(
+            symbol=symbol,
+            amount_usd=amount_usd,
+            side=side,
+            tier=tier,
+            created_at=datetime.now(),
+            last_error=error,
+        )
+
+        self.order_queue.append(order)
+        self._save_order_queue()
+
+        logger.info(f"Order queued for retry: {side} {symbol} ${amount_usd:.2f}")
+        self._send_alert(
+            f"Order queued due to API failure: {side} {symbol} ${amount_usd:.2f}",
+            {"error": error, "queue_size": len(self.order_queue)},
+        )
+
+    def process_order_queue(self, executor: Callable[[QueuedOrder], bool]) -> int:
+        """
+        Process queued orders using provided executor.
+
+        Args:
+            executor: Function that takes QueuedOrder and returns success bool
+
+        Returns:
+            Number of orders successfully processed
+        """
+        if not self.order_queue:
+            return 0
+
+        # Check if API is healthy first
+        health = self.check_health()
+        if health.status in (HealthStatus.CRITICAL, HealthStatus.UNHEALTHY):
+            logger.warning("API unhealthy - skipping order queue processing")
+            return 0
+
+        processed = 0
+        remaining = []
+
+        for order in self.order_queue:
+            order.retry_count += 1
+
+            if order.retry_count > order.max_retries:
+                logger.error(
+                    f"Order exceeded max retries, discarding: {order.side} {order.symbol}"
+                )
+                self._send_alert(
+                    f"FAILED ORDER DISCARDED: {order.side} {order.symbol} ${order.amount_usd:.2f}",
+                    {"retries": order.retry_count, "last_error": order.last_error},
+                )
+                continue
+
+            try:
+                success = executor(order)
+                if success:
+                    processed += 1
+                    logger.info(f"Queued order processed: {order.side} {order.symbol}")
+                else:
+                    remaining.append(order)
+            except Exception as e:
+                order.last_error = str(e)
+                remaining.append(order)
+                logger.warning(f"Order retry failed: {order.side} {order.symbol} - {e}")
+
+        self.order_queue = remaining
+        self._save_order_queue()
+
+        if processed > 0:
+            logger.info(f"Processed {processed} queued orders, {len(remaining)} remaining")
+
+        return processed
+
+    def is_trading_allowed(self) -> tuple[bool, str]:
+        """
+        Check if trading should be allowed based on API health.
+
+        Returns:
+            Tuple of (allowed, reason)
+        """
+        if self.circuit_breaker_tripped:
+            if self._should_reset_circuit_breaker():
+                return True, "Circuit breaker reset - trading allowed"
+            return False, "Circuit breaker tripped - API unstable"
+
+        if self.consecutive_failures >= 2:
+            return True, f"Warning: {self.consecutive_failures} consecutive failures"
+
+        return True, "API healthy"
+
+    def get_status_summary(self) -> dict:
+        """Get current health monitor status."""
+        return {
+            "consecutive_failures": self.consecutive_failures,
+            "circuit_breaker_tripped": self.circuit_breaker_tripped,
+            "circuit_breaker_tripped_at": (
+                self.circuit_breaker_tripped_at.isoformat()
+                if self.circuit_breaker_tripped_at
+                else None
+            ),
+            "last_successful_check": (
+                self.last_successful_check.isoformat()
+                if self.last_successful_check
+                else None
+            ),
+            "queued_orders": len(self.order_queue),
+            "trading_allowed": self.is_trading_allowed()[0],
+        }
+
+    # ==================== Private Methods ====================
+
+    def _trip_circuit_breaker(self, error: str) -> None:
+        """Trip the circuit breaker to stop trading."""
+        if not self.circuit_breaker_tripped:
+            self.circuit_breaker_tripped = True
+            self.circuit_breaker_tripped_at = datetime.now()
+
+            logger.critical(f"CIRCUIT BREAKER TRIPPED: {error}")
+            self._send_alert(
+                f"CRITICAL: Circuit breaker tripped after {self.consecutive_failures} failures",
+                {"error": error, "will_reset_in": f"{self.CIRCUIT_BREAKER_RESET_MINUTES} minutes"},
+            )
+
+    def _reset_circuit_breaker(self) -> None:
+        """Reset the circuit breaker."""
+        if self.circuit_breaker_tripped:
+            self.circuit_breaker_tripped = False
+            self.circuit_breaker_tripped_at = None
+            logger.info("Circuit breaker reset - trading resumed")
+            self._send_alert("Circuit breaker reset - API recovered", {})
+
+    def _should_reset_circuit_breaker(self) -> bool:
+        """Check if circuit breaker should auto-reset."""
+        if not self.circuit_breaker_tripped or not self.circuit_breaker_tripped_at:
+            return True
+
+        elapsed = datetime.now() - self.circuit_breaker_tripped_at
+        if elapsed > timedelta(minutes=self.CIRCUIT_BREAKER_RESET_MINUTES):
+            # Try a health check before resetting
+            health = self.check_health()
+            if health.status in (HealthStatus.HEALTHY, HealthStatus.DEGRADED):
+                self._reset_circuit_breaker()
+                return True
+
+        return False
+
+    def _send_alert(self, message: str, details: dict) -> None:
+        """Send alert via configured channels."""
+        alert_data = {
+            "message": message,
+            "details": details,
+            "timestamp": datetime.now().isoformat(),
+            "source": "AlpacaHealthMonitor",
+        }
+
+        # Log alert
+        logger.warning(f"ALERT: {message}")
+
+        # Send to webhook if configured
+        if self.alert_webhook_url:
+            try:
+                import requests
+                requests.post(
+                    self.alert_webhook_url,
+                    json=alert_data,
+                    timeout=5,
+                )
+            except Exception as e:
+                logger.error(f"Failed to send webhook alert: {e}")
+
+        # Save to alert log
+        alert_log_path = Path("data/alerts/health_alerts.json")
+        alert_log_path.parent.mkdir(parents=True, exist_ok=True)
+
+        try:
+            alerts = []
+            if alert_log_path.exists():
+                with open(alert_log_path) as f:
+                    alerts = json.load(f)
+
+            alerts.append(alert_data)
+
+            # Keep last 100 alerts
+            alerts = alerts[-100:]
+
+            with open(alert_log_path, "w") as f:
+                json.dump(alerts, f, indent=2)
+        except Exception as e:
+            logger.error(f"Failed to save alert log: {e}")
+
+    def _load_order_queue(self) -> None:
+        """Load persisted order queue from disk."""
+        if self.order_queue_path.exists():
+            try:
+                with open(self.order_queue_path) as f:
+                    data = json.load(f)
+
+                self.order_queue = [
+                    QueuedOrder(
+                        symbol=o["symbol"],
+                        amount_usd=o["amount_usd"],
+                        side=o["side"],
+                        tier=o["tier"],
+                        created_at=datetime.fromisoformat(o["created_at"]),
+                        retry_count=o.get("retry_count", 0),
+                        last_error=o.get("last_error"),
+                    )
+                    for o in data
+                ]
+
+                if self.order_queue:
+                    logger.info(f"Loaded {len(self.order_queue)} orders from queue")
+            except Exception as e:
+                logger.error(f"Failed to load order queue: {e}")
+                self.order_queue = []
+
+    def _save_order_queue(self) -> None:
+        """Persist order queue to disk."""
+        self.order_queue_path.parent.mkdir(parents=True, exist_ok=True)
+
+        try:
+            data = [
+                {
+                    "symbol": o.symbol,
+                    "amount_usd": o.amount_usd,
+                    "side": o.side,
+                    "tier": o.tier,
+                    "created_at": o.created_at.isoformat(),
+                    "retry_count": o.retry_count,
+                    "last_error": o.last_error,
+                }
+                for o in self.order_queue
+            ]
+
+            with open(self.order_queue_path, "w") as f:
+                json.dump(data, f, indent=2)
+        except Exception as e:
+            logger.error(f"Failed to save order queue: {e}")
+
+
+# Convenience function for quick health check
+def check_alpaca_health() -> HealthCheckResult:
+    """Quick health check without creating monitor instance."""
+    monitor = AlpacaHealthMonitor()
+    return monitor.check_health()


### PR DESCRIPTION
## Summary

Addresses CEO concern: **"But what if Alpaca decides to fuck us?"**

## New Redundancy Features

### 1. Alpaca Health Monitor (`src/risk/alpaca_health_monitor.py`)
- Real-time API health checks with latency tracking
- **Retry with exponential backoff**: 2s → 4s → 8s → 16s
- **Circuit breaker pattern**: Stops trading after 3 consecutive failures
- **Order queue**: Failed trades saved to disk, retried when API recovers
- **Alert system**: Logs + webhook ready for Slack/Discord

### 2. Position Reconciler (`scripts/reconcile_positions.py`)
- Daily Alpaca ↔ Local state synchronization
- Detects:
  - Equity mismatches (Local: $5.5 vs Alpaca: $17.49)
  - P/L discrepancies
  - Phantom positions (in local but not Alpaca)
  - Missing positions (in Alpaca but not local)
- **Auto-fix mode**: `--fix` flag syncs local to Alpaca ground truth

## Usage

```bash
# Check health
python -c "from src.risk.alpaca_health_monitor import check_alpaca_health; print(check_alpaca_health())"

# Reconcile positions
python scripts/reconcile_positions.py --fix
```

## Test Plan
- [x] Health monitor detects API failures
- [x] Circuit breaker trips after 3 failures
- [x] Order queue persists failed orders
- [x] Reconciler detects equity mismatch
- [x] Auto-fix syncs local state to Alpaca