### PR TITLE
fix(lint): remove unused import and sort imports

### DIFF
--- a/src/signals/__init__.py
+++ b/src/signals/__init__.py
@@ -19,10 +19,10 @@ from src.signals.options_signal_enhancer import (
 )
 
 from src.signals.kalshi_oracle import (
+    AssetClass,
     KalshiOracle,
     KalshiSignal,
     SignalDirection,
-    AssetClass,
     get_kalshi_oracle,
     get_kalshi_signals,
 )

--- a/tests/test_kalshi_oracle.py
+++ b/tests/test_kalshi_oracle.py
@@ -13,7 +13,7 @@ Created: 2025-12-09
 """
 
 from datetime import datetime, timezone
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import pytest
 


### PR DESCRIPTION
Fix CI lint failures:
- Remove unused MagicMock import in test_kalshi_oracle.py
- Sort imports alphabetically in signals/__init__.py