### PR TITLE
fix: Funnel Activity showing 0 orders instead of actual trade count

### DIFF
--- a/wiki/AI-Dashboard.md
+++ b/wiki/AI-Dashboard.md
@@ -29,9 +29,6 @@
 | **P/L** | $+0.00 (+0.00%) |
 | **Status** | ⏸️ No activity yet |
 
-
-| **Funnel Activity** | 0 orders, 0 stops |
-
 ---
 
 ## 🎯 North Star Goal


### PR DESCRIPTION
## Summary
- Fixed Funnel Activity to read from actual trades file instead of non-existent telemetry file
- Removed misleading static Funnel Activity from AI-Dashboard.md
- Order count now reflects actual daily trades

## Test Plan
- Regenerate dashboard and verify Funnel Activity shows correct order count