### PR TITLE
fix: Add missing stub methods for CircuitBreakerPattern and ContextEngine

### DIFF
--- a/src/agent_framework_stubs.py
+++ b/src/agent_framework_stubs.py
@@ -22,6 +22,10 @@ class ContextEngine:
     def get_context(self, *args, **kwargs) -> dict:
         return {}
 
+    def prune_memories(self, *args, **kwargs) -> list:
+        """Stub for memory pruning - returns empty list."""
+        return []
+
 
 class MemoryTimescale:
     """Stub for deleted MemoryTimescale."""

--- a/src/safety/failover_system.py
+++ b/src/safety/failover_system.py
@@ -10,6 +10,10 @@ class CircuitBreakerPattern:
     def is_open(self) -> bool:
         return False
 
+    def can_execute(self) -> bool:
+        """Check if circuit breaker allows execution."""
+        return not self.open
+
     def record_success(self) -> None:
         pass
 


### PR DESCRIPTION
## Summary
- Add can_execute() to CircuitBreakerPattern stub
- Add prune_memories() to ContextEngine stub

## Root Cause
These methods were called by MultiBroker and FailureIsolation but missing from stubs