### PR TITLE
fix: Replace undefined btc variable with aapl in pre_trade_check.py

### DIFF
--- a/src/verification/pre_trade_check.py
+++ b/src/verification/pre_trade_check.py
@@ -450,8 +450,9 @@ if __name__ == "__main__":
     print("\n[3] TESTING LOW CONFIDENCE SIGNAL")
     print("-" * 40)
 
+    aapl = factory.create_equity_symbol("AAPL")
     weak_signal = factory.create_signal(
-        symbol=btc, action=TradeAction.BUY, confidence=0.45, source="test_strategy"
+        symbol=aapl, action=TradeAction.BUY, confidence=0.45, source="test_strategy"
     )
 
     result = verifier.verify(weak_signal)


### PR DESCRIPTION
## Summary
- Fixes ruff lint error F821 (undefined name `btc`) in `src/verification/pre_trade_check.py`
- The `btc` variable was referenced but never defined in the test section
- Replaced with `aapl` following the existing pattern of using `create_equity_symbol()`

This was likely a leftover from when crypto support was removed from the codebase.

## Test plan
- [x] Ruff lint check passes: `ruff check src/ --select=E9,F63,F7,F82`
- [x] Pre-merge gate passes all checks