### PR TITLE
fix: Remove duplicate title and add dates to lessons

### DIFF
--- a/docs/_lessons/ci_failure_blocked_trading.md
+++ b/docs/_lessons/ci_failure_blocked_trading.md
@@ -1,6 +1,6 @@
 ---
 layout: post
-title: "Lesson: CI Test Failures Blocking Trading Execution"
+title: "Lesson: CI Test Failures Blocking Trading Execution (Dec 11, 2025)"
 ---
 
 # Lesson: CI Test Failures Blocking Trading Execution

--- a/docs/_lessons/ll_010_dead_code_and_dormant_systems_dec11.md
+++ b/docs/_lessons/ll_010_dead_code_and_dormant_systems_dec11.md
@@ -1,6 +1,6 @@
 ---
 layout: post
-title: "Lesson Learned: Dead Code and Dormant Systems"
+title: "Lesson Learned: Dead Code and Dormant Systems (Dec 11, 2025)"
 ---
 
 # Lesson Learned: Dead Code and Dormant Systems

--- a/docs/_lessons/ll_011_facts_benchmark_factuality_ceiling.md
+++ b/docs/_lessons/ll_011_facts_benchmark_factuality_ceiling.md
@@ -1,6 +1,6 @@
 ---
 layout: post
-title: "Lesson Learned: FACTS Benchmark & 70% Factuality Ceiling"
+title: "Lesson Learned: FACTS Benchmark & 70% Factuality Ceiling (Dec 11, 2025)"
 ---
 
 # Lesson Learned: FACTS Benchmark & 70% Factuality Ceiling

--- a/docs/_lessons/ll_014_dead_code_dynamic_budget_dec11.md
+++ b/docs/_lessons/ll_014_dead_code_dynamic_budget_dec11.md
@@ -1,6 +1,6 @@
 ---
 layout: post
-title: "Lesson Learned: Dynamic Budget Scaling Was Dead Code"
+title: "Lesson Learned: Dynamic Budget Scaling Was Dead Code (Dec 11, 2025)"
 ---
 
 # Lesson Learned: Dynamic Budget Scaling Was Dead Code

--- a/docs/_lessons/ll_017_claude_md_bloat_antipattern_dec12.md
+++ b/docs/_lessons/ll_017_claude_md_bloat_antipattern_dec12.md
@@ -1,6 +1,6 @@
 ---
 layout: post
-title: "Lesson Learned: CLAUDE.md Bloat Anti-Pattern"
+title: "Lesson Learned: CLAUDE.md Bloat Anti-Pattern (Dec 12, 2025)"
 ---
 
 # Lesson Learned: CLAUDE.md Bloat Anti-Pattern

--- a/docs/_lessons/ll_017_rag_vectorization_gap_dec12.md
+++ b/docs/_lessons/ll_017_rag_vectorization_gap_dec12.md
@@ -1,6 +1,6 @@
 ---
 layout: post
-title: "Lesson Learned: RAG Vectorization Gap - Critical Knowledge Base Failure"
+title: "Lesson Learned: RAG Vectorization Gap - Critical Knowledge Base Failure (Dec 12, 2025)"
 ---
 
 # Lesson Learned: RAG Vectorization Gap - Critical Knowledge Base Failure

--- a/docs/_lessons/ll_022_options_not_automated_dec12.md
+++ b/docs/_lessons/ll_022_options_not_automated_dec12.md
@@ -1,6 +1,6 @@
 ---
 layout: post
-title: "Lesson Learned #022: Options Income Not Automated Despite Being Primary Profit Source"
+title: "Lesson Learned #022: Options Income Not Automated Despite Being Primary Profit Source (Dec 12, 2025)"
 ---
 
 # Lesson Learned #022: Options Income Not Automated Despite Being Primary Profit Source

--- a/docs/_lessons/ll_028_unified_domain_model.md
+++ b/docs/_lessons/ll_028_unified_domain_model.md
@@ -1,6 +1,6 @@
 ---
 layout: post
