### PR TITLE
fix: use PAT_TOKEN for scheduler heartbeat commits

### DIFF
--- a/.github/workflows/scheduler-heartbeat.yml
+++ b/.github/workflows/scheduler-heartbeat.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.PAT_TOKEN || secrets.GITHUB_TOKEN }}
 
       - name: Write heartbeat
         run: |


### PR DESCRIPTION
## Summary
Fix scheduler heartbeat workflow failing to push commits.

## Problem
The workflow was using `GITHUB_TOKEN` which lacks write permissions to push commits.

## Fix
Use `PAT_TOKEN` with fallback to `GITHUB_TOKEN`:
```yaml
token: ${{ secrets.PAT_TOKEN || secrets.GITHUB_TOKEN }}
```

## Test plan
- [ ] Trigger scheduler-heartbeat workflow manually
- [ ] Verify heartbeat file commits successfully