### PR TITLE
fix: Sort imports in orchestrator/main.py

### DIFF
--- a/src/orchestrator/main.py
+++ b/src/orchestrator/main.py
@@ -35,8 +35,8 @@ from src.orchestrator.gates import (
     TradingGatePipeline,
 )
 from src.orchestrator.parallel_processor import (
-    ParallelTickerProcessor,
     ParallelProcessingResult,
+    ParallelTickerProcessor,
     TickerOutcome,
     create_thread_safe_wrapper,
 )


### PR DESCRIPTION
Fix ruff I001 - import block sorting issue causing CI lint failure.