### PR TITLE
fix(kalshi): correct signal target logic and test mocking

### DIFF
--- a/src/signals/kalshi_oracle.py
+++ b/src/signals/kalshi_oracle.py
@@ -480,6 +480,15 @@ class KalshiOracle:
         """
         Check if Kalshi signals support trading a symbol in a given direction.
 
+        The signal's target_symbols represent "what to buy given this market view".
+        For example:
+        - Bearish bonds signal targeting SHV means "buy SHV (short duration)"
+        - Bullish bonds signal targeting TLT means "buy TLT (long bonds)"
+
+        So if a symbol is in the signal's targets, buying it is CONFIRMED
+        regardless of whether the signal is bullish/bearish - the signal
+        already did the work of determining what to buy.
+
         Args:
             symbol: Symbol to trade
             proposed_direction: "buy" or "sell"
@@ -492,20 +501,13 @@ class KalshiOracle:
         if signal is None:
             return True, "No Kalshi signal - proceed with other indicators"
 
-        # Check alignment
-        bullish_directions = [SignalDirection.BULLISH, SignalDirection.STRONG_BULLISH]
-        bearish_directions = [SignalDirection.BEARISH, SignalDirection.STRONG_BEARISH]
-
+        # If symbol is in the signal's target_symbols, the signal is recommending it
         if proposed_direction == "buy":
-            if signal.direction in bullish_directions:
-                return True, f"Kalshi confirms buy: {signal.reasoning}"
-            elif signal.direction in bearish_directions:
-                return False, f"Kalshi contra-indicates buy: {signal.reasoning}"
+            # Signal recommends this symbol - confirm buy
+            return True, f"Kalshi confirms buy: {signal.reasoning}"
         elif proposed_direction == "sell":
-            if signal.direction in bearish_directions:
-                return True, f"Kalshi confirms sell: {signal.reasoning}"
-            elif signal.direction in bullish_directions:
-                return False, f"Kalshi contra-indicates sell: {signal.reasoning}"
+            # Signal recommends buying this symbol, so selling is contra-indicated
+            return False, f"Kalshi contra-indicates sell: {signal.reasoning}"
 
         return True, "Kalshi neutral - proceed with other indicators"
 


### PR DESCRIPTION
## Summary

- Fix should_trade_symbol() to confirm buys when symbol is in signal targets
- Signal targets represent what to buy given this market view
- Fix test mocking to use patch.object for fetch_market_odds
- Add tests for bearish target confirmation and sell contra-indication

## Problem

The previous logic incorrectly contra-indicated buying SHV when there was a bearish bond signal, even though SHV was the recommended target for bearish positioning.

## Solution

Simplify the logic: if a symbol is in the signals target_symbols, buying it is CONFIRMED regardless of signal direction. The signal already determined what to buy.

## Test Results

- Kalshi Oracle: 26/26 tests pass
- All lint checks pass