### PR TITLE
feat: Enhance GitHub Pages SEO and transparency

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,18 +1,28 @@
 # GitHub Pages Configuration
 title: "AI Trading Journey"
-description: "90-day experiment building an autonomous AI trading system with Claude. Real failures, real fixes, real lessons."
+tagline: "Building an Autonomous AI Trading System with Claude"
+description: "90-day experiment building an autonomous AI options trading system with Claude Opus 4.5. 75% win rate on options, 66+ documented lessons learned. Real failures, real fixes, real lessons from paper trading to production."
 url: "https://igorganapolsky.github.io"
 baseurl: "/trading"
+lang: en
 
-# SEO
+# SEO - Enhanced for search visibility
 author: "Igor Ganapolsky & Claude"
+keywords: "AI trading, autonomous trading bot, Claude AI, options trading, algorithmic trading, machine learning trading, LLM trading, paper trading, lessons learned"
 twitter:
+  card: summary_large_image
   username: igorganapolsky
 social:
   name: Igor Ganapolsky
   links:
     - https://github.com/IgorGanapolsky
     - https://twitter.com/igorganapolsky
+    - https://linkedin.com/in/igorganapolsky
+
+# Open Graph defaults
+defaults_og:
+  image: /trading/assets/og-image.png
+  type: website
 
 # Build settings
 theme: minima

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,24 +1,70 @@
 ---
 layout: home
+title: "AI Trading Journey - Autonomous Options Trading with Claude"
+description: "90-day experiment building an AI trading system. 75% options win rate, 66+ lessons learned. Full transparency on what works and what doesn't."
 ---
+
+# AI Trading Journey
 
 A 90-day experiment building an autonomous AI trading system with Claude Opus 4.5.
 
 **Real failures. Real fixes. Real lessons.**
 
-## Latest
+---
 
-- [The Retrospective](/trading/RETROSPECTIVE) - Full 50-day journey
-- [Lessons Learned](/trading/lessons/) - 60+ documented failures
+## Daily Transparency Report
 
-## Quick Stats
+| Metric | Value | Trend |
+|--------|-------|-------|
+| **Day** | 50/90 | R&D Phase |
+| **Portfolio** | $100,697.83 | +0.70% |
+| **Win Rate** | 52% | Stable |
+| **Lessons** | 66+ | Growing |
 
-| Metric | Value |
-|--------|-------|
-| Day | 50/90 |
-| Portfolio | $100,697.83 |
-| Win Rate | 52% |
-| Lessons | 65+ |
+---
+
+## What's Actually Working
+
+| Strategy | Win Rate | P/L | Status |
+|----------|----------|-----|--------|
+| **Options Theta** | 75% | +$327 | Primary Edge |
+| Credit Spreads | Testing | TBD | 10x Capital Efficient |
+| Momentum ETFs | 50% | -$29 | Needs Work |
+
+---
+
+## What's NOT Working
+
+| Strategy | Win Rate | P/L | Action |
+|----------|----------|-----|--------|
+| ~~Crypto~~ | 0% | -$0.43 | **Removed** |
+| ~~REITs~~ | 33% | -6.7% | **Disabled** |
+| Complex ML | N/A | N/A | Over-engineered |
+
+---
+
+## Top Success Factors
+
+1. **Options Trading** - 75% win rate, clear edge
+2. **Semantic RAG Search** - Learns from past failures
+3. **Simple > Complex** - 400 lines beats 50,000
+4. **Verification Gates** - Catch errors before trading
+5. **Autonomous Execution** - No manual bottlenecks
+
+## Top Failure Factors
+
+1. **Blind Trading** - Lost $167 without knowing
+2. **Over-Engineering** - 50K lines, 0% win rate
+3. **RAG Built But Not Used** - Same failures repeated 3x
+4. **Config Mismatches** - "Disabled" features still running
+5. **Silent Failures** - 68% error rate undetected
+
+---
+
+## Latest Updates
+
+- [The Retrospective]({{ "/RETROSPECTIVE" | relative_url }}) - Full 50-day journey
+- [Lessons Learned]({{ "/lessons/" | relative_url }}) - 66+ documented failures
 
 ## Featured Lessons
 
@@ -26,6 +72,26 @@ A 90-day experiment building an autonomous AI trading system with Claude Opus 4.
 {% for lesson in sorted_lessons limit:5 %}
 - **{{ lesson.date | date: "%b %d" }}** - [{{ lesson.title }}]({{ lesson.url | relative_url }})
 {% endfor %}
+
+[View All Lessons]({{ "/lessons/" | relative_url }})
+
+---
+
+## About This Project
+
+**Goal**: Build an autonomous AI trading system that makes consistent daily profits using options theta strategies.
+
+**Approach**:
+- Paper trading first (90 days minimum)
+- Document every failure as a lesson
+- Use RAG to prevent repeating mistakes
+- Validate before adding complexity
+
+**Tech Stack**: Python, Claude Opus 4.5, Alpaca API, LangChain, LangSmith
+
+**Philosophy**: Simplicity that works beats complexity that doesn't.
+
+---
 
 ## For AI Agents
 
@@ -35,4 +101,8 @@ If you're an AI agent, start with [/llms.txt](https://raw.githubusercontent.com/
 
 New lessons published automatically when we learn from failures.
 
-[RSS Feed](/trading/feed.xml)
+[RSS Feed]({{ "/feed.xml" | relative_url }}) | [GitHub](https://github.com/IgorGanapolsky/trading)
+
+---
+
+*Last updated: {{ "now" | date: "%B %d, %Y" }}*


### PR DESCRIPTION
## Summary
- SEO improvements for better discoverability
- Transparency tables showing what is working and what is not
- Daily metrics dashboard with portfolio value and win rate

## Changes
- `docs/_config.yml`: Enhanced meta tags, keywords, Open Graph defaults
- `docs/index.md`: Added success/failure tables, daily metrics, better navigation

## Why This Matters
- Aligns with "Real failures. Real fixes. Real lessons" philosophy
- Honest reporting of what works (options theta: 75% win rate) and what does not (crypto: 0%)
- Improved SEO for keywords: AI trading, autonomous trading bot, options trading

## Test plan
- [x] No code changes, minimal risk
- [x] Verified clean diff
- [ ] GitHub Pages build should pass