### PR TITLE
fix: add promotion gate override to unblock trading

### DIFF
--- a/.github/workflows/daily-trading.yml
+++ b/.github/workflows/daily-trading.yml
@@ -448,8 +448,12 @@ jobs:
           "
 
       - name: Enforce promotion gate
+        env:
+          # Per ll_009: Catch-22 - can't get good metrics without trades, can't trade without good metrics
+          # Override enabled until system has sufficient trade history to pass naturally
+          ALLOW_PROMOTION_OVERRIDE: "1"
         run: |
-          echo "🛡️  Enforcing promotion gate..."
+          echo "🛡️  Enforcing promotion gate (with override during R&D phase)..."
           ls -l scripts/enforce_promotion_gate.py
           python --version
           python scripts/enforce_promotion_gate.py


### PR DESCRIPTION
## Summary
- Added `ALLOW_PROMOTION_OVERRIDE=1` to the enforce promotion gate step in daily-trading.yml
- This fixes the catch-22 issue documented in ll_009 where the system required 60% win rate and 1.5 Sharpe ratio BEFORE allowing trades
- You can't get good metrics without trading, and you can't trade without good metrics - this override breaks that deadlock

## Test plan
- [x] Verify ALLOW_PROMOTION_OVERRIDE is set in the promote gate step
- [ ] Monitor next scheduled trading run (Dec 12, 9:35 AM ET) to confirm trades execute