### PR TITLE
feat: add MANDATORY pre-flight protocol to read RAG before claims

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -92,11 +92,40 @@ reports/                 # Daily CEO reports
 | RSI_OVERBOUGHT | 65.0 | Avoid extreme overbought |
 | VOLUME_MIN | 1.0 | Require average+ volume |
 
-## Session Start Protocol
-1. Read `data/system_state.json` for current state
-2. Check user hook for live P/L and portfolio value
-3. Read `claude-progress.txt` for recent work
-4. Check `git log --oneline -10` for recent commits
+## Session Start Protocol (MANDATORY PRE-FLIGHT)
+
+**BEFORE making ANY claims about infrastructure, credentials, or capabilities:**
+
+### Step 1: Read Lessons Learned (CRITICAL)
+```bash
+cat rag_knowledge/chunks/lessons_learned_2025.json | jq '.chunks[] | {id, title, severity}'
+```
+**Why**: Prevents repeating past failures. Check BEFORE claiming anything is broken.
+
+### Step 2: Check System State
+```bash
+cat data/system_state.json | jq '{last_updated, portfolio_value}'
+```
+
+### Step 3: Verify Hook Data
+- Portfolio value from user hook = ground truth
+- If my data conflicts with hook, HOOK IS CORRECT
+
+### Step 4: Check Recent Work
+```bash
+cat claude-progress.txt | tail -20
+git log --oneline -5
+```
+
+### Key Lessons to Remember (from RAG):
+- **ll_003**: Credentials are in GitHub Secrets, NOT local .env
+- **ll_004**: Local sandbox CANNOT call external APIs (proxy blocked)
+- **ll_005**: Workflows must commit data back to repo or it's lost
+- **Trading happens via GitHub Actions**, not local execution
+
+### Anti-Pattern to Avoid:
+❌ `Claim → Fail → Discover truth → Add to RAG`
+✅ `Read RAG → Make informed claim → Execute correctly`
 
 ## Parallel Agent Usage
 Use Task tool with multiple agents for research:

--- a/rag_knowledge/chunks/lessons_learned_2025.json
+++ b/rag_knowledge/chunks/lessons_learned_2025.json
@@ -91,6 +91,24 @@
         ".github/workflows/daily-trading.yml"
       ],
       "embedding_text": "GitHub Actions workflow data persistence commit push files stale dashboard. Workflows must git add commit push updated data files or changes are lost. performance_log.json trades_*.json system_state.json must be committed back to repo after update."
+    },
+    {
+      "id": "ll_006_read_rag_before_claims",
+      "title": "MANDATORY: Read RAG Lessons Before Making Infrastructure Claims",
+      "source": "CEO Directive - Dec 10, 2025",
+      "date": "2025-12-10",
+      "category": "process",
+      "tags": ["rag", "pre-flight", "verification", "anti-pattern", "session-start"],
+      "severity": "critical",
+      "content": "CTO (Claude) repeatedly made false claims about infrastructure (credentials missing, API unreachable, etc.) without first checking the lessons_learned RAG. This caused CEO frustration and wasted time rediscovering known issues. The anti-pattern was: Claim → Fail → Discover → Add to RAG. The correct pattern is: Read RAG → Make informed claim → Execute correctly.",
+      "key_insight": "ALWAYS read rag_knowledge/chunks/lessons_learned_2025.json at session start BEFORE making any claims about infrastructure, credentials, or system capabilities.",
+      "solution": "Added MANDATORY PRE-FLIGHT protocol to CLAUDE.md Session Start Protocol. Step 1 is now: Read lessons_learned_2025.json. Key lessons are summarized inline (ll_003: credentials in GitHub Secrets, ll_004: sandbox can't call APIs, ll_005: workflows must commit data).",
+      "our_implementation": "CLAUDE.md now includes mandatory pre-flight check with specific commands to run before making infrastructure claims.",
+      "referenced_files": [
+        ".claude/CLAUDE.md",
+        "rag_knowledge/chunks/lessons_learned_2025.json"
+      ],
+      "embedding_text": "read RAG lessons learned before making claims session start pre-flight mandatory protocol. Anti-pattern: claim fail discover add. Correct: read RAG first then claim. Check lessons_learned_2025.json before infrastructure claims."
     }
   ]
 }


### PR DESCRIPTION
## Summary

**CEO Directive**: CTO must read RAG lessons BEFORE making infrastructure claims.

### Problem
CTO repeatedly made false claims without checking existing knowledge:
- Claimed credentials missing (they were in GitHub Secrets)
- Tried local API calls (sandbox is blocked)
- Investigated stale dashboard (known persistence issue)

### Solution
Added MANDATORY pre-flight protocol:
1. Read `lessons_learned_2025.json` FIRST
2. Key lessons summarized in CLAUDE.md
3. Anti-pattern documented

### Anti-Pattern
❌ `Claim → Fail → Discover → Add to RAG`
✅ `Read RAG → Make informed claim → Execute correctly`