### PR TITLE
fix: Use correct StrategyRegistry method list_all()

### DIFF
--- a/.github/workflows/agent-health-check.yml
+++ b/.github/workflows/agent-health-check.yml
@@ -121,10 +121,10 @@ jobs:
           from src.strategies.registry import StrategyRegistry
 
           registry = StrategyRegistry()
-          strategies = registry.list_strategies()
+          strategies = registry.list_all()
 
           print(f"Registered strategies: {len(strategies)}")
-          for s in strategies[:10]:
+          for s in list(strategies.keys())[:10]:
               print(f"  - {s}")
 
           if len(strategies) < 1:


### PR DESCRIPTION
Fixes Agent Health Check workflow by using correct method name:
- `list_strategies()` does not exist
- Changed to `list_all()` which is the actual method