### PR TITLE
URGENT: Fix critical trading workflow failures

### DIFF
--- a/.github/workflows/combined-trading.yml
+++ b/.github/workflows/combined-trading.yml
@@ -174,7 +174,7 @@ jobs:
           import sys
           sys.path.insert(0, '.')
 
-          from src.strategies.options_iv_signal import OptionsIVSignalGenerator, get_iv_signal_generator
+          from src.strategies.options_iv_signal import OptionsIVSignalGenerator, get_options_signal_generator
           from src.strategies.options_executor import OptionsExecutor, get_options_executor
           import yfinance as yf
           import json
@@ -228,7 +228,7 @@ jobs:
           print()
 
           # Generate signal
-          signal_gen = get_iv_signal_generator()
+          signal_gen = get_options_signal_generator()
           signal = signal_gen.generate_signal(
               symbol='SPY',
               current_iv=iv_current,

--- a/.github/workflows/daily-trading.yml
+++ b/.github/workflows/daily-trading.yml
@@ -57,9 +57,10 @@ jobs:
         run: |
           sudo rm -rf /tmp/pip-* /tmp/pipcache ~/.cache/pip ~/.cache/torch || true
           df -h .
-          export PATH="$HOME/.local/bin:$PATH"
-          # UV is 6-18x faster than pip and handles caching automatically
-          uv pip sync --system --no-cache requirements-minimal.txt
+          # Use standard pip to avoid UV flag conflicts
+          python3 -m pip install --upgrade pip
+          python3 -m pip install --no-build-isolation multitasking || python3 -m pip install multitasking==0.0.11
+          python3 -m pip install --no-cache-dir -r requirements-minimal.txt
 
       - name: Install full deps for unit gates (optional)
         if: ${{ false }}  # enable only if additional tests need full stack


### PR DESCRIPTION
## Critical Fixes

### Options Workflow
- ❌ **Bug**: ImportError - wrong function name
- ✅ **Fix**: Rename `get_iv_signal_generator` → `get_options_signal_generator`

### Equities Workflow
- ❌ **Bug**: UV pip flag conflict (duplicate --system)
- ✅ **Fix**: Replace UV with standard pip

## Impact
- Unblocks options trading (failed since Dec 12)
- Unblocks equities trading (failed since Dec 15)
- Restores path to North Star ($100/day goal)

## Testing
Next workflow run at 9:35 AM ET (tomorrow)

**MERGE IMMEDIATELY** - Blocking all revenue generation