### PR TITLE
fix: use set +e around portfolio status to prevent step failure

### DIFF
--- a/.github/workflows/daily-trading.yml
+++ b/.github/workflows/daily-trading.yml
@@ -590,10 +590,12 @@ jobs:
           echo "   Time: $(date -u +'%H:%M:%S UTC')"
 
           # Verify trades were placed by checking system_state.json
+          # Use set +e to prevent failures from crashing the step
+          set +e
           if [ -f "data/system_state.json" ]; then
             echo ""
             echo "📈 PORTFOLIO STATUS:"
-            python3 - <<'PY' || echo "⚠️ Could not read portfolio status"
+            python3 - <<'PY'
             import json
             try:
                 with open("data/system_state.json") as f:
@@ -608,6 +610,7 @@ jobs:
                 print(f"   ⚠️ Error reading state: {e}")
             PY
           fi
+          set -e
 
       - name: Verify Positions (Alpaca vs Local)
         id: verify_positions


### PR DESCRIPTION
Previous fix did not work - heredoc || echo syntax does not work as expected. Using set +e/set -e to disable error exit around portfolio status print.