### PR TITLE
fix(crypto): enable 24/7 weekend trading with 4x daily executions

### DIFF
--- a/.github/workflows/weekend-crypto-trading.yml
+++ b/.github/workflows/weekend-crypto-trading.yml
@@ -2,12 +2,24 @@ name: Weekend Crypto Trading
 
 on:
   schedule:
-    # Run on Saturdays and Sundays at 10:00 AM Eastern
-    # IMPORTANT: Update cron expression when DST changes (March/November)
-    # EST (Nov-Mar): UTC-5 -> 10:00 AM ET = 15:00 UTC
-    # EDT (Mar-Nov): UTC-4 -> 10:00 AM ET = 14:00 UTC
-    # Run: python3 scripts/get_utc_time.py 10 0 0,6
-    - cron: '0 15 * * 0,6'   # 10:00 AM Eastern (EST: Nov-Mar, update to 14:00 UTC in March)
+    # Run on Saturdays and Sundays MULTIPLE TIMES per day for 24/7 crypto coverage
+    # Crypto trades 24/7 - running once/day misses most moves
+    #
+    # Schedule: 6 AM, 12 PM, 6 PM, 12 AM Eastern (every 6 hours)
+    # IMPORTANT: Update cron expressions when DST changes (March/November)
+    # EST (Nov-Mar): UTC-5 | EDT (Mar-Nov): UTC-4
+    #
+    # Current times (EST - Dec 2025):
+    # - 6:00 AM ET = 11:00 UTC
+    # - 12:00 PM ET = 17:00 UTC
+    # - 6:00 PM ET = 23:00 UTC
+    # - 12:00 AM ET = 05:00 UTC (next day)
+    #
+    # Run: python3 scripts/get_utc_time.py <hour> 0 0,6
+    - cron: '0 5 * * 0,6'    # 12:00 AM Eastern (midnight)
+    - cron: '0 11 * * 0,6'   # 6:00 AM Eastern (pre-Asia close)
+    - cron: '0 17 * * 0,6'   # 12:00 PM Eastern (US session)
+    - cron: '0 23 * * 0,6'   # 6:00 PM Eastern (post-US, pre-Asia)
   workflow_dispatch:
     inputs:
       force_trade:

