### PR TITLE
fix: Additional lint cleanup for CI compliance

### DIFF
--- a/mcp/servers/alpaca_wrapper.py
+++ b/mcp/servers/alpaca_wrapper.py
@@ -23,7 +23,8 @@ def submit_order(
     client: MCPClient | None = None,
     **kwargs: Any,
 ) -> dict[str, Any]:
-    # Map to official Alpaca MCP tool: submit_order(symbol, side, qty, type, time_in_force, extended_hours)
+    # Map to official Alpaca MCP tool: submit_order
+    # Args: symbol, side, qty, type, time_in_force, extended_hours
     payload = {
         "symbol": symbol,
         "side": side,

--- a/mcp/servers/bogleheads_server.py
+++ b/mcp/servers/bogleheads_server.py
@@ -8,6 +8,7 @@ Provides MCP tools for monitoring Bogleheads forum and integrating insights.
 import asyncio
 import json
 import logging
+import sys
 from pathlib import Path
 from typing import Any
 
@@ -25,8 +26,6 @@ logger = logging.getLogger(__name__)
 
 # Add project root to path
 project_root = Path(__file__).parent.parent.parent.parent
-import sys
-
 sys.path.insert(0, str(project_root))
 
 

--- a/mcp/servers/langsmith_server.py
+++ b/mcp/servers/langsmith_server.py
@@ -7,6 +7,7 @@ Provides MCP tools for monitoring LangSmith traces and runs.
 import asyncio
 import json
 import logging
+import sys
 from pathlib import Path
 from typing import Any
 
@@ -24,8 +25,6 @@ logger = logging.getLogger(__name__)
 
 # Add project root to path
 project_root = Path(__file__).parent.parent.parent
-import sys
-
 sys.path.insert(0, str(project_root))
 
 

--- a/scripts/autonomous_trader.py
+++ b/scripts/autonomous_trader.py
@@ -2,19 +2,17 @@
 
 from __future__ import annotations
 
-import os
-
-# Early diagnostic output for CI visibility
-import sys
-
-# Reduced annotations to avoid GitHub 10-annotation limit
-print("autonomous_trader.py starting - Python:", sys.version.split()[0], flush=True)
-
 import argparse
 import json
+import os
+import sys
 from datetime import datetime
 from pathlib import Path
 from typing import Any
+
+# Early diagnostic output for CI visibility
+# Reduced annotations to avoid GitHub 10-annotation limit
+print("autonomous_trader.py starting - Python:", sys.version.split()[0], flush=True)
 
 # Removed annotation to stay under limit
 
@@ -177,7 +175,8 @@ def _apply_daily_input_scaling(logger) -> None:
     scaled = calc_daily_input(equity)
     os.environ["DAILY_INVESTMENT"] = f"{scaled:.2f}"
     logger.info(
-        "Daily input auto-scaled to $%.2f (equity=$%.2f). Set ENABLE_DAILY_INPUT_SCALING=false to disable.",
+        "Daily input auto-scaled to $%.2f (equity=$%.2f). "
+        "Set ENABLE_DAILY_INPUT_SCALING=false to disable.",
         scaled,
         equity,
     )
@@ -425,9 +424,8 @@ def _update_reit_daily_returns(logger) -> None:
     try:
         with state_path.open("w", encoding="utf-8") as handle:
             json.dump(state, handle, indent=2)
-        logger.info(
-            f"📊 REIT Daily Returns: ${reit_realized + reit_unrealized:.2f} ({len(reit_positions)} positions)"
-        )
+        reit_total = reit_realized + reit_unrealized
+        logger.info(f"📊 REIT Daily Returns: ${reit_total:.2f} ({len(reit_positions)} positions)")
     except Exception:
         pass
 
@@ -572,9 +570,8 @@ def _update_precious_metals_daily_returns(logger) -> None:
     try:
         with state_path.open("w", encoding="utf-8") as handle:
             json.dump(state, handle, indent=2)
-        logger.info(
-            f"Precious Metals Daily Returns: ${metals_realized + metals_unrealized:.2f} ({len(metals_positions)} positions)"
-        )
+        metals_total = metals_realized + metals_unrealized
+        logger.info(f"Precious Metals Returns: ${metals_total:.2f} ({len(metals_positions)} pos)")
     except Exception:
         pass
 
@@ -655,7 +652,7 @@ def execute_precious_metals_trading() -> None:
                             "timestamp": datetime.now().isoformat(),
                             "status": "SUBMITTED",
                             "strategy": "PreciousMetalsStrategy",
-                            "reason": f"Regime: {regime}, Weight: {sig.get('strength', 0) * 100:.0f}%",
+                            "reason": f"Regime: {regime}, Wt: {sig.get('strength', 0) * 100:.0f}%",
                             "mode": "PAPER",
                             "regime": regime,
                         }
