### PR TITLE
fix(workflows): ensure trading data persists to repo after execution

### DIFF
--- a/.github/workflows/daily-trading.yml
+++ b/.github/workflows/daily-trading.yml
@@ -700,19 +700,42 @@ jobs:
         id: check_state_changes
         if: steps.check_execution.outputs.skip != 'true'
         run: |
-          echo "🔍 Checking for system_state.json updates..."
+          echo "🔍 Checking for trading data updates..."
 
-          # Check if system_state.json changed during execution
-          if git diff --quiet data/system_state.json; then
-            echo "state_changed=false" >> $GITHUB_OUTPUT
-            echo "📋 No changes to system state"
-          else
+          CHANGES_FOUND=false
+
+          # Check if system_state.json changed
+          if ! git diff --quiet data/system_state.json 2>/dev/null; then
+            echo "  ✓ system_state.json changed"
+            CHANGES_FOUND=true
+          fi
+
+          # Check if performance_log.json changed
+          if ! git diff --quiet data/performance_log.json 2>/dev/null; then
+            echo "  ✓ performance_log.json changed"
+            CHANGES_FOUND=true
+          fi
+
+          # Check for NEW or modified trade files (untracked or modified)
+          if git status --short data/trades_*.json 2>/dev/null | grep -q .; then
+            echo "  ✓ Trade files detected"
+            CHANGES_FOUND=true
+          fi
+
+          # Check for any untracked files in data/ directory
+          if git status --short data/ 2>/dev/null | grep -q "^??"; then
+            echo "  ✓ New data files detected"
+            CHANGES_FOUND=true
+          fi
+
+          if [ "$CHANGES_FOUND" = "true" ]; then
             echo "state_changed=true" >> $GITHUB_OUTPUT
-            echo "✅ System state updated after trading"
-
-            # Show summary of changes
-            echo "Changes detected:"
-            git diff --stat data/system_state.json
+            echo "✅ Trading data updates detected"
+            echo "Changes summary:"
+            git status --short data/ 2>/dev/null || true
+          else
+            echo "state_changed=false" >> $GITHUB_OUTPUT
+            echo "📋 No trading data changes detected"
           fi
 
       - name: Commit system state updates
@@ -734,9 +757,15 @@ jobs:
           }
 
           # Stage all trading data files (system state, trades, performance log)
-          git add data/system_state.json
+          git add data/system_state.json 2>/dev/null || true
           git add data/performance_log.json 2>/dev/null || true
           git add data/trades_*.json 2>/dev/null || true
+          git add data/trades/*.json 2>/dev/null || true
+          git add data/last_run_status.json 2>/dev/null || true
+
+          # Show what's being committed
+          echo "📋 Files staged for commit:"
+          git diff --cached --name-only
 
           # Commit with descriptive message
           git commit -m "chore: Update trading data after execution (${{ github.run_id }})" || {

--- a/.github/workflows/dashboard-auto-update.yml
+++ b/.github/workflows/dashboard-auto-update.yml
@@ -62,6 +62,39 @@ jobs:
           echo "🧠 Generating RAG Knowledge Base wiki..."
           python3 scripts/generate_rag_wiki.py || echo "⚠️ RAG wiki generation failed (non-fatal)"
 
+      - name: Commit performance data to main repo
+        continue-on-error: true
+        run: |
+          echo "💾 Committing updated performance data to main repo..."
+
+          git config user.name "GitHub Actions Bot"
+          git config user.email "actions@github.com"
+
+          # Stage performance data files
+          git add data/performance_log.json 2>/dev/null || true
+          git add wiki/Progress-Dashboard.md 2>/dev/null || true
+
+          # Check if there are changes to commit
+          if ! git diff --cached --quiet; then
+            echo "✅ Performance data updated, committing..."
+
+            git commit -m "chore: Update performance data - $(date -u +'%Y-%m-%d %H:%M:%S UTC')" || {
+              echo "::warning::Commit failed (may already be committed)"
+              exit 0
+            }
+
+            # Pull latest and push with retry
+            git pull --rebase origin main || true
+            git push origin main || {
+              echo "::warning::Push failed - will retry on next run"
+              exit 0
+            }
+
+            echo "✅ Performance data committed to main repo"
+          else
+            echo "ℹ️  No performance data changes to commit"
+          fi
+
       - name: Update GitHub Wiki
         env:
           GH_TOKEN: ${{ secrets.PAT_TOKEN }}

--- a/rag_knowledge/chunks/lessons_learned_2025.json
+++ b/rag_knowledge/chunks/lessons_learned_2025.json
@@ -73,6 +73,24 @@
         ".github/workflows/options-trading.yml"
       ],
       "embedding_text": "sandbox network proxy restrictions 403 forbidden cannot call external APIs locally. All trading via GitHub Actions CI/CD. Use workflow_dispatch to trigger manual trades. Local is development only."
+    },
+    {
+      "id": "ll_005_workflow_data_persistence",
+      "title": "GitHub Actions Must Commit Updated Data Files Back to Repo",
+      "source": "CTO Discovery - Dec 10, 2025",
+      "date": "2025-12-10",
+      "category": "infrastructure",
+      "tags": ["github-actions", "data-persistence", "workflows", "dashboard", "stale-data"],
+      "severity": "critical",
+      "content": "Dashboard showed stale Dec 9 data despite workflow running successfully. Root cause: dashboard-auto-update.yml fetched fresh Alpaca data and generated dashboard BUT never committed the updated performance_log.json back to the repo. The file was updated locally in the workflow runner but lost when workflow completed. Similarly, daily-trading.yml only checked system_state.json changes, missing new trade files in data/trades/.",
+      "key_insight": "Any workflow that updates data files must explicitly git add + git commit + git push those files back to the repo, otherwise changes are lost when workflow runner terminates.",
+      "solution": "Added 'Commit performance data to main repo' step in dashboard-auto-update.yml. Enhanced 'Check for state changes' in daily-trading.yml to detect new trade files, not just system_state.json changes. Both fixes ensure data persists across workflow runs.",
+      "our_implementation": "dashboard-auto-update.yml now commits performance_log.json before wiki update. daily-trading.yml checks all data/* files for changes including untracked trade files.",
+      "referenced_files": [
+        ".github/workflows/dashboard-auto-update.yml",
+        ".github/workflows/daily-trading.yml"
+      ],
+      "embedding_text": "GitHub Actions workflow data persistence commit push files stale dashboard. Workflows must git add commit push updated data files or changes are lost. performance_log.json trades_*.json system_state.json must be committed back to repo after update."
     }
   ]
 }


### PR DESCRIPTION
## Summary

**CRITICAL FIX**: Dashboard showed stale Dec 9 data because workflows never committed updated data files back to the repo.

### Root Cause
Workflows updated files locally but never pushed to git. When workflow runner terminated, all changes were lost.

### Changes
1. **dashboard-auto-update.yml**: Added "Commit performance data to main repo" step
2. **daily-trading.yml**: Enhanced state change detection to find:
   - system_state.json changes
   - performance_log.json changes
   - New/modified trade files
   - Untracked files in data/
3. **lessons_learned_2025.json**: Added ll_005 documenting this issue

### Result
Dashboard will now show real-time data after each workflow run.

## Test Plan
- [x] Commit changes
- [ ] Trigger dashboard-auto-update workflow
- [ ] Verify performance_log.json is committed to repo
- [ ] Verify dashboard shows current date data