### PR TITLE
feat: Activate REIT Smart Income Strategy (Tier 7)

### DIFF
--- a/config/strategy_registry.json
+++ b/config/strategy_registry.json
@@ -174,6 +174,44 @@
         "treasury",
         "stable"
       ]
+    },
+    "reit_smart_income": {
+      "name": "reit_smart_income",
+      "description": "REIT strategy with regime-based sector rotation for income and growth",
+      "status": "paper_trading",
+      "asset_class": "equity",
+      "metrics": {
+        "sharpe_ratio": 0.0,
+        "max_drawdown": 0.0,
+        "win_rate": 0.0,
+        "avg_daily_pnl": 0.0,
+        "total_return_pct": 0.0,
+        "total_trades": 0,
+        "backtest_date": "",
+        "backtest_period": "",
+        "hit_rate_100_day": 0.0
+      },
+      "config": {
+        "daily_allocation": 10.0,
+        "min_yield": 0.03,
+        "momentum_window": 60
+      },
+      "version": "1.0.0",
+      "author": "Trading System",
+      "created_date": "2025-12-12",
+      "last_modified": "2025-12-12",
+      "source_file": "src/strategies/reit_strategy.py",
+      "dependencies": [
+        "FredCollector",
+        "market_data_provider"
+      ],
+      "tags": [
+        "reit",
+        "income",
+        "dividend",
+        "regime-rotation",
+        "real-estate"
+      ]
     }
   }
 }

--- a/data/system_state.json
+++ b/data/system_state.json
@@ -2,7 +2,7 @@
   "meta": {
     "version": "1.0",
     "created": "2025-10-29T09:35:00",
-    "last_updated": "2025-12-12T09:37:01.887568",
+    "last_updated": "2025-12-12T17:30:00.000000",
     "last_audit": "2025-11-17T09:00:00.000000",
     "audit_notes": "Day 9 - Added Tier 5 crypto tracking (BTC/ETH weekend strategy)"
   },
@@ -27,7 +27,8 @@
     "tier2_invested": 403.97,
     "tier3_reserve": 0.0,
     "tier4_reserve": 0.0,
-    "tier5_invested": 0.0
+    "tier5_invested": 0.0,
+    "tier7_invested": 0.0
   },
   "performance": {
     "total_trades": 7,
@@ -265,6 +266,27 @@
         }
       ],
       "strategy_update": "2025-12-08: Added SOL per Luke Belmar recommendations"
+    },
+    "tier7": {
+      "name": "REIT Smart Income Strategy",
+      "allocation": 0.10,
+      "daily_amount": 10.0,
+      "sectors": ["Growth", "Defensive", "Residential"],
+      "universe": {
+        "Growth": ["AMT", "CCI", "DLR", "EQIX", "PLD"],
+        "Defensive": ["O", "VICI", "PSA", "WELL"],
+        "Residential": ["AVB", "EQR", "INVH"]
+      },
+      "trades_executed": 0,
+      "total_invested": 0.0,
+      "status": "active",
+      "enabled": true,
+      "execution_schedule": "Daily 9:35 AM ET (market hours)",
+      "last_execution": null,
+      "next_execution": "2025-12-13T14:35:00Z",
+      "regime": "Neutral",
+      "strategy_notes": "Regime-based rotation: Rising Rates → Defensive REITs, Falling Rates → Growth REITs",
+      "strategy_update": "2025-12-12: Activated REIT strategy per CEO priority"
     }
   },
   "backtest_reality": {
@@ -467,7 +489,11 @@
     "[2025-12-11 09:39] Position closed: BIL - Entry: $91.56, Exit: $91.56, P/L: $0.00 (+0.01%)",
     "[2025-12-11 09:39] Position closed: SPY260123P00660000 - Entry: $6.38, Exit: $5.56, P/L: $0.82 (-12.85%)",
     "[2025-12-12 09:37] Position closed: AMD260116P00200000 - Entry: $590.00, Exit: $460.00, P/L: $130.00 (-22.03%)",
-    "[2025-12-12 09:37] Position closed: SPY260123P00660000 - Entry: $638.00, Exit: $441.00, P/L: $197.00 (-30.88%)"
+    "[2025-12-12 09:37] Position closed: SPY260123P00660000 - Entry: $638.00, Exit: $441.00, P/L: $197.00 (-30.88%)",
+    "[2025-12-12 17:30] TIER 7 ACTIVATED: REIT Smart Income Strategy enabled per CEO priority",
+    "[2025-12-12 17:30] REIT Universe: Growth (AMT, CCI, DLR, EQIX, PLD), Defensive (O, VICI, PSA, WELL), Residential (AVB, EQR, INVH)",
+    "[2025-12-12 17:30] REIT Allocation: $10/day (10% of daily budget)",
+    "[2025-12-12 17:30] REIT Strategy: Regime-based sector rotation using Fed rate environment detection"
   ],
   "options": {
     "last_theta_harvest": "2025-12-05T17:53:46.287290+00:00",


### PR DESCRIPTION
## Summary
- Activates REIT Smart Income Strategy as Tier 7 per CEO priority
- Adds regime-based sector rotation using Fed rate environment detection
- Configures $10/day allocation (10% of daily budget)

## REIT Universe (12 REITs)
| Sector | Symbols |
|--------|---------|  
| Growth | AMT, CCI, DLR, EQIX, PLD |
| Defensive | O, VICI, PSA, WELL |
| Residential | AVB, EQR, INVH |

## Changes
- scripts/autonomous_trader.py: Added execute_reit_trading(), reit_enabled()
- config/strategy_registry.json: Registered reit_smart_income strategy
- data/system_state.json: Added Tier 7 configuration