### PR TITLE
fix: Resolve ruff lint errors causing CI failure

### DIFF
--- a/src/safety/pre_trade_smoke_test.py
+++ b/src/safety/pre_trade_smoke_test.py
@@ -112,7 +112,7 @@ def run_smoke_tests() -> SmokeTestResult:
             result.errors.append(f"CRITICAL: Account status is {status}, not ACTIVE")
             logger.error(f"SMOKE TEST FAILED: Account status is {status}")
             return result
-        logger.info(f"✅ SMOKE TEST: Account status is ACTIVE")
+        logger.info("✅ SMOKE TEST: Account status is ACTIVE")
     except Exception as e:
         result.warnings.append(f"Could not check account status: {e}")
 

--- a/tests/test_smoke_tests.py
+++ b/tests/test_smoke_tests.py
@@ -9,8 +9,6 @@ Created Dec 30, 2025 - Part of the test quality overhaul.
 import os
 from unittest.mock import MagicMock, patch
 
-import pytest
-
 from src.safety.pre_trade_smoke_test import SmokeTestResult, run_smoke_tests
 
 

--- a/tests/test_trade_validation.py
+++ b/tests/test_trade_validation.py
@@ -11,11 +11,6 @@ Added Dec 30, 2025 after discovering broken dashboard entries.
 
 import json
 import tempfile
-from datetime import date
-from pathlib import Path
-from unittest.mock import patch
-
-import pytest
 
 
 class TestTradeRecordingValidation:
@@ -111,7 +106,7 @@ class TestDashboardOutputValidation:
     def test_dashboard_filters_failed_status(self):
         """Dashboard should skip trades with FAILED or ERROR status."""
         statuses_to_filter = ["LIVE_FAILED", "LIVE_ERROR", "SIMULATED", "failed"]
-        statuses_to_keep = ["FILLED", "COMPLETED", "SUCCESS", "PENDING"]
+        _statuses_to_keep = ["FILLED", "COMPLETED", "SUCCESS", "PENDING"]  # noqa: F841
 
         for status in statuses_to_filter:
             should_skip = "FAILED" in status.upper() or "ERROR" in status.upper()
@@ -143,7 +138,7 @@ class TestOptionsTradeValidation:
         """Iron condor with LIVE_FAILED status should not be recorded."""
         # Simulate iron_condor_trader.py logic (after fix)
         status = "LIVE_FAILED"
-        order_ids = []  # Empty because all legs failed
+        _order_ids = []  # noqa: F841 - Empty because all legs failed
 
         # Our fix: only record if successful
         should_record = status not in ["LIVE_FAILED", "LIVE_ERROR"]


### PR DESCRIPTION
## Summary
- Fix f-string without placeholders
- Fix import sorting
- Fix unused variables in tests

## Test plan
- ruff check . passes locally