### PR TITLE
docs: validate external analysis - debunk 6 false claims about options infrastructure

### DIFF
--- a/docs/analysis-validation-2025-12-09.md
+++ b/docs/analysis-validation-2025-12-09.md
@@ -1,0 +1,119 @@
+# Analysis Validation Report - December 9, 2025
+
+## Executive Summary
+
+An external analysis claimed the trading system "fundamentally cannot reach $100/day" due to missing options infrastructure. **This analysis was incorrect.** A thorough codebase review reveals extensive options trading infrastructure already in place.
+
+## Claims vs. Reality
+
+### ❌ FALSE CLAIMS
+
+| Claim | Reality | Evidence |
+|-------|---------|----------|
+| "NO OPTIONS INFRASTRUCTURE" | 30+ options-related files | `ls src/**/option*.py` |
+| "No Greeks calculator" | Greeks from Alpaca API + Black-Scholes fallback | `options_client.py:109-118`, `options_profit_planner.py:775-796` |
+| "No theta decay monitoring" | `ThetaHarvestExecutor` with IV percentile tracking | `options_profit_planner.py:382-621` |
+| "No CSP implementation" | Full CSP in wheel strategy | `wheel_strategy.py:516-639` |
+| "No covered calls" | Full CC implementation | `wheel_strategy.py:641-766` |
+| "No Wheel Strategy automation" | 941-line complete implementation | `wheel_strategy.py` |
+| "py_vollib/mibian required" | Custom Black-Scholes + Alpaca Greeks | Already functional |
+
+### ✅ What Actually Exists
+
+#### 1. Wheel Strategy (`src/strategies/wheel_strategy.py`) - 941 lines
+- `WheelPhase` enum: SELLING_PUTS, ASSIGNED, SELLING_CALLS, CALLED_AWAY
+- `WheelPosition` dataclass for tracking
+- `WheelCandidate` for opportunity evaluation
+- Target delta: 0.25 (puts), 0.30 (calls)
+- DTE range: 25-45 days
+- Quality stock universe: AAPL, MSFT, SPY, QQQ, etc.
+- State persistence to JSON
+- Daily operations runner
+
+#### 2. Options Client (`src/core/options_client.py`) - 285 lines
+- Alpaca Options API integration
+- Option chain fetching with full Greeks:
+  - Delta, Gamma, Theta, Vega, Rho
+- Implied Volatility data
+- Order submission (sell_to_open, buy_to_close, etc.)
+
+#### 3. Options Profit Planner (`src/analytics/options_profit_planner.py`) - 1376 lines
+- `OptionsProfitPlanner`: Premium pacing analysis
+- `ThetaHarvestExecutor`: Equity-gated theta strategies
+- Equity thresholds: $5k (PMCC), $10k (Iron Condors), $25k (Full Suite)
+- IV percentile calculation
+- Black-Scholes delta estimation
+- Auto-execution capability
+- Iron condor and poor man's covered call strategies
+
+#### 4. IV Analyzer (`src/utils/iv_analyzer.py`) - 789 lines
+- IV Rank calculation (0-100)
+- IV Percentile calculation (0-100)
+- 2-standard-deviation detection (McMillan's auto-trigger)
+- Expected move calculations (1σ and 2σ)
+- Strategy recommendations based on IV levels
+- Historical volatility analysis
+- Caching for performance
+
+#### 5. Additional Options Infrastructure
+- `src/strategies/options_accumulation_strategy.py`
+- `src/strategies/rule_one_options.py`
+- `src/strategies/options_strategy.py`
+- `src/risk/options_risk_monitor.py`
+- `src/analytics/options_live_sim.py`
+- `src/signals/options_signal_enhancer.py`
+- `src/rag/options_book_retriever.py`
+- Multiple theta harvest signals in `data/options_signals/`
+
+## Actual Gaps Identified
+
+### Minor Gaps (Not Blocking)
+
+1. **Dashboard theta widget**: No theta-specific panel in `dashboard/telemetry_app.py`
+   - Impact: Low (can add easily)
+
+2. **py_vollib/mibian not installed**: Using custom implementations
+   - Impact: None (current solution works)
+
+3. **Options-to-autonomous-trader wiring**: May need verification
+   - Impact: Medium (integration point)
+
+### What's Working
+
+- Greeks calculation: ✅ Via Alpaca API + Black-Scholes fallback
+- Theta monitoring: ✅ ThetaHarvestExecutor
+- CSP execution: ✅ wheel_strategy.execute_put_trade()
+- Covered call execution: ✅ wheel_strategy.execute_call_trade()
+- IV analysis: ✅ IVAnalyzer.get_recommendation()
+- Position tracking: ✅ WheelPosition with state persistence
+- Equity gates: ✅ $5k/$10k/$25k thresholds
+
+## Recommendations
+
+### Immediate Actions (None Needed)
+The infrastructure is already in place. Focus on:
+1. Testing the wheel strategy with paper trading
+2. Verifying the autonomous trader calls the wheel strategy
+3. Monitoring first theta harvest execution
+
+### Future Enhancements (Optional)
+1. Add theta dashboard widget for real-time monitoring
+2. Implement portfolio-level Greeks aggregation
+3. Add assignment risk alerts
+
+## Conclusion
+
+The external analysis contained **6 major factual errors** about missing infrastructure that actually exists and is well-implemented. The codebase has:
+
+- **3,391+ lines** of options-specific code
+- **4 major options modules** (wheel, client, planner, IV analyzer)
+- **Complete CSP and covered call implementation**
+- **Theta harvesting with equity gates**
+- **McMillan's volatility-first approach**
+
+The path to $100/day is already paved. Execute the existing wheel strategy.
+
+---
+
+*Validation performed by CTO Claude on December 9, 2025*
+*Methodology: Full codebase audit using glob, grep, and file analysis*


### PR DESCRIPTION
## Summary

- Validated external analysis claims against actual codebase
- Found 6 major factual errors about "missing" options infrastructure
- Documented 3,391+ lines of existing options code

## Key Findings

| Claimed Missing | Actually Exists |
|-----------------|----------------|
| Greeks calculator | Alpaca API + IVAnalyzer (789 lines) |
| Theta monitoring | ThetaHarvestExecutor |
| CSP implementation | wheel_strategy.py (123 lines) |
| Covered calls | wheel_strategy.py (125 lines) |
| Wheel Strategy | Complete 941-line implementation |

## Test Plan

- [x] Validated all claims against source code
- [x] Created validation report in docs/