-title: "LL-028: Netflix Upper Metamodel - Unified Domain Model"
+title: "LL-028: Netflix Upper Metamodel - Unified Domain Model (Dec 13, 2025)"
 ---
 
 # LL-028: Netflix Upper Metamodel - Unified Domain Model

--- a/docs/_lessons/ll_029_always_verify_date.md
+++ b/docs/_lessons/ll_029_always_verify_date.md
@@ -1,6 +1,6 @@
 ---
 layout: post
-title: "LL-029: ALWAYS Verify Current Date Before Reporting"
+title: "LL-029: ALWAYS Verify Current Date Before Reporting (Dec 14, 2025)"
 ---
 
 # LL-029: ALWAYS Verify Current Date Before Reporting

--- a/docs/_lessons/ll_029_hicra_rl_credit_assignment.md
+++ b/docs/_lessons/ll_029_hicra_rl_credit_assignment.md
@@ -1,6 +1,6 @@
 ---
 layout: post
-title: "LL-029: HICRA - Hierarchy-Aware Credit Assignment for RL"
+title: "LL-029: HICRA - Hierarchy-Aware Credit Assignment for RL (Dec 14, 2025)"
 ---
 
 # LL-029: HICRA - Hierarchy-Aware Credit Assignment for RL

--- a/docs/_lessons/ll_030_langsmith_deep_agent_observability.md
+++ b/docs/_lessons/ll_030_langsmith_deep_agent_observability.md
@@ -1,6 +1,6 @@
 ---
 layout: post
-title: "Lesson Learned #030: LangSmith Deep Agent Observability"
+title: "Lesson Learned #030: LangSmith Deep Agent Observability (Dec 14, 2025)"
 ---
 
 # Lesson Learned #030: LangSmith Deep Agent Observability

--- a/docs/_lessons/ll_031_procedural_memory_trading_skills.md
+++ b/docs/_lessons/ll_031_procedural_memory_trading_skills.md
@@ -1,6 +1,6 @@
 ---
 layout: post
-title: "Lesson Learned #031: Procedural Memory for Trading Skills"
+title: "Lesson Learned #031: Procedural Memory for Trading Skills (Dec 14, 2025)"
 ---
 
 # Lesson Learned #031: Procedural Memory for Trading Skills

--- a/docs/_lessons/ll_040_catching_falling_knives_dec15.md
+++ b/docs/_lessons/ll_040_catching_falling_knives_dec15.md
@@ -1,6 +1,6 @@
 ---
 layout: post
-title: "LL-040: Catching Falling Knives - Trend Confirmation Required"
+title: "LL-040: Catching Falling Knives - Trend Confirmation Required (Dec 15, 2025)"
 ---
 
 # LL-040: Catching Falling Knives - Trend Confirmation Required

--- a/docs/_lessons/ll_041_comprehensive_regression_tests_dec15.md
+++ b/docs/_lessons/ll_041_comprehensive_regression_tests_dec15.md
@@ -1,6 +1,6 @@
 ---
 layout: post
-title: "Lesson Learned 041: Comprehensive Regression Tests for All Lessons"
+title: "Lesson Learned 041: Comprehensive Regression Tests for All Lessons (Dec 15, 2025)"
 ---
 
 # Lesson Learned 041: Comprehensive Regression Tests for All Lessons

--- a/docs/_lessons/ll_042_code_hygiene_automated_prevention_dec15.md
+++ b/docs/_lessons/ll_042_code_hygiene_automated_prevention_dec15.md
@@ -1,6 +1,6 @@
 ---
 layout: post
-title: "Lesson Learned: Code Hygiene - Automated Prevention"
+title: "Lesson Learned: Code Hygiene - Automated Prevention (Dec 15, 2025)"
 ---
 
 # Lesson Learned: Code Hygiene - Automated Prevention

--- a/docs/_lessons/ll_043_crypto_removed_simplify_dec15.md
+++ b/docs/_lessons/ll_043_crypto_removed_simplify_dec15.md
@@ -1,6 +1,6 @@
 ---
 layout: post
