### PR TITLE
fix: Fix strategy registry check in agent health workflow

### DIFF
--- a/.github/workflows/agent-health-check.yml
+++ b/.github/workflows/agent-health-check.yml
@@ -124,7 +124,8 @@ jobs:
           strategies = registry.list_all()
 
           print(f"Registered strategies: {len(strategies)}")
-          for s in list(strategies.keys())[:10]:
+          # list_all() returns a list, not a dict
+          for s in strategies[:10]:
               print(f"  - {s}")
 
           if len(strategies) < 1:


### PR DESCRIPTION
## Summary
Fix: registry.list_all() returns a list, not a dict.

Fixes agent health check CI failure.