### PR TITLE
feat(crypto): enable daily crypto DCA with FORCE_TRADE

### DIFF
--- a/.github/workflows/daily-trading.yml
+++ b/.github/workflows/daily-trading.yml
@@ -493,6 +493,9 @@ jobs:
           PAPER_TRADING: 'true'
           ENABLE_CRYPTO_AGENT: 'true'
           CRYPTO_DAILY_AMOUNT: ${{ secrets.CRYPTO_DAILY_AMOUNT || '10.00' }}
+          # FORCE_TRADE: Enable daily crypto DCA (bypass momentum filters)
+          # CEO directive Dec 10, 2025: Trade crypto every day, not just when signals align
+          FORCE_TRADE: 'true'
           # TURBO MODE: Enable ADK orchestrator
           ADK_ENABLED: ${{ secrets.ADK_ENABLED || '1' }}
           ADK_BASE_URL: ${{ secrets.ADK_BASE_URL || 'http://127.0.0.1:8080/api' }}


### PR DESCRIPTION
## Summary

CEO directive Dec 10, 2025: Trade crypto every day, not just when momentum signals align.

**Problem**: Weekday crypto trades were blocked by hard filters (MACD, RSI, volume). Result: no crypto trades on Mon-Fri.

**Solution**: Set `FORCE_TRADE=true` in daily-trading.yml to bypass filters for consistent daily DCA execution.

## Schedule After This PR

| Day | Workflow | Crypto Execution |
|-----|----------|------------------|
| Mon-Fri | daily-trading.yml | ✅ 3:55 PM ET (FORCE_TRADE) |
| Sat-Sun | weekend-crypto-trading.yml | ✅ 4x/day (FORCE_TRADE) |

## Test Plan

- [ ] Daily workflow triggers at 3:55 PM ET
- [ ] Crypto trade executes (no filter rejection)
- [ ] Trade recorded in trades_YYYY-MM-DD.json