-title: "Lesson Learned #043: Crypto Strategy Removed - Simplify and Focus"
+title: "Lesson Learned #043: Crypto Strategy Removed - Simplify and Focus (Dec 15, 2025)"
 ---
 
 # Lesson Learned #043: Crypto Strategy Removed - Simplify and Focus

--- a/docs/_lessons/ll_043_medallion_architecture_unused_code.md
+++ b/docs/_lessons/ll_043_medallion_architecture_unused_code.md
@@ -1,6 +1,6 @@
 ---
 layout: post
-title: "LL-043: Medallion Architecture - Built But Never Integrated"
+title: "LL-043: Medallion Architecture - Built But Never Integrated (Dec 15, 2025)"
 ---
 
 # LL-043: Medallion Architecture - Built But Never Integrated

--- a/docs/_lessons/ll_044_documentation_hygiene_mandate_dec15.md
+++ b/docs/_lessons/ll_044_documentation_hygiene_mandate_dec15.md
@@ -1,6 +1,6 @@
 ---
 layout: post
-title: "Lesson Learned #044: Documentation Hygiene Mandate - Zero Tolerance for Stale Docs"
+title: "Lesson Learned #044: Documentation Hygiene Mandate - Zero Tolerance for Stale Docs (Dec 15, 2025)"
 ---
 
 # Lesson Learned #044: Documentation Hygiene Mandate - Zero Tolerance for Stale Docs

--- a/docs/_lessons/ll_045_verification_systems_prevent_mistakes_dec15.md
+++ b/docs/_lessons/ll_045_verification_systems_prevent_mistakes_dec15.md
@@ -1,6 +1,6 @@
 ---
 layout: post
-title: "Lesson Learned #045: Verification Systems to Prevent Repeated Mistakes"
+title: "Lesson Learned #045: Verification Systems to Prevent Repeated Mistakes (Dec 15, 2025)"
 ---
 
 # Lesson Learned #045: Verification Systems to Prevent Repeated Mistakes

--- a/docs/_lessons/ll_046_tax_aware_trading_mandate_dec15.md
+++ b/docs/_lessons/ll_046_tax_aware_trading_mandate_dec15.md
@@ -1,6 +1,6 @@
 ---
 layout: post
-title: "Lesson Learned #046: Tax-Aware Trading Mandate"
+title: "Lesson Learned #046: Tax-Aware Trading Mandate (Dec 15, 2025)"
 ---
 
 # Lesson Learned #046: Tax-Aware Trading Mandate

--- a/docs/_lessons/ll_047_e2e_pipeline_verification_dec15.md
+++ b/docs/_lessons/ll_047_e2e_pipeline_verification_dec15.md
@@ -1,6 +1,6 @@
 ---
 layout: post
-title: "Lesson Learned: E2E Pipeline Verification Tests Added"
+title: "Lesson Learned: E2E Pipeline Verification Tests Added (Dec 15, 2025)"
 ---
 
 # Lesson Learned: E2E Pipeline Verification Tests Added

--- a/docs/_lessons/ll_047_rag_dual_database_cleanup_dec15.md
+++ b/docs/_lessons/ll_047_rag_dual_database_cleanup_dec15.md
@@ -1,6 +1,6 @@
 ---
 layout: post
-title: "Lesson Learned #047: RAG Dual Database Cleanup Needed"
+title: "Lesson Learned #047: RAG Dual Database Cleanup Needed (Dec 15, 2025)"
 ---
 
 # Lesson Learned #047: RAG Dual Database Cleanup Needed

--- a/docs/_lessons/ll_048_go_live_readiness_system_dec15.md
+++ b/docs/_lessons/ll_048_go_live_readiness_system_dec15.md
@@ -1,6 +1,6 @@
 ---
 layout: post
