### PR TITLE
fix: Remove duplicate page title from index.md

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,5 @@
 ---
 layout: home
-title: AI Trading Journey
 ---
 
 A 90-day experiment building an autonomous AI trading system with Claude Opus 4.5.


### PR DESCRIPTION
The minima theme displays both the site title (from _config.yml) and the page title (from index.md). Removing the page title fixes the duplicate.