### PR TITLE
style: Fix import sorting in trace_analyzer.py

### DIFF
--- a/scripts/trace_analyzer.py
+++ b/scripts/trace_analyzer.py
@@ -30,7 +30,6 @@ from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any
 
-
 TRACES_DIR = Path("data/traces")
 
 


### PR DESCRIPTION
Auto-fix import sorting with ruff --fix. Maintains all lint checks passing.