### PR TITLE
feat: Add LangSmith tracing to trading workflows

### DIFF
--- a/.github/workflows/daily-trading.yml
+++ b/.github/workflows/daily-trading.yml
@@ -479,6 +479,10 @@ jobs:
           ALPACA_SECRET_KEY: ${{ secrets.ALPACA_SECRET_KEY }}
           OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
           HELICONE_API_KEY: ${{ secrets.HELICONE_API_KEY }}
+          # LangSmith tracing (observability)
+          LANGCHAIN_API_KEY: ${{ secrets.LANGCHAIN_API_KEY }}
+          LANGCHAIN_PROJECT: 'trading-rl-training'
+          LANGCHAIN_TRACING_V2: 'true'
           ALPHA_VANTAGE_API_KEY: ${{ secrets.ALPHA_VANTAGE_API_KEY }}
           # Phase 1: Polygon.io + Finnhub integration
           POLYGON_API_KEY: ${{ secrets.POLYGON_API_KEY }}

--- a/.github/workflows/weekend-crypto-trading.yml
+++ b/.github/workflows/weekend-crypto-trading.yml
@@ -125,6 +125,10 @@ jobs:
           ALPACA_SECRET_KEY: ${{ secrets.ALPACA_SECRET_KEY }}
           OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
           HELICONE_API_KEY: ${{ secrets.HELICONE_API_KEY }}
+          # LangSmith tracing (observability)
+          LANGCHAIN_API_KEY: ${{ secrets.LANGCHAIN_API_KEY }}
+          LANGCHAIN_PROJECT: 'trading-rl-training'
+          LANGCHAIN_TRACING_V2: 'true'
           ALPHA_VANTAGE_API_KEY: ${{ secrets.ALPHA_VANTAGE_API_KEY }}
           POLYGON_API_KEY: ${{ secrets.POLYGON_API_KEY }}
           FINNHUB_API_KEY: ${{ secrets.FINNHUB_API_KEY }}


### PR DESCRIPTION
## Summary
- Add LANGCHAIN_API_KEY, LANGCHAIN_PROJECT, LANGCHAIN_TRACING_V2 env vars to daily-trading.yml and weekend-crypto-trading.yml
- Fixes missing LangSmith observability - only Helicone was configured

## Required Action
Add GitHub Secret: LANGCHAIN_API_KEY

## Test Plan
- [ ] Verify next trading run shows traces at https://smith.langchain.com
- [ ] Check project trading-rl-training for new runs