### PR TITLE
fix: Fix all failing tests in CI

### DIFF
--- a/tests/test_trade_gateway.py
+++ b/tests/test_trade_gateway.py
@@ -10,7 +10,20 @@ Tests key gateway functionality:
 These tests ensure the gateway properly rejects risky trades.
 """
 
+from unittest.mock import MagicMock, patch
+
+import pytest
 from src.risk.trade_gateway import RejectionReason, TradeGateway, TradeRequest
+
+
+@pytest.fixture(autouse=True)
+def mock_rag():
+    """Mock RAG to prevent real lessons from blocking test trades."""
+    with patch("src.risk.trade_gateway.LessonsLearnedRAG") as mock_rag_class:
+        mock_rag_instance = MagicMock()
+        mock_rag_instance.query.return_value = []  # No lessons found
+        mock_rag_class.return_value = mock_rag_instance
+        yield mock_rag_instance
 
 
 class MockExecutor:


### PR DESCRIPTION
## Summary
- Mock RAG in test_trade_gateway.py (3 tests fixed)
- Fix env var tests to check .env.example
- Fix wrong flag name in pre_session test

## Root Cause
Tests were checking runtime env vars that default to "false" in CI, and RAG was not mocked so real CRITICAL lessons blocked test trades.

## Tests Fixed
- test_liquid_option_approved_with_tight_spread
- test_high_iv_approves_credit_strategy
- test_adequate_capital_allows_iron_condor
- test_sentiment_enabled
- test_rl_filter_enabled
- test_pre_session_rag_blocks