-title: "Lesson Learned: Go-Live Readiness System"
+title: "Lesson Learned: Go-Live Readiness System (Dec 15, 2025)"
 ---
 
 # Lesson Learned: Go-Live Readiness System

--- a/docs/_lessons/ll_049_config_workflow_sync_failure_dec16.md
+++ b/docs/_lessons/ll_049_config_workflow_sync_failure_dec16.md
@@ -1,6 +1,6 @@
 ---
 layout: post
-title: "Lesson Learned #049: Config-Workflow Sync Failure - Disabled Features Still Running"
+title: "Lesson Learned #049: Config-Workflow Sync Failure - Disabled Features Still Running (Dec 16, 2025)"
 ---
 
 # Lesson Learned #049: Config-Workflow Sync Failure - Disabled Features Still Running

--- a/docs/_lessons/ll_050_langsmith_tracing_integration_dec16.md
+++ b/docs/_lessons/ll_050_langsmith_tracing_integration_dec16.md
@@ -1,6 +1,6 @@
 ---
 layout: post
-title: "Lesson Learned: LangSmith Tracing Integration"
+title: "Lesson Learned: LangSmith Tracing Integration (Dec 16, 2025)"
 ---
 
 # Lesson Learned: LangSmith Tracing Integration

--- a/docs/_lessons/ll_051_blind_trading_catastrophe_dec17.md
+++ b/docs/_lessons/ll_051_blind_trading_catastrophe_dec17.md
@@ -1,6 +1,6 @@
 ---
 layout: post
-title: "Lesson Learned: Blind Trading Catastrophe - System Lost Money Without Knowing"
+title: "Lesson Learned: Blind Trading Catastrophe - System Lost Money Without Knowing (Dec 17, 2025)"
 ---
 
 # Lesson Learned: Blind Trading Catastrophe - System Lost Money Without Knowing

--- a/docs/_lessons/ll_051_calendar_awareness_critical_dec19.md
+++ b/docs/_lessons/ll_051_calendar_awareness_critical_dec19.md
@@ -1,6 +1,6 @@
 ---
 layout: post
-title: "Lesson Learned #051: Calendar Awareness is Critical for Trading AI"
+title: "Lesson Learned #051: Calendar Awareness is Critical for Trading AI (Dec 19, 2025)"
 ---
 
 # Lesson Learned #051: Calendar Awareness is Critical for Trading AI

--- a/docs/_lessons/ll_051_strategy_thresholds_too_tight_dec17.md
+++ b/docs/_lessons/ll_051_strategy_thresholds_too_tight_dec17.md
@@ -1,6 +1,6 @@
 ---
 layout: post
-title: "Lesson Learned: Strategy Thresholds Too Tight - Positions Closed Before Trends Developed"
+title: "Lesson Learned: Strategy Thresholds Too Tight - Positions Closed Before Trends Developed (Dec 17, 2025)"
 ---
 
 # Lesson Learned: Strategy Thresholds Too Tight - Positions Closed Before Trends Developed

--- a/docs/_lessons/ll_052_credit_spreads_capital_efficiency_dec17.md
+++ b/docs/_lessons/ll_052_credit_spreads_capital_efficiency_dec17.md
@@ -1,6 +1,6 @@
 ---
 layout: post
-title: "Lesson Learned: Credit Spreads for Capital-Efficient Options Trading"
+title: "Lesson Learned: Credit Spreads for Capital-Efficient Options Trading (Dec 17, 2025)"
 ---
 
 # Lesson Learned: Credit Spreads for Capital-Efficient Options Trading

--- a/docs/_lessons/ll_052_no_crypto_trading_dec19.md
+++ b/docs/_lessons/ll_052_no_crypto_trading_dec19.md
@@ -1,6 +1,6 @@
 ---
 layout: post
-title: "Lesson Learned #052: We Do NOT Trade Crypto - Remove All References"
+title: "Lesson Learned #052: We Do NOT Trade Crypto - Remove All References (Dec 19, 2025)"
 ---
 
 # Lesson Learned #052: We Do NOT Trade Crypto - Remove All References

