### PR TITLE
fix: Resolve remaining CI failures (4 checks)

### DIFF
--- a/src/rag/collectors/__init__.py
+++ b/src/rag/collectors/__init__.py
@@ -1,11 +1,7 @@
-# Stub module
+# FRED Collector module exports
+from src.rag.collectors.fred_collector import FREDCollector
 
+# Backward compatibility alias (camelCase)
+FredCollector = FREDCollector
 
-class FredCollector:
-    """Stub for deleted FRED collector."""
-
-    def __init__(self, *args, **kwargs):
-        pass
-
-    def fetch(self, *args, **kwargs) -> dict:
-        return {}
+__all__ = ["FREDCollector", "FredCollector"]

--- a/src/risk/trade_gateway.py
+++ b/src/risk/trade_gateway.py
@@ -507,7 +507,7 @@ class TradeGateway:
                         "side": request.side,
                         "notional": request.notional,
                         "quantity": request.quantity,
-                        "strategy": request.strategy,
+                        "strategy": request.strategy_type,
                     }
                     span.add_output("approved", approved)
                     span.add_output("risk_score", risk_score)

--- a/tests/test_trade_gateway.py
+++ b/tests/test_trade_gateway.py
@@ -168,14 +168,15 @@ class TestTradeGatewayAllocationLimits:
     def test_over_allocation_rejected(self):
         """Test that > 15% allocation to single symbol is rejected."""
         gateway = TradeGateway(executor=None, paper=True)
+        # Use AAPL (not in any correlation group) to avoid HIGH_CORRELATION rejection
         gateway.executor = MockExecutor(
             account_equity=10000,
-            positions=[{"symbol": "TSLA", "market_value": 1400}],  # 14% already
+            positions=[{"symbol": "AAPL", "market_value": 1400}],  # 14% already
         )
 
         # Trying to add $200 more would push to 16%
         request = TradeRequest(
-            symbol="TSLA",
+            symbol="AAPL",
             side="buy",
             notional=200,
             source="test",


### PR DESCRIPTION
## Summary
Fix all remaining CI check failures.

## Fixes

### 1. Syntax & Import Verification
- `src/risk/trade_gateway.py:510`: Fixed `request.strategy` → `request.strategy_type`
- `src/rag/collectors/__init__.py`: Fixed FredCollector alias to properly import FREDCollector

### 2. Test Suite
- `tests/test_trade_gateway.py`: Changed test from TSLA (in correlation group) to AAPL (not in correlation group) to correctly test MAX_ALLOCATION_EXCEEDED without triggering HIGH_CORRELATION first

### 3. Core Strategy Metric Validation  
- Created `scripts/run_core_strategy_reference_backtest.py` - the missing script that CI was trying to run
- Validates backtest metrics against thresholds

## Test Plan
- [x] All files compile (`py_compile`)
- [x] Ruff lint passes
- [x] `run_core_strategy_reference_backtest.py` runs successfully locally
- [ ] CI passes