@@ -775,9 +772,7 @@ def execute_reit_trading() -> None:
                 json.dump(daily_trades, f, indent=4)
 
             logger.info(f"💾 REIT trades saved to {trades_file}")
-            logger.info(
-                f"✅ REIT strategy executed: {len(signals)} positions @ ${per_trade_amount:.2f} each"
-            )
+            logger.info(f"✅ REIT: {len(signals)} positions @ ${per_trade_amount:.2f} each")
 
             # Update REIT daily returns in system_state for easy CEO visibility
             _update_reit_daily_returns(logger)

--- a/scripts/generate_daily_blog_post.py
+++ b/scripts/generate_daily_blog_post.py
@@ -23,19 +23,16 @@ def get_treasury_yields() -> dict:
     """Fetch live Treasury yields from FRED API."""
     try:
         from src.rag.collectors.fred_collector import FREDCollector
+
         fred = FREDCollector()
         yields = fred.get_treasury_yields()
         spread = fred.get_yield_curve_spread()
         inverted = fred.is_yield_curve_inverted()
-        return {
-            "yields": yields,
-            "spread": spread,
-            "inverted": inverted,
-            "available": True
-        }
+        return {"yields": yields, "spread": spread, "inverted": inverted, "available": True}
     except Exception as e:
         print(f"Warning: Could not fetch FRED data: {e}")
         return {"available": False}
+
 
 # Paths
 DATA_DIR = Path(__file__).parent.parent / "data"
@@ -141,10 +138,10 @@ def generate_blog_post(perf: dict, trades: list, day_num: int) -> str:
         curve_status = "**INVERTED** (recession warning)" if inverted else "Normal (positive slope)"
         spread_str = f"{spread:+.2f}%" if spread is not None else "N/A"
 
-        y2 = f"{yields.get('2Y', 0):.2f}%" if yields.get('2Y') else "N/A"
-        y5 = f"{yields.get('5Y', 0):.2f}%" if yields.get('5Y') else "N/A"
-        y10 = f"{yields.get('10Y', 0):.2f}%" if yields.get('10Y') else "N/A"
-        y30 = f"{yields.get('30Y', 0):.2f}%" if yields.get('30Y') else "N/A"
+        y2 = f"{yields.get('2Y', 0):.2f}%" if yields.get("2Y") else "N/A"
+        y5 = f"{yields.get('5Y', 0):.2f}%" if yields.get("5Y") else "N/A"
+        y10 = f"{yields.get('10Y', 0):.2f}%" if yields.get("10Y") else "N/A"
+        y30 = f"{yields.get('30Y', 0):.2f}%" if yields.get("30Y") else "N/A"
 
         treasury_section = f"""| Maturity | Yield |
 |----------|-------|


### PR DESCRIPTION
## Summary
- Split long comment in alpaca_wrapper.py to fit 100 char limit
- Move sys import to top in bogleheads_server.py and langsmith_server.py  
- Reorder imports in autonomous_trader.py (all imports before print statement)
- Shorten long log messages to fit 100 char limit

## Test plan
- [ ] CI Lint & Format check passes
- [ ] CI Syntax & Import Verification passes
- [ ] Local ruff check passes