### PR TITLE
fix: use abs() for options exit qty to prevent negative quantity error

### DIFF
--- a/src/orchestrator/main.py
+++ b/src/orchestrator/main.py
@@ -699,10 +699,12 @@ class TradingOrchestrator:
                     logger.info(f"Executing exit for {symbol}: {reason}")
 
                     # Create sell request through trade gateway
+                    # Use abs() because short options have negative qty (e.g., -1.0)
+                    # but we need positive qty for the sell order
                     trade_request = TradeRequest(
                         symbol=symbol,
                         side="sell",
-                        quantity=position.quantity,
+                        quantity=abs(position.quantity),
                         source=f"position_manager.{reason}",
                     )
 


### PR DESCRIPTION
## Summary
- **CRITICAL BUG FIX**: Short options positions were failing to close because the system was passing negative quantity (e.g., qty=-1.0) to Alpaca, which rejects orders with qty <= 0

## Root Cause
- Short options positions have negative quantity (e.g., -1.0) in Alpaca's position API
- The `submit_order` API requires positive qty
- Without `abs()`, the sell order was rejected with: `{"code":40010001,"message":"qty must be > 0"}`

## Impact
On Dec 16, 2025, two profitable options positions failed to close:
- AMD260116P00200000: +33.90% profit - FAILED to close
- SPY260123P00660000: +9.72% profit - FAILED to close

## Fix
Use `abs(position.quantity)` when creating the sell order request.

## Test Plan
- [x] Syntax valid (`python3 -m py_compile src/orchestrator/main.py`)
- [x] Unit tests pass