### PR TITLE
fix(strategy): disable losing Treasury/REIT, lower equity thresholds

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -57,6 +57,21 @@ MAX_POSITION_SIZE_PCT=10.0
 MAX_DRAWDOWN_PCT=10.0
 STOP_LOSS_PCT=5.0
 
+# ============================================================
+# STRATEGY ALLOCATION (Dec 10, 2025)
+# Control which strategies receive capital allocation
+# ============================================================
+TREASURY_ALLOCATION_PCT=0.0       # Treasury ladder (SHY/IEF/TLT) - disabled in bond bear market
+REIT_ALLOCATION_PCT=0.0           # REIT income strategy - disabled until rates stabilize
+
+# ============================================================
+# TRADING GATE THRESHOLDS
+# Lower values = more trades allowed through funnel
+# ============================================================
+RL_CONFIDENCE_THRESHOLD=0.30      # RL filter confidence (default was 0.45)
+MOMENTUM_MIN_SCORE=-0.05          # Minimum momentum score (allow slight negative)
+LLM_NEGATIVE_SENTIMENT_THRESHOLD=-0.3  # Sentiment filter threshold
+
 # Order Execution
 USE_LIMIT_ORDERS=true
 LIMIT_ORDER_BUFFER_PCT=0.1

--- a/.github/workflows/daily-trading.yml
+++ b/.github/workflows/daily-trading.yml
@@ -169,6 +169,17 @@ jobs:
       ENABLE_BROKER_FAILOVER: 'true'
       TRADIER_API_KEY: ${{ secrets.TRADIER_API_KEY }}
       TRADIER_ACCOUNT_NUMBER: ${{ secrets.TRADIER_ACCOUNT_NUMBER }}
+      # ============================================================
+      # STRATEGY ALLOCATION FIX (Dec 10, 2025)
+      # Problem: System was only trading Treasuries (SHY/IEF/TLT) during
+      # a bond bear market, resulting in negative Sharpe (-7 to -2086).
+      # Fix: Disable losing strategies, lower thresholds for equity trades.
+      # ============================================================
+      TREASURY_ALLOCATION_PCT: '0.0'      # Disable treasury ladder (bond bear market)
+      REIT_ALLOCATION_PCT: '0.0'          # Disable REITs (underperforming)
+      RL_CONFIDENCE_THRESHOLD: '0.30'     # Lower from 0.45 to allow more equity trades
+      MOMENTUM_MIN_SCORE: '-0.05'         # Allow slight negative momentum
+      LLM_NEGATIVE_SENTIMENT_THRESHOLD: '-0.3'  # More lenient sentiment filter
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
## Problem
System was only trading Treasury ETFs (SHY/IEF/TLT) during a bond bear market, resulting in **negative Sharpe ratios (-7 to -2086)** across all 13 backtest scenarios.

## Root Cause
- Treasury ladder getting 100% of trades
- Equity gates (momentum, RL, sentiment) too restrictive
- Bonds down 15-40% during 2022-2024 rate hikes

## Fix
- `TREASURY_ALLOCATION_PCT=0.0` - disable bonds
- `REIT_ALLOCATION_PCT=0.0` - disable REITs
- `RL_CONFIDENCE_THRESHOLD=0.30` - allow more equity trades
- `MOMENTUM_MIN_SCORE=-0.05` - more lenient
- `LLM_NEGATIVE_SENTIMENT_THRESHOLD=-0.3` - more lenient

## Expected Outcome
System will trade SPY/QQQ (bull market) instead of TLT/IEF/SHY (bear market).