### PR TITLE
fix: Add crypto order fill verification (LL-034)

### DIFF
--- a/.github/workflows/force-crypto-trade.yml
+++ b/.github/workflows/force-crypto-trade.yml
@@ -216,15 +216,37 @@ jobs:
                   time_in_force=TimeInForce.GTC
               ))
 
-              print(f"✅ Order submitted: {order.id}")
-              print(f"📋 Status: {order.status}")
+              print(f"📤 Order submitted: {order.id} (status: {order.status})")
+
+              # CRITICAL FIX (LL-034): Wait for fill confirmation
+              import time
+              fill_timeout = 30
+              start = time.time()
+              filled_price = None
+              while time.time() - start < fill_timeout:
+                  order = client.get_order_by_id(order.id)
+                  print(f"   Checking: {order.status}")
+                  if str(order.status) == "OrderStatus.FILLED":
+                      filled_price = float(order.filled_avg_price) if order.filled_avg_price else best_price
+                      print(f"✅ FILLED at ${filled_price:.2f}")
+                      break
+                  elif str(order.status) in ["OrderStatus.CANCELLED", "OrderStatus.REJECTED", "OrderStatus.EXPIRED"]:
+                      print(f"❌ Order {order.status}")
+                      break
+                  time.sleep(2)
+
+              final_status = str(order.status)
+              print(f"📋 Final Status: {final_status}")
 
               result["symbol"] = best_symbol
               result["action"] = "BUY"
               result["notional"] = final_amount
               result["price"] = best_price
+              result["filled_price"] = filled_price
+              result["filled_qty"] = float(order.filled_qty) if order.filled_qty else 0
               result["order_id"] = str(order.id)
-              result["status"] = str(order.status)
+              result["status"] = final_status
+              result["verified_fill"] = final_status == "OrderStatus.FILLED"
 
           except Exception as e:
               print(f"\n❌ ERROR: {e}")

--- a/.github/workflows/weekend-crypto-trading.yml
+++ b/.github/workflows/weekend-crypto-trading.yml
@@ -218,8 +218,39 @@ jobs:
               if amt < 1: amt = 1
               print(f"💰 BUY ${amt:.2f} {best} (momentum: {momentum:+.2f}%)")
               order = client.submit_order(MarketOrderRequest(symbol=best, notional=amt, side=OrderSide.BUY, time_in_force=TimeInForce.GTC))
-              result.update({"symbol":best,"action":"BUY","notional":amt,"price":price,"order_id":str(order.id),"status":str(order.status),"size_multiplier":mult})
-              print(f"✅ Order: {order.id}")
+              print(f"📤 Order submitted: {order.id} (status: {order.status})")
+
+              # CRITICAL FIX (LL-034): Wait for fill confirmation
+              import time
+              fill_timeout = 30
+              start = time.time()
+              filled_price = None
+              while time.time() - start < fill_timeout:
+                  order = client.get_order_by_id(order.id)
+                  print(f"   Checking: {order.status}")
+                  if str(order.status) == "OrderStatus.FILLED":
+                      filled_price = float(order.filled_avg_price) if order.filled_avg_price else price
+                      print(f"✅ FILLED at ${filled_price:.2f}")
+                      break
+                  elif str(order.status) in ["OrderStatus.CANCELLED", "OrderStatus.REJECTED", "OrderStatus.EXPIRED"]:
+                      print(f"❌ Order {order.status}")
+                      break
+                  time.sleep(2)
+
+              final_status = str(order.status)
+              result.update({
+                  "symbol": best,
+                  "action": "BUY",
+                  "notional": amt,
+                  "price": price,
+                  "filled_price": filled_price,
+                  "filled_qty": float(order.filled_qty) if order.filled_qty else 0,
+                  "order_id": str(order.id),
+                  "status": final_status,
+                  "size_multiplier": mult,
+                  "verified_fill": final_status == "OrderStatus.FILLED"
+              })
+              print(f"✅ Order: {order.id} - Final: {final_status}")
           except Exception as e:
               print(f"❌ {e}")
               traceback.print_exc()

