### PR TITLE
feat(resilience): enable broker failover in daily trading

### DIFF
--- a/.github/workflows/daily-trading.yml
+++ b/.github/workflows/daily-trading.yml
@@ -162,6 +162,10 @@ jobs:
       PYTHONPATH: ${{ github.workspace }}
       ENABLE_WEEKEND_PROXY: 'false'
       ALLOW_PROMOTION_OVERRIDE: '1'  # Temporary override to allow trading while metrics are repaired
+      # Multi-broker failover for resilience (Alpaca → Tradier)
+      ENABLE_BROKER_FAILOVER: 'true'
+      TRADIER_API_KEY: ${{ secrets.TRADIER_API_KEY }}
+      TRADIER_ACCOUNT_NUMBER: ${{ secrets.TRADIER_ACCOUNT_NUMBER }}
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
## Summary

Enable multi-broker failover (Alpaca → Tradier) for production resilience.

## Changes

- Set `ENABLE_BROKER_FAILOVER=true` in execute-trading job
- Add `TRADIER_API_KEY` and `TRADIER_ACCOUNT_NUMBER` from secrets

## Why This Matters

This ensures trades automatically failover to Tradier if Alpaca is unavailable, providing **true redundancy** across different clearing infrastructures.

## Requirements

⚠️ **Add these secrets to GitHub repository settings:**
- `TRADIER_API_KEY`
- `TRADIER_ACCOUNT_NUMBER`

Without these, failover will still work - it just wont have Tradier as a backup.

## Test Plan

- [x] Workflow syntax validated