### PR TITLE
fix: Check last_trade_date not last_updated for duplicate detection

### DIFF
--- a/data/system_state.json
+++ b/data/system_state.json
@@ -512,5 +512,10 @@
     "premium_gap": 0,
     "opportunities_count": 3,
     "on_track": true
+  },
+  "trades": {
+    "last_trade_date": null,
+    "total_trades_today": 0,
+    "daily_trade_log": []
   }
 }


### PR DESCRIPTION
ROOT CAUSE of trading skip: system_state.json was updated by account-status workflow, not actual trading. Script incorrectly assumed trading happened.