### PR TITLE
fix: Use existing LangSmith project claude-code-learning

### DIFF
--- a/.github/workflows/daily-trading.yml
+++ b/.github/workflows/daily-trading.yml
@@ -481,7 +481,7 @@ jobs:
           HELICONE_API_KEY: ${{ secrets.HELICONE_API_KEY }}
           # LangSmith tracing (observability)
           LANGCHAIN_API_KEY: ${{ secrets.LANGCHAIN_API_KEY }}
-          LANGCHAIN_PROJECT: 'trading-rl-training'
+          LANGCHAIN_PROJECT: 'claude-code-learning'
           LANGCHAIN_TRACING_V2: 'true'
           ALPHA_VANTAGE_API_KEY: ${{ secrets.ALPHA_VANTAGE_API_KEY }}
           # Phase 1: Polygon.io + Finnhub integration

--- a/.github/workflows/weekend-crypto-trading.yml
+++ b/.github/workflows/weekend-crypto-trading.yml
@@ -127,7 +127,7 @@ jobs:
           HELICONE_API_KEY: ${{ secrets.HELICONE_API_KEY }}
           # LangSmith tracing (observability)
           LANGCHAIN_API_KEY: ${{ secrets.LANGCHAIN_API_KEY }}
-          LANGCHAIN_PROJECT: 'trading-rl-training'
+          LANGCHAIN_PROJECT: 'claude-code-learning'
           LANGCHAIN_TRACING_V2: 'true'
           ALPHA_VANTAGE_API_KEY: ${{ secrets.ALPHA_VANTAGE_API_KEY }}
           POLYGON_API_KEY: ${{ secrets.POLYGON_API_KEY }}


### PR DESCRIPTION
Changes LANGCHAIN_PROJECT from non-existent trading-rl-training to existing claude-code-learning project.