### PR TITLE
fix(tests): add min_trades to promotion gate test fixture

### DIFF
--- a/tests/fixtures/system_state_sample.json
+++ b/tests/fixtures/system_state_sample.json
@@ -1,6 +1,7 @@
 {
   "performance": {
-    "win_rate": 0.66
+    "win_rate": 0.66,
+    "total_trades": 150
   },
   "heuristics": {
     "sharpe_ratio": 1.82,

--- a/tests/test_promotion_gate.py
+++ b/tests/test_promotion_gate.py
@@ -18,6 +18,7 @@ def base_args() -> Namespace:
         required_sharpe=1.5,
         max_drawdown=10.0,
         min_profitable_days=30,
+        min_trades=100,  # Added Dec 9, 2025 - required for statistical significance check
     )
 
 


### PR DESCRIPTION
Fixes AttributeError: 'Namespace' object has no attribute 'min_trades' in promotion gate tests.