--- a/rag_knowledge/lessons_learned/ll_034_crypto_order_fill_verification.md
+++ b/rag_knowledge/lessons_learned/ll_034_crypto_order_fill_verification.md
@@ -1,0 +1,86 @@
+# LL-034: Always Verify Crypto Order Fills
+
+**Date**: 2025-12-14
+**Category**: Trading Execution
+**Severity**: HIGH - Revenue Impact
+
+## The Bug
+
+Crypto orders were logged with `status: OrderStatus.PENDING_NEW` immediately after submission, without waiting for fill confirmation. The system reported trades as executed when they were only submitted.
+
+## Impact
+
+- Crypto P/L tracking was inaccurate
+- Orders stuck in PENDING_NEW state were not detected
+- System showed trades that may not have filled
+- ~$96 unrealized loss went untracked
+
+## Root Cause
+
+In GitHub Actions workflows (`weekend-crypto-trading.yml`, `force-crypto-trade.yml`):
+
+```python
+# BAD - Saves immediately without waiting for fill
+order = client.submit_order(MarketOrderRequest(...))
+result["status"] = str(order.status)  # PENDING_NEW
+save()  # Saves before fill!
+```
+
+## The Fix
+
+Wait for order fill with timeout before logging:
+
+```python
+# GOOD - Wait for fill confirmation
+order = client.submit_order(MarketOrderRequest(...))
+
+# Wait for fill (up to 30 seconds for crypto)
+import time
+fill_timeout = 30
+start = time.time()
+filled_price = None
+
+while time.time() - start < fill_timeout:
+    order = client.get_order_by_id(order.id)
+    if str(order.status) == "OrderStatus.FILLED":
+        filled_price = float(order.filled_avg_price)
+        break
+    elif str(order.status) in ["OrderStatus.CANCELLED", "OrderStatus.REJECTED"]:
+        break
+    time.sleep(2)
+
+result["status"] = str(order.status)  # Now shows FILLED
+result["filled_price"] = filled_price
+result["verified_fill"] = str(order.status) == "OrderStatus.FILLED"
+save()
+```
+
+## Prevention Rules
+
+1. **Never log trade as executed before fill confirmation**
+2. **Always include `verified_fill` boolean in trade records**
+3. **Store `filled_price` separately from estimated price**
+4. **Use 30-second timeout for crypto (GTC orders fill quickly)**
+5. **Log final status, not initial status**
+
+## Related Files
+
+- `.github/workflows/weekend-crypto-trading.yml`
+- `.github/workflows/force-crypto-trade.yml`
+- `src/strategies/crypto_strategy.py`
+- `src/core/alpaca_trader.py`
+
+## Tradier Note
+
+Tradier CANNOT be used as a crypto backup - it only supports equities and options. For crypto redundancy, consider:
+- Coinbase Pro API
+- Kraken API
+- Binance.US API
+
+## RAG Query Patterns
+
+- "crypto order not filling"
+- "PENDING_NEW status"
+- "verify trade fill"
+- "crypto trade execution"
+- "Alpaca crypto order"


### PR DESCRIPTION
## Summary

CRITICAL BUG FIX: Crypto orders were logged with `PENDING_NEW` status immediately after submission, without waiting for fill confirmation.

## Changes

- `weekend-crypto-trading.yml`: Wait up to 30s for fill confirmation
- `force-crypto-trade.yml`: Wait up to 30s for fill confirmation
- Added RAG lesson LL-034 documenting the issue

## Now Logs

- `filled_price`: actual execution price
- `filled_qty`: actual filled quantity
- `verified_fill`: boolean confirming fill
- `status`: final order status (not initial PENDING_NEW)

## Test Plan

- [x] YAML syntax validated
- [x] Workflow structure validated
- [x] RAG lesson created
- [ ] Next crypto trade will verify fill status