### PR TITLE
fix: URGENT - Downgrade pillow for fastembed compatibility

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -115,7 +115,7 @@ ormsgpack==1.12.0
 packaging==25.0
 pandas==2.3.3
 peewee==3.18.3
-pillow==12.0.0
+pillow==11.1.0  # Compatible with fastembed (<12.0 requirement)
 platformdirs==4.5.1
 praw==7.8.1
 prawcore==2.4.0


### PR DESCRIPTION
## Problem

CI is failing on **ALL PRs** due to dependency conflict:
```
pillow==12.0.0 conflicts with fastembed which requires pillow<12.0
```

## Solution

Downgrade pillow from 12.0.0 to 11.1.0.

## Impact

- Unblocks pre-merge verification gate
- Allows PR #740 and #744 to proceed

## Test Plan

- [ ] CI passes on this PR
- [ ] Other PRs can now merge