### PR TITLE
fix: add missing timedelta import in langsmith_tracer

### DIFF
--- a/src/observability/langsmith_tracer.py
+++ b/src/observability/langsmith_tracer.py
@@ -35,7 +35,7 @@ import os
 import uuid
 from contextlib import contextmanager
 from dataclasses import asdict, dataclass, field
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from enum import Enum
 from pathlib import Path
 from typing import Any, Callable, Optional, TypeVar


### PR DESCRIPTION
## Summary
- Fixed missing `timedelta` import in `langsmith_tracer.py`
- The `get_analytics()` method uses `timedelta` but it wasn't imported, causing a `NameError` at runtime

## Root Cause
The `from datetime import datetime, timezone` line was missing `timedelta`, which is used on line 447.

## Test Plan
- [x] Ruff check passes for this file
- [x] Python syntax validation passes