### PR TITLE
fix: Agent Health Check with cached dependencies

### DIFF
--- a/.github/workflows/agent-health-check.yml
+++ b/.github/workflows/agent-health-check.yml
@@ -16,7 +16,7 @@ jobs:
   agent-health:
     name: Verify All Agents Operational
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 15
 
     steps:
       - name: Checkout
@@ -26,13 +26,28 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: '3.11'
-          cache: 'pip'
+
+      - name: Install Poetry
+        uses: snok/install-poetry@v1
+        with:
+          version: latest
+          virtualenvs-create: true
+          virtualenvs-in-project: true
+          installer-parallel: true
+
+      - name: Load cached venv
+        id: cached-poetry-dependencies
+        uses: actions/cache@v4
+        with:
+          path: .venv
+          key: venv-${{ runner.os }}-${{ hashFiles('**/poetry.lock') }}
 
       - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install poetry
-          poetry install --no-interaction
+        if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
+        run: poetry install --no-interaction --no-root
+
+      - name: Install project
+        run: poetry install --no-interaction
 
       - name: Check Core Agent Imports
         run: |


### PR DESCRIPTION
## Summary

- Increase timeout to 15 minutes
- Use snok/install-poetry for faster install
- Add dependency caching for .venv
- Split install into cached/non-cached steps

This should resolve the poetry install timeout issues.

## Test plan

- [ ] Agent Health Check workflow passes