### PR TITLE
feat(backtest): add benchmark comparison and OHLCV data caching

### DIFF
--- a/src/backtesting/__init__.py
+++ b/src/backtesting/__init__.py
@@ -8,13 +8,29 @@ Modules:
     - backtest_results: Results data structure and reporting
     - walk_forward_matrix: Walk-forward validation with rolling OOS evaluation
     - target_integration: $100/day target evaluation for backtests
+    - benchmark_comparison: Compare strategy vs SPY, buy-and-hold, and other benchmarks
+    - data_cache: OHLCV data caching with medallion architecture
 
 Author: Trading System
 Created: 2025-11-02
+Updated: 2025-12-09 - Added benchmark comparison and data caching
 """
 
 from src.backtesting.backtest_engine import BacktestEngine
 from src.backtesting.backtest_results import BacktestResults
+from src.backtesting.benchmark_comparison import (
+    BenchmarkComparator,
+    BenchmarkComparisonResult,
+    BenchmarkMetrics,
+    compare_to_benchmark,
+    compare_to_buy_and_hold,
+)
+from src.backtesting.data_cache import (
+    CacheMetadata,
+    OHLCVDataCache,
+    cached_fetch,
+    get_data_cache,
+)
 from src.backtesting.monte_carlo import (
     MonteCarloResult,
     MonteCarloSimulator,
@@ -42,24 +58,41 @@ from src.backtesting.walk_forward_matrix import (
 )
 
 __all__ = [
+    # Core backtest engine
     "BacktestEngine",
     "BacktestResults",
+    # Performance reporting
     "PerformanceReport",
     "PerformanceReporter",
+    # Walk-forward validation
     "WalkForwardValidator",
     "WalkForwardResults",
     "WalkForwardFold",
     "create_time_aware_split",
+    # Matrix backtesting
     "BacktestMatrixResults",
     "WalkForwardMatrixValidator",
     "LiveVsBacktestTracker",
     "run_walk_forward_matrix",
+    # Target integration
     "evaluate_backtest_with_target",
     "add_target_section_to_report",
     "save_target_evaluation",
     "BacktestTargetValidator",
     "TargetBacktestReport",
+    # Monte Carlo simulation
     "MonteCarloResult",
     "MonteCarloSimulator",
     "run_monte_carlo_validation",
+    # Benchmark comparison (new)
+    "BenchmarkComparator",
+    "BenchmarkComparisonResult",
+    "BenchmarkMetrics",
+    "compare_to_benchmark",
+    "compare_to_buy_and_hold",
+    # Data caching (new)
+    "OHLCVDataCache",
+    "CacheMetadata",
+    "get_data_cache",
+    "cached_fetch",
 ]

--- a/src/backtesting/benchmark_comparison.py
+++ b/src/backtesting/benchmark_comparison.py
@@ -1,0 +1,670 @@
+"""
+Benchmark Comparison Module
+
+Provides comprehensive benchmark comparison capabilities for backtest results,
+including buy-and-hold comparison, alpha/beta calculation, and relative performance metrics.
+
+Features:
+    - Automatic benchmark data fetching (SPY, QQQ, or custom)
+    - Buy-and-hold strategy comparison
+    - Alpha/Beta calculation using regression
+    - Information Ratio and Tracking Error
+    - Relative drawdown analysis
+    - Market outperformance statistics
+
+Author: Trading System
+Created: 2025-12-09
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta
+from typing import Any
+
+import numpy as np
+import pandas as pd
+import yfinance as yf
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class BenchmarkMetrics:
+    """Metrics for a single benchmark comparison."""
+
+    # Benchmark identification
+    symbol: str
+    name: str
+
+    # Returns comparison
+    strategy_return: float  # Total strategy return %
+    benchmark_return: float  # Total benchmark return %
+    excess_return: float  # Strategy - Benchmark
+    outperformance_ratio: float  # Strategy / Benchmark
+
+    # Risk-adjusted metrics
+    alpha: float  # Jensen's Alpha (annualized)
+    beta: float  # Market sensitivity
+    r_squared: float  # Correlation with benchmark
+    information_ratio: float  # Risk-adjusted excess return
+    tracking_error: float  # Standard deviation of excess returns
+
+    # Drawdown comparison
+    strategy_max_drawdown: float
+    benchmark_max_drawdown: float
+    relative_drawdown: float  # Strategy DD vs Benchmark DD
+
+    # Outperformance statistics
+    pct_days_outperformed: float  # % of days strategy beat benchmark
+    best_outperformance_day: float  # Largest single-day outperformance
+    worst_underperformance_day: float  # Worst single-day underperformance
+    max_consecutive_outperformance: int  # Longest streak of outperforming
+
+    # Sharpe comparison
+    strategy_sharpe: float
+    benchmark_sharpe: float
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert to dictionary for serialization."""
+        return {
+            "symbol": self.symbol,
+            "name": self.name,
+            "strategy_return": self.strategy_return,
+            "benchmark_return": self.benchmark_return,
+            "excess_return": self.excess_return,
+            "outperformance_ratio": self.outperformance_ratio,
+            "alpha": self.alpha,
+            "beta": self.beta,
+            "r_squared": self.r_squared,
+            "information_ratio": self.information_ratio,
+            "tracking_error": self.tracking_error,
+            "strategy_max_drawdown": self.strategy_max_drawdown,
+            "benchmark_max_drawdown": self.benchmark_max_drawdown,
+            "relative_drawdown": self.relative_drawdown,
+            "pct_days_outperformed": self.pct_days_outperformed,
+            "best_outperformance_day": self.best_outperformance_day,
+            "worst_underperformance_day": self.worst_underperformance_day,
+            "max_consecutive_outperformance": self.max_consecutive_outperformance,
+            "strategy_sharpe": self.strategy_sharpe,
+            "benchmark_sharpe": self.benchmark_sharpe,
+        }
+
+
+@dataclass
+class BenchmarkComparisonResult:
+    """Complete benchmark comparison results for a backtest."""
+
+    # Metadata
+    strategy_name: str
+    start_date: str
+    end_date: str
+    trading_days: int
+
+    # Primary benchmark (usually SPY)
+    primary_benchmark: BenchmarkMetrics
+
+    # Additional benchmarks for comparison
+    additional_benchmarks: list[BenchmarkMetrics] = field(default_factory=list)
+
+    # Buy-and-hold comparison
+    buy_hold_return: float = 0.0  # Return if just buying and holding primary
+    buy_hold_sharpe: float = 0.0
+    buy_hold_max_drawdown: float = 0.0
+
+    # Time series data for charting
+    strategy_equity_curve: list[float] = field(default_factory=list)
+    benchmark_equity_curves: dict[str, list[float]] = field(default_factory=dict)
+    excess_return_curve: list[float] = field(default_factory=list)
+
+    def generate_report(self) -> str:
+        """Generate human-readable benchmark comparison report."""
+        lines = [
+            "=" * 80,
+            "BENCHMARK COMPARISON REPORT",
+            "=" * 80,
+            "",
+            f"Strategy: {self.strategy_name}",
+            f"Period: {self.start_date} to {self.end_date} ({self.trading_days} trading days)",
+            "",
+            "PRIMARY BENCHMARK: " + self.primary_benchmark.name,
+            "-" * 80,
+            f"  Strategy Return:     {self.primary_benchmark.strategy_return:+.2f}%",
+            f"  Benchmark Return:    {self.primary_benchmark.benchmark_return:+.2f}%",
+            f"  Excess Return:       {self.primary_benchmark.excess_return:+.2f}%",
+            f"  Outperformance:      {self.primary_benchmark.outperformance_ratio:.2f}x",
+            "",
+            "RISK-ADJUSTED METRICS",
+            "-" * 80,
+            f"  Alpha (annualized):  {self.primary_benchmark.alpha:+.2f}%",
+            f"  Beta:                {self.primary_benchmark.beta:.2f}",
+            f"  R-Squared:           {self.primary_benchmark.r_squared:.2f}",
+            f"  Information Ratio:   {self.primary_benchmark.information_ratio:.2f}",
+            f"  Tracking Error:      {self.primary_benchmark.tracking_error:.2f}%",
+            "",
+            "DRAWDOWN COMPARISON",
+            "-" * 80,
+            f"  Strategy Max DD:     {self.primary_benchmark.strategy_max_drawdown:.2f}%",
+            f"  Benchmark Max DD:    {self.primary_benchmark.benchmark_max_drawdown:.2f}%",
+            f"  Relative DD:         {self.primary_benchmark.relative_drawdown:.2f}x",
+            "",
+            "OUTPERFORMANCE STATISTICS",
+            "-" * 80,
+            f"  Days Outperformed:   {self.primary_benchmark.pct_days_outperformed:.1f}%",
+            f"  Best Day vs Bench:   {self.primary_benchmark.best_outperformance_day:+.2f}%",
+            f"  Worst Day vs Bench:  {self.primary_benchmark.worst_underperformance_day:+.2f}%",
+            f"  Max Win Streak:      {self.primary_benchmark.max_consecutive_outperformance} days",
+            "",
+            "SHARPE RATIO COMPARISON",
+            "-" * 80,
+            f"  Strategy Sharpe:     {self.primary_benchmark.strategy_sharpe:.2f}",
+            f"  Benchmark Sharpe:    {self.primary_benchmark.benchmark_sharpe:.2f}",
+            "",
+            "BUY-AND-HOLD COMPARISON",
+            "-" * 80,
+            f"  Buy & Hold Return:   {self.buy_hold_return:+.2f}%",
+            f"  Buy & Hold Sharpe:   {self.buy_hold_sharpe:.2f}",
+            f"  Buy & Hold Max DD:   {self.buy_hold_max_drawdown:.2f}%",
+            "",
+        ]
+
+        # Additional benchmarks
+        if self.additional_benchmarks:
+            lines.append("ADDITIONAL BENCHMARKS")
+            lines.append("-" * 80)
+            for bm in self.additional_benchmarks:
+                lines.append(f"  {bm.name} ({bm.symbol}):")
+                lines.append(f"    Return: {bm.benchmark_return:+.2f}%")
+                lines.append(f"    Excess: {bm.excess_return:+.2f}%")
+                lines.append(f"    Alpha:  {bm.alpha:+.2f}%")
+                lines.append("")
+
+        # Summary
+        lines.append("SUMMARY")
+        lines.append("-" * 80)
+        if self.primary_benchmark.excess_return > 0:
+            lines.append(
+                f"  Strategy OUTPERFORMED benchmark by {self.primary_benchmark.excess_return:.2f}%"
+            )
+        else:
+            lines.append(
+                f"  Strategy UNDERPERFORMED benchmark by {abs(self.primary_benchmark.excess_return):.2f}%"
+            )
+
+        if self.primary_benchmark.alpha > 0:
+            lines.append(f"  Positive alpha of {self.primary_benchmark.alpha:.2f}% suggests skill")
+        else:
+            lines.append(f"  Negative alpha of {self.primary_benchmark.alpha:.2f}% suggests no edge")
+
+        lines.append("")
+        lines.append("=" * 80)
+
+        return "\n".join(lines)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert to dictionary for serialization."""
+        return {
+            "strategy_name": self.strategy_name,
+            "start_date": self.start_date,
+            "end_date": self.end_date,
+            "trading_days": self.trading_days,
+            "primary_benchmark": self.primary_benchmark.to_dict(),
+            "additional_benchmarks": [b.to_dict() for b in self.additional_benchmarks],
+            "buy_hold_return": self.buy_hold_return,
+            "buy_hold_sharpe": self.buy_hold_sharpe,
+            "buy_hold_max_drawdown": self.buy_hold_max_drawdown,
+        }
+
+
+class BenchmarkComparator:
+    """
+    Compare backtest results against market benchmarks.
+
+    Provides comprehensive analysis of strategy performance relative to
+    buy-and-hold and common market indices.
+    """
+
+    # Common benchmark symbols with descriptions
+    BENCHMARKS = {
+        "SPY": "S&P 500 ETF",
+        "QQQ": "NASDAQ-100 ETF",
+        "IWM": "Russell 2000 Small Cap ETF",
+        "DIA": "Dow Jones Industrial ETF",
+        "VTI": "Total US Stock Market ETF",
+        "EFA": "International Developed Markets ETF",
+        "BND": "US Aggregate Bond ETF",
+    }
+
+    def __init__(
+        self,
+        primary_benchmark: str = "SPY",
+        risk_free_rate: float = 0.04,
+        additional_benchmarks: list[str] | None = None,
+    ):
+        """
+        Initialize benchmark comparator.
+
+        Args:
+            primary_benchmark: Primary benchmark symbol (default: SPY)
+            risk_free_rate: Annual risk-free rate for Sharpe calculation (default: 4%)
+            additional_benchmarks: Optional list of additional benchmarks to compare
+        """
+        self.primary_benchmark = primary_benchmark
+        self.risk_free_rate = risk_free_rate
+        self.additional_benchmarks = additional_benchmarks or []
+        self._benchmark_cache: dict[str, pd.DataFrame] = {}
+
+    def compare(
+        self,
+        equity_curve: list[float],
+        dates: list[str],
+        strategy_name: str = "Strategy",
+    ) -> BenchmarkComparisonResult:
+        """
+        Compare strategy performance against benchmarks.
+
+        Args:
+            equity_curve: List of daily portfolio values
+            dates: List of dates corresponding to equity curve (YYYY-MM-DD format)
+            strategy_name: Name of the strategy for reporting
+
+        Returns:
+            BenchmarkComparisonResult with comprehensive comparison metrics
+        """
+        if len(equity_curve) < 2 or len(dates) < 2:
+            raise ValueError("Need at least 2 data points for comparison")
+
+        if len(equity_curve) != len(dates):
+            raise ValueError("equity_curve and dates must have same length")
+
+        # Parse dates
+        start_date = dates[0]
+        end_date = dates[-1]
+
+        # Calculate strategy returns
+        strategy_returns = self._calculate_returns(equity_curve)
+
+        # Fetch and process primary benchmark
+        primary_data = self._fetch_benchmark_data(self.primary_benchmark, start_date, end_date)
+        if primary_data is None or primary_data.empty:
+            raise ValueError(f"Failed to fetch benchmark data for {self.primary_benchmark}")
+
+        # Align benchmark data with strategy dates
+        primary_aligned = self._align_benchmark_to_dates(primary_data, dates)
+        primary_returns = self._calculate_returns(primary_aligned)
+
+        # Calculate primary benchmark metrics
+        primary_metrics = self._calculate_benchmark_metrics(
+            symbol=self.primary_benchmark,
+            name=self.BENCHMARKS.get(self.primary_benchmark, self.primary_benchmark),
+            strategy_returns=strategy_returns,
+            benchmark_returns=primary_returns,
+            strategy_equity=equity_curve,
+            benchmark_equity=primary_aligned,
+        )
+
+        # Calculate buy-and-hold metrics
+        buy_hold_return = (primary_aligned[-1] / primary_aligned[0] - 1) * 100
+        buy_hold_sharpe = self._calculate_sharpe(primary_returns)
+        buy_hold_max_dd = self._calculate_max_drawdown(primary_aligned)
+
+        # Process additional benchmarks
+        additional_metrics = []
+        benchmark_curves = {self.primary_benchmark: primary_aligned}
+
+        for symbol in self.additional_benchmarks:
+            try:
+                data = self._fetch_benchmark_data(symbol, start_date, end_date)
+                if data is not None and not data.empty:
+                    aligned = self._align_benchmark_to_dates(data, dates)
+                    returns = self._calculate_returns(aligned)
+                    metrics = self._calculate_benchmark_metrics(
+                        symbol=symbol,
+                        name=self.BENCHMARKS.get(symbol, symbol),
+                        strategy_returns=strategy_returns,
+                        benchmark_returns=returns,
+                        strategy_equity=equity_curve,
+                        benchmark_equity=aligned,
+                    )
+                    additional_metrics.append(metrics)
+                    benchmark_curves[symbol] = aligned
+            except Exception as e:
+                logger.warning(f"Failed to process benchmark {symbol}: {e}")
+
+        # Calculate excess return curve
+        excess_curve = [
+            (s / primary_aligned[0]) / (b / primary_aligned[0]) - 1
+            for s, b in zip(equity_curve, primary_aligned)
+        ]
+
+        return BenchmarkComparisonResult(
+            strategy_name=strategy_name,
+            start_date=start_date,
+            end_date=end_date,
+            trading_days=len(dates),
+            primary_benchmark=primary_metrics,
+            additional_benchmarks=additional_metrics,
+            buy_hold_return=buy_hold_return,
+            buy_hold_sharpe=buy_hold_sharpe,
+            buy_hold_max_drawdown=buy_hold_max_dd,
+            strategy_equity_curve=equity_curve,
+            benchmark_equity_curves=benchmark_curves,
+            excess_return_curve=excess_curve,
+        )
+
+    def _fetch_benchmark_data(
+        self,
+        symbol: str,
+        start_date: str,
+        end_date: str,
+    ) -> pd.DataFrame | None:
+        """
+        Fetch historical benchmark data.
+
+        Uses yfinance with caching to minimize API calls.
+        """
+        cache_key = f"{symbol}_{start_date}_{end_date}"
+        if cache_key in self._benchmark_cache:
+            return self._benchmark_cache[cache_key]
+
+        try:
+            # Add buffer days for alignment
+            start_dt = datetime.strptime(start_date, "%Y-%m-%d") - timedelta(days=5)
+            end_dt = datetime.strptime(end_date, "%Y-%m-%d") + timedelta(days=5)
+
+            ticker = yf.Ticker(symbol)
+            history = ticker.history(
+                start=start_dt.strftime("%Y-%m-%d"),
+                end=end_dt.strftime("%Y-%m-%d"),
+                auto_adjust=True,
+            )
+
+            if history is None or history.empty:
+                logger.warning(f"No data returned for {symbol}")
+                return None
+
+            self._benchmark_cache[cache_key] = history
+            logger.info(f"Fetched {len(history)} bars for benchmark {symbol}")
+            return history
+
+        except Exception as e:
+            logger.error(f"Failed to fetch benchmark {symbol}: {e}")
+            return None
+
+    def _align_benchmark_to_dates(
+        self,
+        benchmark_data: pd.DataFrame,
+        dates: list[str],
+    ) -> list[float]:
+        """
+        Align benchmark data to strategy dates.
+
+        Uses forward-fill for missing dates.
+        """
+        aligned = []
+        benchmark_data.index = pd.to_datetime(benchmark_data.index).date
+
+        last_price = None
+        for date_str in dates:
+            target_date = datetime.strptime(date_str, "%Y-%m-%d").date()
+
+            # Find matching or previous date
+            if target_date in benchmark_data.index:
+                last_price = float(benchmark_data.loc[target_date, "Close"])
+            else:
+                # Forward-fill from last known price
+                earlier_dates = [d for d in benchmark_data.index if d <= target_date]
+                if earlier_dates:
+                    last_price = float(benchmark_data.loc[max(earlier_dates), "Close"])
+                elif last_price is None:
+                    # Use first available price
+                    last_price = float(benchmark_data["Close"].iloc[0])
+
+            aligned.append(last_price)
+
+        # Normalize to start at same value as strategy
+        if aligned and aligned[0] != 0:
+            return aligned
+
+        return aligned
+
+    def _calculate_returns(self, values: list[float]) -> np.ndarray:
+        """Calculate daily returns from value series."""
+        values_arr = np.array(values)
+        returns = np.diff(values_arr) / values_arr[:-1]
+        return returns
+
+    def _calculate_sharpe(self, returns: np.ndarray) -> float:
+        """Calculate annualized Sharpe ratio."""
+        if len(returns) == 0:
+            return 0.0
+
+        mean_return = np.mean(returns)
+        std_return = np.std(returns)
+
+        if std_return == 0:
+            return 0.0
+
+        daily_rf = self.risk_free_rate / 252
+        sharpe = (mean_return - daily_rf) / std_return * np.sqrt(252)
+        return float(sharpe)
+
+    def _calculate_max_drawdown(self, values: list[float]) -> float:
+        """Calculate maximum drawdown percentage."""
+        values_arr = np.array(values)
+        running_max = np.maximum.accumulate(values_arr)
+        drawdowns = (values_arr - running_max) / running_max
+        return float(abs(np.min(drawdowns)) * 100)
+
+    def _calculate_benchmark_metrics(
+        self,
+        symbol: str,
+        name: str,
+        strategy_returns: np.ndarray,
+        benchmark_returns: np.ndarray,
+        strategy_equity: list[float],
+        benchmark_equity: list[float],
+    ) -> BenchmarkMetrics:
+        """Calculate comprehensive benchmark comparison metrics."""
+        # Ensure same length
+        min_len = min(len(strategy_returns), len(benchmark_returns))
+        strat_ret = strategy_returns[:min_len]
+        bench_ret = benchmark_returns[:min_len]
+
+        # Total returns
+        strategy_total = (strategy_equity[-1] / strategy_equity[0] - 1) * 100
+        benchmark_total = (benchmark_equity[-1] / benchmark_equity[0] - 1) * 100
+        excess_return = strategy_total - benchmark_total
+        outperformance_ratio = (
+            (1 + strategy_total / 100) / (1 + benchmark_total / 100)
+            if benchmark_total != -100
+            else 0.0
+        )
+
+        # Alpha and Beta using linear regression
+        if len(strat_ret) > 1 and np.std(bench_ret) > 0:
+            # Beta = Cov(strategy, benchmark) / Var(benchmark)
+            covariance = np.cov(strat_ret, bench_ret)[0, 1]
+            variance = np.var(bench_ret)
+            beta = covariance / variance if variance > 0 else 1.0
+
+            # Alpha = mean(strategy) - beta * mean(benchmark) - risk_free
+            daily_rf = self.risk_free_rate / 252
+            alpha_daily = np.mean(strat_ret) - beta * np.mean(bench_ret) - daily_rf * (1 - beta)
+            alpha = alpha_daily * 252 * 100  # Annualized %
+
+            # R-squared
+            correlation = np.corrcoef(strat_ret, bench_ret)[0, 1]
+            r_squared = correlation**2 if not np.isnan(correlation) else 0.0
+        else:
+            beta = 1.0
+            alpha = 0.0
+            r_squared = 0.0
+
+        # Information Ratio and Tracking Error
+        excess_returns = strat_ret - bench_ret
+        tracking_error = np.std(excess_returns) * np.sqrt(252) * 100
+        if tracking_error > 0:
+            information_ratio = (np.mean(excess_returns) * 252 * 100) / tracking_error
+        else:
+            information_ratio = 0.0
+
+        # Drawdown comparison
+        strategy_dd = self._calculate_max_drawdown(strategy_equity)
+        benchmark_dd = self._calculate_max_drawdown(benchmark_equity)
+        relative_dd = strategy_dd / benchmark_dd if benchmark_dd > 0 else 1.0
+
+        # Outperformance statistics
+        daily_outperformance = strat_ret - bench_ret
+        pct_outperformed = (np.sum(daily_outperformance > 0) / len(daily_outperformance)) * 100
+        best_day = float(np.max(daily_outperformance) * 100)
+        worst_day = float(np.min(daily_outperformance) * 100)
+
+        # Max consecutive outperformance
+        max_streak = 0
+        current_streak = 0
+        for out in daily_outperformance > 0:
+            if out:
+                current_streak += 1
+                max_streak = max(max_streak, current_streak)
+            else:
+                current_streak = 0
+
+        # Sharpe ratios
+        strategy_sharpe = self._calculate_sharpe(strat_ret)
+        benchmark_sharpe = self._calculate_sharpe(bench_ret)
+
+        return BenchmarkMetrics(
+            symbol=symbol,
+            name=name,
+            strategy_return=strategy_total,
+            benchmark_return=benchmark_total,
+            excess_return=excess_return,
+            outperformance_ratio=outperformance_ratio,
+            alpha=alpha,
+            beta=beta,
+            r_squared=r_squared,
+            information_ratio=information_ratio,
+            tracking_error=tracking_error,
+            strategy_max_drawdown=strategy_dd,
+            benchmark_max_drawdown=benchmark_dd,
+            relative_drawdown=relative_dd,
+            pct_days_outperformed=pct_outperformed,
+            best_outperformance_day=best_day,
+            worst_underperformance_day=worst_day,
+            max_consecutive_outperformance=max_streak,
+            strategy_sharpe=strategy_sharpe,
+            benchmark_sharpe=benchmark_sharpe,
+        )
+
+
+def compare_to_benchmark(
+    equity_curve: list[float],
+    dates: list[str],
+    benchmark: str = "SPY",
+    strategy_name: str = "Strategy",
+) -> BenchmarkComparisonResult:
+    """
+    Convenience function to compare backtest results to a benchmark.
+
+    Args:
+        equity_curve: List of daily portfolio values
+        dates: List of dates (YYYY-MM-DD format)
+        benchmark: Benchmark symbol (default: SPY)
+        strategy_name: Name of strategy for reporting
+
+    Returns:
+        BenchmarkComparisonResult
+    """
+    comparator = BenchmarkComparator(primary_benchmark=benchmark)
+    return comparator.compare(equity_curve, dates, strategy_name)
+
+
+def compare_to_buy_and_hold(
+    equity_curve: list[float],
+    dates: list[str],
+    symbols: list[str],
+    initial_capital: float,
+) -> dict[str, Any]:
+    """
+    Compare strategy to buy-and-hold of the traded symbols.
+
+    Args:
+        equity_curve: Strategy equity curve
+        dates: List of dates
+        symbols: List of symbols that were traded
+        initial_capital: Starting capital
+
+    Returns:
+        Dictionary with buy-and-hold comparison metrics
+    """
+    if not symbols:
+        return {"error": "No symbols provided"}
+
+    comparator = BenchmarkComparator()
+    results = {}
+
+    for symbol in symbols:
+        try:
+            data = comparator._fetch_benchmark_data(symbol, dates[0], dates[-1])
+            if data is not None and not data.empty:
+                aligned = comparator._align_benchmark_to_dates(data, dates)
+
+                # Calculate buy-and-hold assuming equal allocation
+                allocation = initial_capital / len(symbols)
+                shares = allocation / aligned[0]
+                buy_hold_curve = [shares * price for price in aligned]
+
+                bh_return = (buy_hold_curve[-1] / buy_hold_curve[0] - 1) * 100
+                bh_returns = comparator._calculate_returns(buy_hold_curve)
+                bh_sharpe = comparator._calculate_sharpe(bh_returns)
+                bh_dd = comparator._calculate_max_drawdown(buy_hold_curve)
+
+                results[symbol] = {
+                    "return": bh_return,
+                    "sharpe": bh_sharpe,
+                    "max_drawdown": bh_dd,
+                    "final_value": buy_hold_curve[-1],
+                }
+        except Exception as e:
+            logger.warning(f"Failed to calculate buy-and-hold for {symbol}: {e}")
+            results[symbol] = {"error": str(e)}
+
+    # Combined buy-and-hold (equal weight)
+    if results:
+        combined_return = sum(r.get("return", 0) for r in results.values() if "return" in r)
+        combined_return /= len([r for r in results.values() if "return" in r])
+        results["combined"] = {"return": combined_return}
+
+    # Compare to strategy
+    strategy_return = (equity_curve[-1] / equity_curve[0] - 1) * 100
+    results["strategy"] = {"return": strategy_return}
+    results["excess_vs_buy_hold"] = strategy_return - results.get("combined", {}).get("return", 0)
+
+    return results
+
+
+# Example usage
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+
+    # Example equity curve
+    initial = 100000
+    equity_curve = [initial]
+    dates = []
+
+    from datetime import date, timedelta
+
+    current = date(2024, 1, 1)
+    for i in range(252):  # One year
+        if current.weekday() < 5:  # Weekdays only
+            # Random walk with slight upward bias
+            change = np.random.normal(0.0005, 0.01)
+            equity_curve.append(equity_curve[-1] * (1 + change))
+            dates.append(current.strftime("%Y-%m-%d"))
+        current += timedelta(days=1)
+
+    # Compare to SPY
+    result = compare_to_benchmark(equity_curve, dates, benchmark="SPY")
+    print(result.generate_report())

