### PR TITLE
docs: Add lesson #057 - Google context engineering patterns

### DIFF
--- a/rag_knowledge/lessons_learned/ll_057_context_engineering_patterns_dec22.md
+++ b/rag_knowledge/lessons_learned/ll_057_context_engineering_patterns_dec22.md
@@ -1,0 +1,61 @@
+# Lesson Learned: Google's Context Engineering Patterns for Multi-Agent Systems
+
+**ID**: LL-057
+**Date**: December 22, 2025
+**Category**: Architecture
+**Severity**: Low (Future Reference)
+**Status**: Documented for future use
+
+## Summary
+
+Google published ADK (Agent Development Kit) patterns for context engineering. Relevant when our system hits context limits - NOT needed now.
+
+## Key Patterns (For Future Use)
+
+### 1. Tiered Context Architecture
+- **Working Context**: Ephemeral, per-call prompt
+- **Session**: Durable event log (our `performance_log.json`)
+- **Artifacts**: Large objects stored externally with handles
+
+### 2. Compaction Pattern
+When log exceeds threshold, summarize older entries:
+```python
+# FUTURE: When performance_log.json > 100 entries
+def compact_old_entries(log, keep_recent=30):
+    if len(log) <= keep_recent:
+        return log
+    old = log[:-keep_recent]
+    summary = llm_summarize(old)  # "Oct-Nov: -$21 to +$17, 3 trades"
+    return [{"type": "summary", "content": summary}] + log[-keep_recent:]
+```
+
+### 3. Context Processors Pipeline
+Order hooks/processors consistently:
+```
+auth → state → instructions → execution → output
+```
+
+## When to Implement
+
+Trigger conditions (NOT met today):
+- [ ] `performance_log.json` > 100 entries
+- [ ] Context window errors in production
+- [ ] Hook execution > 2 seconds
+- [ ] Token costs exceed budget
+
+## Current State (Dec 22, 2025)
+
+- Performance log: ~20 entries ✅ (no action needed)
+- Hooks: Fast ✅
+- System: Profitable +$531 ✅
+
+**Decision**: Document pattern, implement when needed.
+
+## Source
+
+- [Google ADK Blog Post](https://developers.googleblog.com/en/architecting-efficient-context-aware-multi-agent-framework-for-production/)
+- [@omarsar0 Tweet](https://x.com/omarsar0/status/1997348089888374918)
+
+## Tags
+
+#architecture #context-engineering #future-reference #adk


### PR DESCRIPTION
Documented Google ADK context engineering patterns as lesson #057 for future reference. Not implementing now - system is working and profitable.