### PR TITLE
fix: add crypto key to VALID_SYMBOLS and BASELINES attribute

### DIFF
--- a/src/ml/anomaly_detector.py
+++ b/src/ml/anomaly_detector.py
@@ -113,6 +113,7 @@ class TradingAnomalyDetector:
     # Known valid symbols
     VALID_SYMBOLS = {
         "stocks": ["SPY", "QQQ", "VOO", "NVDA", "GOOGL", "AMZN", "BIL", "SHY", "IEF", "TLT"],
+        "crypto": ["BTCUSD", "ETHUSD", "BTC/USD", "ETH/USD"],
     }
 
     def __init__(

--- a/src/verification/ml_anomaly_detector.py
+++ b/src/verification/ml_anomaly_detector.py
@@ -66,6 +66,10 @@ class MLAnomalyDetector:
             "code_change_size": 50,  # >50 files changed
         }
 
+        # Baselines alias for test compatibility
+        self.baselines = self.thresholds
+        self.BASELINES = self.thresholds
+
     def load_system_state(self) -> Optional[dict]:
         """Load current system state."""
         if not self.system_state_file.exists():


### PR DESCRIPTION
## Summary
- Add 'crypto' key to `VALID_SYMBOLS` to fix KeyError in tests
- Add `baselines`/`BASELINES` alias for test compatibility in verification ML anomaly detector

## Test Plan
- [x] All ML anomaly detection tests pass
- [x] Python syntax validated