### PR TITLE
fix(sentiment): reduce noise in trading signals

### DIFF
--- a/src/agents/rl_agent.py
+++ b/src/agents/rl_agent.py
@@ -89,10 +89,12 @@ class RLFilter:
                 logger.warning("Transformer RL initialisation failed: %s", exc)
 
         # DiscoRL-inspired DQN initialization (Dec 2025)
+        # Dec 9, 2025: Disabled by default until validated with real trades (0 closed trades so far)
+        # Domain transfer from Atari games to financial markets is unproven
         disco_flag = (
             enable_disco_dqn
             if enable_disco_dqn is not None
-            else os.getenv("RL_USE_DISCO_DQN", "1").lower() in {"1", "true", "yes", "on"}
+            else os.getenv("RL_USE_DISCO_DQN", "0").lower() in {"1", "true", "yes", "on"}
         )
         if disco_flag and DISCO_DQN_AVAILABLE:
             try:

--- a/src/utils/unified_sentiment.py
+++ b/src/utils/unified_sentiment.py
@@ -88,22 +88,25 @@ class UnifiedSentiment:
     """
 
     # Source weights (must sum to 1.0)
+    # Dec 9, 2025: Reduced Reddit from 0.25 to 0.10 - meme forum noise outweighs signal
+    # Redistributed weight to news (professional analysts more reliable)
     SOURCE_WEIGHTS = {
-        "news": 0.30,  # Professional news and analyst sentiment
-        "reddit": 0.25,  # Retail investor sentiment
+        "news": 0.45,  # Professional news and analyst sentiment (increased from 0.30)
+        "reddit": 0.10,  # Retail investor sentiment (reduced from 0.25 - meme forum noise)
         "youtube": 0.20,  # Expert content creator analysis
         "linkedin": 0.15,  # Professional network sentiment
         "tiktok": 0.10,  # Viral trends and momentum
     }
 
     # Signal thresholds
-    BULLISH_THRESHOLD = 0.20  # > 0.20 = bullish
-    BEARISH_THRESHOLD = -0.20  # < -0.20 = bearish
+    # Dec 9, 2025: Increased from 0.20 to 0.35 to reduce false positives from noise
+    BULLISH_THRESHOLD = 0.35  # > 0.35 = bullish (was 0.20)
+    BEARISH_THRESHOLD = -0.35  # < -0.35 = bearish (was -0.20)
 
     # Recommendation thresholds (more conservative)
-    BUY_THRESHOLD = 0.40  # > 0.40 + high confidence = BUY_SIGNAL
-    SELL_THRESHOLD = -0.40  # < -0.40 + high confidence = SELL_SIGNAL
-    MIN_CONFIDENCE_FOR_ACTION = 0.60  # Need 60%+ confidence for BUY/SELL
+    BUY_THRESHOLD = 0.50  # > 0.50 + high confidence = BUY_SIGNAL (was 0.40)
+    SELL_THRESHOLD = -0.50  # < -0.50 + high confidence = SELL_SIGNAL (was -0.40)
+    MIN_CONFIDENCE_FOR_ACTION = 0.75  # Need 75%+ confidence for BUY/SELL (was 0.60)
 
     # Cache settings
     CACHE_TTL_SECONDS = 3600  # 1 hour
@@ -587,6 +590,34 @@ class UnifiedSentiment:
         overall_confidence = (
             sum(confidence_scores) / len(confidence_scores) if confidence_scores else 0.0
         )
+
+        # Dec 9, 2025: Source disagreement circuit breaker
+        # If professional sources (news) disagree significantly with retail (reddit),
+        # reduce confidence - the signal is unreliable
+        news_sent = source_sentiments.get("news")
+        reddit_sent = source_sentiments.get("reddit")
+        if (
+            news_sent
+            and reddit_sent
+            and news_sent.available
+            and reddit_sent.available
+        ):
+            # Check for significant disagreement (opposite directions with strong signals)
+            news_score = news_sent.score
+            reddit_score = reddit_sent.score
+            DISAGREEMENT_THRESHOLD = 0.3  # Both need to be strongly opinionated
+
+            if (news_score > DISAGREEMENT_THRESHOLD and reddit_score < -DISAGREEMENT_THRESHOLD) or (
+                news_score < -DISAGREEMENT_THRESHOLD and reddit_score > DISAGREEMENT_THRESHOLD
+            ):
+                # Sources disagree significantly - reduce confidence by 50%
+                original_confidence = overall_confidence
+                overall_confidence *= 0.5
+                logger.warning(
+                    f"{symbol}: Source disagreement detected! "
+                    f"news={news_score:.2f}, reddit={reddit_score:.2f}. "
+                    f"Reducing confidence from {original_confidence:.2f} to {overall_confidence:.2f}"
+                )
 
         # Determine signal
         if overall_score > self.BULLISH_THRESHOLD:


### PR DESCRIPTION
## Summary
- Reduce Reddit weight from 25% to 10% (meme forum noise)
- Increase news weight from 30% to 45% (professional analysts)
- Raise confidence threshold from 60% to 75% for trade signals
- Raise bullish/bearish thresholds from ±0.20 to ±0.35
- Raise buy/sell thresholds from ±0.40 to ±0.50
- Add source disagreement circuit breaker (50% confidence penalty)
- Disable DiscoRL by default until validated with real trades

## Test Plan
- [x] Branch merges cleanly with main
- [x] Changes are localized to 2 files (rl_agent.py, unified_sentiment.py)