### PR TITLE
fix: Fix test mock paths and skip conditions

### DIFF
--- a/tests/test_rag_vector_db.py
+++ b/tests/test_rag_vector_db.py
@@ -81,8 +81,8 @@ class TestVectorDBData:
     """Verify vector database has data (if running in full environment)."""
 
     @pytest.mark.skipif(
-        not __import__("pathlib").Path("data/vector_db").exists(),
-        reason="Vector DB directory not present (CI environment)",
+        not __import__("pathlib").Path("data/vector_db/chroma.sqlite3").exists(),
+        reason="Vector DB not built (CI environment - run vectorize_rag_knowledge.py)",
     )
     def test_vector_db_has_data(self):
         """Production vector DB should have indexed documents."""

--- a/tests/test_smoke_tests.py
+++ b/tests/test_smoke_tests.py
@@ -79,7 +79,7 @@ class TestRunSmokeTests:
             clear=True,
         ):
             with patch(
-                "src.safety.pre_trade_smoke_test.TradingClient",
+                "alpaca.trading.client.TradingClient",
                 side_effect=Exception("Connection refused"),
             ):
                 result = run_smoke_tests()
@@ -99,7 +99,7 @@ class TestRunSmokeTests:
             clear=True,
         ):
             with patch(
-                "src.safety.pre_trade_smoke_test.TradingClient",
+                "alpaca.trading.client.TradingClient",
                 return_value=mock_client,
             ):
                 result = run_smoke_tests()
@@ -127,7 +127,7 @@ class TestRunSmokeTests:
             clear=True,
         ):
             with patch(
-                "src.safety.pre_trade_smoke_test.TradingClient",
+                "alpaca.trading.client.TradingClient",
                 return_value=mock_client,
             ):
                 result = run_smoke_tests()
@@ -156,7 +156,7 @@ class TestRunSmokeTests:
             clear=True,
         ):
             with patch(
-                "src.safety.pre_trade_smoke_test.TradingClient",
+                "alpaca.trading.client.TradingClient",
                 return_value=mock_client,
             ):
                 result = run_smoke_tests()
@@ -183,7 +183,7 @@ class TestRunSmokeTests:
             clear=True,
         ):
             with patch(
-                "src.safety.pre_trade_smoke_test.TradingClient",
+                "alpaca.trading.client.TradingClient",
                 return_value=mock_client,
             ):
                 result = run_smoke_tests()
@@ -210,7 +210,7 @@ class TestRunSmokeTests:
             clear=True,
         ):
             with patch(
-                "src.safety.pre_trade_smoke_test.TradingClient",
+                "alpaca.trading.client.TradingClient",
                 return_value=mock_client,
             ):
                 result = run_smoke_tests()
@@ -238,7 +238,7 @@ class TestRunSmokeTests:
             clear=True,
         ):
             with patch(
-                "src.safety.pre_trade_smoke_test.TradingClient",
+                "alpaca.trading.client.TradingClient",
                 return_value=mock_client,
             ):
                 result = run_smoke_tests()


### PR DESCRIPTION
## Summary
Fixes 5 test failures in CI.

## Changes
- **test_smoke_tests.py**: Fixed patch path from 'src.safety.pre_trade_smoke_test.TradingClient' to 'alpaca.trading.client.TradingClient' (TradingClient is imported inside the function, not at module level)
- **test_rag_vector_db.py**: Changed skip condition to check for chroma.sqlite3 file instead of just directory existence (directory exists in git but is empty in CI)

## Evidence
```
ruff check . -> All checks passed!
ruff format --check . -> 222 files already formatted
```