--- a/scripts/check_duplicate_execution.py
+++ b/scripts/check_duplicate_execution.py
@@ -1,10 +1,11 @@
 #!/usr/bin/env python3
 """
-Check if trading has already been executed today.
+Check if trading has already been executed recently.
 
 This script checks the system_state.json file to determine if trading
-has already been executed today. It writes the result to GitHub Actions
-output file for conditional workflow execution.
+has already been executed. For stock trading (weekdays), it checks once per day.
+For crypto trading (weekends/24-7), it allows multiple executions per day
+with a minimum gap of 4 hours.
 
 Exit codes:
     0: Success (skip=true or skip=false determined)
@@ -14,7 +15,12 @@ Exit codes:
 import json
 import os
 import sys
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
+
+
+def is_weekend() -> bool:
+    """Check if today is Saturday or Sunday."""
+    return datetime.now().weekday() in [5, 6]  # Saturday=5, Sunday=6
 
 
 def main():
@@ -22,13 +28,19 @@ def main():
     skip = False
     reason = ""
 
-    today = datetime.now(timezone.utc).date()
+    now = datetime.now(timezone.utc)
+    today = now.date()
     force_trade = os.getenv("FORCE_TRADE", "").strip().lower() in {
         "1",
         "true",
         "yes",
         "force",
     }
+
+    # Crypto trades every 4-6 hours on weekends; stocks trade once per day
+    # Minimum gap between executions (in hours)
+    crypto_mode = is_weekend() or os.getenv("ENABLE_CRYPTO_AGENT", "").lower() in {"1", "true"}
+    min_gap_hours = 4 if crypto_mode else 24  # 4 hours for crypto, 24 for stocks
 
     if os.path.exists(state_path):
         try:
@@ -43,14 +55,33 @@ def main():
                         last_dt = datetime.fromisoformat(last_updated.replace("Z", "+00:00"))
                     else:
                         last_dt = datetime.strptime(last_updated, "%Y-%m-%d %H:%M:%S")
+                        last_dt = last_dt.replace(tzinfo=timezone.utc)
 
-                    if last_dt.date() == today:
-                        skip = True
-                        reason = f"Trading already executed today at {last_dt.isoformat()}"
+                    hours_since_last = (now - last_dt).total_seconds() / 3600
+
+                    if crypto_mode:
+                        # Crypto: Allow multiple executions per day with 4-hour minimum gap
+                        if hours_since_last < min_gap_hours:
+                            skip = True
+                            reason = (
+                                f"Crypto executed {hours_since_last:.1f}h ago "
+                                f"(min gap: {min_gap_hours}h). Next run allowed in "
+                                f"{(min_gap_hours - hours_since_last):.1f}h"
+                            )
+                        else:
+                            reason = (
+                                f"Crypto: {hours_since_last:.1f}h since last execution "
+                                f"(>{min_gap_hours}h), proceeding with trade"
+                            )
                     else:
-                        reason = (
-                            f"Last execution was {last_dt.date()}, proceeding with today's trade"
-                        )
+                        # Stocks: Once per day
+                        if last_dt.date() == today:
+                            skip = True
+                            reason = f"Trading already executed today at {last_dt.isoformat()}"
+                        else:
+                            reason = (
+                                f"Last execution was {last_dt.date()}, proceeding with today's trade"
+                            )
                 except ValueError as e:
                     reason = f"Could not parse last_updated timestamp: {e}"
         except json.JSONDecodeError as e:
@@ -66,7 +97,10 @@ def main():
         skip = False
         reason = "Forced execution requested via FORCE_TRADE flag"
     elif not skip and not reason:
-        reason = "No previous execution recorded for today"
+        reason = "No previous execution recorded"
+
+    # Log mode for debugging
+    print(f"Mode: {'CRYPTO (4h gap)' if crypto_mode else 'STOCK (daily)'}")
 
     # Write to GitHub Actions output file
     output_path = os.environ.get("GITHUB_OUTPUT")

--- a/src/strategies/crypto_strategy.py
+++ b/src/strategies/crypto_strategy.py
@@ -133,10 +133,18 @@ class CryptoStrategy:
     RSI_OVERSOLD = 40  # Tighter than stocks (30)
     RSI_OVERBOUGHT = 60  # Tighter than stocks (70)
 
-    # MACD parameters
-    MACD_FAST_PERIOD = 12
-    MACD_SLOW_PERIOD = 26
-    MACD_SIGNAL_PERIOD = 9
+    # MACD parameters - OPTIMIZED FOR CRYPTO 24/7 TRADING
+    # Stock defaults (12, 26, 9) lag by ~4x in crypto because:
+    # - Stocks: "Daily candle" = 6.5 hours of trading
+    # - Crypto: "Daily candle" = 24 hours of trading
+    #
+    # Faster settings (8, 17, 6) are better for crypto:
+    # - Responds faster to momentum shifts
+    # - Better suited for 24/7 volatile markets
+    # - Can be overridden via env vars for A/B testing
+    MACD_FAST_PERIOD = int(os.getenv("CRYPTO_MACD_FAST", "8"))  # Default: 8 (was 12)
+    MACD_SLOW_PERIOD = int(os.getenv("CRYPTO_MACD_SLOW", "17"))  # Default: 17 (was 26)
+    MACD_SIGNAL_PERIOD = int(os.getenv("CRYPTO_MACD_SIGNAL", "6"))  # Default: 6 (was 9)
 
     # Risk parameters (adapted for crypto)
     DEFAULT_STOP_LOSS_PCT = 0.07  # 7% (wider than stocks' 3-5%)


### PR DESCRIPTION
## Summary

- **Weekend workflow**: Now runs 4x/day (every 6 hours) instead of 1x/day
- **Duplicate check**: Allows 4-hour gap for crypto (was blocking all re-runs)
- **MACD parameters**: Optimized for crypto (8,17,6) vs stock defaults (12,26,9)

## Test plan

- [ ] Verify workflow triggers on weekend at all 4 times
- [ ] Confirm crypto trades execute without duplicate-skip
- [ ] Monitor MACD signals for improved responsiveness