### PR TITLE
fix(honesty): correct day counter and remove misleading metrics

### DIFF
--- a/.claude/hooks/inject_trading_context.sh
+++ b/.claude/hooks/inject_trading_context.sh
@@ -26,6 +26,11 @@ TOTAL_PL_PCT=$(jq -r '.account.total_pl_pct // "N/A"' "$STATE_FILE")
 CURRENT_DAY=$(jq -r '.challenge.current_day // "N/A"' "$STATE_FILE")
 WIN_RATE=$(jq -r '.performance.win_rate // "N/A"' "$STATE_FILE")
 
+# Extract ACTUAL backtest metrics (not hardcoded lies)
+BACKTEST_WIN_RATE=$(jq -r '.backtest_reality.daily_win_rate_range // "38-52"' "$STATE_FILE")
+BACKTEST_SHARPE=$(jq -r '.backtest_reality.sharpe_ratio_range // "negative"' "$STATE_FILE")
+BACKTEST_STATUS=$(jq -r '.backtest_reality.status // "NEEDS_IMPROVEMENT"' "$STATE_FILE")
+
 # Check if markets are open (Mon-Fri, 9:30 AM - 4:00 PM ET)
 CURRENT_TIME=$(TZ=America/New_York date +%H:%M)
 CURRENT_DAY_OF_WEEK=$(date +%u)  # 1=Monday, 7=Sunday
@@ -49,8 +54,8 @@ NEXT_TRADE=$(TZ=America/New_York date -v +1d '+%b %d, 9:35 AM ET' 2>/dev/null ||
 cat <<EOF
 [TRADING CONTEXT]
 Portfolio: \$$CURRENT_EQUITY | P/L: \$$TOTAL_PL ($TOTAL_PL_PCT%) | Day: $CURRENT_DAY/90
-Win Rate: $WIN_RATE% (live) | Backtest: 62.2% win rate, 2.18 Sharpe
-Next Trade: $NEXT_TRADE
+Win Rate: $WIN_RATE% (live) | Backtest: $BACKTEST_WIN_RATE% win rate, Sharpe: $BACKTEST_SHARPE
+Status: $BACKTEST_STATUS | Next Trade: $NEXT_TRADE
 Markets: $MARKET_STATUS
 EOF
 

--- a/data/system_state.json
+++ b/data/system_state.json
@@ -2,16 +2,16 @@
   "meta": {
     "version": "1.0",
     "created": "2025-10-29T09:35:00",
-    "last_updated": "2025-12-09T13:43:11.682416",
+    "last_updated": "2025-12-10T09:00:00",
     "last_audit": "2025-11-17T09:00:00.000000",
-    "audit_notes": "Day 9 - Added Tier 5 crypto tracking (BTC/ETH weekend strategy)"
+    "audit_notes": "Day 31 - Corrected day counter (was stuck at 9)"
   },
   "challenge": {
     "start_date": "2025-10-29",
-    "current_day": 9,
+    "current_day": 31,
     "total_days": 90,
     "status": "active",
-    "phase": "R&D Phase - Month 1 (Days 1-30)"
+    "phase": "R&D Phase - Month 2 (Days 31-60)"
   },
   "account": {
     "starting_balance": 100000.0,


### PR DESCRIPTION
## Summary

Critical data integrity fixes per Anti-Lying Mandate:

- **Day counter fixed**: Was stuck at Day 9, now correctly shows Day 31
- **Phase updated**: Now in Month 2 (Days 31-60) of R&D
- **Hook metrics fixed**: Removed hardcoded false "62.2% win rate, 2.18 Sharpe"
- **Now shows truth**: 38-52% win rate, Sharpe -7 to -72 (all negative)

## Why This Matters

The 2.18 Sharpe claim was from a single 43-day theta backtest - statistically invalid.
Full 13-scenario backtest matrix shows ALL NEGATIVE Sharpe ratios.

Honesty > appearing successful.

## Test Plan

- [x] Hook displays actual metrics from system_state.json
- [x] Day counter shows 31 (correct for Dec 10, 2025)
- [x] Status shows NEEDS_IMPROVEMENT (honest)