### PR TITLE
fix(options): create logs/data directories before logging config

### DIFF
--- a/scripts/execute_options_trade.py
+++ b/scripts/execute_options_trade.py
@@ -31,6 +31,10 @@ from pathlib import Path
 project_root = Path(__file__).parent.parent
 sys.path.insert(0, str(project_root))
 
+# Ensure directories exist BEFORE configuring logging
+Path("logs").mkdir(exist_ok=True)
+Path("data").mkdir(exist_ok=True)
+
 # Configure logging
 logging.basicConfig(
     level=logging.INFO,
@@ -325,9 +329,6 @@ def main():
     logger.info(f"   Symbol: {args.symbol}")
     logger.info(f"   Dry Run: {args.dry_run}")
     logger.info("")
-
-    # Ensure logs directory exists
-    Path("logs").mkdir(exist_ok=True)
 
     try:
         trading_client, options_client = get_alpaca_clients()


### PR DESCRIPTION
## Summary
- Moved mkdir calls to top of script (before logging.basicConfig)
- Fixes FileNotFoundError when workflow runs on fresh runner
- Removes redundant mkdir call in main()

## Test Plan
- Re-run options-trading.yml workflow after merge