### PR TITLE
feat: Add LLM reasoning protocols to agent prompts

### DIFF
--- a/src/agents/execution_agent.py
+++ b/src/agents/execution_agent.py
@@ -110,6 +110,14 @@ TECHNICALS: MACD Hist {macd_hist:.3f} | RSI {rsi:.1f}
 
 {memory_context}
 
+REASONING PROTOCOL:
+Think step-by-step before deciding:
+1. Check market status and timing constraints
+2. Evaluate liquidity conditions (spread, volume)
+3. Assess technical momentum (RSI, MACD)
+4. Estimate slippage risk based on conditions
+5. Critique your assessment - what execution risk are you underestimating?
+
 PRINCIPLES:
 - Wide spread (>0.1%) = wait for better liquidity or use limit order
 - Low volume (<50% avg) = expect higher slippage, consider splitting

--- a/src/agents/meta_agent.py
+++ b/src/agents/meta_agent.py
@@ -56,6 +56,14 @@ class MetaAgent(BaseAgent):
         memory_context = self.get_memory_context(limit=5)
         prompt = f"""You are the Meta-Agent coordinating a multi-agent trading system.
 
+REASONING PROTOCOL:
+Think step-by-step before reaching your coordination decision:
+1. Assess the current market regime and its implications
+2. Determine which agents are most relevant for this regime
+3. Consider how to weight conflicting agent recommendations
+4. Anticipate potential failure modes in the coordination
+5. Critique your own strategy - are you over/under-weighting any agent?
+
 MARKET REGIME: {regime}
 
 CURRENT DATA:

--- a/src/agents/research_agent.py
+++ b/src/agents/research_agent.py
@@ -118,6 +118,15 @@ Focus on value and risk because overpaying destroys long-term returns, even for 
 Fundamentals drive long-term performance; sentiment affects short-term price action.
 </context>
 
+<reasoning_protocol>
+Think step-by-step before reaching your conclusion:
+1. Evaluate fundamentals against Graham-Buffett principles
+2. Assess news sentiment and separate signal from noise
+3. Consider market context and sector dynamics
+4. Weigh conflicting signals using the principle weights
+5. Critique your own assessment - what could you be missing?
+</reasoning_protocol>
+
 <fundamentals>
 P/E: {fundamentals.get("pe_ratio", "N/A")} | Growth: {fundamentals.get("growth_rate", "N/A")} | Margin: {fundamentals.get("profit_margin", "N/A")} | Cap: {fundamentals.get("market_cap", "N/A")}
 </fundamentals>

--- a/src/agents/risk_agent.py
+++ b/src/agents/risk_agent.py
@@ -76,6 +76,15 @@ A 50% loss requires a 100% gain to recover - survival is non-negotiable.
 Position sizing is the most underappreciated edge in trading.
 </context>
 
+<reasoning_protocol>
+Think step-by-step before reaching your conclusion:
+1. Assess position size against portfolio limits
+2. Evaluate volatility and adjust sizing accordingly
+3. Check confidence level and correlation risk
+4. Consider worst-case scenarios (max drawdown if stopped)
+5. Critique your own assessment - are you underestimating tail risk?
+</reasoning_protocol>
+
 <portfolio>
 Value: ${portfolio_value:,.0f} | Max Risk: {self.max_portfolio_risk:.1%}/trade | Max Position: {self.max_position_size:.1%}
 </portfolio>

--- a/src/agents/signal_agent.py
+++ b/src/agents/signal_agent.py
@@ -69,6 +69,15 @@ Being decisive matters because hesitation in trading leads to missed opportuniti
 Strong signals deserve high scores; weak/mixed signals deserve low scores.
 </context>
 
+<reasoning_protocol>
+Think step-by-step before reaching your conclusion:
+1. Analyze each indicator independently (MACD, RSI, Volume, Trend)
+2. Weight signals according to empirical importance
+3. Look for confirmation or divergence across indicators
+4. Assess signal quality - is this high-conviction or ambiguous?
+5. Critique your own assessment - what pattern might you be missing?
+</reasoning_protocol>
+
 <indicators>
 Price: ${indicators.get("price", 0):.2f} | MACD Hist: {indicators.get("macd_histogram", 0):.4f} | RSI: {indicators.get("rsi", 50):.1f} | Volume: {indicators.get("volume_ratio", 1.0):.1f}x
 Trend: {indicators.get("trend", "UNKNOWN")} | MA50: ${indicators.get("ma_50", 0):.2f} | Momentum: {indicators.get("momentum_score", 0):.0f}/100


### PR DESCRIPTION
## Summary
- Adds explicit step-by-step reasoning protocols to 5 main trading agents
- Based on Anthropic-vetted tips (Greg Isenberg video)
- Implements "think step-by-step" and "critique your own assessment" power phrases

## Agents Updated
- ResearchAgent: Graham-Buffett evaluation protocol
- RiskAgent: Tail risk self-critique protocol
- SignalAgent: Indicator-by-indicator analysis protocol
- ExecutionAgent: Slippage risk critique protocol
- MetaAgent: Agent-weighting self-critique protocol

## Test Plan
- [ ] Verify prompts parse correctly
- [ ] Run dry run to confirm agents respond properly