### PR TITLE
fix: add PYTHONPATH to langsmith-check workflow steps

### DIFF
--- a/.github/workflows/pre-merge-gate.yml
+++ b/.github/workflows/pre-merge-gate.yml
@@ -70,6 +70,8 @@ jobs:
           python3 -m pip install python-dotenv langsmith openai
 
       - name: Verify LangSmith wrapper imports
+        env:
+          PYTHONPATH: ${{ github.workspace }}
         run: |  # pragma: allowlist secret
           echo "🔍 Verifying LangSmith wrapper imports correctly..."
           python3 -c "
@@ -103,6 +105,8 @@ jobs:
           "
 
       - name: Verify env var fallback (LANGSMITH_* names)
+        env:
+          PYTHONPATH: ${{ github.workspace }}
         run: |  # pragma: allowlist secret
           echo "🔍 Verifying LANGSMITH_* env var names work..."
           python3 -c "


### PR DESCRIPTION
## Summary

Fixes CI failures in PR #716 by adding PYTHONPATH configuration.

## Changes
- Added `PYTHONPATH: ${{ github.workspace }}` env var to both langsmith verification steps
- Without this, Python cannot find `src.utils.langsmith_wrapper` module

## Related
- Fixes CI issues in PR #716