### PR TITLE
fix: Commit trade files and performance log in workflow (LL-020)

### DIFF
--- a/.github/workflows/daily-trading.yml
+++ b/.github/workflows/daily-trading.yml
@@ -694,30 +694,37 @@ jobs:
             python3 scripts/workflow_health_monitor.py --record daily-trading --status failure
           fi
 
-      - name: Check for state changes
+      - name: Check for trading data changes
         id: check_state_changes
         if: steps.check_execution.outputs.skip != 'true'
         run: |
-          echo "🔍 Checking for system_state.json updates..."
+          echo "🔍 Checking for trading data updates..."
 
-          # Check if system_state.json changed during execution
-          if git diff --quiet data/system_state.json; then
+          # Check for any changes in data/ directory (trades, performance, state)
+          if git diff --quiet data/; then
             echo "state_changed=false" >> $GITHUB_OUTPUT
-            echo "📋 No changes to system state"
+            echo "📋 No changes to trading data"
           else
             echo "state_changed=true" >> $GITHUB_OUTPUT
-            echo "✅ System state updated after trading"
+            echo "✅ Trading data updated"
 
             # Show summary of changes
             echo "Changes detected:"
-            git diff --stat data/system_state.json
+            git diff --stat data/
           fi
 
-      - name: Commit system state updates
-        if: steps.check_execution.outputs.skip != 'true' && steps.check_state_changes.outputs.state_changed == 'true'
+          # Also check for new untracked trade files
+          TODAY=$(date +%Y-%m-%d)
+          if [ -f "data/trades_${TODAY}.json" ]; then
+            git status data/trades_${TODAY}.json
+            echo "state_changed=true" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Commit trading data updates
+        if: steps.check_execution.outputs.skip != 'true'
         continue-on-error: true  # Non-fatal - trading already succeeded
         run: |
-          echo "💾 Committing system_state.json updates..."
+          echo "💾 Committing trading data updates..."
 
           git config user.name "GitHub Actions Bot"
           git config user.email "actions@github.com"
@@ -725,17 +732,25 @@ jobs:
           # Pull latest changes to avoid conflicts
           git pull --rebase origin main || {
             echo "⚠️  Merge conflict detected - resolving..."
-            git checkout --ours data/system_state.json
-            git add data/system_state.json
+            git checkout --ours data/
+            git add data/
             git rebase --continue || echo "::warning::Rebase continue failed"
           }
 
-          # Stage system_state.json
-          git add data/system_state.json
+          # Stage ALL trading data files (FIX: was only staging system_state.json)
+          # This ensures trade files and performance log are committed
+          git add data/system_state.json data/performance_log.json data/trades_*.json 2>/dev/null || true
 
-          # Simple commit message (heredoc variables don't expand with 'EOF')
-          git commit -m "chore: Update system state after trading (${{ github.run_id }})" || {
-            echo "::warning::No changes to commit or commit failed"
+          # Check if there are changes to commit
+          if git diff --cached --quiet; then
+            echo "📋 No trading data changes to commit"
+            exit 0
+          fi
+
+          # Commit with descriptive message
+          TODAY=$(date +%Y-%m-%d)
+          git commit -m "chore: Update trading data ($TODAY) [${{ github.run_id }}]" || {
+            echo "::warning::Commit failed"
             exit 0
           }
 
@@ -745,7 +760,7 @@ jobs:
             exit 0
           }
 
-          echo "✅ System state changes committed and pushed"
+          echo "✅ Trading data committed and pushed"
 
       - name: Stop ADK service
         if: always()

--- a/rag_knowledge/lessons_learned/ll_020_trade_files_not_committed_dec12.md
+++ b/rag_knowledge/lessons_learned/ll_020_trade_files_not_committed_dec12.md
@@ -1,0 +1,70 @@
+# Lesson Learned: Trade Files Not Committed to Repo (Dec 12, 2025)
+
+## Incident ID: LL-020
+## Severity: HIGH
+## Category: workflow_bug, data_loss
+
+## What Happened
+
+Trade files (`data/trades_YYYY-MM-DD.json`) were being created during workflow execution but NOT committed to the repository. This caused confusion about whether trades were actually executing.
+
+**Timeline:**
+- Dec 10: Last trade file in repo: `trades_2025-12-10.json`
+- Dec 12 14:37: Daily trading workflow ran successfully (all steps passed)
+- Dec 12 14:55: Artifacts contain trade data, but no `trades_2025-12-12.json` in repo
+
+**Evidence:**
+- Workflow artifacts show `trading-logs-20170130041` (17,883 bytes)
+- Execute daily trading step: SUCCESS
+- Update performance log step: SUCCESS
+- Verify Positions step: SUCCESS
+- P/L Sanity Check step: SUCCESS
+- BUT: No `trades_2025-12-12.json` committed to repo
+
+## Root Cause
+
+The "Commit system state updates" step only staged `system_state.json`:
+
+```yaml
+# WRONG - Only commits system_state.json
+git add data/system_state.json
+```
+
+Trade files (`trades_*.json`) and performance log updates were NOT staged or committed.
+
+## Prevention Fix
+
+Updated the step to commit ALL trading data:
+
+```yaml
+- name: Commit trading data updates
+  run: |
+    # Stage ALL trading data files
+    git add data/system_state.json data/performance_log.json data/trades_*.json 2>/dev/null || true
+
+    # Check if there are changes to commit
+    if git diff --cached --quiet; then
+      echo "No trading data changes to commit"
+      exit 0
+    fi
+
+    # Commit with descriptive message
+    TODAY=$(date +%Y-%m-%d)
+    git commit -m "chore: Update trading data ($TODAY)"
+    git push origin main
+```
+
+## Verification
+
+After this fix, every successful trading run should:
+1. Have `data/trades_{today}.json` committed to repo
+2. Have `data/performance_log.json` updated with today's entry
+3. Have `data/system_state.json` updated
+
+## Related Issues
+
+- LL-019: Trading system dead for 2 days (detected because no trade files)
+- Trade files were being created but not committed, masking the issue
+
+## Tags
+`workflow` `data` `trades` `commit` `bug-fix` `ci`


### PR DESCRIPTION
## Summary
- **CRITICAL FIX**: Trade files were created during workflow but NOT committed to repo
- Changed "Commit system state updates" to "Commit trading data updates"
- Now stages: `system_state.json`, `performance_log.json`, `trades_*.json`
- Added check for new untracked trade files
- Added LL-020 documenting this bug

## Test plan
- [ ] Merge this PR
- [ ] Trigger daily trading workflow with `force_trade=true`
- [ ] Verify `trades_2025-12-12.json` appears in repo after workflow completes