### PR TITLE
chore: Update feedback hook timeout and stats

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -39,7 +39,7 @@
           {
             "type": "command",
             "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/capture_feedback.sh \"$CLAUDE_USER_PROMPT\"",
-            "timeout": 2
+            "timeout": 10
           }
         ]
       }

--- a/data/feedback/stats.json
+++ b/data/feedback/stats.json
@@ -1,7 +1,7 @@
 {
-  "total": 3,
-  "positive": 3,
+  "total": 4,
+  "positive": 4,
   "negative": 0,
   "satisfaction_rate": 100.00,
-  "last_updated": "2025-12-24 21:16:12"
+  "last_updated": "2025-12-28 18:25:15"
 }


### PR DESCRIPTION
- Increase feedback hook timeout from 2s to 10s for RL pipeline
- Update feedback stats (4 positive)