--- a/src/backtesting/data_cache.py
+++ b/src/backtesting/data_cache.py
@@ -1,0 +1,570 @@
+"""
+OHLCV Data Cache Module
+
+Provides persistent caching for historical market data used in backtesting.
+Uses a medallion architecture (bronze/silver/gold) for data quality management.
+
+Features:
+    - Parquet-based storage for efficient read/write
+    - Automatic cache invalidation based on age
+    - Multi-source support (Alpaca, yfinance)
+    - Incremental data updates
+    - Data validation and quality checks
+
+Author: Trading System
+Created: 2025-12-09
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import os
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import pandas as pd
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class CacheMetadata:
+    """Metadata for cached data."""
+
+    symbol: str
+    start_date: str
+    end_date: str
+    source: str
+    created_at: str
+    last_updated: str
+    row_count: int
+    checksum: str
+    quality_score: float
+
+
+class OHLCVDataCache:
+    """
+    Persistent cache for OHLCV market data.
+
+    Uses a medallion architecture:
+    - Bronze: Raw data as fetched from source
+    - Silver: Cleaned and validated data
+    - Gold: Aggregated and analysis-ready data
+    """
+
+    def __init__(
+        self,
+        cache_dir: str | Path | None = None,
+        max_age_days: int = 7,
+        use_parquet: bool = True,
+    ):
+        """
+        Initialize data cache.
+
+        Args:
+            cache_dir: Directory for cache storage (default: data/market_cache)
+            max_age_days: Maximum age in days before cache is considered stale
+            use_parquet: Use parquet format (True) or CSV (False)
+        """
+        if cache_dir is None:
+            cache_dir = Path(os.getenv("TRADING_DIR", ".")) / "data" / "market_cache"
+
+        self.cache_dir = Path(cache_dir)
+        self.max_age_days = max_age_days
+        self.use_parquet = use_parquet
+
+        # Create directory structure
+        self.bronze_dir = self.cache_dir / "bronze"
+        self.silver_dir = self.cache_dir / "silver"
+        self.gold_dir = self.cache_dir / "gold"
+        self.metadata_dir = self.cache_dir / "metadata"
+
+        for directory in [self.bronze_dir, self.silver_dir, self.gold_dir, self.metadata_dir]:
+            directory.mkdir(parents=True, exist_ok=True)
+
+        logger.info(f"OHLCV cache initialized at {self.cache_dir}")
+
+    def get(
+        self,
+        symbol: str,
+        start_date: str | datetime,
+        end_date: str | datetime,
+        tier: str = "silver",
+    ) -> pd.DataFrame | None:
+        """
+        Get cached data for a symbol.
+
+        Args:
+            symbol: Ticker symbol
+            start_date: Start date (YYYY-MM-DD or datetime)
+            end_date: End date (YYYY-MM-DD or datetime)
+            tier: Data tier (bronze/silver/gold)
+
+        Returns:
+            DataFrame with OHLCV data or None if not cached
+        """
+        start_str = self._normalize_date(start_date)
+        end_str = self._normalize_date(end_date)
+
+        # Check if we have valid cached data
+        cache_file = self._get_cache_path(symbol, tier)
+        if not cache_file.exists():
+            logger.debug(f"No cache found for {symbol}")
+            return None
+
+        # Check cache freshness
+        if not self._is_cache_fresh(symbol, tier):
+            logger.info(f"Cache for {symbol} is stale, will need refresh")
+            return None
+
+        # Load cached data
+        try:
+            df = self._load_data(cache_file)
+
+            # Filter to requested date range
+            df.index = pd.to_datetime(df.index)
+            start_dt = pd.to_datetime(start_str)
+            end_dt = pd.to_datetime(end_str)
+
+            filtered = df[(df.index >= start_dt) & (df.index <= end_dt)]
+
+            if filtered.empty:
+                logger.warning(f"No data in cache for {symbol} in range {start_str} to {end_str}")
+                return None
+
+            logger.info(f"Retrieved {len(filtered)} bars for {symbol} from cache")
+            return filtered
+
+        except Exception as e:
+            logger.error(f"Failed to load cache for {symbol}: {e}")
+            return None
+
+    def put(
+        self,
+        symbol: str,
+        data: pd.DataFrame,
+        source: str = "unknown",
+        tier: str = "bronze",
+    ) -> bool:
+        """
+        Store data in cache.
+
+        Args:
+            symbol: Ticker symbol
+            data: DataFrame with OHLCV data (index should be datetime)
+            source: Data source identifier
+            tier: Data tier to store in
+
+        Returns:
+            True if successful
+        """
+        if data is None or data.empty:
+            logger.warning(f"No data to cache for {symbol}")
+            return False
+
+        try:
+            # Ensure proper column names
+            data = self._normalize_columns(data)
+
+            # Validate data
+            quality_score = self._validate_data(data)
+            if quality_score < 0.5:
+                logger.warning(f"Data quality for {symbol} is low: {quality_score:.2f}")
+
+            # Save data
+            cache_file = self._get_cache_path(symbol, tier)
+            self._save_data(data, cache_file)
+
+            # Save metadata
+            metadata = CacheMetadata(
+                symbol=symbol,
+                start_date=str(data.index.min().date()),
+                end_date=str(data.index.max().date()),
+                source=source,
+                created_at=datetime.now().isoformat(),
+                last_updated=datetime.now().isoformat(),
+                row_count=len(data),
+                checksum=self._calculate_checksum(data),
+                quality_score=quality_score,
+            )
+            self._save_metadata(symbol, tier, metadata)
+
+            logger.info(f"Cached {len(data)} bars for {symbol} to {tier}")
+            return True
+
+        except Exception as e:
+            logger.error(f"Failed to cache data for {symbol}: {e}")
+            return False
+
+    def update(
+        self,
+        symbol: str,
+        new_data: pd.DataFrame,
+        source: str = "unknown",
+        tier: str = "bronze",
+    ) -> bool:
+        """
+        Update cache with new data (append or merge).
+
+        Args:
+            symbol: Ticker symbol
+            new_data: New DataFrame to merge
+            source: Data source
+            tier: Data tier
+
+        Returns:
+            True if successful
+        """
+        existing = self.get(symbol, "1900-01-01", "2100-12-31", tier)
+
+        if existing is not None:
+            # Merge with existing data
+            combined = pd.concat([existing, new_data])
+            combined = combined[~combined.index.duplicated(keep="last")]
+            combined = combined.sort_index()
+        else:
+            combined = new_data
+
+        return self.put(symbol, combined, source, tier)
+
+    def promote(self, symbol: str, from_tier: str = "bronze", to_tier: str = "silver") -> bool:
+        """
+        Promote data from one tier to another after validation.
+
+        Args:
+            symbol: Ticker symbol
+            from_tier: Source tier
+            to_tier: Destination tier
+
+        Returns:
+            True if successful
+        """
+        data = self.get(symbol, "1900-01-01", "2100-12-31", from_tier)
+        if data is None:
+            logger.warning(f"No data to promote for {symbol}")
+            return False
+
+        # Apply cleaning for silver tier
+        if to_tier == "silver":
+            data = self._clean_data(data)
+
+        # Apply aggregation for gold tier
+        elif to_tier == "gold":
+            data = self._aggregate_data(data)
+
+        # Get source from original metadata
+        metadata = self._load_metadata(symbol, from_tier)
+        source = metadata.source if metadata else "promoted"
+
+        return self.put(symbol, data, source, to_tier)
+
+    def invalidate(self, symbol: str, tier: str | None = None) -> bool:
+        """
+        Invalidate cache for a symbol.
+
+        Args:
+            symbol: Ticker symbol
+            tier: Specific tier to invalidate (None = all tiers)
+
+        Returns:
+            True if any cache was invalidated
+        """
+        tiers = [tier] if tier else ["bronze", "silver", "gold"]
+        invalidated = False
+
+        for t in tiers:
+            cache_file = self._get_cache_path(symbol, t)
+            metadata_file = self._get_metadata_path(symbol, t)
+
+            if cache_file.exists():
+                cache_file.unlink()
+                invalidated = True
+
+            if metadata_file.exists():
+                metadata_file.unlink()
+
+        if invalidated:
+            logger.info(f"Invalidated cache for {symbol}")
+
+        return invalidated
+
+    def list_cached_symbols(self, tier: str = "silver") -> list[str]:
+        """List all symbols with cached data in a tier."""
+        tier_dir = getattr(self, f"{tier}_dir")
+        extension = ".parquet" if self.use_parquet else ".csv"
+
+        symbols = []
+        for file in tier_dir.glob(f"*{extension}"):
+            symbols.append(file.stem)
+
+        return sorted(symbols)
+
+    def get_cache_info(self, symbol: str, tier: str = "silver") -> dict[str, Any] | None:
+        """Get cache information for a symbol."""
+        metadata = self._load_metadata(symbol, tier)
+        if metadata is None:
+            return None
+
+        cache_file = self._get_cache_path(symbol, tier)
+        file_size = cache_file.stat().st_size if cache_file.exists() else 0
+
+        return {
+            "symbol": metadata.symbol,
+            "start_date": metadata.start_date,
+            "end_date": metadata.end_date,
+            "source": metadata.source,
+            "created_at": metadata.created_at,
+            "last_updated": metadata.last_updated,
+            "row_count": metadata.row_count,
+            "quality_score": metadata.quality_score,
+            "file_size_bytes": file_size,
+            "is_fresh": self._is_cache_fresh(symbol, tier),
+        }
+
+    def _get_cache_path(self, symbol: str, tier: str) -> Path:
+        """Get cache file path for a symbol."""
+        tier_dir = getattr(self, f"{tier}_dir")
+        extension = ".parquet" if self.use_parquet else ".csv"
+        return tier_dir / f"{symbol}{extension}"
+
+    def _get_metadata_path(self, symbol: str, tier: str) -> Path:
+        """Get metadata file path."""
+        return self.metadata_dir / f"{symbol}_{tier}.json"
+
+    def _normalize_date(self, date: str | datetime) -> str:
+        """Normalize date to YYYY-MM-DD string."""
+        if isinstance(date, datetime):
+            return date.strftime("%Y-%m-%d")
+        return date
+
+    def _normalize_columns(self, df: pd.DataFrame) -> pd.DataFrame:
+        """Normalize column names to standard format."""
+        column_map = {
+            "open": "Open",
+            "high": "High",
+            "low": "Low",
+            "close": "Close",
+            "volume": "Volume",
+            "adj_close": "Adj Close",
+            "adjusted_close": "Adj Close",
+        }
+
+        df = df.copy()
+        df.columns = [column_map.get(c.lower(), c) for c in df.columns]
+
+        # Ensure required columns exist
+        required = ["Open", "High", "Low", "Close", "Volume"]
+        for col in required:
+            if col not in df.columns:
+                logger.warning(f"Missing required column: {col}")
+
+        return df
+
+    def _validate_data(self, df: pd.DataFrame) -> float:
+        """
+        Validate data quality.
+
+        Returns quality score from 0 to 1.
+        """
+        score = 1.0
+
+        # Check for required columns
+        required = ["Open", "High", "Low", "Close", "Volume"]
+        missing = [c for c in required if c not in df.columns]
+        score -= len(missing) * 0.1
+
+        # Check for null values
+        null_pct = df.isnull().sum().sum() / (len(df) * len(df.columns))
+        score -= null_pct
+
+        # Check OHLC validity (High >= Low, Open/Close within High/Low)
+        if all(c in df.columns for c in ["Open", "High", "Low", "Close"]):
+            invalid_hl = (df["High"] < df["Low"]).sum()
+            invalid_o = ((df["Open"] > df["High"]) | (df["Open"] < df["Low"])).sum()
+            invalid_c = ((df["Close"] > df["High"]) | (df["Close"] < df["Low"])).sum()
+            invalid_pct = (invalid_hl + invalid_o + invalid_c) / (len(df) * 3)
+            score -= invalid_pct * 0.5
+
+        # Check for zero/negative prices
+        if "Close" in df.columns:
+            bad_prices = (df["Close"] <= 0).sum() / len(df)
+            score -= bad_prices * 0.3
+
+        # Check for gaps > 5%
+        if "Close" in df.columns and len(df) > 1:
+            returns = df["Close"].pct_change().abs()
+            big_gaps = (returns > 0.05).sum() / len(returns)
+            score -= big_gaps * 0.1
+
+        return max(0.0, min(1.0, score))
+
+    def _clean_data(self, df: pd.DataFrame) -> pd.DataFrame:
+        """Clean data for silver tier."""
+        df = df.copy()
+
+        # Forward-fill missing values
+        df = df.ffill()
+
+        # Remove duplicate indices
+        df = df[~df.index.duplicated(keep="last")]
+
+        # Sort by date
+        df = df.sort_index()
+
+        # Fix invalid OHLC (High < Low)
+        if all(c in df.columns for c in ["High", "Low"]):
+            mask = df["High"] < df["Low"]
+            df.loc[mask, ["High", "Low"]] = df.loc[mask, ["Low", "High"]].values
+
+        # Remove rows with zero/negative close
+        if "Close" in df.columns:
+            df = df[df["Close"] > 0]
+
+        return df
+
+    def _aggregate_data(self, df: pd.DataFrame) -> pd.DataFrame:
+        """Aggregate data for gold tier (add calculated fields)."""
+        df = df.copy()
+
+        if len(df) < 2:
+            return df
+
+        # Add daily returns
+        df["Return"] = df["Close"].pct_change()
+
+        # Add moving averages
+        df["SMA_20"] = df["Close"].rolling(20).mean()
+        df["SMA_50"] = df["Close"].rolling(50).mean()
+
+        # Add volatility
+        df["Volatility_20"] = df["Return"].rolling(20).std() * np.sqrt(252)
+
+        # Add volume moving average
+        df["Volume_MA_20"] = df["Volume"].rolling(20).mean()
+        df["Volume_Ratio"] = df["Volume"] / df["Volume_MA_20"]
+
+        return df
+
+    def _is_cache_fresh(self, symbol: str, tier: str) -> bool:
+        """Check if cache is still fresh."""
+        metadata = self._load_metadata(symbol, tier)
+        if metadata is None:
+            return False
+
+        try:
+            last_updated = datetime.fromisoformat(metadata.last_updated)
+            age = datetime.now() - last_updated
+            return age.days <= self.max_age_days
+        except Exception:
+            return False
+
+    def _calculate_checksum(self, df: pd.DataFrame) -> str:
+        """Calculate checksum for data integrity."""
+        # Use hash of shape and sample values
+        content = f"{df.shape}_{df.iloc[0].to_json() if len(df) > 0 else ''}"
+        return hashlib.md5(content.encode()).hexdigest()[:16]
+
+    def _save_data(self, df: pd.DataFrame, path: Path) -> None:
+        """Save DataFrame to file."""
+        if self.use_parquet:
+            df.to_parquet(path)
+        else:
+            df.to_csv(path)
+
+    def _load_data(self, path: Path) -> pd.DataFrame:
+        """Load DataFrame from file."""
+        if self.use_parquet:
+            return pd.read_parquet(path)
+        else:
+            return pd.read_csv(path, index_col=0, parse_dates=True)
+
+    def _save_metadata(self, symbol: str, tier: str, metadata: CacheMetadata) -> None:
+        """Save metadata to file."""
+        path = self._get_metadata_path(symbol, tier)
+        with open(path, "w") as f:
+            json.dump(
+                {
+                    "symbol": metadata.symbol,
+                    "start_date": metadata.start_date,
+                    "end_date": metadata.end_date,
+                    "source": metadata.source,
+                    "created_at": metadata.created_at,
+                    "last_updated": metadata.last_updated,
+                    "row_count": metadata.row_count,
+                    "checksum": metadata.checksum,
+                    "quality_score": metadata.quality_score,
+                },
+                f,
+                indent=2,
+            )
+
+    def _load_metadata(self, symbol: str, tier: str) -> CacheMetadata | None:
+        """Load metadata from file."""
+        path = self._get_metadata_path(symbol, tier)
+        if not path.exists():
+            return None
+
+        try:
+            with open(path) as f:
+                data = json.load(f)
+                return CacheMetadata(**data)
+        except Exception as e:
+            logger.warning(f"Failed to load metadata for {symbol}: {e}")
+            return None
+
+
+# Global cache instance
+_cache: OHLCVDataCache | None = None
+
+
+def get_data_cache() -> OHLCVDataCache:
+    """Get the global data cache instance."""
+    global _cache
+    if _cache is None:
+        _cache = OHLCVDataCache()
+    return _cache
+
+
+def cached_fetch(
+    symbol: str,
+    start_date: str,
+    end_date: str,
+    fetch_func: callable,
+    source: str = "custom",
+) -> pd.DataFrame | None:
+    """
+    Fetch data with automatic caching.
+
+    Args:
+        symbol: Ticker symbol
+        start_date: Start date
+        end_date: End date
+        fetch_func: Function to call if cache miss (takes symbol, start, end)
+        source: Source identifier
+
+    Returns:
+        DataFrame with OHLCV data
+    """
+    cache = get_data_cache()
+
+    # Try cache first
+    data = cache.get(symbol, start_date, end_date)
+    if data is not None:
+        return data
+
+    # Fetch fresh data
+    try:
+        data = fetch_func(symbol, start_date, end_date)
+        if data is not None and not data.empty:
+            cache.put(symbol, data, source, "bronze")
+            cache.promote(symbol, "bronze", "silver")
+            return cache.get(symbol, start_date, end_date)
+    except Exception as e:
+        logger.error(f"Failed to fetch data for {symbol}: {e}")
+
+    return None

--- a/tests/test_benchmark_comparison.py
+++ b/tests/test_benchmark_comparison.py
@@ -1,0 +1,383 @@
+"""
+Tests for Benchmark Comparison Module
+
+Tests the benchmark comparison functionality including:
+- BenchmarkComparator class
+- Alpha/Beta calculation
+- Buy-and-hold comparison
+- Data caching
+
+Author: Trading System
+Created: 2025-12-09
+"""
+
+import tempfile
+from datetime import date, timedelta
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from src.backtesting.benchmark_comparison import (
+    BenchmarkComparator,
+    BenchmarkComparisonResult,
+    BenchmarkMetrics,
+    compare_to_benchmark,
+    compare_to_buy_and_hold,
+)
+from src.backtesting.data_cache import CacheMetadata, OHLCVDataCache
+
+
+class TestBenchmarkMetrics:
+    """Tests for BenchmarkMetrics dataclass."""
+
+    def test_to_dict(self):
+        """Test conversion to dictionary."""
+        metrics = BenchmarkMetrics(
+            symbol="SPY",
+            name="S&P 500",
+            strategy_return=15.0,
+            benchmark_return=10.0,
+            excess_return=5.0,
+            outperformance_ratio=1.05,
+            alpha=3.0,
+            beta=1.1,
+            r_squared=0.85,
+            information_ratio=0.5,
+            tracking_error=2.0,
+            strategy_max_drawdown=8.0,
+            benchmark_max_drawdown=10.0,
+            relative_drawdown=0.8,
+            pct_days_outperformed=55.0,
+            best_outperformance_day=2.5,
+            worst_underperformance_day=-1.8,
+            max_consecutive_outperformance=5,
+            strategy_sharpe=1.5,
+            benchmark_sharpe=1.2,
+        )
+
+        result = metrics.to_dict()
+
+        assert result["symbol"] == "SPY"
+        assert result["excess_return"] == 5.0
+        assert result["alpha"] == 3.0
+        assert result["beta"] == 1.1
+
+
+class TestBenchmarkComparisonResult:
+    """Tests for BenchmarkComparisonResult dataclass."""
+
+    def test_generate_report(self):
+        """Test report generation."""
+        primary = BenchmarkMetrics(
+            symbol="SPY",
+            name="S&P 500",
+            strategy_return=15.0,
+            benchmark_return=10.0,
+            excess_return=5.0,
+            outperformance_ratio=1.05,
+            alpha=3.0,
+            beta=1.1,
+            r_squared=0.85,
+            information_ratio=0.5,
+            tracking_error=2.0,
+            strategy_max_drawdown=8.0,
+            benchmark_max_drawdown=10.0,
+            relative_drawdown=0.8,
+            pct_days_outperformed=55.0,
+            best_outperformance_day=2.5,
+            worst_underperformance_day=-1.8,
+            max_consecutive_outperformance=5,
+            strategy_sharpe=1.5,
+            benchmark_sharpe=1.2,
+        )
+
+        result = BenchmarkComparisonResult(
+            strategy_name="Test Strategy",
+            start_date="2024-01-01",
+            end_date="2024-12-31",
+            trading_days=252,
+            primary_benchmark=primary,
+            buy_hold_return=10.0,
+            buy_hold_sharpe=1.2,
+            buy_hold_max_drawdown=10.0,
+        )
+
+        report = result.generate_report()
+
+        assert "BENCHMARK COMPARISON REPORT" in report
+        assert "Test Strategy" in report
+        assert "S&P 500" in report
+        assert "OUTPERFORMED" in report
+        assert "Alpha" in report
+
+    def test_to_dict(self):
+        """Test serialization."""
+        primary = BenchmarkMetrics(
+            symbol="SPY",
+            name="S&P 500",
+            strategy_return=15.0,
+            benchmark_return=10.0,
+            excess_return=5.0,
+            outperformance_ratio=1.05,
+            alpha=3.0,
+            beta=1.1,
+            r_squared=0.85,
+            information_ratio=0.5,
+            tracking_error=2.0,
+            strategy_max_drawdown=8.0,
+            benchmark_max_drawdown=10.0,
+            relative_drawdown=0.8,
+            pct_days_outperformed=55.0,
+            best_outperformance_day=2.5,
+            worst_underperformance_day=-1.8,
+            max_consecutive_outperformance=5,
+            strategy_sharpe=1.5,
+            benchmark_sharpe=1.2,
+        )
+
+        result = BenchmarkComparisonResult(
+            strategy_name="Test",
+            start_date="2024-01-01",
+            end_date="2024-12-31",
+            trading_days=252,
+            primary_benchmark=primary,
+        )
+
+        data = result.to_dict()
+
+        assert data["strategy_name"] == "Test"
+        assert data["trading_days"] == 252
+        assert "primary_benchmark" in data
+
+
+class TestBenchmarkComparator:
+    """Tests for BenchmarkComparator class."""
+
+    @pytest.fixture
+    def sample_equity_curve(self):
+        """Generate sample equity curve for testing."""
+        np.random.seed(42)
+        initial = 100000
+
+        # Generate dates
+        dates = []
+        equity = [initial]
+        current = date(2024, 1, 2)
+
+        for _ in range(100):
+            while current.weekday() >= 5:  # Skip weekends
+                current += timedelta(days=1)
+            dates.append(current.strftime("%Y-%m-%d"))
+            # Random walk with slight upward bias
+            change = np.random.normal(0.0005, 0.01)
+            equity.append(equity[-1] * (1 + change))
+            current += timedelta(days=1)
+
+        return equity, dates
+
+    def test_calculate_returns(self):
+        """Test return calculation."""
+        comparator = BenchmarkComparator()
+        values = [100, 105, 110, 108]
+        returns = comparator._calculate_returns(values)
+
+        assert len(returns) == 3
+        assert np.isclose(returns[0], 0.05)
+        assert np.isclose(returns[1], 0.05 / 1.05, rtol=0.01)
+
+    def test_calculate_sharpe(self):
+        """Test Sharpe ratio calculation."""
+        comparator = BenchmarkComparator(risk_free_rate=0.0)
+
+        # Perfect positive returns
+        returns = np.array([0.01, 0.01, 0.01, 0.01, 0.01])
+        sharpe = comparator._calculate_sharpe(returns)
+        assert sharpe > 0
+
+        # Negative returns
+        returns = np.array([-0.01, -0.01, -0.01])
+        sharpe = comparator._calculate_sharpe(returns)
+        assert sharpe < 0
+
+    def test_calculate_max_drawdown(self):
+        """Test max drawdown calculation."""
+        comparator = BenchmarkComparator()
+
+        # 10% drawdown
+        values = [100, 105, 95, 100]
+        dd = comparator._calculate_max_drawdown(values)
+        assert np.isclose(dd, (105 - 95) / 105 * 100, rtol=0.01)
+
+        # No drawdown (always increasing)
+        values = [100, 101, 102, 103]
+        dd = comparator._calculate_max_drawdown(values)
+        assert dd == 0.0
+
+
+class TestOHLCVDataCache:
+    """Tests for OHLCV data caching."""
+
+    @pytest.fixture
+    def temp_cache_dir(self):
+        """Create temporary cache directory."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            yield Path(tmpdir)
+
+    @pytest.fixture
+    def sample_ohlcv_data(self):
+        """Generate sample OHLCV data."""
+        dates = pd.date_range(start="2024-01-01", periods=100, freq="B")
+        np.random.seed(42)
+
+        close = 100 + np.cumsum(np.random.randn(100) * 2)
+        high = close + np.random.rand(100) * 2
+        low = close - np.random.rand(100) * 2
+        open_price = close + np.random.randn(100) * 0.5
+        volume = np.random.randint(1000000, 10000000, 100)
+
+        df = pd.DataFrame(
+            {
+                "Open": open_price,
+                "High": high,
+                "Low": low,
+                "Close": close,
+                "Volume": volume,
+            },
+            index=dates,
+        )
+
+        return df
+
+    def test_cache_initialization(self, temp_cache_dir):
+        """Test cache directory creation."""
+        cache = OHLCVDataCache(cache_dir=temp_cache_dir)
+
+        assert (temp_cache_dir / "bronze").exists()
+        assert (temp_cache_dir / "silver").exists()
+        assert (temp_cache_dir / "gold").exists()
+        assert (temp_cache_dir / "metadata").exists()
+
+    def test_put_and_get(self, temp_cache_dir, sample_ohlcv_data):
+        """Test storing and retrieving data."""
+        cache = OHLCVDataCache(cache_dir=temp_cache_dir)
+
+        # Store data
+        success = cache.put("SPY", sample_ohlcv_data, "test", "bronze")
+        assert success
+
+        # Retrieve data
+        retrieved = cache.get("SPY", "2024-01-01", "2024-12-31", "bronze")
+        assert retrieved is not None
+        assert len(retrieved) == len(sample_ohlcv_data)
+
+    def test_data_validation(self, temp_cache_dir):
+        """Test data quality validation."""
+        cache = OHLCVDataCache(cache_dir=temp_cache_dir)
+
+        # Good data
+        good_data = pd.DataFrame(
+            {
+                "Open": [100, 101],
+                "High": [102, 103],
+                "Low": [99, 100],
+                "Close": [101, 102],
+                "Volume": [1000, 1100],
+            },
+            index=pd.date_range("2024-01-01", periods=2),
+        )
+
+        score = cache._validate_data(good_data)
+        assert score > 0.8
+
+        # Bad data (High < Low)
+        bad_data = pd.DataFrame(
+            {
+                "Open": [100, 101],
+                "High": [99, 100],  # Less than Low
+                "Low": [102, 103],
+                "Close": [101, 102],
+                "Volume": [1000, 1100],
+            },
+            index=pd.date_range("2024-01-01", periods=2),
+        )
+
+        score = cache._validate_data(bad_data)
+        assert score < 0.8
+
+    def test_promote_data(self, temp_cache_dir, sample_ohlcv_data):
+        """Test data promotion between tiers."""
+        cache = OHLCVDataCache(cache_dir=temp_cache_dir)
+
+        # Store in bronze
+        cache.put("SPY", sample_ohlcv_data, "test", "bronze")
+
+        # Promote to silver
+        success = cache.promote("SPY", "bronze", "silver")
+        assert success
+
+        # Verify silver data exists
+        silver_data = cache.get("SPY", "2024-01-01", "2024-12-31", "silver")
+        assert silver_data is not None
+
+    def test_list_cached_symbols(self, temp_cache_dir, sample_ohlcv_data):
+        """Test listing cached symbols."""
+        cache = OHLCVDataCache(cache_dir=temp_cache_dir)
+
+        # Store multiple symbols
+        cache.put("SPY", sample_ohlcv_data, "test", "silver")
+        cache.put("QQQ", sample_ohlcv_data, "test", "silver")
+        cache.put("VOO", sample_ohlcv_data, "test", "silver")
+
+        symbols = cache.list_cached_symbols("silver")
+        assert len(symbols) == 3
+        assert "SPY" in symbols
+        assert "QQQ" in symbols
+
+    def test_invalidate_cache(self, temp_cache_dir, sample_ohlcv_data):
+        """Test cache invalidation."""
+        cache = OHLCVDataCache(cache_dir=temp_cache_dir)
+
+        # Store data
+        cache.put("SPY", sample_ohlcv_data, "test", "silver")
+        assert cache.get("SPY", "2024-01-01", "2024-12-31", "silver") is not None
+
+        # Invalidate
+        success = cache.invalidate("SPY", "silver")
+        assert success
+
+        # Verify gone
+        assert cache.get("SPY", "2024-01-01", "2024-12-31", "silver") is None
+
+    def test_cache_info(self, temp_cache_dir, sample_ohlcv_data):
+        """Test cache information retrieval."""
+        cache = OHLCVDataCache(cache_dir=temp_cache_dir)
+
+        cache.put("SPY", sample_ohlcv_data, "yfinance", "silver")
+
+        info = cache.get_cache_info("SPY", "silver")
+
+        assert info is not None
+        assert info["symbol"] == "SPY"
+        assert info["source"] == "yfinance"
+        assert info["row_count"] == len(sample_ohlcv_data)
+        assert info["is_fresh"] is True
+
+
+class TestConvenienceFunctions:
+    """Tests for convenience functions."""
+
+    def test_compare_to_benchmark_empty_data(self):
+        """Test error handling for empty data."""
+        with pytest.raises(ValueError):
+            compare_to_benchmark([], [], "SPY")
+
+    def test_compare_to_benchmark_mismatched_lengths(self):
+        """Test error handling for mismatched lengths."""
+        with pytest.raises(ValueError):
+            compare_to_benchmark([100, 101, 102], ["2024-01-01", "2024-01-02"], "SPY")
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

- Add **BenchmarkComparator** for comparing strategy vs SPY/QQQ with alpha, beta, information ratio
- Add **OHLCVDataCache** with medallion architecture (bronze/silver/gold tiers)
- Add **compare_to_buy_and_hold()** convenience function
- Add unit tests for new modules

## Changes

| File | Description |
|------|-------------|
| `src/backtesting/benchmark_comparison.py` | Benchmark comparison with alpha/beta/IR calculation |
| `src/backtesting/data_cache.py` | Parquet-based OHLCV caching with quality scoring |
| `src/backtesting/__init__.py` | Updated exports |
| `tests/test_benchmark_comparison.py` | Unit tests |

## Test plan

- [x] Module syntax validated
- [x] BenchmarkComparator calculates returns, Sharpe, max drawdown correctly
- [x] OHLCVDataCache stores/retrieves data with validation