### PR TITLE
fix: Correct percentage calculation in dashboard generator

### DIFF
--- a/scripts/generate_world_class_dashboard_enhanced.py
+++ b/scripts/generate_world_class_dashboard_enhanced.py
@@ -66,7 +66,7 @@ def calculate_basic_metrics():
         latest_perf = perf_log[-1]
         current_equity = latest_perf.get("equity", current_equity)
         total_pl = latest_perf.get("pl", total_pl)
-        total_pl_pct = latest_perf.get("pl_pct", total_pl_pct) * 100
+        total_pl_pct = latest_perf.get("pl_pct", total_pl_pct)  # Already in percentage form
 
     trading_days = len(perf_log) if isinstance(perf_log, list) and perf_log else days_elapsed
     trading_days = max(trading_days, 1)
@@ -79,7 +79,7 @@ def calculate_basic_metrics():
         progress_pct = max(0.01, (total_pl / north_star_target) * 100)
 
     performance = system_state.get("performance", {})
-    win_rate = performance.get("win_rate", 0.0) * 100
+    win_rate = performance.get("win_rate", 0.0)  # Already in percentage form (e.g., 50.0 = 50%)
     total_trades = performance.get("total_trades", 0)
 
     challenge = system_state.get("challenge", {})
@@ -108,7 +108,7 @@ def calculate_basic_metrics():
                 today_perf = entry
                 today_equity = entry.get("equity", current_equity)
                 today_pl = entry.get("pl", 0.0)
-                today_pl_pct = entry.get("pl_pct", 0.0) * 100  # Convert to percentage
+                today_pl_pct = entry.get("pl_pct", 0.0)  # Already in percentage form
                 break
 
         # If no entry for today, calculate from yesterday


### PR DESCRIPTION
## Summary
Fixed dashboard showing wrong percentage values:
- P/L % showed 94.00% instead of 0.94%
- Win rate showed 5000.0% instead of 50.0%

## Root Cause
Script multiplied values by 100 when they're already stored as percentages.

## Evidence
| Metric | Before | After |
|--------|--------|-------|
| Equity | $100,697.83 | $100,942.23 |
| P/L % | 94.00% | 0.94% |
| Win Rate | 5000% | 50.0% |

## Test plan
- [x] Verified values match system_state.json
- [x] Regenerated dashboard shows correct values