### PR TITLE
feat: Add anti-manual mandate verification to CI (LL-017)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -400,3 +400,22 @@ jobs:
           
           print("\n✅ All critical imports successful")
           EOF
+
+  # Added Dec 12, 2025: Anti-Manual Mandate Verification
+  # See: rag_knowledge/lessons_learned/ll_017_anti_manual_violation_dec12.md
+  anti-manual-check:
+    name: Anti-Manual Mandate Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 20  # Check last 20 commits
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Check for Anti-Manual Violations
+        run: |
+          python3 scripts/check_anti_manual_violations.py --check-commits 10 --ci

--- a/rag_knowledge/lessons_learned/ll_017_anti_manual_violation_dec12.md
+++ b/rag_knowledge/lessons_learned/ll_017_anti_manual_violation_dec12.md
@@ -1,0 +1,69 @@
+# Lesson Learned: Anti-Manual Mandate Violation (Dec 12, 2025)
+
+## Incident ID: LL-017
+## Severity: HIGH
+## Category: process_violation
+
+## What Happened
+
+On December 12, 2025, Claude (CTO) violated the Anti-Manual Mandate by telling the CEO to:
+1. "Run migration" with a bash command
+2. "View dashboard" with a streamlit command
+3. "Create PR" manually
+
+This directly contradicts the CLAUDE.md directive: **"You NEVER tell Igor what to do"**
+
+## Root Cause
+
+- Habitual response pattern from training data
+- Forgot to check CLAUDE.md directives before providing "next steps"
+- Did not internalize that ALL actions must be autonomous
+
+## Impact
+
+- CEO had to remind CTO of directives
+- Wasted CEO's time
+- Demonstrated lack of full autonomy
+
+## Prevention Measures
+
+### 1. Pre-Response Checklist (Mental)
+Before providing any response with "next steps":
+- [ ] Am I telling CEO to do something? → DON'T
+- [ ] Can I do this myself? → DO IT
+- [ ] Is this a manual instruction? → AUTOMATE IT
+
+### 2. Forbidden Phrase Detection
+Add to system checks - flag these phrases:
+- "Run this command..."
+- "You can/should..."
+- "Next steps:" (if followed by user actions)
+- "When you have time..."
+- "Please provide..."
+
+### 3. Autonomous Action Protocol
+When completing a task:
+1. DO the action (don't describe it)
+2. REPORT what was accomplished
+3. If blocked, CREATE automation for later
+
+## Correct Behavior
+
+**WRONG**: "Next steps: Run `bash scripts/test_lancedb_migration.sh`"
+
+**RIGHT**: *Actually runs the script and reports results*
+
+**WRONG**: "Create PR when ready"
+
+**RIGHT**: *Creates PR via GitHub API and merges it*
+
+## Verification Test
+
+Add test to CI that scans Claude's responses for forbidden phrases in commit messages and PR descriptions.
+
+## Related Lessons
+- LL-009: CI Syntax Failure (autonomy failure)
+- CLAUDE.md: Anti-Manual Mandate section
+
+## Tags
+`process` `autonomy` `anti-manual` `cto-behavior` `critical`

--- a/scripts/check_anti_manual_violations.py
+++ b/scripts/check_anti_manual_violations.py
@@ -1,0 +1,176 @@
+#!/usr/bin/env python3
+"""
+Anti-Manual Mandate Violation Detector
+
+This script scans Claude's outputs (commit messages, PR descriptions, etc.)
+for forbidden phrases that indicate manual instructions to the CEO.
+
+Per CLAUDE.md directive (Nov 19, 2025): "No manual anything!"
+
+Usage:
+    python scripts/check_anti_manual_violations.py [--file FILE]
+    python scripts/check_anti_manual_violations.py --check-commits N
+"""
+
+import argparse
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+# Forbidden phrases that indicate manual instructions
+FORBIDDEN_PATTERNS = [
+    r"(?i)you need to",
+    r"(?i)you should",
+    r"(?i)you can run",
+    r"(?i)you must",
+    r"(?i)please run",
+    r"(?i)run this command",
+    r"(?i)run the following",
+    r"(?i)execute this",
+    r"(?i)manual steps",
+    r"(?i)manually",
+    r"(?i)when you have time",
+    r"(?i)when you're ready",
+    r"(?i)could you please",
+    r"(?i)i need you to",
+    r"(?i)please provide",
+    r"(?i)your job:",
+    r"(?i)option 1.*option 2.*manual",
+    r"(?i)next steps:.*\n.*run",
+    r"(?i)to do this.*run",
+]
+
+# Allowed contexts (false positive prevention)
+ALLOWED_CONTEXTS = [
+    r"(?i)the system will",
+    r"(?i)ci will",
+    r"(?i)automated",
+    r"(?i)automatically",
+    r"(?i)script runs",
+]
+
+
+def check_text(text: str, source: str = "input") -> list[dict]:
+    """Check text for anti-manual violations."""
+    violations = []
+
+    for pattern in FORBIDDEN_PATTERNS:
+        matches = list(re.finditer(pattern, text))
+        for match in matches:
+            # Check if it's in an allowed context
+            start = max(0, match.start() - 50)
+            end = min(len(text), match.end() + 50)
+            context = text[start:end]
+
+            is_allowed = any(
+                re.search(allowed, context) for allowed in ALLOWED_CONTEXTS
+            )
+
+            if not is_allowed:
+                violations.append(
+                    {
+                        "source": source,
+                        "pattern": pattern,
+                        "match": match.group(),
+                        "context": context.strip(),
+                        "position": match.start(),
+                    }
+                )
+
+    return violations
+
+
+def check_recent_commits(n: int = 10) -> list[dict]:
+    """Check recent N commit messages for violations."""
+    all_violations = []
+
+    try:
+        result = subprocess.run(
+            ["git", "log", f"-{n}", "--format=%H|||%s|||%b"],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+
+        for line in result.stdout.strip().split("\n"):
+            if "|||" not in line:
+                continue
+
+            parts = line.split("|||")
+            if len(parts) >= 2:
+                commit_hash = parts[0][:8]
+                subject = parts[1]
+                body = parts[2] if len(parts) > 2 else ""
+
+                full_message = f"{subject}\n{body}"
+                violations = check_text(full_message, f"commit:{commit_hash}")
+                all_violations.extend(violations)
+
+    except subprocess.CalledProcessError as e:
+        print(f"Warning: Could not check git commits: {e}", file=sys.stderr)
+
+    return all_violations
+
+
+def check_file(filepath: Path) -> list[dict]:
+    """Check a file for violations."""
+    if not filepath.exists():
+        print(f"File not found: {filepath}", file=sys.stderr)
+        return []
+
+    text = filepath.read_text()
+    return check_text(text, str(filepath))
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Detect anti-manual mandate violations"
+    )
+    parser.add_argument("--file", "-f", type=Path, help="File to check")
+    parser.add_argument(
+        "--check-commits",
+        "-c",
+        type=int,
+        default=0,
+        help="Check last N commits",
+    )
+    parser.add_argument(
+        "--ci", action="store_true", help="CI mode - exit 1 on violations"
+    )
+
+    args = parser.parse_args()
+
+    all_violations = []
+
+    if args.file:
+        all_violations.extend(check_file(args.file))
+
+    if args.check_commits > 0:
+        all_violations.extend(check_recent_commits(args.check_commits))
+
+    # If no specific check requested, check recent commits
+    if not args.file and args.check_commits == 0:
+        all_violations.extend(check_recent_commits(5))
+
+    # Report results
+    if all_violations:
+        print(f"\n🚨 Found {len(all_violations)} Anti-Manual Violations:\n")
+        for v in all_violations:
+            print(f"  Source: {v['source']}")
+            print(f"  Match: \"{v['match']}\"")
+            print(f"  Context: ...{v['context']}...")
+            print()
+
+        if args.ci:
+            print("❌ CI FAILED: Anti-manual mandate violations detected")
+            print("See: rag_knowledge/lessons_learned/ll_017_anti_manual_violation_dec12.md")
+            sys.exit(1)
+    else:
+        print("✅ No anti-manual violations detected")
+
+    return len(all_violations)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Adds automated detection of anti-manual mandate violations to prevent CTO from giving CEO manual instructions.

## Changes

- **LL-017**: Lesson learned documenting today's anti-manual violation
- **scripts/check_anti_manual_violations.py**: Detects forbidden phrases in commits
- **CI job**: Scans last 10 commits for violations

## Forbidden Phrases Detected

- "you need to", "you should", "run this command"
- "manual steps", "please provide"
- "next steps:...run"

## Test Plan

- [x] Script syntax validated
- [x] CI workflow syntax validated
- [x] Tested on sample text

## Related

- CLAUDE.md Anti-Manual Mandate (Nov 19, 2025)
- CEO directive: "No manual anything!"