### PR TITLE
fix: use abs() for options exit qty to prevent negative quantity error

### DIFF
--- a/src/orchestrator/main.py
+++ b/src/orchestrator/main.py
@@ -699,10 +699,12 @@ class TradingOrchestrator:
                     logger.info(f"Executing exit for {symbol}: {reason}")
 
                     # Create sell request through trade gateway
+                    # Use abs() because short options have negative qty (e.g., -1.0)
+                    # but we need positive qty for the sell order
                     trade_request = TradeRequest(
                         symbol=symbol,
                         side="sell",
-                        quantity=position.quantity,
+                        quantity=abs(position.quantity),
                         source=f"position_manager.{reason}",
                     )
 


### PR DESCRIPTION
## Summary
- Fix negative quantity error when selling short options positions
- Add abs() to quantity when creating sell orders for options exits

## Details
Short options positions have negative quantities (e.g., -1.0 for a sold put), but Alpaca's API requires positive quantities for sell orders. This PR adds abs() to convert negative quantities to positive before creating the sell order.

## Test Plan
- [x] Code compiles without syntax errors
- [x] Fix addresses the specific bug in options exit flow
- [ ] Test with live options position exit

## Related Issues
- Part of daily earnings investigation to fix options automation issues