### PR TITLE
fix(theta): add critical VIX filter and CRYPTO tier

### DIFF
--- a/src/core/alpaca_trader.py
+++ b/src/core/alpaca_trader.py
@@ -101,6 +101,7 @@ class AlpacaTrader:
         "T2_GROWTH": 0.20,  # 20% of daily investment
         "T3_IPO": 0.10,  # 10% of daily investment
         "T4_CROWD": 0.10,  # 10% of daily investment
+        "CRYPTO": 1.00,  # Crypto uses separate $10/day allocation (not from equity budget)
     }
 
     # Safety multiplier: reject orders >10x expected amount


### PR DESCRIPTION
## Summary

Critical safety improvements from CEO audit (Dec 10, 2025):

### Changes

1. **VIX Filter** (`credit_spreads.py`)
   - Added `MIN_VIX = 13.0` threshold
   - Rejects credit spread trades when VIX < 13
   - Prevents picking up pennies in front of steamroller

2. **CRYPTO Tier** (`alpaca_trader.py`)
   - Added `CRYPTO` to `TIER_ALLOCATIONS`
   - Fixes validation fallback issue

### Audit Results

| Component | Status |
|-----------|--------|
| Weekend Guard | Already solid |
| Stop-Loss | 2.0-2.2x credit |
| VIX Filter | **FIXED** |
| CRYPTO Tier | **FIXED** |