### PR TITLE
fix: Pin langchain dependencies to prevent version conflicts

### DIFF
--- a/requirements-minimal.txt
+++ b/requirements-minimal.txt
@@ -38,10 +38,12 @@ anthropic>=0.73.0,<1.0.0  # Aligned with pyproject.toml
 vaderSentiment==3.3.2      # Sentiment scoring for macro/analyst agent
 cohere>=5.11.4             # Cohere Rerank API for RAG retrieval optimization
 # LLM orchestration (kept minimal but required for trading agent)
+# IMPORTANT: These versions are tightly coupled - do not upgrade independently
+# All langchain packages must stay in the 0.3.x series
 langchain==0.3.27
-langchain-core>=0.3.72,<1.0.0  # Must be <1.0.0 for langchain 0.3.x compatibility
+langchain-core==0.3.72  # Pinned exact version to prevent conflicts
 langchain-anthropic==0.3.22
-langchain-community==0.3.31
+langchain-community==0.3.27  # Downgraded to match langchain version
 sentence-transformers==3.4.1   # Required for RAG embedder used by trading orchestrator
 
 # Testing (for CI)


### PR DESCRIPTION
## Summary
Fixes daily trading CI failures since Dec 22.

**Root cause**: langchain-core 1.x was being pulled in transitively, conflicting with langchain 0.3.x requirement.

**Fix**:
- Pin langchain-core to exact 0.3.72
- Downgrade langchain-community to 0.3.27

## Test plan
- [ ] CI passes
- [ ] Daily trading workflow succeeds