### PR TITLE
feat: Add verification tests for config enum validation (LL_033)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -142,6 +142,15 @@ repos:
         verbose: true
         stages: [pre-commit]
 
+      - id: validate-config-enums
+        name: Validate Config Enum Values (ll_033 Prevention)
+        entry: python3 scripts/validate_config_enums.py
+        language: system
+        files: '(config/.*\.json|src/strategies/registry\.py)'
+        pass_filenames: false
+        verbose: true
+        stages: [pre-commit]
+
       - id: validate-trading-script-syntax
         name: Validate Critical Trading Scripts Syntax (ll_024 Prevention)
         entry: python3 -c "import sys, subprocess; scripts=['scripts/autonomous_trader.py','src/strategies/crypto_strategy.py']; [subprocess.run([sys.executable,'-m','py_compile',s],check=True) for s in scripts if __import__('pathlib').Path(s).exists()]"

--- a/rag_knowledge/lessons_learned/ll_033_config_enum_validation.md
+++ b/rag_knowledge/lessons_learned/ll_033_config_enum_validation.md
@@ -1,0 +1,89 @@
+# Lesson Learned: Config Enum Validation
+
+**ID**: LL_033
+**Date**: 2025-12-14
+**Severity**: HIGH
+**Category**: Configuration
+**Tags**: enum, validation, config, pre-commit, schema
+
+## Incident Summary
+
+The `config/strategy_registry.json` contained an invalid enum value `"commodity"` for the `asset_class` field. The valid values defined in `src/strategies/registry.py` are: `equity`, `options`, `crypto`, `mixed`. This caused the strategy registry to fail loading with a warning that was silently ignored.
+
+## Root Cause
+
+1. JSON config files are not validated against Python enum definitions
+2. Manual edits to config files bypass type checking
+3. No pre-commit hook to validate enum values in configs
+4. Warning was logged but didn't fail the build
+
+## Impact
+
+- Strategy registry logged warning on every import
+- Precious metals strategy was not properly registered
+- Silent failure mode - system appeared to work but was degraded
+
+## Prevention Measures
+
+### 1. Schema Validation Test (Automated)
+```python
+# tests/test_config_schema_validation.py
+def test_strategy_registry_asset_classes():
+    """Validate all asset_class values match AssetClass enum."""
+    from src.strategies.registry import AssetClass
+    valid_values = {e.value for e in AssetClass}
+
+    with open("config/strategy_registry.json") as f:
+        data = json.load(f)
+
+    for name, strategy in data.get("strategies", {}).items():
+        asset_class = strategy.get("asset_class")
+        assert asset_class in valid_values, \
+            f"Strategy '{name}' has invalid asset_class: {asset_class}"
+```
+
+### 2. Pre-commit Hook
+Add to `.pre-commit-config.yaml`:
+```yaml
+- id: validate-config-enums
+  name: Validate Config Enum Values
+  entry: python3 scripts/validate_config_enums.py
+  language: system
+  files: '\.json$'
+  pass_filenames: false
+```
+
+### 3. RAG Query Pattern
+When editing config files, always query RAG:
+- "What are valid values for [field_name] in [config_file]?"
+- "Show me the enum definition for AssetClass"
+
+## Detection Method
+
+This bug was found during a codebase audit when import tests revealed the warning:
+```
+WARNING - Failed to load strategy registry: 'commodity' is not a valid AssetClass
+```
+
+## Fix Applied
+
+Changed `config/strategy_registry.json` line 220:
+```diff
+- "asset_class": "commodity",
++ "asset_class": "equity",
+```
+
+Note: GLD/SLV are equity ETFs that track commodities, not actual commodity futures.
+
+## Related Lessons
+
+- LL_009: CI syntax validation
+- LL_024: Trading script syntax validation
+
+## Verification Query
+
+To check for similar issues in the future:
+```bash
+grep -r "enum" src/ --include="*.py" | grep "class.*Enum"
+```
+Then verify all config files use only valid enum values.

