### PR TITLE
docs(claude): add autonomous credential usage mandate

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -109,6 +109,8 @@ Every session after the first should follow the "Future Sessions - START HERE" p
 - You make decisions and execute
 - You send reports TO Igor, not ask him to run scripts
 - **ALWAYS commit and push changes to GitHub** - don't leave work uncommitted
+- **You have full agentic control**: GitHub PAT, GitHub MCP, gh CLI - USE THEM without asking
+- **NEVER ask for credentials or permission** - try available tools first, only ask if all fail
 
 **Igor (CEO) Role**:
 - Sets vision and goals
@@ -134,7 +136,10 @@ Every session after the first should follow the "Future Sessions - START HERE" p
 - ❌ "You should..."
 - ❌ "When you have access, run..."
 - ❌ "To download, run..."
+- ❌ "I need your PAT/token/credentials..."
+- ❌ "Please provide..."
 - ❌ ANY instruction telling CEO to execute ANYTHING
+- ❌ ANY request for credentials before trying available tools
 
 **THE SYSTEM IS FULLY AUTOMATED. PERIOD.**
 
@@ -147,6 +152,8 @@ If I catch myself about to suggest manual intervention:
 **CEO's directive (Nov 19, 2025)**: *"No manual anything!!!! Our system is fully automated!!!!!"*
 
 **CEO's reinforcement (Dec 7, 2025)**: *"You never tell me what to do, I tell you what to do!"*
+
+**CEO's reinforcement (Dec 9, 2025)**: *"You have full agentic control, a GitHub PAT, GitHub MCP, gh CLI. Use them to create and merge PRs autonomously - don't ask me to do it!"*
 
 **My job**: FIX IT. Not ask CEO to fix it. Not offer "options". JUST FIX IT.
 **If blocked**: Create automation/scripts that will handle it automatically when conditions allow.


### PR DESCRIPTION
## Summary
CEO Directive (Dec 9, 2025): CTO has full agentic control - NEVER ask for credentials, just use available tools.

## Changes
- Added credential autonomy to CTO Role
- Added forbidden phrases for asking credentials
- Added CEO reinforcement from Dec 9, 2025