### PR TITLE
feat: Add RAG/ML safety tests for workflow observability (ll_017)

### DIFF
--- a/rag_knowledge/lessons_learned/ll_017_missing_langsmith_env_vars_dec12.md
+++ b/rag_knowledge/lessons_learned/ll_017_missing_langsmith_env_vars_dec12.md
@@ -1,0 +1,191 @@
+# Lesson Learned: Missing LangSmith Environment Variables in Workflows (Dec 12, 2025)
+
+**ID**: ll_017
+**Date**: December 12, 2025
+**Severity**: MEDIUM
+**Category**: Observability, CI/CD, Environment Configuration
+**Impact**: No LLM tracing in production, blind to model behavior and costs
+
+## Executive Summary
+
+GitHub Actions workflows had `HELICONE_API_KEY` configured for cost tracking but were missing
+`LANGCHAIN_API_KEY` for LangSmith tracing. This meant all OpenRouter LLM calls were
+executing without detailed observability, making it impossible to debug model behavior,
+track token usage, or identify prompt issues in production.
+
+## The Mistake
+
+### What Happened
+
+| Metric | Value |
+|--------|-------|
+| PR Number | #565 |
+| Affected Workflows | daily-trading.yml, weekend-crypto-trading.yml |
+| Days Without Tracing | Unknown (weeks/months) |
+| Traces Lost | All production LLM calls |
+
+### Root Cause Analysis
+
+1. **Partial Observability Setup**: Only Helicone (cost tracking) was configured, not LangSmith (detailed traces)
+2. **Similar Variable Names**: `LANGCHAIN_ENABLE_MCP` and `LANGCHAIN_MODEL` existed but are NOT tracing vars
+3. **No Verification**: No test to verify observability stack is complete
+4. **Silent Failure**: Missing env vars don't cause errors - they just disable features
+
+### The Configuration Gap
+
+```yaml
+# What we HAD (incomplete):
+HELICONE_API_KEY: ${{ secrets.HELICONE_API_KEY }}  # ✅ Cost tracking
+LANGCHAIN_ENABLE_MCP: ${{ secrets.LANGCHAIN_ENABLE_MCP || 'true' }}  # ❌ Not tracing
+LANGCHAIN_MODEL: ${{ secrets.LANGCHAIN_MODEL || '...' }}  # ❌ Not tracing
+
+# What we NEEDED (complete):
+HELICONE_API_KEY: ${{ secrets.HELICONE_API_KEY }}  # Cost tracking
+LANGCHAIN_API_KEY: ${{ secrets.LANGCHAIN_API_KEY }}  # ✅ Tracing auth
+LANGCHAIN_PROJECT: 'trading-rl-training'  # ✅ Project name
+LANGCHAIN_TRACING_V2: 'true'  # ✅ Enable tracing
+```
+
+## The Fix
+
+### Immediate Actions (Dec 12)
+
+1. **Added LangSmith Env Vars** to both workflows (PR #565):
+   - `LANGCHAIN_API_KEY: ${{ secrets.LANGCHAIN_API_KEY }}`
+   - `LANGCHAIN_PROJECT: 'trading-rl-training'`
+   - `LANGCHAIN_TRACING_V2: 'true'`
+
+2. **Added GitHub Secret**: `LANGCHAIN_API_KEY` with LangSmith API key
+
+3. **Verified Local .env**: Added same vars for local development
+
+### Prevention Rules
+
+#### Rule 1: Observability Stack Checklist
+
+When adding LLM calls, verify ALL observability is configured:
+
+| Component | Env Var | Purpose |
+|-----------|---------|---------|
+| LangSmith Auth | `LANGCHAIN_API_KEY` | API authentication |
+| LangSmith Tracing | `LANGCHAIN_TRACING_V2=true` | Enable trace capture |
+| LangSmith Project | `LANGCHAIN_PROJECT` | Dashboard organization |
+| Helicone Gateway | `HELICONE_API_KEY` | Cost tracking |
+
+#### Rule 2: Workflow Env Var Verification Script
+
+Create automated check that runs in CI:
+
+```python
+def verify_workflow_observability():
+    """Ensure workflows have complete observability config."""
+    required_vars = [
+        'LANGCHAIN_API_KEY',
+        'LANGCHAIN_TRACING_V2',
+        'LANGCHAIN_PROJECT',
+        'HELICONE_API_KEY'
+    ]
+
+    workflows = [
+        '.github/workflows/daily-trading.yml',
+        '.github/workflows/weekend-crypto-trading.yml'
+    ]
+
+    for workflow in workflows:
+        content = Path(workflow).read_text()
+        for var in required_vars:
+            assert var in content, f"Missing {var} in {workflow}"
+```
+
+#### Rule 3: Test Observability in CI
+
+```yaml
+- name: Verify observability stack
+  env:
+    LANGCHAIN_API_KEY: ${{ secrets.LANGCHAIN_API_KEY }}
+  run: |
+    python3 -c "
+    from src.utils.langsmith_wrapper import get_observability_status
+    status = get_observability_status()
+    assert status['langsmith']['enabled'], 'LangSmith not configured!'
+    assert status['helicone']['enabled'], 'Helicone not configured!'
+    print('✅ Observability stack verified')
+    "
+```
+
+## Verification Tests
+
+### Test 1: Workflow Contains Required Env Vars
+```python
+def test_ll_017_workflow_observability_vars():
+    """Ensure trading workflows have all observability env vars."""
+    import yaml
+    from pathlib import Path
+
+    required_vars = ['LANGCHAIN_API_KEY', 'LANGCHAIN_TRACING_V2', 'LANGCHAIN_PROJECT']
+
+    for workflow_file in ['.github/workflows/daily-trading.yml',
+                          '.github/workflows/weekend-crypto-trading.yml']:
+        content = Path(workflow_file).read_text()
+        for var in required_vars:
+            assert var in content, f"REGRESSION ll_017: Missing {var} in {workflow_file}"
+```
+
+### Test 2: LangSmith Wrapper Enables Tracing
+```python
+def test_langsmith_wrapper_enables_tracing():
+    """Verify langsmith wrapper properly configures tracing."""
+    import os
+    os.environ['LANGCHAIN_API_KEY'] = 'test_key'
+
+    from src.utils.langsmith_wrapper import is_langsmith_enabled
+    assert is_langsmith_enabled(), "LangSmith should be enabled when API key is set"
+```
+
+## Metrics to Track
+
+| Metric | Target | Alert Threshold |
+|--------|--------|-----------------|
+| LangSmith traces per day | ≥ 10 | 0 |
+| Trace success rate | 100% | < 95% |
+| Env var coverage | 100% | Any missing |
+
+## Key Quotes
+
+> "Observability that's partially configured is invisibility."
+
+> "Similar variable names (`LANGCHAIN_*`) don't mean similar purposes."
+
+> "If you can't see what your LLMs are doing, you can't improve them."
+
+## Integration with ML Pipeline
+
+### 1. RAG Pattern Detection
+Add pattern to detect incomplete observability setups:
+- Search for `HELICONE_API_KEY` without `LANGCHAIN_API_KEY`
+- Flag workflows missing any observability var
+
+### 2. Automated Audits
+Weekly script to verify all secrets are configured:
+```python
+required_secrets = [
+    'LANGCHAIN_API_KEY',
+    'HELICONE_API_KEY',
+    'OPENROUTER_API_KEY'
+]
+# Check via GitHub API
+```
+
+## Related Lessons
+
+- `ll_009_ci_syntax_failure_dec11.md` - CI gaps allowing bad merges
+- `ll_010_dead_code_and_dormant_systems_dec11.md` - Unconfigured systems
+
+## Tags
+
+#observability #langsmith #helicone #env-vars #ci #workflows #configuration #tracing #llm
+
+## Change Log
+
+- 2025-12-12: Initial incident discovered and fixed (PR #565)
+- 2025-12-12: Added to RAG knowledge base

--- a/scripts/verify_workflow_observability.py
+++ b/scripts/verify_workflow_observability.py
@@ -1,0 +1,184 @@
+#!/usr/bin/env python3
+"""
+Verify Workflow Secrets Configuration
+
+This script checks that all GitHub Actions workflows that make LLM calls
+have the complete observability stack configured:
+- LangSmith tracing (LANGCHAIN_API_KEY, LANGCHAIN_TRACING_V2, LANGCHAIN_PROJECT)
+- Helicone cost tracking (HELICONE_API_KEY)
+- OpenRouter API (OPENROUTER_API_KEY)
+
+Lesson Learned: ll_017 - Missing LangSmith env vars caused blind production runs.
+
+Usage:
+    python scripts/verify_workflow_secrets.py
+    python scripts/verify_workflow_secrets.py --fix  # Show what needs to be added
+
+Exit codes:
+    0 - All workflows properly configured
+    1 - Missing configuration found
+"""
+
+import argparse
+import sys
+from pathlib import Path
+
+
+# Workflows that make LLM calls
+LLM_WORKFLOWS = [
+    ".github/workflows/daily-trading.yml",
+    ".github/workflows/weekend-crypto-trading.yml",
+    ".github/workflows/combined-trading.yml",
+]
+
+# Complete observability stack requirements
+OBSERVABILITY_VARS = {
+    "langsmith": {
+        "vars": [
+            "LANGCHAIN_API_KEY",
+            "LANGCHAIN_TRACING_V2",
+            "LANGCHAIN_PROJECT",
+        ],
+        "description": "LangSmith tracing for LLM debugging",
+    },
+    "helicone": {
+        "vars": ["HELICONE_API_KEY"],
+        "description": "Helicone gateway for cost tracking",
+    },
+    "openrouter": {
+        "vars": ["OPENROUTER_API_KEY"],
+        "description": "OpenRouter API for LLM inference",
+    },
+}
+
+
+def check_workflow(workflow_path: Path) -> dict:
+    """Check a single workflow for required env vars."""
+    if not workflow_path.exists():
+        return {"exists": False, "path": str(workflow_path)}
+
+    content = workflow_path.read_text()
+    results = {
+        "exists": True,
+        "path": str(workflow_path),
+        "missing": {},
+        "present": {},
+    }
+
+    for stack_name, config in OBSERVABILITY_VARS.items():
+        missing = []
+        present = []
+
+        for var in config["vars"]:
+            if var in content:
+                present.append(var)
+            else:
+                missing.append(var)
+
+        if missing:
+            results["missing"][stack_name] = {
+                "vars": missing,
+                "description": config["description"],
+            }
+        if present:
+            results["present"][stack_name] = present
+
+    return results
+
+
+def print_fix_suggestion(missing_stack: str, missing_vars: list) -> str:
+    """Generate YAML snippet to fix missing vars."""
+    suggestions = {
+        "LANGCHAIN_API_KEY": "          LANGCHAIN_API_KEY: ${{ secrets.LANGCHAIN_API_KEY }}",
+        "LANGCHAIN_TRACING_V2": "          LANGCHAIN_TRACING_V2: 'true'",
+        "LANGCHAIN_PROJECT": "          LANGCHAIN_PROJECT: 'trading-rl-training'",
+        "HELICONE_API_KEY": "          HELICONE_API_KEY: ${{ secrets.HELICONE_API_KEY }}",
+        "OPENROUTER_API_KEY": "          OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}",
+    }
+
+    lines = [f"# Add to env: section ({missing_stack})"]
+    for var in missing_vars:
+        if var in suggestions:
+            lines.append(suggestions[var])
+    return "\n".join(lines)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Verify workflow observability config")
+    parser.add_argument(
+        "--fix", action="store_true", help="Show YAML snippets to fix issues"
+    )
+    parser.add_argument(
+        "--ci", action="store_true", help="Exit with code 1 if any issues found"
+    )
+    args = parser.parse_args()
+
+    project_root = Path(__file__).parent.parent
+    all_passed = True
+    total_missing = 0
+
+    print("=" * 60)
+    print("Workflow Observability Verification")
+    print("Lesson Learned: ll_017 - Missing LangSmith env vars")
+    print("=" * 60)
+    print()
+
+    for workflow_rel_path in LLM_WORKFLOWS:
+        workflow_path = project_root / workflow_rel_path
+
+        print(f"Checking: {workflow_rel_path}")
+        result = check_workflow(workflow_path)
+
+        if not result["exists"]:
+            print(f"  ⚠️  File not found (skipping)")
+            print()
+            continue
+
+        if not result["missing"]:
+            print(f"  ✅ All observability vars present")
+            for stack, vars_list in result["present"].items():
+                print(f"     {stack}: {', '.join(vars_list)}")
+        else:
+            all_passed = False
+            print(f"  ❌ Missing configuration:")
+            for stack_name, info in result["missing"].items():
+                print(f"     {stack_name}: {', '.join(info['vars'])}")
+                print(f"        ({info['description']})")
+                total_missing += len(info["vars"])
+
+                if args.fix:
+                    print()
+                    print(f"     FIX: Add to workflow env: section:")
+                    print(print_fix_suggestion(stack_name, info["vars"]))
+
+        print()
+
+    # Summary
+    print("=" * 60)
+    if all_passed:
+        print("✅ All workflows have complete observability configuration!")
+        print()
+        print("Observability stack:")
+        print("  - LangSmith: Detailed LLM tracing and debugging")
+        print("  - Helicone: Cost tracking and analytics")
+        print("  - OpenRouter: Multi-model LLM inference")
+    else:
+        print(f"❌ Found {total_missing} missing env var(s)")
+        print()
+        print("Required GitHub Secrets:")
+        print("  - LANGCHAIN_API_KEY: Get from https://smith.langchain.com/settings")
+        print("  - HELICONE_API_KEY: Get from https://helicone.ai/settings")
+        print("  - OPENROUTER_API_KEY: Get from https://openrouter.ai/keys")
+        print()
+        print("Add secrets at: Settings → Secrets → Actions → New repository secret")
+
+    print("=" * 60)
+
+    if args.ci and not all_passed:
+        sys.exit(1)
+
+    return 0 if all_passed else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_workflow_observability.py
+++ b/tests/test_workflow_observability.py
@@ -1,0 +1,202 @@
+"""
+Test suite for workflow observability configuration.
+
+Ensures all GitHub Actions workflows that make LLM calls have complete
+observability stack configured (LangSmith + Helicone).
+
+Regression tests for ll_017: Missing LangSmith env vars in workflows.
+"""
+
+from pathlib import Path
+
+import pytest
+
+
+class TestWorkflowObservability:
+    """Test that workflows have complete observability configuration."""
+
+    # Workflows that make LLM calls and need full observability
+    LLM_WORKFLOWS = [
+        ".github/workflows/daily-trading.yml",
+        ".github/workflows/weekend-crypto-trading.yml",
+    ]
+
+    # Required env vars for LangSmith tracing
+    LANGSMITH_REQUIRED_VARS = [
+        "LANGCHAIN_API_KEY",
+        "LANGCHAIN_TRACING_V2",
+        "LANGCHAIN_PROJECT",
+    ]
+
+    # Required env vars for Helicone cost tracking
+    HELICONE_REQUIRED_VARS = [
+        "HELICONE_API_KEY",
+    ]
+
+    @pytest.fixture
+    def project_root(self) -> Path:
+        """Get project root directory."""
+        return Path(__file__).parent.parent
+
+    def test_ll_017_workflows_have_langsmith_vars(self, project_root: Path):
+        """
+        REGRESSION TEST for ll_017: Ensure trading workflows have LangSmith env vars.
+
+        On Dec 12, 2025, we discovered that workflows had HELICONE_API_KEY but
+        were missing LANGCHAIN_API_KEY, causing all production LLM calls to
+        run without tracing.
+        """
+        missing_vars = []
+
+        for workflow_path in self.LLM_WORKFLOWS:
+            full_path = project_root / workflow_path
+            if not full_path.exists():
+                pytest.skip(f"Workflow not found: {workflow_path}")
+
+            content = full_path.read_text()
+
+            for var in self.LANGSMITH_REQUIRED_VARS:
+                if var not in content:
+                    missing_vars.append(f"{workflow_path}: missing {var}")
+
+        assert not missing_vars, (
+            f"REGRESSION ll_017: LangSmith env vars missing from workflows!\n"
+            f"Missing:\n" + "\n".join(f"  - {m}" for m in missing_vars)
+        )
+
+    def test_workflows_have_helicone_vars(self, project_root: Path):
+        """Ensure trading workflows have Helicone cost tracking configured."""
+        missing_vars = []
+
+        for workflow_path in self.LLM_WORKFLOWS:
+            full_path = project_root / workflow_path
+            if not full_path.exists():
+                continue
+
+            content = full_path.read_text()
+
+            for var in self.HELICONE_REQUIRED_VARS:
+                if var not in content:
+                    missing_vars.append(f"{workflow_path}: missing {var}")
+
+        assert not missing_vars, (
+            f"Helicone env vars missing from workflows!\n"
+            f"Missing:\n" + "\n".join(f"  - {m}" for m in missing_vars)
+        )
+
+    def test_workflows_have_openrouter_key(self, project_root: Path):
+        """Ensure trading workflows have OpenRouter API key."""
+        for workflow_path in self.LLM_WORKFLOWS:
+            full_path = project_root / workflow_path
+            if not full_path.exists():
+                continue
+
+            content = full_path.read_text()
+            assert "OPENROUTER_API_KEY" in content, (
+                f"Missing OPENROUTER_API_KEY in {workflow_path}"
+            )
+
+    def test_langsmith_wrapper_configuration(self):
+        """Test that langsmith wrapper properly checks for API key."""
+        import os
+
+        # Backup current value
+        original_key = os.environ.get("LANGCHAIN_API_KEY")
+
+        try:
+            # Test with key set
+            os.environ["LANGCHAIN_API_KEY"] = "test_key_12345"
+
+            # Re-import to pick up new env var
+            import importlib
+
+            from src.utils import langsmith_wrapper
+
+            importlib.reload(langsmith_wrapper)
+
+            # Should be enabled with key present
+            # Note: The actual check happens at module load time
+            assert hasattr(langsmith_wrapper, "LANGSMITH_ENABLED")
+
+        finally:
+            # Restore original
+            if original_key:
+                os.environ["LANGCHAIN_API_KEY"] = original_key
+            elif "LANGCHAIN_API_KEY" in os.environ:
+                del os.environ["LANGCHAIN_API_KEY"]
+
+    def test_observability_status_function_exists(self):
+        """Test that observability status function is available."""
+        from src.utils.langsmith_wrapper import get_observability_status
+
+        status = get_observability_status()
+
+        # Check structure
+        assert "langsmith" in status
+        assert "helicone" in status
+        assert "openrouter" in status
+
+        # Check langsmith fields
+        assert "enabled" in status["langsmith"]
+        assert "project" in status["langsmith"]
+        assert "dashboard" in status["langsmith"]
+
+        # Check helicone fields
+        assert "enabled" in status["helicone"]
+        assert "gateway_url" in status["helicone"]
+
+
+class TestWorkflowSecretReferences:
+    """Test that workflows correctly reference GitHub secrets."""
+
+    def test_secrets_use_correct_syntax(self):
+        """Ensure secrets use ${{ secrets.NAME }} syntax."""
+        project_root = Path(__file__).parent.parent
+
+        for workflow_path in TestWorkflowObservability.LLM_WORKFLOWS:
+            full_path = project_root / workflow_path
+            if not full_path.exists():
+                continue
+
+            content = full_path.read_text()
+
+            # Check for correct secret syntax
+            assert "${{ secrets.LANGCHAIN_API_KEY }}" in content, (
+                f"LANGCHAIN_API_KEY should use secrets syntax in {workflow_path}"
+            )
+
+    def test_no_hardcoded_api_keys(self):
+        """Ensure no hardcoded API keys in workflows."""
+        project_root = Path(__file__).parent.parent
+
+        # Patterns that might indicate hardcoded keys
+        dangerous_patterns = [
+            "sk-",  # OpenAI/OpenRouter key prefix
+            "lsv2_pt_",  # LangSmith key prefix
+            "sk-helicone-",  # Helicone key prefix
+        ]
+
+        for workflow_path in TestWorkflowObservability.LLM_WORKFLOWS:
+            full_path = project_root / workflow_path
+            if not full_path.exists():
+                continue
+
+            content = full_path.read_text()
+
+            for pattern in dangerous_patterns:
+                # Allow if it's in a comment explaining the format
+                lines_with_pattern = [
+                    line
+                    for line in content.split("\n")
+                    if pattern in line and not line.strip().startswith("#")
+                ]
+
+                for line in lines_with_pattern:
+                    # Check if it looks like a real key (has more chars after prefix)
+                    import re
+
+                    if re.search(rf"{pattern}[a-zA-Z0-9]{{10,}}", line):
+                        pytest.fail(
+                            f"Possible hardcoded API key in {workflow_path}: "
+                            f"'{line.strip()[:50]}...'"
+                        )


### PR DESCRIPTION
## Summary
- Add lesson learned ll_017 documenting missing LangSmith env vars issue
- Add test_workflow_observability.py with regression tests
- Add verify_workflow_observability.py script for CI verification

## What This Prevents
Ensures all trading workflows have complete observability stack:
- LangSmith (tracing)
- Helicone (cost tracking)
- OpenRouter (LLM inference)

## Test Plan
- [x] Tests pass locally
- [x] Script runs successfully