--- a/docs/_lessons/ll_053_stop_bleeding_crypto_reit_dec17.md
+++ b/docs/_lessons/ll_053_stop_bleeding_crypto_reit_dec17.md
@@ -1,6 +1,6 @@
 ---
 layout: post
-title: "Lesson Learned: Stop Bleeding - Disable Crypto and REIT Strategies"
+title: "Lesson Learned: Stop Bleeding - Disable Crypto and REIT Strategies (Dec 17, 2025)"
 ---
 
 # Lesson Learned: Stop Bleeding - Disable Crypto and REIT Strategies

--- a/docs/_lessons/ll_054_rag_not_actually_used_dec17.md
+++ b/docs/_lessons/ll_054_rag_not_actually_used_dec17.md
@@ -1,6 +1,6 @@
 ---
 layout: post
-title: "Lesson Learned: RAG Was Built But Not Used - Keyword Matching is Useless"
+title: "Lesson Learned: RAG Was Built But Not Used - Keyword Matching is Useless (Dec 17, 2025)"
 ---
 
 # Lesson Learned: RAG Was Built But Not Used - Keyword Matching is Useless

--- a/docs/_lessons/ll_055_gitignore_breaks_workflow_commits_dec20.md
+++ b/docs/_lessons/ll_055_gitignore_breaks_workflow_commits_dec20.md
@@ -1,6 +1,6 @@
 ---
 layout: post
-title: "Lesson Learned #055: Multiple Workflow Commit Failures"
+title: "Lesson Learned #055: Multiple Workflow Commit Failures (Dec 20, 2025)"
 ---
 
 # Lesson Learned #055: Multiple Workflow Commit Failures

--- a/docs/_lessons/ll_autonomous_commands.md
+++ b/docs/_lessons/ll_autonomous_commands.md
@@ -1,13 +1,6 @@
 ---
 layout: post
-title: "Lesson: Always Execute Commands Autonomously"
----
-
----
-title: "Lesson: Always Execute Commands Autonomously"
-date: "2025-12-12"
-severity: "high"
-tags: ["autonomous", "protocol", "error-correction"]
+title: "Lesson: Always Execute Commands Autonomously (Dec 12, 2025)"
 ---
 
 # Lesson: Always Execute Commands Autonomously

--- a/docs/_lessons/ll_permanent_autonomous_mandate.md
+++ b/docs/_lessons/ll_permanent_autonomous_mandate.md
@@ -1,6 +1,6 @@
 ---
 layout: post
-title: "Permanent Mandate: Autonomous GitHub Operations"
+title: "Permanent Mandate: Autonomous GitHub Operations (Dec 14, 2025)"
 ---
 
 # Permanent Mandate: Autonomous GitHub Operations

--- a/docs/_lessons/over_engineering_trading_system.md
+++ b/docs/_lessons/over_engineering_trading_system.md
@@ -1,6 +1,6 @@
 ---
 layout: post
-title: "Lesson Learned: Over-Engineering Trading System"
+title: "Lesson Learned: Over-Engineering Trading System (Dec 11, 2025)"
 ---
 
 # Lesson Learned: Over-Engineering Trading System

--- a/docs/_lessons/the_one_thing_trading.md
+++ b/docs/_lessons/the_one_thing_trading.md
@@ -1,6 +1,6 @@
 ---
 layout: post
-title: "The ONE Thing - Applied to Trading Systems"
+title: "The ONE Thing - Applied to Trading Systems (Dec 11, 2025)"
 ---
 
 # The ONE Thing - Applied to Trading Systems

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,8 +3,6 @@ layout: home
 title: AI Trading Journey
 ---
 
-# AI Trading Journey
-
 A 90-day experiment building an autonomous AI trading system with Claude Opus 4.5.
 
 **Real failures. Real fixes. Real lessons.**


### PR DESCRIPTION
Fixes two issues:
1. Removes duplicate H1 heading from index.md
2. Adds dates to 37 lesson titles that were missing them