### PR TITLE
fix: Add missing macd_threshold attribute to fix trading execution

### DIFF
--- a/src/strategies/legacy_momentum.py
+++ b/src/strategies/legacy_momentum.py
@@ -2,7 +2,16 @@
 
 
 class LegacyMomentumCalculator:
-    """Stub for deleted momentum calculator."""
+    """Stub for deleted momentum calculator.
+
+    Provides minimal attributes needed by MomentumAgent.
+    """
+
+    # Default thresholds used by MomentumAgent
+    macd_threshold: float = 0.0
+    rsi_overbought: float = 70.0
+    volume_min: float = 1000000.0
+
     def __init__(self, *args, **kwargs):
         pass
 


### PR DESCRIPTION
## Summary
- LegacyMomentumCalculator stub was missing macd_threshold, rsi_overbought, volume_min attributes
- MomentumAgent was failing with AttributeError during TradingOrchestrator instantiation
- This was blocking ALL trade execution

## Root Cause
Workflow logs showed:
```
AttributeError: 'LegacyMomentumCalculator' object has no attribute 'macd_threshold'
```

## Test plan
- CI should pass import verification
- Trading workflow should proceed past orchestrator instantiation