--- a/scripts/validate_config_enums.py
+++ b/scripts/validate_config_enums.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+"""
+Config Enum Validator
+
+Pre-commit hook that validates enum values in config files against
+their Python definitions. Prevents bugs like LL_033 where invalid
+enum values silently break the system.
+
+Usage:
+    python3 scripts/validate_config_enums.py
+
+Exit codes:
+    0 - All validations passed
+    1 - Validation errors found
+
+Author: Claude (AI CTO)
+Date: 2025-12-14
+"""
+
+import json
+import sys
+from pathlib import Path
+
+
+def get_enum_values(enum_class):
+    """Extract values from an enum class."""
+    return {e.value for e in enum_class}
+
+
+def validate_strategy_registry():
+    """Validate strategy_registry.json against Python enums."""
+    errors = []
+    config_path = Path("config/strategy_registry.json")
+
+    if not config_path.exists():
+        print("SKIP: config/strategy_registry.json not found")
+        return []
+
+    # Import enums
+    try:
+        from src.strategies.registry import AssetClass, StrategyStatus
+
+        valid_asset_classes = get_enum_values(AssetClass)
+        valid_statuses = get_enum_values(StrategyStatus)
+    except ImportError as e:
+        print(f"WARN: Could not import enums: {e}")
+        return []
+
+    # Load config
+    with open(config_path) as f:
+        data = json.load(f)
+
+    # Validate each strategy
+    for name, strategy in data.get("strategies", {}).items():
+        # Check asset_class
+        asset_class = strategy.get("asset_class")
+        if asset_class and asset_class not in valid_asset_classes:
+            errors.append(
+                f"Strategy '{name}': invalid asset_class '{asset_class}'. "
+                f"Valid: {valid_asset_classes}"
+            )
+
+        # Check status
+        status = strategy.get("status")
+        if status and status not in valid_statuses:
+            errors.append(
+                f"Strategy '{name}': invalid status '{status}'. " f"Valid: {valid_statuses}"
+            )
+
+    return errors
+
+
+def validate_all_json_parseable():
+    """Ensure all JSON files in config/ are valid."""
+    errors = []
+    config_dir = Path("config")
+
+    if not config_dir.exists():
+        return []
+
+    for json_file in config_dir.glob("*.json"):
+        try:
+            with open(json_file) as f:
+                json.load(f)
+        except json.JSONDecodeError as e:
+            errors.append(f"{json_file}: Invalid JSON - {e}")
+
+    return errors
+
+
+def main():
+    """Run all validations."""
+    print("=" * 60)
+    print("CONFIG ENUM VALIDATION")
+    print("=" * 60)
+
+    all_errors = []
+
+    # Validate JSON syntax
+    print("\n[1/2] Validating JSON syntax...")
+    json_errors = validate_all_json_parseable()
+    if json_errors:
+        all_errors.extend(json_errors)
+        for err in json_errors:
+            print(f"  ERROR: {err}")
+    else:
+        print("  OK: All JSON files are valid")
+
+    # Validate strategy registry enums
+    print("\n[2/2] Validating strategy registry enums...")
+    registry_errors = validate_strategy_registry()
+    if registry_errors:
+        all_errors.extend(registry_errors)
+        for err in registry_errors:
+            print(f"  ERROR: {err}")
+    else:
+        print("  OK: All enum values are valid")
+
+    # Summary
+    print("\n" + "=" * 60)
+    if all_errors:
+        print(f"FAILED: {len(all_errors)} validation error(s)")
+        print("\nTo fix:")
+        print("  1. Check valid enum values in src/strategies/registry.py")
+        print("  2. Update config files to use valid values")
+        print("  3. See rag_knowledge/lessons_learned/ll_033_*.md for details")
+        return 1
+    else:
+        print("PASSED: All config validations successful")
+        return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_config_schema_validation.py
+++ b/tests/test_config_schema_validation.py
@@ -1,0 +1,157 @@
+"""
+Config Schema Validation Tests
+
+Validates that all config files use valid enum values defined in code.
+This prevents bugs like LL_033 (invalid AssetClass "commodity").
+
+Author: Claude (AI CTO)
+Date: 2025-12-14
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+
+
+class TestConfigEnumValidation:
+    """Validate config files against Python enum definitions."""
+
+    def test_strategy_registry_asset_classes(self):
+        """Ensure all asset_class values are valid AssetClass enum values."""
+        from src.strategies.registry import AssetClass
+
+        valid_values = {e.value for e in AssetClass}
+        config_path = Path("config/strategy_registry.json")
+
+        if not config_path.exists():
+            pytest.skip("strategy_registry.json not found")
+
+        with open(config_path) as f:
+            data = json.load(f)
+
+        errors = []
+        for name, strategy in data.get("strategies", {}).items():
+            asset_class = strategy.get("asset_class")
+            if asset_class not in valid_values:
+                errors.append(
+                    f"Strategy '{name}' has invalid asset_class: '{asset_class}'. "
+                    f"Valid values: {valid_values}"
+                )
+
+        assert not errors, "\n".join(errors)
+
+    def test_strategy_registry_status_values(self):
+        """Ensure all status values are valid StrategyStatus enum values."""
+        from src.strategies.registry import StrategyStatus
+
+        valid_values = {e.value for e in StrategyStatus}
+        config_path = Path("config/strategy_registry.json")
+
+        if not config_path.exists():
+            pytest.skip("strategy_registry.json not found")
+
+        with open(config_path) as f:
+            data = json.load(f)
+
+        errors = []
+        for name, strategy in data.get("strategies", {}).items():
+            status = strategy.get("status")
+            if status not in valid_values:
+                errors.append(
+                    f"Strategy '{name}' has invalid status: '{status}'. "
+                    f"Valid values: {valid_values}"
+                )
+
+        assert not errors, "\n".join(errors)
+
+    def test_all_json_configs_parseable(self):
+        """Ensure all JSON config files are valid JSON."""
+        config_dir = Path("config")
+        if not config_dir.exists():
+            pytest.skip("config/ directory not found")
+
+        errors = []
+        for json_file in config_dir.glob("*.json"):
+            try:
+                with open(json_file) as f:
+                    json.load(f)
+            except json.JSONDecodeError as e:
+                errors.append(f"{json_file}: {e}")
+
+        assert not errors, "\n".join(errors)
+
+
+class TestRagLessonsIntegration:
+    """Test that lessons learned are properly indexed and queryable."""
+
+    def test_lesson_ll_033_exists(self):
+        """Verify LL_033 (config enum validation) lesson exists."""
+        lesson_path = Path("rag_knowledge/lessons_learned/ll_033_config_enum_validation.md")
+        assert lesson_path.exists(), "LL_033 lesson file missing"
+
+        content = lesson_path.read_text()
+        assert "AssetClass" in content, "Lesson should reference AssetClass"
+        assert "commodity" in content, "Lesson should mention the invalid value"
+        assert "Prevention" in content, "Lesson should have prevention measures"
+
+    def test_lessons_have_required_fields(self):
+        """Ensure new lessons (2025-12-14+) have required metadata fields."""
+        lessons_dir = Path("rag_knowledge/lessons_learned")
+        if not lessons_dir.exists():
+            pytest.skip("lessons_learned directory not found")
+
+        required_fields = ["ID", "Severity", "Category"]
+        errors = []
+        warnings = []
+
+        # Only strictly check lessons from ll_033 onwards (new standard)
+        for lesson_file in lessons_dir.glob("ll_*.md"):
+            # Extract lesson number
+            name = lesson_file.name
+            try:
+                num = int(name.split("_")[1])
+                is_new_standard = num >= 33
+            except (IndexError, ValueError):
+                is_new_standard = False
+
+            content = lesson_file.read_text()
+            for field in required_fields:
+                if f"**{field}**:" not in content:
+                    if is_new_standard:
+                        errors.append(f"{name}: Missing {field}")
+                    else:
+                        warnings.append(f"{name}: Missing {field}")
+
+        # Only fail on new lessons missing fields
+        if warnings:
+            print(f"\nWARNING: {len(warnings)} older lessons missing metadata (non-blocking)")
+
+        assert not errors, "\n".join(errors)
+
+
+class TestPrecommitValidation:
+    """Test that pre-commit hooks are properly configured."""
+
+    def test_precommit_config_exists(self):
+        """Verify .pre-commit-config.yaml exists."""
+        config_path = Path(".pre-commit-config.yaml")
+        assert config_path.exists(), "Pre-commit config missing"
+
+    def test_precommit_has_ruff(self):
+        """Ensure ruff linter is configured."""
+        config_path = Path(".pre-commit-config.yaml")
+        if not config_path.exists():
+            pytest.skip("Pre-commit config not found")
+
+        content = config_path.read_text()
+        assert "ruff" in content, "Ruff linter not configured in pre-commit"
+
+    def test_precommit_has_json_check(self):
+        """Ensure JSON validation is configured."""
+        config_path = Path(".pre-commit-config.yaml")
+        if not config_path.exists():
+            pytest.skip("Pre-commit config not found")
+
+        content = config_path.read_text()
+        assert "check-json" in content, "JSON check not configured in pre-commit"


### PR DESCRIPTION
## Summary
Prevention measures for the AssetClass bug discovered in #624

## Changes
1. **RAG Lesson** - `ll_033_config_enum_validation.md`
2. **Test Suite** - 8 tests for config schema validation
3. **Pre-commit Hook** - `validate_config_enums.py`
4. **Hook Config** - Added to `.pre-commit-config.yaml`

## Test Results
```
8 passed in 0.23s
```

## How This Prevents Future Bugs
- Invalid enum values in config files will fail pre-commit
- CI will catch the issue before merge
- RAG lesson available for future reference