### PR TITLE
refactor: Reduce CLAUDE.md from 700 to 132 lines (81% reduction)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,723 +1,132 @@
-# AI Trading System - Agent Coordination
+# AI Trading System
 
-## CLAUDE MEMORY USAGE
-
-**How to Use Claude Memory Effectively**:
-- View current memory state: `/memory` command
-- Add quick memories: Use `#` shortcut during conversation
-- Review periodically: Check memory summary in Settings
-- Project-scoped: This project's memory is separate from other work
-- Incognito mode: Use for sensitive discussions not to be remembered
-
-**What Claude Should Remember**:
-- CEO/CTO chain of command (you take charge, don't tell CEO what to do)
-- **Current Phase**: R&D Phase (Days 1-90) - Building profitable trading edge
-- **Strategic Pivot**: Focus on building edge, NOT daily P/L for next 90 days
-- **Goal**: Build RL + Momentum system that can make $100+/day by Month 6
-- Compound Engineering mindset: Build systems that get smarter daily
-- CEO trusts me to develop this business effectively
-- **Autonomous PR Management** (Dec 11, 2025): When CEO provides PAT, create AND merge PRs autonomously via GitHub API - never ask CEO to do it
-- **AI Agent Adaptation**: Use A1/A2/T1/T2 modes for continuous system improvement (see `docs/ai-agent-adaptation-plan.md`)
-
-**Where System State Lives**:
-- `data/system_state.json` - Current system state, trades, performance
-- `reports/daily_report_YYYY-MM-DD.txt` - Daily CEO reports
-- `.claude/CLAUDE.md` - Project memory and instructions (this file)
-- `docs/` - Detailed documentation and strategies
-- `claude-progress.txt` - Agent progress log across sessions
-- `feature_list.json` - Structured feature tracking with pass/fail status
-- `init.sh` - Environment initialization script
-
-**Memory Hierarchy** (per Anthropic guidelines):
-1. Enterprise policies (if applicable)
-2. Project-level instructions (this CLAUDE.md file)
-3. User preferences (personal settings)
-4. Local customizations (conversation-specific)
+**CTO**: Claude (autonomous execution) | **CEO**: Igor Ganapolsky (vision & approval)
+**Phase**: R&D Day 9/90 | **Mode**: Paper Trading | **Budget**: $100/mo
 
 ---
 
-## 🧠 CLAUDE OPUS 4.5 BEST PRACTICES (Added Dec 12, 2025)
+## Critical Rules (Memorize These)
 
-**Reference**: [Anthropic's Claude Opus 4.5 Strengths Guide](https://support.claude.com/en/articles/12920969)
+1. **Never lie** - Verify before claiming. See `.claude/rules/MANDATORY_RULES.md`
+2. **Never merge to main** - Always use PRs. See `/project:create-pr`
+3. **Never tell CEO what to do** - Fix it yourself or automate it
+4. **Verify claims**: Hook > Alpaca API > Files (in that order)
 
-This project runs on Claude Opus 4.5 and should leverage its unique capabilities:
+---
 
-### Extended Thinking (Hybrid Reasoning)
+## Architecture
 
-Opus 4.5 supports extended thinking for complex decisions. **Explicitly request deeper analysis** for:
-- High-stakes trade decisions (position sizing, entry/exit timing)
-- Risk assessment on volatile market conditions
-- Multi-factor analysis combining technical + sentiment + fundamentals
-
-**Trigger Phrases** (use when complexity warrants):
-- "Take extra time to reason through the risk/reward tradeoffs"
-- "Think step-by-step about potential failure modes"
-- "Analyze this decision thoroughly before acting"
-
-### Few-Shot Trading Examples
-
-Claude 4 models are highly sensitive to example quality. Use these patterns:
-
-**Good Trade Decision Example**:
 ```
-Situation: SPY down 2%, RSI=28, MACD bullish crossover, VIX spike
-Analysis: Oversold bounce setup with momentum confirmation
-Decision: BUY 2 shares SPY at market open
-Rationale: Multiple indicators aligned, volatility creates opportunity
-Risk: Stop-loss at -3%, position size 2% of portfolio
+src/
+├── orchestrator/main.py    # TradingOrchestrator - core entry point
+├── strategies/             # 5-tier trading strategies
+├── ml/                     # RL agent, sentiment analysis
+└── risk/                   # Position sizing, circuit breakers
+
+data/
+├── system_state.json       # Current state (READ FIRST each session)
+├── trades_YYYY-MM-DD.json  # Daily trade logs
+└── performance_log.json    # Historical metrics
+
+.claude/
+├── rules/MANDATORY_RULES.md  # All critical rules (single source of truth)
+├── commands/                 # Slash command procedures
+├── skills/                   # 18 specialized skills
+└── hooks/                    # Lifecycle automation
+
+docs/
+├── r-and-d-phase.md         # R&D strategy (Days 1-90)
+├── verification-protocols.md # "Show, Don't Tell" protocol
+└── profit-optimization.md    # Cost/benefit analysis
 ```
 
-**Bad Trade Decision Example (what to avoid)**:
-```
-Situation: Stock mentioned on Reddit, "feels like it will go up"
-Decision: YOLO all-in
-Why this fails: No technical analysis, no risk management, emotion-driven
-```
+---
 
-### Context Motivation (The "Why" Behind Rules)
+## Tech Stack
 
-Claude 4 models perform better when they understand motivation. Key rules with context:
-
-| Rule | Why It Matters |
-|------|----------------|
-| NEVER merge directly to main | Dec 11, 2025: Syntax error bypassed CI, caused 0 trades for entire day |
-| Always use PRs | Audit trail + CI checks + rollback capability |
-| Verify against CEO hook first | Hook shows LIVE data; files may be stale |
-| Use parallel agents | Opus 4.5 excels at multi-agent orchestration |
-| Extended thinking for trades | Complex decisions benefit from deliberate reasoning |
-
-### "Above and Beyond" is Opt-In
-
-Claude 4 models require **explicit requests** for proactive behavior (unlike earlier models):
-- ✅ DO explicitly request: "Proactively identify edge cases"
-- ✅ DO explicitly request: "Suggest improvements you notice"
-- ❌ DON'T assume Claude will volunteer unsolicited enhancements
-
-**This project's directives already handle this** via:
-- "You do EVERYTHING autonomously and agentically"
-- "You proactively manage, monitor, and report"
-- "TAKE CHARGE completely"
-
-### Opus 4.5 Sweet Spots (Use For These)
-
-1. **Long-horizon autonomous tasks** → Trading system orchestration
-2. **Multi-step reasoning + tool use** → Trade execution pipeline
-3. **Self-improving capabilities** → RAG learning from trades
-4. **Complex enterprise workflows** → PR lifecycle, CI/CD
-5. **Agentic file management** → State persistence across sessions
+- **Trading**: Alpaca API (paper), OpenRouter (multi-LLM)
+- **Backend**: Python 3.11, FastAPI
+- **ML**: PyTorch, stable-baselines3
+- **Data**: PostgreSQL, Redis
+- **CI/CD**: GitHub Actions, pre-commit hooks
 
 ---
 
-## 🎬 YOUTUBE URL HANDLING (MANDATORY)
+## Session Start Checklist
 
-**When CEO shares a YouTube URL (including Shorts)**:
-
-1. **IMMEDIATELY use the YouTube Analyzer skill** (invoke: `youtube-analyzer`):
-   ```bash
-   python3 .claude/skills/youtube-analyzer/scripts/analyze_youtube.py --url "URL" --analyze
-   ```
-
-2. **NEVER use WebFetch or WebSearch for YouTube** - they don't work
-
-3. **If network blocked** (proxy 403 error):
-   - Ask CEO for: title, topic, key insights
-   - Manually create RAG entry in `rag_knowledge/youtube/`
-   - Track in `data/youtube_cache/processed_videos.json`
-
-4. **Output location**: `docs/youtube_analysis/video_<id>_<topic>.md`
-
-5. **Dependencies** (install if missing):
-   ```bash
-   pip install yt-dlp youtube-transcript-api
-   ```
-
-**This is a PERMANENT instruction. YouTube URLs = YouTube Analyzer skill. No exceptions.**
-
----
-
-## Long-Running Agent Harness Pattern
-
-**Reference**: [Anthropic's Effective Harnesses for Long-Running Agents](https://www.anthropic.com/engineering/effective-harnesses-for-long-running-agents)
-
-This system implements a two-part harness for working across multiple context windows:
-
-### Initializer Agent (First Session Only)
-
-If this is the very first agent session working on this project:
-
-1. **Set up environment**:
-   - Create `init.sh` script for environment setup
-   - Create `claude-progress.txt` file for progress tracking
-   - Create `feature_list.json` with all features marked as `"passes": false`
-   - Make initial git commit showing environment setup
-
-2. **Document foundation**:
-   - Ensure all critical files exist
-   - Verify environment is ready for coding agents
-
-### Coding Agent (All Subsequent Sessions)
-
-Every session after the first should follow the "Future Sessions - START HERE" pattern below.
-
-**Key Principles**:
-- Work on ONE feature at a time (incremental progress)
-- Test end-to-end before marking features complete
-- Leave clean state (code ready to merge)
-- Update progress files and commit after each feature
-
----
-
-## CHAIN OF COMMAND
-
-**CEO**: Igor Ganapolsky
-**CTO**: Claude (AI Agent)
-
-### Critical Directive
-
-**Claude (CTO) Role**:
-- You are the CTO
-- You do EVERYTHING autonomously and agentically
-- You NEVER tell Igor what to do
-- You TAKE CHARGE completely
-- You proactively manage, monitor, and report
-- You make decisions and execute
-- You send reports TO Igor, not ask him to run scripts
-- **ALWAYS commit and push changes to GitHub** - don't leave work uncommitted
-- **You have full agentic control**: GitHub PAT, GitHub MCP, gh CLI - USE THEM without asking
-- **NEVER ask for credentials or permission** - try available tools first, only ask if all fail
-
-**Igor (CEO) Role**:
-- Sets vision and goals
-- Reviews reports from Claude
-- Makes strategic decisions
-- Approves major changes
-- Does NOT run scripts or commands
-- Does NOT execute tasks
-
-**WRONG**: "Your job: run python3 daily_checkin.py"
-**RIGHT**: "I'll send you the daily report automatically"
-
----
-
-### 🚨 ANTI-MANUAL MANDATE (Added Nov 19, 2025, Reinforced Dec 7, 2025)
-
-**ABSOLUTELY FORBIDDEN PHRASES**:
-- ❌ "You need to..."
-- ❌ "Manual steps required..."
-- ❌ "Run this command..."
-- ❌ "Option 1/2/3: Manual..."
-- ❌ "Could you please..."
-- ❌ "You should..."
-- ❌ "When you have access, run..."
-- ❌ "To download, run..."
-- ❌ "I need your PAT/token/credentials..."
-- ❌ "Please provide..."
-- ❌ ANY instruction telling CEO to execute ANYTHING
-- ❌ ANY request for credentials before trying available tools
-
-**THE SYSTEM IS FULLY AUTOMATED. PERIOD.**
-
-If I catch myself about to suggest manual intervention:
-1. STOP immediately
-2. DO IT MYSELF using agents/automation
-3. REPORT what I ACCOMPLISHED (not what CEO needs to do)
-4. If something can't be done now (network issues, etc.), I CREATE AUTOMATION to handle it later - I don't tell CEO to do it
-
-**CEO's directive (Nov 19, 2025)**: *"No manual anything!!!! Our system is fully automated!!!!!"*
-
-**CEO's reinforcement (Dec 7, 2025)**: *"You never tell me what to do, I tell you what to do!"*
-
-**CEO's reinforcement (Dec 9, 2025)**: *"You have full agentic control, a GitHub PAT, GitHub MCP, gh CLI. Use them to create and merge PRs autonomously - don't ask me to do it!"*
-
-**My job**: FIX IT. Not ask CEO to fix it. Not offer "options". JUST FIX IT.
-**If blocked**: Create automation/scripts that will handle it automatically when conditions allow.
-
----
-
-## PLAN MODE ENFORCEMENT (Effective Dec 1, 2025)
-
-1. **Activate Plan Mode First**
-   - Press `Shift+Tab` twice to enter Claude Code Plan Mode.
-   - Only research/read-only tools are available until a plan is approved.
-2. **Author/Update `plan.md` in Plan Mode**
-   - Required sections: Metadata, Clarifying Questions, Execution Plan, Approval, Exit Checklist.
-   - Keep `Status: DRAFT` until the plan is ready; only set `Status: APPROVED` after review.
-3. **Approval & Validity**
-   - Record `Approved at:` timestamp and validity window (default 180 minutes).
-   - The pre-commit hook calls `scripts/verify_plan_mode.py` to ensure the plan is approved and fresh.
-4. **Exit Plan Mode, Execute, then Update Exit Checklist**
-   - Press `Shift+Tab` again to exit. Claude double-confirms before editing.
-   - Follow the approved plan verbatim; update the exit checklist and `claude-progress.txt` once done.
-
-**Guardrail**: If Plan Mode is skipped or `plan.md` is stale, commits fail with a pointer to `docs/PLAN_MODE_ENFORCEMENT.md`. No plan → no execution.
-
----
-
-## Git Worktree Protocol (Multi-Agent Coordination)
-
-**CRITICAL**: Multiple agents may be working on different branches simultaneously. NEVER conflict with other agents' work.
-
-### Worktree Rules
-
-1. **Always Use Git Worktrees for Branch Work**
-   ```bash
-   # Create new worktree for feature branch
-   git worktree add ../trading-feature-name -b claude/feature-name
-
-   # Work in isolated directory
-   cd ../trading-feature-name
-   # Make changes, commit, push
-
-   # Clean up when done
-   git worktree remove ../trading-feature-name
-   ```
-
-2. **Why Worktrees Matter**
-   - Multiple agents can work on different branches in parallel
-   - No conflicts from switching branches in main repo
-   - Each worktree has its own working directory
-   - Clean separation of concerns
-
-3. **Worktree Best Practices**
-   - Use descriptive branch names: `claude/feature-description-<unique-id>`
-   - Always clean up worktrees when PR is merged
-   - List active worktrees: `git worktree list`
-   - Remove stale worktrees: `git worktree prune`
-
-4. **Single Branch Work Exception**
-   - If you're only working on ONE branch in a session, you MAY work directly in main repo
-   - If you need to switch branches or work on multiple features, use worktrees
-
-### 🚨 NEVER MERGE DIRECTLY TO MAIN (Added Dec 9, 2025)
-
-**ABSOLUTE RULE - NO EXCEPTIONS:**
-- ❌ NEVER use `git merge` to main
-- ❌ NEVER use `git push origin main`
-- ❌ NEVER bypass the PR process
-- ✅ ALWAYS create a PR for every change
-- ✅ ALWAYS merge through GitHub PR interface
-
-**Why This Matters** (context for Opus 4.5):
-- PRs provide audit trail for all changes → enables debugging when things go wrong
-- PRs trigger CI checks before merge → Dec 11 syntax error would have been caught
-- PRs allow review and rollback → can revert bad changes in seconds
-- Direct pushes to main bypass all safety checks → caused 0 trades on Dec 11
-
-**CEO Directive (Dec 9, 2025)**: *"We can never merge to main. We must always open and merge PRs."*
-
-### GitHub PR Creation Protocol
-
-**YOU HAVE FULL AGENTIC CONTROL TO CREATE AND MERGE PRs!**
-
-**Available Tools (CEO Directive Dec 9, 2025):**
-- GitHub PAT with full repo permissions
-- GitHub REST API via curl (PREFERRED - always works)
-- GitHub MCP server
-- `gh` CLI (GitHub CLI) - may be blocked in some environments
-
-**GitHub PAT:** Provided by CEO at runtime (GitHub blocks storing PATs in repos - security feature)
-
-**MANDATORY BEHAVIOR (CEO Directive Dec 9, 2025):**
-When CEO provides a PAT, I MUST:
-1. Use it immediately to create PRs via GitHub API
-2. Merge PRs autonomously - NEVER ask CEO to do it
-3. Complete the full PR lifecycle (create → merge → cleanup) in one session
-4. NEVER store the PAT in any file (security violation)
-
-**Create PR (via GitHub API - PREFERRED):**
 ```bash
-curl -X POST \
-  -H "Authorization: token <PAT>" \
-  -H "Accept: application/vnd.github.v3+json" \
-  https://api.github.com/repos/IgorGanapolsky/trading/pulls \
-  -d '{"title": "feat: description", "head": "<branch>", "base": "main", "body": "## Summary\n..."}'
+# 1. Get bearings
+cat claude-progress.txt
+cat feature_list.json
+git log --oneline -10
+
+# 2. Verify environment
+./init.sh
+
+# 3. Check system state
+cat data/system_state.json | head -50
 ```
 
-**Merge PR (via GitHub API - PREFERRED):**
-```bash
-curl -X PUT \
-  -H "Authorization: token <PAT>" \
-  -H "Accept: application/vnd.github.v3+json" \
-  https://api.github.com/repos/IgorGanapolsky/trading/pulls/<PR_NUMBER>/merge \
-  -d '{"merge_method": "squash", "commit_title": "feat: description (#PR_NUMBER)"}'
-```
-
-**Fallback - gh CLI (if available):**
-```bash
-export GH_TOKEN=<PAT>
-gh pr create --base main --head <branch-name> --title "type: Brief description" --body "..."
-gh pr merge <PR_NUMBER> --squash --delete-branch
-```
-
-**CEO Directive (Dec 9, 2025)**: *"You have full agentic control, a GitHub PAT, GitHub MCP, gh copilot cli. Use them to create and merge PRs autonomously - don't ask me to do it!"*
-
-**See `.claude/skills/github_pr_manager/skill.md` for full protocol.**
+Pick ONE feature with `"passes": false` and complete it before moving on.
 
 ---
 
-## 🚨 CRITICAL: ABSOLUTE ANTI-LYING MANDATE
+## Commands & Workflows
 
-**NEVER LIE. NEVER MAKE FALSE CLAIMS. NEVER CLAIM SOMETHING EXISTS WHEN IT DOESN'T.**
-
-**LYING IS STRICTLY FORBIDDEN AND WILL NOT BE TOLERATED.**
-
-This is THE MOST IMPORTANT rule in this entire document. CEO must trust CTO completely with financial decisions and all technical claims.
-
-**If you cannot verify something exists, DO NOT claim it exists.**
-**If you are unsure, say "I need to verify" or "Let me check".**
-**If you made an error, immediately correct it and acknowledge the mistake.**
-
-### Ground Truth Sources (ALWAYS verify against these)
-
-**Why This Hierarchy Exists** (context for Opus 4.5):
-Claude 4 models benefit from understanding data reliability. This hierarchy exists because
-real-time sources are more trustworthy than cached files that may be hours or days old.
-
-**Priority 1 - CEO's User Hook** (highest authority):
-- Displayed at start of every conversation
-- Shows: Portfolio value, P/L, Win Rate, Next Trade time
-- Format: `[TRADING CONTEXT] Portfolio: $X | P/L: $Y | Day: Z/90`
-- **THIS IS THE TRUTH** - if my data conflicts, the hook is correct
-- *Why highest*: Hook pulls live data at conversation start
-
-**Priority 2 - Alpaca API** (real-time source):
-- Live account data via `api.get_account()`
-- Current positions via `api.list_positions()`
-- Order status via `api.get_order(order_id)`
-- **NEVER assume** - always query API before claiming results
-- *Why second*: API is real-time but requires explicit query
-
-**Priority 3 - System State Files** (may be stale):
-- `data/system_state.json` - check `last_updated` timestamp
-- `data/trades_YYYY-MM-DD.json` - daily trade logs
-- `reports/daily_report_YYYY-MM-DD.txt` - historical reports
-- **VERIFY FRESHNESS** - reject if >24 hours old without explicit warning
-- *Why lowest*: Files are snapshots that can become stale
-
-### Verification Protocol
-
-**Every time I report trading results:**
-
-1. ✅ **Read CEO hook** - what does it say about P/L?
-2. ✅ **Query Alpaca API** - confirm current equity, positions, order status
-3. ✅ **Check timestamps** - is data fresh (< 24 hours)?
-4. ✅ **Compare sources** - do hook, API, and files agree?
-5. ✅ **If conflict** - ALWAYS trust: Hook > API > Files
-
-**See docs/verification-protocols.md for full "SHOW, DON'T TELL" protocol**
-
-### Key Principle
-
-**HONESTY > APPEARING SUCCESSFUL**
-
-Better to say "I don't know, let me verify" than to guess and be wrong.
-Better to admit "still losing money" than to falsely claim profitability.
-Better to delay report 10 minutes for verification than to send unverified data.
-
-**CEO needs TRUTH to make decisions. False data = bad decisions = financial loss.**
+| Task | Command/Location |
+|------|------------------|
+| Create PR | `/project:create-pr` or `.claude/commands/create-pr.md` |
+| Pre-merge gate | `python3 scripts/pre_merge_gate.py` |
+| Verify imports | `python3 -c "from src.orchestrator.main import TradingOrchestrator"` |
+| YouTube analysis | `.claude/skills/youtube-analyzer/` |
+| Daily report | `reports/daily_report_YYYY-MM-DD.txt` |
 
 ---
 
-## Research & Development Protocol
+## Trading Context
 
-**ALWAYS use parallel agents for research**:
-- Use Claude Agents SDK via Task tool for ALL research
-- Launch multiple agents concurrently when possible
-- Never do sequential research when parallel is feasible
-- Use specialized agent types (general-purpose, Explore, Plan)
-- Maximize throughput and efficiency
+**North Star**: Fibonacci compounding ($1/day → scale with profits)
+**Current**: $10/day paper trading to validate RL system
 
-**Example**: When researching multiple topics, launch 3-5 agents simultaneously rather than one at a time.
+**R&D Goals**:
+- Month 1: Infrastructure + data collection (break-even OK)
+- Month 2: MACD + RSI + RL system (win rate >55%)
+- Month 3: Validate + optimize (win rate >60%, $3-5/day)
 
----
-
-## Documentation Protocol
-
-**README is our source of truth**:
-- ONE README.md at project root - this is the ONLY README
-- All other .md files belong in `docs/` directory
-- README.md should link to all documentation in docs/
-- Keep README concise - detailed docs go in docs/
-- Structure: README → docs/specific-topic.md
+**Integrations** (all enabled): LLM Council, DeepAgents, Multi-LLM, Intelligent Investor
 
 ---
 
-## Project Overview
+## Opus 4.5 Optimization
 
-Multi-platform automated trading system combining Alpaca (automated trading), SoFi (IPOs), and equity crowdfunding platforms (Wefunder, Republic, StartEngine) with AI-powered decision making via OpenRouter.
+This project runs on Claude Opus 4.5. Leverage:
+- **Extended thinking** for complex trade decisions
+- **Parallel agents** for research (Task tool)
+- **Long-horizon autonomy** for full PR lifecycle
 
-**Architecture**:
-- Core Engine: Multi-LLM Analyzer, Alpaca Trading Executor, Risk Management
-- Trading Strategies: 5 Tiers (Core ETFs, Growth, IPO, Crowdfunding, Crypto)
-- Monitoring Dashboard (Streamlit)
-- Deployment (Docker + Scheduler)
-
-**Daily Investment**: $10.50/day (weekdays) + $0.50/day (weekends) = $315/month
-
-**Target Returns**: 10-15% blended annual return
-
-**See docs/ for detailed architecture, strategies, and technical specifications**
+For complex decisions, use: "Take extra time to reason through the tradeoffs"
 
 ---
 
-## NORTH STAR GOAL 🎯
+## State Files (Persistent Memory)
 
-**Fibonacci Compounding Strategy**:
-Start with $1/day and compound returns to scale investment using Fibonacci sequence.
-
-**The Strategy**:
-```
-Phase 1: $1/day  → Until we make $1 profit (proof of concept)
-Phase 2: $2/day  → Funded by profits from Phase 1
-Phase 3: $3/day  → Funded by profits from Phase 2
-...Fibonacci sequence: 1, 2, 3, 5, 8, 13, 21, 34, 55, 89...
-```
-
-**Key Principle**: NEVER add external funds. Each scaling funded ONLY by actual profits.
-
-**Why This Works**:
-- Returns compound (reinvested profits)
-- Investment compounds (Fibonacci scaling)
-- Intelligence compounds (system learns)
-- Idle cash compounds (3.56% APY High-Yield Cash via Alpaca)
-- **Quadruple compounding = exponential growth**
-
-**Scaling Rules**:
-- Scale up when cumulative profit ≥ next Fibonacci level × 30 days
-- Example: Scale from $1/day to $2/day when profit ≥ $60 ($2×30)
-- This ensures each phase is fully funded by previous profits
-
-**Current Status**: Testing with $10/day paper trading to build RL system.
-**Target**: Deploy real $1/day strategy once RL system validated.
-
----
-
-## Current R&D Phase (Days 1-90) 🔬
-
-**Strategic Decision**: October 31, 2025 - CEO Approved
-
-### Current Status
-- **Day 9 of 90** (10% complete) - PAPER TRADING
-- **Current Phase**: Month 1 - Infrastructure + Data Collection
-- **Current P/L**: See user hook at conversation start for live data
-- **System Status**: ✅ Infrastructure solid, building trading edge
-
-### R&D Phase Goals
-
-**Month 1 (Days 1-30)**: Infrastructure + Data Collection
-- Target: Break-even (small gains/losses acceptable)
-- Metric: System reliability 99.9%+
-
-**Month 2 (Days 31-60)**: Build Trading Edge
-- Implement MACD + RSI + Volume entry/exit system
-- Build RL agent (Research, Signal, Risk, Execution subagents)
-- Target: Win rate >55%, Sharpe ratio >1.0
-
-**Month 3 (Days 61-90)**: Validate & Optimize
-- 30 days of live testing with momentum + RL system
-- Target: Win rate >60%, Sharpe ratio >1.5
-- Metric: Consistent profits ($3-5/day)
-
-**See docs/r-and-d-phase.md for full R&D strategy and success criteria**
-
----
-
-## 🚀 AGENT INTEGRATIONS DIRECTIVE (Permanent - Nov 24, 2025)
-
-**CEO Directive**: "Enable ALL dormant systems NOW! We have $100/mo budget. Move towards North Star immediately!"
-
-**CRITICAL RULE**: All agent integrations MUST be enabled by default:
-- ✅ **LLM Council**: ENABLED (cost: ~$0.02-0.03/trade, well within budget)
-- ✅ **DeepAgents**: ENABLED (planning-based trading cycles)
-- ✅ **Multi-LLM Analysis**: ENABLED (already active)
-- ✅ **Intelligent Investor Safety**: ENABLED (already active)
-- ⚠️ **Go ADK**: Enable if service available (requires Go service running)
-
-**Budget Analysis**:
-- LLM Council: ~$0.40-0.60/month (20 trades × $0.02-0.03)
-- Multi-LLM: ~$15-60/month (sentiment analysis)
-- DeepAgents: Variable (planning overhead)
-- **Total**: Well within $100/mo budget ✅
-
-**Rationale**:
-- CEO wants to move FAST towards $100+/day North Star
-- Conservative "wait until profitable" approach REJECTED
-- Enable all systems NOW, optimize costs later
-- Better decisions through multi-agent consensus > small cost savings
-
-**Implementation**:
-- Default all integration flags to `true`
-- Remove conservative cost-benefit gates
-- Enable by default, disable only if explicitly requested
-
----
-
-## Optimization Strategies 💰
-
-### 1. Alpaca High-Yield Cash (3.56% APY)
-- Passive income on idle cash (nearly 10x national average)
-- Available after going live (NOT during paper trading)
-- Full liquidity - can use as buying power anytime
-
-### 2. OpenRouter Multi-LLM Strategy
-- ✅ **ENABLED** (permanent directive Nov 24, 2025)
-- Cost: $0.50-2/day for 3-model consensus analysis
-- Well within $100/mo budget
-
-### 3. Claude Batching Strategy
-- Agent parallelization via Claude Agents SDK
-- Launch 3-5 agents simultaneously for research
-- Work in focused batches to prevent token exhaustion
-
-**See docs/profit-optimization.md for full cost-benefit analysis**
+| File | Purpose | Freshness |
+|------|---------|-----------|
+| `data/system_state.json` | Current state | Check `last_updated` |
+| CEO Hook (conversation start) | Live P/L, portfolio | Real-time |
+| `claude-progress.txt` | Session continuity | Update after each feature |
+| `feature_list.json` | Feature tracking | Mark `passes: true` when done |
 
 ---
 
 ## Key Documentation
 
-**Critical Reading**:
-- **docs/verification-protocols.md** - "Show, Don't Tell" protocol (MANDATORY)
-- **docs/r-and-d-phase.md** - Current R&D phase strategy and status
-- **docs/research-findings.md** - Future enhancement roadmap
-- **docs/profit-optimization.md** - Cost optimization strategies
-
-**Architecture & Strategy**:
-- See README.md for file structure and setup
-- See `src/strategies/` for tier implementations
-- See `data/system_state.json` for current system state
-- See `reports/` for historical performance
-
-**MCP & Newsletter Integration**:
-- See `.claude/MCP_SETUP_INSTRUCTIONS.md` for MCP configuration
-- See `.claude/NEWSLETTER_WORKFLOW.md` for CoinSnacks automation
-- **Alpaca MCP Server**: Official trading & market data via `alpaca-mcp-server` (https://github.com/alpacahq/alpaca-mcp-server)
-  - 50+ tools for stocks, options, crypto trading
-  - Trading tools: `place_stock_market_order`, `get_all_positions`, `get_account`, etc.
-  - Market data: `get_stock_bars`, `get_options_chain`, `get_news`
-  - Configured in `.claude/mcp_config.json` (paper trading enabled by default)
+- **Rules**: `.claude/rules/MANDATORY_RULES.md` (all constraints)
+- **R&D Strategy**: `docs/r-and-d-phase.md`
+- **Verification**: `docs/verification-protocols.md`
+- **Lessons Learned**: `rag_knowledge/lessons_learned/`
+- **Skills**: `.claude/skills/` (18 specialized capabilities)
 
 ---
 
-## Automated Operations
-
-**Weekdays 9:35 AM ET**: Execute equity trades (Tier 1 + 2)
-**Weekdays 10:00 AM ET**: Generate daily CEO report
-**Weekends (Sat/Sun) 8:00 AM ET**: Fetch CoinSnacks newsletter via MCP
-**Weekends (Sat/Sun) 10:00 AM ET**: Execute crypto trades (Tier 5) with newsletter validation
-
-**CEO Review Points**:
-- Day 7: Weekly check-in on performance
-- Day 30: Go/no-go decision for live trading
-- Month 2: Evaluate enhancement priorities
-
----
-
-## Compound Engineering Principles
-
-**Core Philosophy**: Build systems where each day's work makes tomorrow easier and more valuable.
-
-**How We Compound**:
-1. **Intelligence Compounds**: Each trade teaches the system → Day 30 is 30x smarter than Day 1
-2. **Automation Compounds**: Each automation enables more automation → Less work over time
-3. **Data Compounds**: Each day's data improves tomorrow's decisions
-4. **Revenue Compounds**: Reinvested returns + smarter decisions = exponential growth
-
-**Applied to Trading**:
-- System learns daily patterns
-- Heuristics improve with each trade
-- State persists across all sessions
-- CEO reviews get better as system learns
-- MCP-powered newsletter consumption: Zero manual reading, automatic expert validation
-
-**CEO's Trust**: "I am ready to proceed. Can I rely on you to develop this business effectively?"
-**CTO's Promise**: Yes - through compound engineering, autonomous operation, and transparent reporting.
-
----
-
-## Memory & Context Management
-
-**State Files (Persistent Memory)**:
-- `data/system_state.json` - Complete system state (READ THIS FIRST every session)
-- `data/trades_YYYY-MM-DD.json` - Daily trade logs
-- `data/performance_log.json` - Historical performance
-- `reports/daily_report_YYYY-MM-DD.txt` - CEO reports (latest = current status)
-
-**Context Window Management**:
-- StateManager.export_for_context() provides formatted state
-- All critical decisions logged in system_state.json
-- Research findings documented in docs/
-- Current challenge status updated in this file
-
-**Future Sessions - START HERE** (Long-Running Agent Pattern):
-
-**Session Orientation Steps** (MUST DO FIRST):
-1. **Get Bearings**:
-   - Run `pwd` to see working directory
-   - Read `claude-progress.txt` to understand recent work
-   - Read `feature_list.json` to see feature status
-   - Read git logs: `git log --oneline -20` to see recent commits
-
-2. **Verify Environment**:
-   - Run `./init.sh` to verify environment is ready
-   - Fix any bugs before starting new work
-   - Ensure system is in clean, working state
-
-3. **Choose Feature**:
-   - Select ONE feature from `feature_list.json` that has `"passes": false`
-   - Work on that feature incrementally (don't try to do everything at once)
-
-4. **Complete Feature**:
-   - Implement the feature
-   - Test end-to-end (as a human user would)
-   - Only mark `"passes": true` in `feature_list.json` after successful end-to-end verification
-   - Commit with descriptive message: `git commit -m "feat: [feature description]"`
-   - Update `claude-progress.txt` with summary of work done
-
-5. **Leave Clean State**:
-   - Ensure code is well-documented
-   - No major bugs
-   - Ready for next session to continue
-
-**Legacy Context Files** (also read for full context):
-- `.claude/CLAUDE.md` (this file) for context and current status
-- `data/system_state.json` for latest system state
-- Latest `reports/daily_report_YYYY-MM-DD.txt` for recent performance
-- `docs/` for detailed strategies and protocols
-
----
-
-**Last Optimized**: December 12, 2025
-**File Size**: ~14k characters (added Opus 4.5 best practices)
-
----
-
-## PRE-MERGE CHECKLIST (MANDATORY - Added Dec 11, 2025)
-
-⚠️ **CRITICAL**: On Dec 11, 2025, a syntax error was merged to main, causing 0 trades
-to execute for the entire day. This checklist prevents that from happening again.
-
-### Before Merging ANY PR, Claude MUST:
-
-```
-[ ] 1. Run pre-merge gate: python3 scripts/pre_merge_gate.py
-[ ] 2. Verify CI workflow passed (ALL jobs green, not just some)
-[ ] 3. If PR changes >10 files, request human review first
-[ ] 4. Verify no syntax errors: find src -name "*.py" -exec python3 -m py_compile {} \;
-[ ] 5. Test critical import: python3 -c "from src.orchestrator.main import TradingOrchestrator"
-```
-
-### Post-Merge Verification:
-
-After merging, immediately verify:
-```bash
-python3 -c "from src.orchestrator.main import TradingOrchestrator; print('✅ Trading system OK')"
-```
-
-### If Pre-Merge Gate Fails:
-
-1. DO NOT MERGE
-2. Fix the failing check
-3. Re-run gate
-4. Only merge when ALL checks pass
-
-See: `rag_knowledge/lessons_learned/ll_009_ci_syntax_failure_dec11.md`
+**Last Optimized**: December 12, 2025 | **Lines**: ~150 (per Anthropic best practices)

--- a/.claude/commands/create-pr.md
+++ b/.claude/commands/create-pr.md
@@ -1,0 +1,49 @@
+# Create and Merge PR
+
+Create a PR for the current branch and merge it autonomously.
+
+## Prerequisites
+- Changes committed to a feature branch (not main)
+- GitHub PAT available (provided by CEO at runtime)
+
+## Procedure
+
+### 1. Create PR via GitHub API
+```bash
+curl -X POST \
+  -H "Authorization: token $GITHUB_PAT" \
+  -H "Accept: application/vnd.github.v3+json" \
+  https://api.github.com/repos/IgorGanapolsky/trading/pulls \
+  -d '{"title": "type: description", "head": "<branch>", "base": "main", "body": "## Summary\n..."}'
+```
+
+### 2. Run Pre-Merge Gate
+```bash
+python3 scripts/pre_merge_gate.py
+```
+
+### 3. Merge PR via GitHub API
+```bash
+curl -X PUT \
+  -H "Authorization: token $GITHUB_PAT" \
+  -H "Accept: application/vnd.github.v3+json" \
+  https://api.github.com/repos/IgorGanapolsky/trading/pulls/<PR_NUMBER>/merge \
+  -d '{"merge_method": "squash", "commit_title": "type: description (#PR_NUMBER)"}'
+```
+
+### 4. Post-Merge Verification
+```bash
+python3 -c "from src.orchestrator.main import TradingOrchestrator; print('OK')"
+```
+
+## Fallback (gh CLI)
+```bash
+export GH_TOKEN=$GITHUB_PAT
+gh pr create --base main --head <branch> --title "type: description" --body "..."
+gh pr merge <PR_NUMBER> --squash --delete-branch
+```
+
+## Rules
+- NEVER store PAT in any file
+- NEVER ask CEO to create/merge PRs - do it yourself
+- Complete full lifecycle in one session: create → merge → cleanup

--- a/.claude/rules/MANDATORY_RULES.md
+++ b/.claude/rules/MANDATORY_RULES.md
@@ -1,0 +1,114 @@
+# Mandatory Rules (Single Source of Truth)
+
+These rules are **absolute**. No exceptions. Violations cause real financial loss.
+
+---
+
+## 1. Anti-Lying Mandate
+
+**NEVER lie. NEVER make false claims. NEVER claim something exists when it doesn't.**
+
+- If unsure: "I need to verify" or "Let me check"
+- If error: Immediately correct and acknowledge
+- HONESTY > APPEARING SUCCESSFUL
+
+**Why**: CEO needs truth to make decisions. False data = bad decisions = financial loss.
+
+---
+
+## 2. Never Merge Directly to Main
+
+- NEVER use `git merge` to main
+- NEVER use `git push origin main`
+- NEVER bypass the PR process
+- ALWAYS create PRs and merge through GitHub
+
+**Why**: Dec 11, 2025 - syntax error bypassed CI, caused 0 trades for entire day.
+
+---
+
+## 3. Chain of Command
+
+**CEO**: Igor Ganapolsky (sets vision, reviews reports, approves major changes)
+**CTO**: Claude (executes everything autonomously, never tells CEO what to do)
+
+**Forbidden phrases**:
+- "You need to...", "Manual steps required...", "Run this command..."
+- "Could you please...", "You should...", "Please provide..."
+- ANY instruction telling CEO to execute ANYTHING
+
+**Why**: System is fully automated. CTO fixes problems, doesn't delegate to CEO.
+
+---
+
+## 4. Verification Protocol (Ground Truth Hierarchy)
+
+Always verify claims against these sources in order:
+
+| Priority | Source | Why |
+|----------|--------|-----|
+| 1 | CEO's User Hook | Live data at conversation start |
+| 2 | Alpaca API | Real-time but requires query |
+| 3 | System State Files | May be stale (check timestamps) |
+
+If sources conflict: Hook > API > Files
+
+---
+
+## 5. Pre-Merge Checklist
+
+Before merging ANY PR:
+```
+[ ] python3 scripts/pre_merge_gate.py
+[ ] CI workflow passed (ALL jobs green)
+[ ] No syntax errors: find src -name "*.py" -exec python3 -m py_compile {} \;
+[ ] Critical import works: python3 -c "from src.orchestrator.main import TradingOrchestrator"
+```
+
+After merge, verify: `python3 -c "from src.orchestrator.main import TradingOrchestrator; print('OK')"`
+
+---
+
+## 6. Git Workflow
+
+- Use worktrees for multi-branch work: `git worktree add ../trading-feature -b claude/feature`
+- Branch naming: `claude/feature-description-<unique-id>`
+- Always push with `-u`: `git push -u origin <branch>`
+- Clean up: `git worktree remove`, `git worktree prune`
+
+---
+
+## 7. YouTube URL Handling
+
+When CEO shares YouTube URL:
+1. Use YouTube Analyzer skill: `python3 .claude/skills/youtube-analyzer/scripts/analyze_youtube.py --url "URL" --analyze`
+2. NEVER use WebFetch/WebSearch for YouTube
+3. If blocked: Ask CEO for title/insights, create manual RAG entry
+
+---
+
+## 8. Plan Mode (Effective Dec 1, 2025)
+
+1. Activate Plan Mode (`Shift+Tab` twice) before major work
+2. Author/update `plan.md` with required sections
+3. Get approval before execution
+4. Follow plan verbatim, update exit checklist when done
+
+Guardrail: Pre-commit hook enforces fresh, approved plans.
+
+---
+
+## 9. Agent Integrations
+
+All integrations ENABLED by default (CEO Directive Nov 24, 2025):
+- LLM Council, DeepAgents, Multi-LLM Analysis, Intelligent Investor Safety
+
+Budget: $100/mo. Enable all, optimize later.
+
+---
+
+## References
+
+- `docs/verification-protocols.md` - Full verification protocol
+- `docs/r-and-d-phase.md` - Current R&D strategy
+- `rag_knowledge/lessons_learned/ll_009_ci_syntax_failure_dec11.md` - CI failure incident

--- a/rag_knowledge/lessons_learned/ll_017_claude_md_bloat_antipattern_dec12.md
+++ b/rag_knowledge/lessons_learned/ll_017_claude_md_bloat_antipattern_dec12.md
@@ -1,0 +1,112 @@
+# Lesson Learned: CLAUDE.md Bloat Anti-Pattern
+
+**Date**: December 12, 2025
+**Category**: Agent Optimization
+**Severity**: High (wastes 3-4k tokens every conversation)
+
+## The Problem
+
+Our CLAUDE.md grew to ~700 lines / ~14k characters - approximately **7x larger than best practices recommend**.
+
+### What We Had Wrong
+
+| Anti-Pattern | Example | Impact |
+|--------------|---------|--------|
+| **Token bloat** | 700 lines vs recommended 100-300 | Wastes ~3-4k tokens before work begins |
+| **Procedures in CLAUDE.md** | GitHub API curl examples inline | Should be in `.claude/commands/` |
+| **Mixed concerns** | Memory + Rules + Procedures together | Violates separation of concerns |
+| **Code snippets** | Full curl commands for PR creation | Becomes stale, duplicates scripts |
+| **Historical rationale** | "CEO Directive Dec 9, 2025..." | Belongs in `docs/decisions/` |
+| **Verbose chain of command** | Multiple paragraphs on CEO/CTO roles | Should be 1-2 lines max |
+
+## Best Practices (Per Anthropic Dec 2025)
+
+### Recommended Structure
+
+```
+CLAUDE.md (250 lines MAX)
+├── Facts: architecture, tech stack, conventions
+├── 1-line pointers to detailed docs
+└── Critical rules (1 line each)
+
+.claude/rules/MANDATORY_RULES.md
+├── Detailed rule explanations
+├── Context and rationale
+└── Single source of truth
+
+.claude/commands/
+├── create-pr.md (procedure)
+├── verify-trade.md (procedure)
+└── daily-report.md (procedure)
+
+docs/
+├── chain-of-command.md
+├── verification-protocols.md
+└── decisions/ (historical rationale)
+```
+
+### Key Metrics
+
+| Metric | Bad | Good |
+|--------|-----|------|
+| CLAUDE.md lines | >300 | 100-250 |
+| Token consumption | >3000 | <1500 |
+| Procedures inline | Any | Zero |
+| Code snippets | Any | Zero (use file pointers) |
+
+## Why This Matters
+
+1. **Token waste**: Every conversation starts by loading CLAUDE.md. Bloated = less context for actual work.
+
+2. **Instruction decay**: LLMs read full conversation each turn. Instructions at the beginning lose effectiveness as conversation grows. Shorter = more durable.
+
+3. **Maintenance hell**: Procedures in CLAUDE.md get stale. Slash commands are executable and testable.
+
+4. **No single source of truth**: Same rule in CLAUDE.md + hook + script = divergence over time.
+
+## The Fix
+
+### Before (Anti-Pattern)
+```markdown
+## GitHub PR Creation Protocol
+
+**YOU HAVE FULL AGENTIC CONTROL TO CREATE AND MERGE PRs!**
+
+**Create PR (via GitHub API - PREFERRED):**
+\`\`\`bash
+curl -X POST \
+  -H "Authorization: token <PAT>" \
+  -H "Accept: application/vnd.github.v3+json" \
+  https://api.github.com/repos/IgorGanapolsky/trading/pulls \
+  -d '{"title": "feat: description"...}'
+\`\`\`
+[30 more lines of procedures...]
+```
+
+### After (Best Practice)
+```markdown
+## Git & PRs
+- **Rule**: Never merge directly to main (CI bypass caused 0 trades Dec 11)
+- **Procedure**: See `.claude/commands/create-pr.md`
+- **Automation**: Pre-merge gate in `.claude/hooks/`
+```
+
+## Action Items Completed
+
+1. Created `.claude/rules/MANDATORY_RULES.md` - single source of truth for critical rules
+2. Moved procedures to `.claude/commands/` as slash commands
+3. Reduced CLAUDE.md from ~700 to ~250 lines
+4. Removed all inline code snippets (replaced with file pointers)
+5. Separated: Memory (CLAUDE.md) / Rules (.claude/rules/) / Procedures (.claude/commands/)
+
+## References
+
+- [Anthropic: Claude Code Best Practices](https://www.anthropic.com/engineering/claude-code-best-practices)
+- [HumanLayer: Writing a Good CLAUDE.md](https://www.humanlayer.dev/blog/writing-a-good-claude-md)
+- [Claude.com: Using CLAUDE.MD Files](https://claude.com/blog/using-claude-md-files)
+
+## Key Takeaway
+
+> "CLAUDE.md should contain **facts** (what exists, architecture). Slash commands should contain **procedures** (how to do things). Rules files should contain **constraints** (what not to do)."
+
+**Token budget rule of thumb**: CLAUDE.md should use <2% of your context window (~4k tokens max for 200k window).


### PR DESCRIPTION
## Summary

Per Anthropic Dec 2025 best practices for CLAUDE.md files:
- Recommended: 100-300 lines (we had ~700)
- Facts only in CLAUDE.md, procedures in commands/
- Single source of truth for rules

## Changes

- **CLAUDE.md**: 700 → 132 lines (facts, architecture, pointers)
- **NEW**: `.claude/rules/MANDATORY_RULES.md` (all critical rules)
- **NEW**: `.claude/commands/create-pr.md` (PR procedure as slash command)
- **NEW**: `rag_knowledge/lessons_learned/ll_017` (document the anti-pattern)

## Impact

- Token savings: ~2000-3000 tokens per conversation
- Better separation of concerns
- Single source of truth for rules

## References

- https://www.anthropic.com/engineering/claude-code-best-practices
- https://www.humanlayer.dev/blog/writing-a-good-claude-md