### PR TITLE
fix: Implement honest reporting and proper RAG vectorization

### DIFF
--- a/data/system_state.json
+++ b/data/system_state.json
@@ -39,8 +39,8 @@
   "performance": {
     "total_trades": 20,
     "winning_trades": 4,
-    "losing_trades": 4,
-    "win_rate": 50.0,
+    "losing_trades": 1,
+    "win_rate": 80.0,
     "best_trade": {
       "symbol": "SPY260123P00660000",
       "pl": 197.0,
@@ -162,7 +162,9 @@
         "unrealized_pl_pct": 0.021927229572647314,
         "last_updated": "2025-12-07T18:16:23.571385"
       }
-    ]
+    ],
+    "_win_rate_source": "calculated_from_closed_trades",
+    "_win_rate_fixed_at": "2025-12-31T02:57:09.901650"
   },
   "strategies": {
     "tier1": {

--- a/data/vector_db/vectorized_files.json
+++ b/data/vector_db/vectorized_files.json
@@ -1,665 +1,665 @@
 {
   "files": {
-    "rag_knowledge/youtube/transcripts/Rm69dKSsTrA_How_to_Invest_in_Stocks_for_Beginners_2024.md": {
-      "hash": "8ba825d49cec28e1f84ca0325f4619da",
+    "rag_knowledge/youtube/transcripts/9hWMAL0q-xw_How_to_Read_Financial_Statements.md": {
+      "hash": "39ef789e9c15222b46a12ff2d4a298e8",
       "chunks": 2,
-      "vectorized_at": "2025-12-30T21:06:37.173056"
-    },
-    "rag_knowledge/youtube/transcripts/WRF86rX2wXs_Cash_Secured_Puts_Strategy.md": {
-      "hash": "2c6a463d1fba496250e6ec23f81c0292",
-      "chunks": 2,
-      "vectorized_at": "2025-12-30T21:06:37.249105"
-    },
-    "rag_knowledge/youtube/transcripts/B9xVBqxTHKI_Understanding_ROIC_-_Return_on_Invested_Capital.md": {
-      "hash": "5497c31d5115fafbb15b4ce407af5f06",
-      "chunks": 2,
-      "vectorized_at": "2025-12-30T21:06:37.298028"
-    },
-    "rag_knowledge/youtube/transcripts/E7t8qPKGMxs_When_to_Sell_a_Stock_-_Exit_Strategy.md": {
-      "hash": "35cedf09ec17fad8b0fb94f1bd27bbfd",
-      "chunks": 2,
-      "vectorized_at": "2025-12-30T21:06:37.347954"
-    },
-    "rag_knowledge/youtube/transcripts/k2z7K4PLkQg_Building_a_Watchlist_-_Stock_Analysis_Process.md": {
-      "hash": "e31d4dfc1696168bd5a210a25d634a3b",
-      "chunks": 2,
-      "vectorized_at": "2025-12-30T21:06:37.395781"
-    },
-    "rag_knowledge/youtube/transcripts/gWIi6WLczZA_Warren_Buffett_How_to_Invest_for_Beginners.md": {
-      "hash": "3f1264adf4c5cb3b844c46e20869bf0c",
-      "chunks": 2,
-      "vectorized_at": "2025-12-30T21:06:37.445057"
-    },
-    "rag_knowledge/youtube/transcripts/XyYjVrMbMpI_How_to_Calculate_Sticker_Price_-_Intrinsic_Value.md": {
-      "hash": "02e95b0c177ad60c0d0ccba719f02f98",
-      "chunks": 2,
-      "vectorized_at": "2025-12-30T21:06:37.494712"
-    },
-    "rag_knowledge/youtube/transcripts/Hfq4K1nP4v4_The_Wheel_Strategy_Explained.md": {
-      "hash": "003149dcec5ef473407e398670cc3629",
-      "chunks": 2,
-      "vectorized_at": "2025-12-30T21:06:37.546614"
-    },
-    "rag_knowledge/youtube/transcripts/dVKjsPQbZNo_Owner_Earnings_Explained_-_Buffetts_Secret_Metric.md": {
-      "hash": "6cc4ad58934e383d1ddc1c78a6d42438",
-      "chunks": 2,
-      "vectorized_at": "2025-12-30T21:06:37.602788"
+      "vectorized_at": "2025-12-31T02:59:47.757081"
     },
     "rag_knowledge/youtube/transcripts/Z5chrxMuBoo_Rule_1_Dont_Lose_Money.md": {
       "hash": "85fb5eabb1801bcac74e848c79ee951f",
       "chunks": 2,
-      "vectorized_at": "2025-12-30T21:06:37.659998"
-    },
-    "rag_knowledge/youtube/transcripts/8pPnLzZmKKY_What_is_a_Moat_in_Investing.md": {
-      "hash": "840ded1909051e4f8ea8eaa13bcffba1",
-      "chunks": 2,
-      "vectorized_at": "2025-12-30T21:06:37.709836"
-    },
-    "rag_knowledge/youtube/transcripts/A9kZ_fVwLLo_Margin_of_Safety_Explained.md": {
-      "hash": "95bd8feb98df45bdd9a68a179fbd45a0",
-      "chunks": 2,
-      "vectorized_at": "2025-12-30T21:06:37.761637"
-    },
-    "rag_knowledge/youtube/transcripts/iRvKG9yFNBo_Debt_and_the_Balance_Sheet.md": {
-      "hash": "7413e6cd225fccb8cf47ff3ecf730e57",
-      "chunks": 2,
-      "vectorized_at": "2025-12-30T21:06:37.817942"
-    },
-    "rag_knowledge/youtube/transcripts/9hWMAL0q-xw_How_to_Read_Financial_Statements.md": {
-      "hash": "39ef789e9c15222b46a12ff2d4a298e8",
-      "chunks": 2,
-      "vectorized_at": "2025-12-30T21:06:37.868889"
-    },
-    "rag_knowledge/youtube/transcripts/K6CkCQU_qkE_The_4_Ms_of_Investing_-_Rule_1_Investing.md": {
-      "hash": "92473a5d69f96cea912db0e4aa8355ad",
-      "chunks": 2,
-      "vectorized_at": "2025-12-30T21:06:37.919387"
-    },
-    "rag_knowledge/youtube/transcripts/HcZRD3YUKZM_Value_Investing_vs_Growth_Investing.md": {
-      "hash": "c15e8a8396cedeb980ba45a45732582e",
-      "chunks": 2,
-      "vectorized_at": "2025-12-30T21:06:37.975107"
-    },
-    "rag_knowledge/youtube/transcripts/QmVKxH2PdCI_Circle_of_Competence_-_Stay_in_Your_Lane.md": {
-      "hash": "e815dfaf64b55cb3dd6de0a335aee379",
-      "chunks": 2,
-      "vectorized_at": "2025-12-30T21:06:38.029291"
+      "vectorized_at": "2025-12-31T02:59:48.184888"
     },
     "rag_knowledge/youtube/transcripts/oLaGH5LVhJ8_Covered_Calls_for_Income_-_Options_Strategy.md": {
       "hash": "d56cc848f7733fb2f3536f64bde0c65b",
       "chunks": 2,
-      "vectorized_at": "2025-12-30T21:06:38.085286"
+      "vectorized_at": "2025-12-31T02:59:48.550719"
     },
     "rag_knowledge/youtube/transcripts/Yp7_oQEGfNc_Market_Crashes_-_Opportunity_of_a_Lifetime.md": {
       "hash": "d3c1bfc70fed1937d7e33635e108a6b9",
       "chunks": 2,
-      "vectorized_at": "2025-12-30T21:06:38.140847"
+      "vectorized_at": "2025-12-31T02:59:48.912198"
+    },
+    "rag_knowledge/youtube/transcripts/dVKjsPQbZNo_Owner_Earnings_Explained_-_Buffetts_Secret_Metric.md": {
+      "hash": "6cc4ad58934e383d1ddc1c78a6d42438",
+      "chunks": 2,
+      "vectorized_at": "2025-12-31T02:59:49.284882"
+    },
+    "rag_knowledge/youtube/transcripts/k2z7K4PLkQg_Building_a_Watchlist_-_Stock_Analysis_Process.md": {
+      "hash": "e31d4dfc1696168bd5a210a25d634a3b",
+      "chunks": 2,
+      "vectorized_at": "2025-12-31T02:59:49.648282"
+    },
+    "rag_knowledge/youtube/transcripts/HcZRD3YUKZM_Value_Investing_vs_Growth_Investing.md": {
+      "hash": "c15e8a8396cedeb980ba45a45732582e",
+      "chunks": 2,
+      "vectorized_at": "2025-12-31T02:59:50.025349"
+    },
+    "rag_knowledge/youtube/transcripts/A9kZ_fVwLLo_Margin_of_Safety_Explained.md": {
+      "hash": "95bd8feb98df45bdd9a68a179fbd45a0",
+      "chunks": 2,
+      "vectorized_at": "2025-12-31T02:59:50.398239"
+    },
+    "rag_knowledge/youtube/transcripts/Rm69dKSsTrA_How_to_Invest_in_Stocks_for_Beginners_2024.md": {
+      "hash": "8ba825d49cec28e1f84ca0325f4619da",
+      "chunks": 2,
+      "vectorized_at": "2025-12-31T02:59:50.792726"
     },
     "rag_knowledge/youtube/transcripts/P6dqZMjZxHA_The_Payback_Time_Strategy.md": {
       "hash": "fc5ad438081794943c13ac502e9fccdf",
       "chunks": 2,
-      "vectorized_at": "2025-12-30T21:06:38.195853"
+      "vectorized_at": "2025-12-31T02:59:51.175408"
+    },
+    "rag_knowledge/youtube/transcripts/iRvKG9yFNBo_Debt_and_the_Balance_Sheet.md": {
+      "hash": "7413e6cd225fccb8cf47ff3ecf730e57",
+      "chunks": 2,
+      "vectorized_at": "2025-12-31T02:59:51.566313"
+    },
+    "rag_knowledge/youtube/transcripts/Hfq4K1nP4v4_The_Wheel_Strategy_Explained.md": {
+      "hash": "003149dcec5ef473407e398670cc3629",
+      "chunks": 2,
+      "vectorized_at": "2025-12-31T02:59:51.941949"
+    },
+    "rag_knowledge/youtube/transcripts/XyYjVrMbMpI_How_to_Calculate_Sticker_Price_-_Intrinsic_Value.md": {
+      "hash": "02e95b0c177ad60c0d0ccba719f02f98",
+      "chunks": 2,
+      "vectorized_at": "2025-12-31T02:59:52.318025"
+    },
+    "rag_knowledge/youtube/transcripts/QmVKxH2PdCI_Circle_of_Competence_-_Stay_in_Your_Lane.md": {
+      "hash": "e815dfaf64b55cb3dd6de0a335aee379",
+      "chunks": 2,
+      "vectorized_at": "2025-12-31T02:59:52.697977"
+    },
+    "rag_knowledge/youtube/transcripts/E7t8qPKGMxs_When_to_Sell_a_Stock_-_Exit_Strategy.md": {
+      "hash": "35cedf09ec17fad8b0fb94f1bd27bbfd",
+      "chunks": 2,
+      "vectorized_at": "2025-12-31T02:59:53.100469"
+    },
+    "rag_knowledge/youtube/transcripts/B9xVBqxTHKI_Understanding_ROIC_-_Return_on_Invested_Capital.md": {
+      "hash": "5497c31d5115fafbb15b4ce407af5f06",
+      "chunks": 2,
+      "vectorized_at": "2025-12-31T02:59:53.492829"
+    },
+    "rag_knowledge/youtube/transcripts/gWIi6WLczZA_Warren_Buffett_How_to_Invest_for_Beginners.md": {
+      "hash": "3f1264adf4c5cb3b844c46e20869bf0c",
+      "chunks": 2,
+      "vectorized_at": "2025-12-31T02:59:53.882563"
+    },
+    "rag_knowledge/youtube/transcripts/8pPnLzZmKKY_What_is_a_Moat_in_Investing.md": {
+      "hash": "840ded1909051e4f8ea8eaa13bcffba1",
+      "chunks": 2,
+      "vectorized_at": "2025-12-31T02:59:54.280825"
+    },
+    "rag_knowledge/youtube/transcripts/K6CkCQU_qkE_The_4_Ms_of_Investing_-_Rule_1_Investing.md": {
+      "hash": "92473a5d69f96cea912db0e4aa8355ad",
+      "chunks": 2,
+      "vectorized_at": "2025-12-31T02:59:54.680158"
+    },
+    "rag_knowledge/youtube/transcripts/WRF86rX2wXs_Cash_Secured_Puts_Strategy.md": {
+      "hash": "2c6a463d1fba496250e6ec23f81c0292",
+      "chunks": 2,
+      "vectorized_at": "2025-12-31T02:59:55.079878"
     },
     "rag_knowledge/youtube/insights/gemini_notebooklm_analysis_20251228.md": {
       "hash": "aaeb1941e356c338381f7fb9cf50c5f1",
       "chunks": 3,
-      "vectorized_at": "2025-12-30T21:06:38.273616"
-    },
-    "rag_knowledge/youtube/insights/Hfq4K1nP4v4_insights.json": {
-      "hash": "0610ff5ce130cb8239548568260da195",
-      "chunks": 1,
-      "vectorized_at": "2025-12-30T21:06:38.315798"
-    },
-    "rag_knowledge/youtube/insights/B9xVBqxTHKI_insights.json": {
-      "hash": "7d647f50e09aeaaaf263cd277fa187d9",
-      "chunks": 1,
-      "vectorized_at": "2025-12-30T21:06:38.354525"
-    },
-    "rag_knowledge/youtube/insights/Yp7_oQEGfNc_insights.json": {
-      "hash": "b03d6aba702886e8608780ce00a2b97e",
-      "chunks": 1,
-      "vectorized_at": "2025-12-30T21:06:38.395397"
+      "vectorized_at": "2025-12-31T02:59:55.479972"
     },
     "rag_knowledge/youtube/insights/HcZRD3YUKZM_insights.json": {
       "hash": "41564f40d5e6af38f327ec19f54aab0d",
       "chunks": 1,
-      "vectorized_at": "2025-12-30T21:06:38.433698"
+      "vectorized_at": "2025-12-31T02:59:55.846120"
     },
-    "rag_knowledge/youtube/insights/9hWMAL0q-xw_insights.json": {
-      "hash": "0309b65547b4203d79478c5ca6b85da7",
+    "rag_knowledge/youtube/insights/Yp7_oQEGfNc_insights.json": {
+      "hash": "b03d6aba702886e8608780ce00a2b97e",
       "chunks": 1,
-      "vectorized_at": "2025-12-30T21:06:38.472829"
-    },
-    "rag_knowledge/youtube/insights/P6dqZMjZxHA_insights.json": {
-      "hash": "8d9d2117cf6031fdfb5bc2628398ebe1",
-      "chunks": 1,
-      "vectorized_at": "2025-12-30T21:06:38.511865"
-    },
-    "rag_knowledge/youtube/insights/oLaGH5LVhJ8_insights.json": {
-      "hash": "b1e09b188e706d7199f28fde3f2ed160",
-      "chunks": 1,
-      "vectorized_at": "2025-12-30T21:06:38.547489"
-    },
-    "rag_knowledge/youtube/insights/QmVKxH2PdCI_insights.json": {
-      "hash": "2836b5fd064596411451886e59083b8a",
-      "chunks": 1,
-      "vectorized_at": "2025-12-30T21:06:38.583200"
-    },
-    "rag_knowledge/youtube/insights/dVKjsPQbZNo_insights.json": {
-      "hash": "c6b7c868a1bc2ec0fcef3b2f065c97c1",
-      "chunks": 1,
-      "vectorized_at": "2025-12-30T21:06:38.619161"
-    },
-    "rag_knowledge/youtube/insights/k2z7K4PLkQg_insights.json": {
-      "hash": "e33245327f8d6212bbe9371dafd85665",
-      "chunks": 1,
-      "vectorized_at": "2025-12-30T21:06:38.654206"
-    },
-    "rag_knowledge/youtube/insights/A9kZ_fVwLLo_insights.json": {
-      "hash": "184d52e138702cd492a74c26d043f49e",
-      "chunks": 1,
-      "vectorized_at": "2025-12-30T21:06:38.694221"
-    },
-    "rag_knowledge/youtube/insights/E7t8qPKGMxs_insights.json": {
-      "hash": "c9243404fd48a6552c0ad7d4e7a49c36",
-      "chunks": 1,
-      "vectorized_at": "2025-12-30T21:06:38.731737"
+      "vectorized_at": "2025-12-31T02:59:56.227719"
     },
     "rag_knowledge/youtube/insights/gWIi6WLczZA_insights.json": {
       "hash": "1612efcc656f6170b4bae4e219e15ac5",
       "chunks": 1,
-      "vectorized_at": "2025-12-30T21:06:38.770133"
+      "vectorized_at": "2025-12-31T02:59:56.614496"
     },
-    "rag_knowledge/youtube/insights/Rm69dKSsTrA_insights.json": {
-      "hash": "9e2702816a8fac24b5e2bb23203c050a",
+    "rag_knowledge/youtube/insights/A9kZ_fVwLLo_insights.json": {
+      "hash": "184d52e138702cd492a74c26d043f49e",
       "chunks": 1,
-      "vectorized_at": "2025-12-30T21:06:38.807436"
-    },
-    "rag_knowledge/youtube/insights/K6CkCQU_qkE_insights.json": {
-      "hash": "d14c9e6acabdd1aacc8f5884d281d21f",
-      "chunks": 1,
-      "vectorized_at": "2025-12-30T21:06:38.846556"
-    },
-    "rag_knowledge/youtube/insights/WRF86rX2wXs_insights.json": {
-      "hash": "08e55ea198e2efc9bb325f37737c3e33",
-      "chunks": 1,
-      "vectorized_at": "2025-12-30T21:06:38.894872"
+      "vectorized_at": "2025-12-31T02:59:56.999302"
     },
     "rag_knowledge/youtube/insights/8pPnLzZmKKY_insights.json": {
       "hash": "1cb124d0cef5e90e52f9ec7cd0092683",
       "chunks": 1,
-      "vectorized_at": "2025-12-30T21:06:38.936453"
+      "vectorized_at": "2025-12-31T02:59:57.352638"
     },
-    "rag_knowledge/youtube/insights/Z5chrxMuBoo_insights.json": {
-      "hash": "930848032e3334b6f4b5f9ca2083630d",
+    "rag_knowledge/youtube/insights/Hfq4K1nP4v4_insights.json": {
+      "hash": "0610ff5ce130cb8239548568260da195",
       "chunks": 1,
-      "vectorized_at": "2025-12-30T21:06:38.978974"
+      "vectorized_at": "2025-12-31T02:59:57.740350"
+    },
+    "rag_knowledge/youtube/insights/k2z7K4PLkQg_insights.json": {
+      "hash": "e33245327f8d6212bbe9371dafd85665",
+      "chunks": 1,
+      "vectorized_at": "2025-12-31T02:59:58.096824"
+    },
+    "rag_knowledge/youtube/insights/Rm69dKSsTrA_insights.json": {
+      "hash": "9e2702816a8fac24b5e2bb23203c050a",
+      "chunks": 1,
+      "vectorized_at": "2025-12-31T02:59:58.493668"
     },
     "rag_knowledge/youtube/insights/iRvKG9yFNBo_insights.json": {
       "hash": "f45c63b6731d2c9fcae7fa01c9e68332",
       "chunks": 1,
-      "vectorized_at": "2025-12-30T21:06:39.022631"
+      "vectorized_at": "2025-12-31T02:59:58.858044"
+    },
+    "rag_knowledge/youtube/insights/WRF86rX2wXs_insights.json": {
+      "hash": "08e55ea198e2efc9bb325f37737c3e33",
+      "chunks": 1,
+      "vectorized_at": "2025-12-31T02:59:59.240139"
     },
     "rag_knowledge/youtube/insights/XyYjVrMbMpI_insights.json": {
       "hash": "884d13805f821deeb68bb05013fcedaa",
       "chunks": 1,
-      "vectorized_at": "2025-12-30T21:06:39.061175"
+      "vectorized_at": "2025-12-31T02:59:59.606104"
     },
-    "rag_knowledge/blogs/phil_town/why-you-dont-need-a-financial-_You_Dont_Need_a_Financial_Advisor.md": {
-      "hash": "dffb9ceb845ae465af72f7d1bad72332",
-      "chunks": 14,
-      "vectorized_at": "2025-12-30T21:06:39.370900"
+    "rag_knowledge/youtube/insights/QmVKxH2PdCI_insights.json": {
+      "hash": "2836b5fd064596411451886e59083b8a",
+      "chunks": 1,
+      "vectorized_at": "2025-12-31T02:59:59.985586"
     },
-    "rag_knowledge/blogs/phil_town/personal-development_Personal_Development.md": {
-      "hash": "2f86178f8f549f1b18d79207201a3c6a",
-      "chunks": 2,
-      "vectorized_at": "2025-12-30T21:06:39.425298"
+    "rag_knowledge/youtube/insights/oLaGH5LVhJ8_insights.json": {
+      "hash": "b1e09b188e706d7199f28fde3f2ed160",
+      "chunks": 1,
+      "vectorized_at": "2025-12-31T03:00:00.349571"
     },
-    "rag_knowledge/blogs/phil_town/how-to-invest_How_to_Invest.md": {
-      "hash": "70dc3581f5df5077402d05dcd3c6a12b",
-      "chunks": 2,
-      "vectorized_at": "2025-12-30T21:06:39.476653"
+    "rag_knowledge/youtube/insights/P6dqZMjZxHA_insights.json": {
+      "hash": "8d9d2117cf6031fdfb5bc2628398ebe1",
+      "chunks": 1,
+      "vectorized_at": "2025-12-31T03:00:00.741375"
+    },
+    "rag_knowledge/youtube/insights/9hWMAL0q-xw_insights.json": {
+      "hash": "0309b65547b4203d79478c5ca6b85da7",
+      "chunks": 1,
+      "vectorized_at": "2025-12-31T03:00:01.129895"
+    },
+    "rag_knowledge/youtube/insights/B9xVBqxTHKI_insights.json": {
+      "hash": "7d647f50e09aeaaaf263cd277fa187d9",
+      "chunks": 1,
+      "vectorized_at": "2025-12-31T03:00:01.517828"
+    },
+    "rag_knowledge/youtube/insights/Z5chrxMuBoo_insights.json": {
+      "hash": "930848032e3334b6f4b5f9ca2083630d",
+      "chunks": 1,
+      "vectorized_at": "2025-12-31T03:00:01.875826"
+    },
+    "rag_knowledge/youtube/insights/E7t8qPKGMxs_insights.json": {
+      "hash": "c9243404fd48a6552c0ad7d4e7a49c36",
+      "chunks": 1,
+      "vectorized_at": "2025-12-31T03:00:02.238454"
+    },
+    "rag_knowledge/youtube/insights/K6CkCQU_qkE_insights.json": {
+      "hash": "d14c9e6acabdd1aacc8f5884d281d21f",
+      "chunks": 1,
+      "vectorized_at": "2025-12-31T03:00:02.603964"
+    },
+    "rag_knowledge/youtube/insights/dVKjsPQbZNo_insights.json": {
+      "hash": "c6b7c868a1bc2ec0fcef3b2f065c97c1",
+      "chunks": 1,
+      "vectorized_at": "2025-12-31T03:00:02.971778"
     },
     "rag_knowledge/blogs/phil_town/stock-market-basics_Stock_Market_Basics.md": {
       "hash": "1bc3842f526eb15a49134b5a51ceefff",
       "chunks": 2,
-      "vectorized_at": "2025-12-30T21:06:39.537938"
+      "vectorized_at": "2025-12-31T03:00:03.366859"
     },
-    "rag_knowledge/blogs/phil_town/financial-control_Financial_Control.md": {
-      "hash": "5d285afa8f5030bb6d7f293c8ccfce6c",
-      "chunks": 2,
-      "vectorized_at": "2025-12-30T21:06:39.596760"
+    "rag_knowledge/blogs/phil_town/why-you-dont-need-a-financial-_You_Dont_Need_a_Financial_Advisor.md": {
+      "hash": "dffb9ceb845ae465af72f7d1bad72332",
+      "chunks": 14,
+      "vectorized_at": "2025-12-31T03:00:03.958299"
     },
     "rag_knowledge/blogs/phil_town/best-way-to-invest-10k_Best_Way_to_Invest_10K.md": {
       "hash": "c1bf868f68a7c2f7d5598a127fcce1e6",
       "chunks": 11,
-      "vectorized_at": "2025-12-30T21:06:39.807536"
+      "vectorized_at": "2025-12-31T03:00:04.495585"
     },
-    "rag_knowledge/blogs/phil_town/investing-news-and-tips_Investing_News_and_Tips.md": {
-      "hash": "c7ec8a578ec2d0a0e54a27e46306c1c8",
+    "rag_knowledge/blogs/phil_town/how-to-invest_How_to_Invest.md": {
+      "hash": "70dc3581f5df5077402d05dcd3c6a12b",
       "chunks": 2,
-      "vectorized_at": "2025-12-30T21:06:39.856981"
-    },
-    "rag_knowledge/blogs/phil_town/using-the-rule-of-72_The_Rule_of_72.md": {
-      "hash": "7941756f2c46cefe028f6546ae726d74",
-      "chunks": 20,
-      "vectorized_at": "2025-12-30T21:06:40.162273"
-    },
-    "rag_knowledge/blogs/phil_town/retirement-planning_Retirement_Planning.md": {
-      "hash": "a954ae8f71450ee627b64ae7be41d762",
-      "chunks": 2,
-      "vectorized_at": "2025-12-30T21:06:40.218039"
-    },
-    "rag_knowledge/blogs/phil_town/value-investing_What_is_Value_Investing.md": {
-      "hash": "480e09896ddc3f208b6533ed392510bb",
-      "chunks": 25,
-      "vectorized_at": "2025-12-30T21:06:40.601883"
-    },
-    "rag_knowledge/blogs/phil_town/become-investor_How_to_Become_an_Investor.md": {
-      "hash": "aa9ca7365e991bdedefec1ca2bc7b1c2",
-      "chunks": 26,
-      "vectorized_at": "2025-12-30T21:06:40.980567"
-    },
-    "rag_knowledge/blogs/phil_town/market-capitalization-meaning-_Market_Cap_Doesnt_Equal_Value.md": {
-      "hash": "94f0e413d1d5f2bbf094ecc1d2d77c20",
-      "chunks": 13,
-      "vectorized_at": "2025-12-30T21:06:41.172887"
+      "vectorized_at": "2025-12-31T03:00:04.875434"
     },
     "rag_knowledge/blogs/phil_town/spending-money-wisely_7_Tips_for_Spending_Money_Wisely.md": {
       "hash": "b61206459d736ba59697b0a91636fa6d",
       "chunks": 24,
-      "vectorized_at": "2025-12-30T21:06:41.518710"
+      "vectorized_at": "2025-12-31T03:00:05.625434"
     },
-    "rag_knowledge/lessons_learned/ll_011_ai_agent_adaptation_dec11.md": {
-      "hash": "91921cc11b31fb1f273d7ede43f4c71c",
-      "chunks": 8,
-      "vectorized_at": "2025-12-30T21:06:41.652418"
+    "rag_knowledge/blogs/phil_town/retirement-planning_Retirement_Planning.md": {
+      "hash": "a954ae8f71450ee627b64ae7be41d762",
+      "chunks": 2,
+      "vectorized_at": "2025-12-31T03:00:06.058081"
     },
-    "rag_knowledge/lessons_learned/ll_017_missing_langsmith_env_vars_dec12.md": {
-      "hash": "d52a05984cdf86620a69381076eb5eb7",
-      "chunks": 9,
-      "vectorized_at": "2025-12-30T21:06:41.808000"
+    "rag_knowledge/blogs/phil_town/using-the-rule-of-72_The_Rule_of_72.md": {
+      "hash": "7941756f2c46cefe028f6546ae726d74",
+      "chunks": 20,
+      "vectorized_at": "2025-12-31T03:00:06.777233"
     },
-    "rag_knowledge/lessons_learned/ll_011_facts_benchmark_factuality_ceiling.md": {
-      "hash": "b1c3e64b014b0e6cb4490e7c91eb84d2",
-      "chunks": 3,
-      "vectorized_at": "2025-12-30T21:06:41.875010"
+    "rag_knowledge/blogs/phil_town/value-investing_What_is_Value_Investing.md": {
+      "hash": "480e09896ddc3f208b6533ed392510bb",
+      "chunks": 25,
+      "vectorized_at": "2025-12-31T03:00:07.557297"
     },
-    "rag_knowledge/lessons_learned/ll_025_bats_budget_framework.md": {
-      "hash": "7dafd5af76cbf875947b4ae4365a0df6",
-      "chunks": 8,
-      "vectorized_at": "2025-12-30T21:06:42.002194"
-    },
-    "rag_knowledge/lessons_learned/ll_056_silent_pipeline_failures_dec22.md": {
-      "hash": "5a4651904315a54931b7b4f8f5815bc0",
-      "chunks": 5,
-      "vectorized_at": "2025-12-30T21:06:42.107073"
-    },
-    "rag_knowledge/lessons_learned/ll_012_deep_research_safety_improvements_dec11.md": {
-      "hash": "cfe6a2e26c0721d9eea8343828e2df95",
+    "rag_knowledge/blogs/phil_town/market-capitalization-meaning-_Market_Cap_Doesnt_Equal_Value.md": {
+      "hash": "94f0e413d1d5f2bbf094ecc1d2d77c20",
       "chunks": 13,
-      "vectorized_at": "2025-12-30T21:06:42.398015"
+      "vectorized_at": "2025-12-31T03:00:08.075727"
     },
-    "rag_knowledge/lessons_learned/ll_014_dead_code_dynamic_budget_dec11.md": {
-      "hash": "94f1b08ce4ed5798c945fc626256753f",
-      "chunks": 5,
-      "vectorized_at": "2025-12-30T21:06:42.688322"
-    },
-    "rag_knowledge/lessons_learned/ci_failure_blocked_trading.md": {
-      "hash": "56183d243e401649de50f953e245fdba",
-      "chunks": 6,
-      "vectorized_at": "2025-12-30T21:06:42.807120"
-    },
-    "rag_knowledge/lessons_learned/ll_020_options_primary_strategy_dec12.md": {
-      "hash": "6ab39304a8e5e979f67db3c0feddbe0a",
-      "chunks": 5,
-      "vectorized_at": "2025-12-30T21:06:42.898417"
-    },
-    "rag_knowledge/lessons_learned/ll_053_stop_bleeding_crypto_reit_dec17.md": {
-      "hash": "0cbe5f38ae041eaef29554c02307a351",
-      "chunks": 3,
-      "vectorized_at": "2025-12-30T21:06:42.957969"
-    },
-    "rag_knowledge/lessons_learned/ll_051_blind_trading_catastrophe_dec17.md": {
-      "hash": "16da1319210c85128386a22f7dc6dc97",
-      "chunks": 6,
-      "vectorized_at": "2025-12-30T21:06:43.060965"
-    },
-    "rag_knowledge/lessons_learned/ll_009_ci_syntax_failure_dec11.md": {
-      "hash": "3f66b59d3c8ae50d6804082cae056606",
-      "chunks": 11,
-      "vectorized_at": "2025-12-30T21:06:43.255624"
-    },
-    "rag_knowledge/lessons_learned/ll_052_credit_spreads_capital_efficiency_dec17.md": {
-      "hash": "526abb682837c62439673c8b99da3010",
-      "chunks": 4,
-      "vectorized_at": "2025-12-30T21:06:43.333478"
-    },
-    "rag_knowledge/lessons_learned/ll_018_pl_verification_failure_dec12.md": {
-      "hash": "0677621773113e3d5db2efcad56b7cfe",
-      "chunks": 4,
-      "vectorized_at": "2025-12-30T21:06:43.412340"
-    },
-    "rag_knowledge/lessons_learned/ll_073_options_theta_success_dec30.md": {
-      "hash": "26222b90cbae9ae2430aeb185dcf742d",
-      "chunks": 3,
-      "vectorized_at": "2025-12-30T21:06:43.489941"
-    },
-    "rag_knowledge/lessons_learned/ll_029_always_verify_date.md": {
-      "hash": "6b440519f0df449afa570abadcae09ba",
-      "chunks": 3,
-      "vectorized_at": "2025-12-30T21:06:43.561673"
-    },
-    "rag_knowledge/lessons_learned/ll_048_go_live_readiness_system_dec15.md": {
-      "hash": "279446e723b1219a8e5479ced146ffb3",
-      "chunks": 8,
-      "vectorized_at": "2025-12-30T21:06:43.688979"
-    },
-    "rag_knowledge/lessons_learned/ll_070_acknowledge_user_feedback.md": {
-      "hash": "dab2860424380f9b0e758a818a4340e1",
+    "rag_knowledge/blogs/phil_town/investing-news-and-tips_Investing_News_and_Tips.md": {
+      "hash": "c7ec8a578ec2d0a0e54a27e46306c1c8",
       "chunks": 2,
-      "vectorized_at": "2025-12-30T21:06:43.737578"
+      "vectorized_at": "2025-12-31T03:00:08.409051"
     },
-    "rag_knowledge/lessons_learned/ll_059_simulated_sync_lie_dec29.md": {
-      "hash": "9fcb48881c660fe7282c0aabe5eaad5a",
-      "chunks": 3,
-      "vectorized_at": "2025-12-30T21:06:43.800002"
-    },
-    "rag_knowledge/lessons_learned/the_one_thing_trading.md": {
-      "hash": "bdf55fc6c13a08cb20b2e7605ba91e2c",
-      "chunks": 6,
-      "vectorized_at": "2025-12-30T21:06:43.915932"
-    },
-    "rag_knowledge/lessons_learned/ll_015_ai_friendly_repo_structure_dec11.md": {
-      "hash": "90f0667bfe5fe398ae31db61b11e3292",
-      "chunks": 7,
-      "vectorized_at": "2025-12-30T21:06:44.035507"
-    },
-    "rag_knowledge/lessons_learned/ll_071_daily_lesson_capture_gap_dec29.md": {
-      "hash": "3bc22e503c2223d437efd1621b9ba1d8",
-      "chunks": 3,
-      "vectorized_at": "2025-12-30T21:06:44.097846"
-    },
-    "rag_knowledge/lessons_learned/ll_028_unified_domain_model.md": {
-      "hash": "c4c14a9bd576dcb2211988aed7b5e85d",
-      "chunks": 7,
-      "vectorized_at": "2025-12-30T21:06:44.212119"
-    },
-    "rag_knowledge/lessons_learned/ll_010_dead_code_and_dormant_systems_dec11.md": {
-      "hash": "0c9526275bd6dcfeb026307d3c435951",
-      "chunks": 3,
-      "vectorized_at": "2025-12-30T21:06:44.279210"
-    },
-    "rag_knowledge/lessons_learned/ll_011_opus_45_optimization_dec11.md": {
-      "hash": "f4b5678e437aed4c1ddcf461867efd0a",
-      "chunks": 8,
-      "vectorized_at": "2025-12-30T21:06:44.397500"
-    },
-    "rag_knowledge/lessons_learned/ll_017_rag_vectorization_gap_dec12.md": {
-      "hash": "137da5f17d6fc19b09faa63c0d80bd52",
-      "chunks": 7,
-      "vectorized_at": "2025-12-30T21:06:44.553104"
-    },
-    "rag_knowledge/lessons_learned/ll_029_hicra_rl_credit_assignment.md": {
-      "hash": "8e4f7a00a6e3d9100aead6297036b6e3",
-      "chunks": 5,
-      "vectorized_at": "2025-12-30T21:06:44.635620"
-    },
-    "rag_knowledge/lessons_learned/ll_058_stale_data_lying_incident_dec23.md": {
-      "hash": "aca2fb7c706124aaa077972c56f194d3",
-      "chunks": 5,
-      "vectorized_at": "2025-12-30T21:06:44.740562"
-    },
-    "rag_knowledge/lessons_learned/ll_021_backtest_thresholds_rnd_phase_dec15.md": {
-      "hash": "9bdcb0e8e360b4d8a930c93671f2d33b",
-      "chunks": 5,
-      "vectorized_at": "2025-12-30T21:06:44.839434"
-    },
-    "rag_knowledge/lessons_learned/ll_016_regime_pivot_safety_gates_dec12.md": {
-      "hash": "41de34560a09dd48cda0cf640d3ae51f",
-      "chunks": 12,
-      "vectorized_at": "2025-12-30T21:06:45.008174"
-    },
-    "rag_knowledge/lessons_learned/ll_030_langsmith_deep_agent_observability.md": {
-      "hash": "e6870241ada31fff7bfb1631b2473c17",
-      "chunks": 9,
-      "vectorized_at": "2025-12-30T21:06:45.151149"
-    },
-    "rag_knowledge/lessons_learned/ll_047_e2e_pipeline_verification_dec15.md": {
-      "hash": "96cab472f6c5b88fb9a3ae556bcfc5c3",
-      "chunks": 5,
-      "vectorized_at": "2025-12-30T21:06:45.262689"
-    },
-    "rag_knowledge/lessons_learned/ll_021_dashboard_gpu_requirements_dec12.md": {
-      "hash": "563dd003227562b7105a81f9a7b0dcda",
-      "chunks": 4,
-      "vectorized_at": "2025-12-30T21:06:45.361168"
-    },
-    "rag_knowledge/lessons_learned/ll_049_config_workflow_sync_failure_dec16.md": {
-      "hash": "a05c152b63112a3c07f42b86b44a1569",
-      "chunks": 5,
-      "vectorized_at": "2025-12-30T21:06:45.470346"
-    },
-    "rag_knowledge/lessons_learned/ll_019_trading_system_dead_dec12.md": {
-      "hash": "a81cff1af5b0e441c3b46b372e9c7934",
-      "chunks": 6,
-      "vectorized_at": "2025-12-30T21:06:45.575764"
-    },
-    "rag_knowledge/lessons_learned/ll_023_session_start_checklist_violation_dec13.md": {
-      "hash": "d4dcde681b50e5200513b202ed60b8fe",
-      "chunks": 7,
-      "vectorized_at": "2025-12-30T21:06:45.692597"
-    },
-    "rag_knowledge/lessons_learned/ll_052_no_crypto_trading_dec19.md": {
-      "hash": "3060f6c9845a7b29c4755418adb87453",
+    "rag_knowledge/blogs/phil_town/financial-control_Financial_Control.md": {
+      "hash": "5d285afa8f5030bb6d7f293c8ccfce6c",
       "chunks": 2,
-      "vectorized_at": "2025-12-30T21:06:45.752383"
+      "vectorized_at": "2025-12-31T03:00:08.719134"
     },
-    "rag_knowledge/lessons_learned/ll_074_rag_vector_db_not_installed_dec30.md": {
-      "hash": "5bdc36d9bd6468d3026eb2305302a0dc",
-      "chunks": 3,
-      "vectorized_at": "2025-12-30T21:06:45.834066"
+    "rag_knowledge/blogs/phil_town/become-investor_How_to_Become_an_Investor.md": {
+      "hash": "aa9ca7365e991bdedefec1ca2bc7b1c2",
+      "chunks": 26,
+      "vectorized_at": "2025-12-31T03:00:09.446607"
     },
-    "rag_knowledge/lessons_learned/ll_055_gitignore_breaks_workflow_commits_dec20.md": {
-      "hash": "cc5791e1b74918068e16a148f2a75272",
-      "chunks": 4,
-      "vectorized_at": "2025-12-30T21:06:45.911222"
-    },
-    "rag_knowledge/lessons_learned/ll_020_pyramid_buying_fear_destroyed_96_dec15.md": {
-      "hash": "b9080c9727ff448cc08f1b9eacd70772",
-      "chunks": 12,
-      "vectorized_at": "2025-12-30T21:06:46.084538"
-    },
-    "rag_knowledge/lessons_learned/ll_020_trade_files_not_committed_dec12.md": {
-      "hash": "b30279d216b6ca4ce84f276a8f4b7b80",
-      "chunks": 4,
-      "vectorized_at": "2025-12-30T21:06:46.176491"
-    },
-    "rag_knowledge/lessons_learned/ll_044_documentation_hygiene_mandate_dec15.md": {
-      "hash": "90e7cfdfda677f16248ea3bb9f846268",
-      "chunks": 7,
-      "vectorized_at": "2025-12-30T21:06:46.289462"
-    },
-    "rag_knowledge/lessons_learned/ll_043_crypto_removed_simplify_dec15.md": {
-      "hash": "49610b452f25d233986fd3f0b973857b",
-      "chunks": 5,
-      "vectorized_at": "2025-12-30T21:06:46.401596"
-    },
-    "rag_knowledge/lessons_learned/ll_050_langsmith_tracing_integration_dec16.md": {
-      "hash": "306f1ed02b3c0b8355d6a73aeb76c65d",
-      "chunks": 5,
-      "vectorized_at": "2025-12-30T21:06:46.497546"
+    "rag_knowledge/blogs/phil_town/personal-development_Personal_Development.md": {
+      "hash": "2f86178f8f549f1b18d79207201a3c6a",
+      "chunks": 2,
+      "vectorized_at": "2025-12-31T03:00:09.756781"
     },
     "rag_knowledge/lessons_learned/ll_019_system_dead_2_days_overly_strict_filters_dec12.md": {
       "hash": "b12366441d9102eb50d86a6970f7cefc",
       "chunks": 6,
-      "vectorized_at": "2025-12-30T21:06:46.631492"
-    },
-    "rag_knowledge/lessons_learned/ll_057_context_engineering_patterns_dec22.md": {
-      "hash": "e5d4046b592b69f9a5162454a99b3945",
-      "chunks": 4,
-      "vectorized_at": "2025-12-30T21:06:46.715788"
-    },
-    "rag_knowledge/lessons_learned/ll_024_fstring_syntax_error_dec13.md": {
-      "hash": "466b38dabbfb9a83fc1c39815dcdb188",
-      "chunks": 4,
-      "vectorized_at": "2025-12-30T21:06:46.796404"
-    },
-    "rag_knowledge/lessons_learned/ll_026_text_feature_engineering.md": {
-      "hash": "588728e1ebe2321e59ffc8c353986925",
-      "chunks": 13,
-      "vectorized_at": "2025-12-30T21:06:47.012016"
-    },
-    "rag_knowledge/lessons_learned/ll_017_anti_manual_violation_dec12.md": {
-      "hash": "88f91420def128aba6128b711bae734d",
-      "chunks": 4,
-      "vectorized_at": "2025-12-30T21:06:47.102520"
-    },
-    "rag_knowledge/lessons_learned/ll_035_failed_to_use_rag_dec15.md": {
-      "hash": "695dbb6c885f55e21ac8ed62247872da",
-      "chunks": 11,
-      "vectorized_at": "2025-12-30T21:06:47.292162"
-    },
-    "rag_knowledge/lessons_learned/ll_permanent_autonomous_mandate.md": {
-      "hash": "aefd39d496539a2f6b414136932565a7",
-      "chunks": 2,
-      "vectorized_at": "2025-12-30T21:06:47.369113"
-    },
-    "rag_knowledge/lessons_learned/ll_027_gemini_deep_research.md": {
-      "hash": "29ebe3ca0acd2fe0d232637e22002117",
-      "chunks": 16,
-      "vectorized_at": "2025-12-30T21:06:47.610686"
-    },
-    "rag_knowledge/lessons_learned/ll_017_claude_md_bloat_antipattern_dec12.md": {
-      "hash": "4f9b46336f5de61fd15d56a6022b4038",
-      "chunks": 6,
-      "vectorized_at": "2025-12-30T21:06:47.729142"
-    },
-    "rag_knowledge/lessons_learned/ll_068_google_adk_month3_priority.md": {
-      "hash": "c8c584a2250b1b46d1fa9f4dfb879a1d",
-      "chunks": 3,
-      "vectorized_at": "2025-12-30T21:06:47.803706"
-    },
-    "rag_knowledge/lessons_learned/ll_045_verification_systems_prevent_mistakes_dec15.md": {
-      "hash": "f6f342fbb1ad13834dec06dd7f497a00",
-      "chunks": 11,
-      "vectorized_at": "2025-12-30T21:06:47.995799"
+      "vectorized_at": "2025-12-31T03:00:10.176503"
     },
     "rag_knowledge/lessons_learned/ll_012_reit_strategy_not_activated_dec12.md": {
       "hash": "bda75693d28d6056e559954a01c78820",
       "chunks": 8,
-      "vectorized_at": "2025-12-30T21:06:48.154508"
+      "vectorized_at": "2025-12-31T03:00:10.613218"
     },
-    "rag_knowledge/lessons_learned/ll_011_theta_pivot_dec11.md": {
-      "hash": "12909df7f3ab44378736d0dd5d47a58b",
-      "chunks": 5,
-      "vectorized_at": "2025-12-30T21:06:48.260923"
-    },
-    "rag_knowledge/lessons_learned/ll_043_medallion_architecture_unused_code.md": {
-      "hash": "a8c6daf6b3d1fc77887ae67834ad53a2",
-      "chunks": 11,
-      "vectorized_at": "2025-12-30T21:06:48.529026"
-    },
-    "rag_knowledge/lessons_learned/ll_013_external_analysis_safety_gaps_dec11.md": {
-      "hash": "5de5233ae30936dcb6773cb4c1248602",
-      "chunks": 10,
-      "vectorized_at": "2025-12-30T21:06:48.745174"
-    },
-    "rag_knowledge/lessons_learned/ll_041_comprehensive_regression_tests_dec15.md": {
-      "hash": "c5a596c9489916d84751ffc235f119e4",
-      "chunks": 7,
-      "vectorized_at": "2025-12-30T21:06:48.924620"
-    },
-    "rag_knowledge/lessons_learned/ll_051_strategy_thresholds_too_tight_dec17.md": {
-      "hash": "c04c1f8562ef94966196e08f6a0049df",
+    "rag_knowledge/lessons_learned/ll_021_dashboard_gpu_requirements_dec12.md": {
+      "hash": "563dd003227562b7105a81f9a7b0dcda",
       "chunks": 4,
-      "vectorized_at": "2025-12-30T21:06:49.015577"
-    },
-    "rag_knowledge/lessons_learned/ll_autonomous_commands.md": {
-      "hash": "78bba747c2fa6bfd060247e0abcd06d6",
-      "chunks": 2,
-      "vectorized_at": "2025-12-30T21:06:49.070479"
-    },
-    "rag_knowledge/lessons_learned/ll_054_rag_not_actually_used_dec17.md": {
-      "hash": "af27847bf5d2e2cac559452e6c3d6088",
-      "chunks": 7,
-      "vectorized_at": "2025-12-30T21:06:49.212058"
-    },
-    "rag_knowledge/lessons_learned/over_engineering_trading_system.md": {
-      "hash": "18d5b3c6b5a9b06622852df49b4d7065",
-      "chunks": 7,
-      "vectorized_at": "2025-12-30T21:06:49.345526"
-    },
-    "rag_knowledge/lessons_learned/ll_051_calendar_awareness_critical_dec19.md": {
-      "hash": "b9010b2e623415d8b55505923dfff5d9",
-      "chunks": 3,
-      "vectorized_at": "2025-12-30T21:06:49.414991"
-    },
-    "rag_knowledge/lessons_learned/ll_022_options_not_automated_dec12.md": {
-      "hash": "5e1e41802c645377dda915e6e41e02eb",
-      "chunks": 5,
-      "vectorized_at": "2025-12-30T21:06:49.519419"
-    },
-    "rag_knowledge/lessons_learned/ll_042_code_hygiene_automated_prevention_dec15.md": {
-      "hash": "4297790957ca1fb218ac555674162b54",
-      "chunks": 4,
-      "vectorized_at": "2025-12-30T21:06:49.606265"
-    },
-    "rag_knowledge/lessons_learned/ll_058_langsmith_trace_errors_dec23.md": {
-      "hash": "300c4b16ab28ffd2118112ffc2135d30",
-      "chunks": 3,
-      "vectorized_at": "2025-12-30T21:06:49.679874"
-    },
-    "rag_knowledge/lessons_learned/ll_046_tax_aware_trading_mandate_dec15.md": {
-      "hash": "ffaca1737ce0db52b56482f0d7539d96",
-      "chunks": 8,
-      "vectorized_at": "2025-12-30T21:06:49.838445"
-    },
-    "rag_knowledge/lessons_learned/ll_031_procedural_memory_trading_skills.md": {
-      "hash": "6ca7e4b41c8c0891d563455c54a28f6b",
-      "chunks": 9,
-      "vectorized_at": "2025-12-30T21:06:49.987757"
-    },
-    "rag_knowledge/lessons_learned/ll_040_catching_falling_knives_dec15.md": {
-      "hash": "8eb6232067bef3684d2ac30f608881b8",
-      "chunks": 5,
-      "vectorized_at": "2025-12-30T21:06:50.122270"
-    },
-    "rag_knowledge/lessons_learned/ll_047_rag_dual_database_cleanup_dec15.md": {
-      "hash": "097c06877e7e67690ad7df4af40d23d8",
-      "chunks": 3,
-      "vectorized_at": "2025-12-30T21:06:50.182328"
+      "vectorized_at": "2025-12-31T03:00:10.953304"
     },
     "rag_knowledge/lessons_learned/ll_072_silent_data_corruption_dec30.md": {
       "hash": "a50f65015b4f1ae83c118479dd226142",
       "chunks": 3,
-      "vectorized_at": "2025-12-30T21:06:50.249846"
+      "vectorized_at": "2025-12-31T03:00:11.287881"
+    },
+    "rag_knowledge/lessons_learned/ll_050_langsmith_tracing_integration_dec16.md": {
+      "hash": "306f1ed02b3c0b8355d6a73aeb76c65d",
+      "chunks": 5,
+      "vectorized_at": "2025-12-31T03:00:11.670512"
+    },
+    "rag_knowledge/lessons_learned/ll_071_daily_lesson_capture_gap_dec29.md": {
+      "hash": "3bc22e503c2223d437efd1621b9ba1d8",
+      "chunks": 3,
+      "vectorized_at": "2025-12-31T03:00:12.005004"
+    },
+    "rag_knowledge/lessons_learned/ll_011_theta_pivot_dec11.md": {
+      "hash": "12909df7f3ab44378736d0dd5d47a58b",
+      "chunks": 5,
+      "vectorized_at": "2025-12-31T03:00:12.385602"
+    },
+    "rag_knowledge/lessons_learned/ll_043_crypto_removed_simplify_dec15.md": {
+      "hash": "49610b452f25d233986fd3f0b973857b",
+      "chunks": 5,
+      "vectorized_at": "2025-12-31T03:00:12.761611"
+    },
+    "rag_knowledge/lessons_learned/ll_042_code_hygiene_automated_prevention_dec15.md": {
+      "hash": "4297790957ca1fb218ac555674162b54",
+      "chunks": 4,
+      "vectorized_at": "2025-12-31T03:00:13.113775"
+    },
+    "rag_knowledge/lessons_learned/ll_073_options_theta_success_dec30.md": {
+      "hash": "26222b90cbae9ae2430aeb185dcf742d",
+      "chunks": 3,
+      "vectorized_at": "2025-12-31T03:00:13.444690"
+    },
+    "rag_knowledge/lessons_learned/ll_040_catching_falling_knives_dec15.md": {
+      "hash": "8eb6232067bef3684d2ac30f608881b8",
+      "chunks": 5,
+      "vectorized_at": "2025-12-31T03:00:13.831680"
+    },
+    "rag_knowledge/lessons_learned/ll_019_trading_system_dead_dec12.md": {
+      "hash": "a81cff1af5b0e441c3b46b372e9c7934",
+      "chunks": 6,
+      "vectorized_at": "2025-12-31T03:00:14.216346"
+    },
+    "rag_knowledge/lessons_learned/ll_011_facts_benchmark_factuality_ceiling.md": {
+      "hash": "b1c3e64b014b0e6cb4490e7c91eb84d2",
+      "chunks": 3,
+      "vectorized_at": "2025-12-31T03:00:14.564289"
+    },
+    "rag_knowledge/lessons_learned/ll_043_medallion_architecture_unused_code.md": {
+      "hash": "a8c6daf6b3d1fc77887ae67834ad53a2",
+      "chunks": 11,
+      "vectorized_at": "2025-12-31T03:00:15.076250"
+    },
+    "rag_knowledge/lessons_learned/ll_051_calendar_awareness_critical_dec19.md": {
+      "hash": "b9010b2e623415d8b55505923dfff5d9",
+      "chunks": 3,
+      "vectorized_at": "2025-12-31T03:00:15.430900"
+    },
+    "rag_knowledge/lessons_learned/ll_029_hicra_rl_credit_assignment.md": {
+      "hash": "8e4f7a00a6e3d9100aead6297036b6e3",
+      "chunks": 5,
+      "vectorized_at": "2025-12-31T03:00:15.832041"
+    },
+    "rag_knowledge/lessons_learned/ll_011_opus_45_optimization_dec11.md": {
+      "hash": "f4b5678e437aed4c1ddcf461867efd0a",
+      "chunks": 8,
+      "vectorized_at": "2025-12-31T03:00:16.259185"
+    },
+    "rag_knowledge/lessons_learned/ll_031_procedural_memory_trading_skills.md": {
+      "hash": "6ca7e4b41c8c0891d563455c54a28f6b",
+      "chunks": 9,
+      "vectorized_at": "2025-12-31T03:00:16.707959"
+    },
+    "rag_knowledge/lessons_learned/ll_permanent_autonomous_mandate.md": {
+      "hash": "aefd39d496539a2f6b414136932565a7",
+      "chunks": 2,
+      "vectorized_at": "2025-12-31T03:00:17.042291"
+    },
+    "rag_knowledge/lessons_learned/ll_068_google_adk_month3_priority.md": {
+      "hash": "c8c584a2250b1b46d1fa9f4dfb879a1d",
+      "chunks": 3,
+      "vectorized_at": "2025-12-31T03:00:17.404879"
+    },
+    "rag_knowledge/lessons_learned/ll_022_options_not_automated_dec12.md": {
+      "hash": "5e1e41802c645377dda915e6e41e02eb",
+      "chunks": 5,
+      "vectorized_at": "2025-12-31T03:00:17.795788"
+    },
+    "rag_knowledge/lessons_learned/ll_015_ai_friendly_repo_structure_dec11.md": {
+      "hash": "90f0667bfe5fe398ae31db61b11e3292",
+      "chunks": 7,
+      "vectorized_at": "2025-12-31T03:00:18.257627"
+    },
+    "rag_knowledge/lessons_learned/ll_030_langsmith_deep_agent_observability.md": {
+      "hash": "e6870241ada31fff7bfb1631b2473c17",
+      "chunks": 9,
+      "vectorized_at": "2025-12-31T03:00:18.752314"
     },
     "rag_knowledge/lessons_learned/ll_011_missing_function_imports_dec11.md": {
       "hash": "88428f5bfd36dd11e6ce772658b78881",
       "chunks": 6,
-      "vectorized_at": "2025-12-30T21:06:50.367319"
+      "vectorized_at": "2025-12-31T03:00:19.157787"
+    },
+    "rag_knowledge/lessons_learned/ll_058_stale_data_lying_incident_dec23.md": {
+      "hash": "aca2fb7c706124aaa077972c56f194d3",
+      "chunks": 5,
+      "vectorized_at": "2025-12-31T03:00:19.604925"
+    },
+    "rag_knowledge/lessons_learned/the_one_thing_trading.md": {
+      "hash": "bdf55fc6c13a08cb20b2e7605ba91e2c",
+      "chunks": 6,
+      "vectorized_at": "2025-12-31T03:00:20.064109"
+    },
+    "rag_knowledge/lessons_learned/ll_026_text_feature_engineering.md": {
+      "hash": "588728e1ebe2321e59ffc8c353986925",
+      "chunks": 13,
+      "vectorized_at": "2025-12-31T03:00:20.610840"
+    },
+    "rag_knowledge/lessons_learned/ll_055_gitignore_breaks_workflow_commits_dec20.md": {
+      "hash": "cc5791e1b74918068e16a148f2a75272",
+      "chunks": 4,
+      "vectorized_at": "2025-12-31T03:00:20.983860"
+    },
+    "rag_knowledge/lessons_learned/ll_023_session_start_checklist_violation_dec13.md": {
+      "hash": "d4dcde681b50e5200513b202ed60b8fe",
+      "chunks": 7,
+      "vectorized_at": "2025-12-31T03:00:21.464630"
+    },
+    "rag_knowledge/lessons_learned/ll_029_always_verify_date.md": {
+      "hash": "6b440519f0df449afa570abadcae09ba",
+      "chunks": 3,
+      "vectorized_at": "2025-12-31T03:00:21.827640"
+    },
+    "rag_knowledge/lessons_learned/ll_017_anti_manual_violation_dec12.md": {
+      "hash": "88f91420def128aba6128b711bae734d",
+      "chunks": 4,
+      "vectorized_at": "2025-12-31T03:00:22.257244"
+    },
+    "rag_knowledge/lessons_learned/ll_052_no_crypto_trading_dec19.md": {
+      "hash": "3060f6c9845a7b29c4755418adb87453",
+      "chunks": 2,
+      "vectorized_at": "2025-12-31T03:00:22.608136"
+    },
+    "rag_knowledge/lessons_learned/ll_020_pyramid_buying_fear_destroyed_96_dec15.md": {
+      "hash": "b9080c9727ff448cc08f1b9eacd70772",
+      "chunks": 12,
+      "vectorized_at": "2025-12-31T03:00:23.179896"
+    },
+    "rag_knowledge/lessons_learned/ll_044_documentation_hygiene_mandate_dec15.md": {
+      "hash": "90e7cfdfda677f16248ea3bb9f846268",
+      "chunks": 7,
+      "vectorized_at": "2025-12-31T03:00:23.645971"
+    },
+    "rag_knowledge/lessons_learned/ll_045_verification_systems_prevent_mistakes_dec15.md": {
+      "hash": "f6f342fbb1ad13834dec06dd7f497a00",
+      "chunks": 11,
+      "vectorized_at": "2025-12-31T03:00:24.168939"
+    },
+    "rag_knowledge/lessons_learned/ll_074_rag_vector_db_not_installed_dec30.md": {
+      "hash": "5bdc36d9bd6468d3026eb2305302a0dc",
+      "chunks": 3,
+      "vectorized_at": "2025-12-31T03:00:24.555091"
+    },
+    "rag_knowledge/lessons_learned/ll_021_backtest_thresholds_rnd_phase_dec15.md": {
+      "hash": "9bdcb0e8e360b4d8a930c93671f2d33b",
+      "chunks": 5,
+      "vectorized_at": "2025-12-31T03:00:24.960568"
+    },
+    "rag_knowledge/lessons_learned/over_engineering_trading_system.md": {
+      "hash": "18d5b3c6b5a9b06622852df49b4d7065",
+      "chunks": 7,
+      "vectorized_at": "2025-12-31T03:00:25.412923"
+    },
+    "rag_knowledge/lessons_learned/ll_051_blind_trading_catastrophe_dec17.md": {
+      "hash": "16da1319210c85128386a22f7dc6dc97",
+      "chunks": 6,
+      "vectorized_at": "2025-12-31T03:00:25.854639"
+    },
+    "rag_knowledge/lessons_learned/ll_046_tax_aware_trading_mandate_dec15.md": {
+      "hash": "ffaca1737ce0db52b56482f0d7539d96",
+      "chunks": 8,
+      "vectorized_at": "2025-12-31T03:00:26.303145"
+    },
+    "rag_knowledge/lessons_learned/ll_020_trade_files_not_committed_dec12.md": {
+      "hash": "b30279d216b6ca4ce84f276a8f4b7b80",
+      "chunks": 4,
+      "vectorized_at": "2025-12-31T03:00:26.706658"
+    },
+    "rag_knowledge/lessons_learned/ll_017_claude_md_bloat_antipattern_dec12.md": {
+      "hash": "4f9b46336f5de61fd15d56a6022b4038",
+      "chunks": 6,
+      "vectorized_at": "2025-12-31T03:00:27.115467"
+    },
+    "rag_knowledge/lessons_learned/ll_012_deep_research_safety_improvements_dec11.md": {
+      "hash": "cfe6a2e26c0721d9eea8343828e2df95",
+      "chunks": 13,
+      "vectorized_at": "2025-12-31T03:00:27.711095"
+    },
+    "rag_knowledge/lessons_learned/ll_017_rag_vectorization_gap_dec12.md": {
+      "hash": "137da5f17d6fc19b09faa63c0d80bd52",
+      "chunks": 7,
+      "vectorized_at": "2025-12-31T03:00:28.177121"
+    },
+    "rag_knowledge/lessons_learned/ll_054_rag_not_actually_used_dec17.md": {
+      "hash": "af27847bf5d2e2cac559452e6c3d6088",
+      "chunks": 7,
+      "vectorized_at": "2025-12-31T03:00:28.618797"
     },
     "rag_knowledge/lessons_learned/ll_018_weekend_market_awareness_dec12.md": {
       "hash": "71291babc649c3cb0bf5a7cb98ebd234",
       "chunks": 5,
-      "vectorized_at": "2025-12-30T21:06:50.472838"
+      "vectorized_at": "2025-12-31T03:00:29.023414"
+    },
+    "rag_knowledge/lessons_learned/ci_failure_blocked_trading.md": {
+      "hash": "56183d243e401649de50f953e245fdba",
+      "chunks": 6,
+      "vectorized_at": "2025-12-31T03:00:29.479824"
+    },
+    "rag_knowledge/lessons_learned/ll_024_fstring_syntax_error_dec13.md": {
+      "hash": "466b38dabbfb9a83fc1c39815dcdb188",
+      "chunks": 4,
+      "vectorized_at": "2025-12-31T03:00:29.862590"
+    },
+    "rag_knowledge/lessons_learned/ll_047_e2e_pipeline_verification_dec15.md": {
+      "hash": "96cab472f6c5b88fb9a3ae556bcfc5c3",
+      "chunks": 5,
+      "vectorized_at": "2025-12-31T03:00:30.293640"
+    },
+    "rag_knowledge/lessons_learned/ll_018_pl_verification_failure_dec12.md": {
+      "hash": "0677621773113e3d5db2efcad56b7cfe",
+      "chunks": 4,
+      "vectorized_at": "2025-12-31T03:00:30.695481"
+    },
+    "rag_knowledge/lessons_learned/ll_048_go_live_readiness_system_dec15.md": {
+      "hash": "279446e723b1219a8e5479ced146ffb3",
+      "chunks": 8,
+      "vectorized_at": "2025-12-31T03:00:31.142529"
+    },
+    "rag_knowledge/lessons_learned/ll_010_dead_code_and_dormant_systems_dec11.md": {
+      "hash": "0c9526275bd6dcfeb026307d3c435951",
+      "chunks": 3,
+      "vectorized_at": "2025-12-31T03:00:31.520199"
+    },
+    "rag_knowledge/lessons_learned/ll_070_acknowledge_user_feedback.md": {
+      "hash": "dab2860424380f9b0e758a818a4340e1",
+      "chunks": 2,
+      "vectorized_at": "2025-12-31T03:00:31.887485"
+    },
+    "rag_knowledge/lessons_learned/ll_014_dead_code_dynamic_budget_dec11.md": {
+      "hash": "94f1b08ce4ed5798c945fc626256753f",
+      "chunks": 5,
+      "vectorized_at": "2025-12-31T03:00:32.322474"
+    },
+    "rag_knowledge/lessons_learned/ll_059_simulated_sync_lie_dec29.md": {
+      "hash": "9fcb48881c660fe7282c0aabe5eaad5a",
+      "chunks": 3,
+      "vectorized_at": "2025-12-31T03:00:32.706330"
+    },
+    "rag_knowledge/lessons_learned/ll_047_rag_dual_database_cleanup_dec15.md": {
+      "hash": "097c06877e7e67690ad7df4af40d23d8",
+      "chunks": 3,
+      "vectorized_at": "2025-12-31T03:00:33.084819"
+    },
+    "rag_knowledge/lessons_learned/ll_041_comprehensive_regression_tests_dec15.md": {
+      "hash": "c5a596c9489916d84751ffc235f119e4",
+      "chunks": 7,
+      "vectorized_at": "2025-12-31T03:00:33.536987"
+    },
+    "rag_knowledge/lessons_learned/ll_027_gemini_deep_research.md": {
+      "hash": "29ebe3ca0acd2fe0d232637e22002117",
+      "chunks": 16,
+      "vectorized_at": "2025-12-31T03:00:34.126313"
+    },
+    "rag_knowledge/lessons_learned/ll_056_silent_pipeline_failures_dec22.md": {
+      "hash": "5a4651904315a54931b7b4f8f5815bc0",
+      "chunks": 5,
+      "vectorized_at": "2025-12-31T03:00:34.625981"
+    },
+    "rag_knowledge/lessons_learned/ll_013_external_analysis_safety_gaps_dec11.md": {
+      "hash": "5de5233ae30936dcb6773cb4c1248602",
+      "chunks": 10,
+      "vectorized_at": "2025-12-31T03:00:35.149971"
+    },
+    "rag_knowledge/lessons_learned/ll_009_ci_syntax_failure_dec11.md": {
+      "hash": "3f66b59d3c8ae50d6804082cae056606",
+      "chunks": 11,
+      "vectorized_at": "2025-12-31T03:00:35.687914"
+    },
+    "rag_knowledge/lessons_learned/ll_051_strategy_thresholds_too_tight_dec17.md": {
+      "hash": "c04c1f8562ef94966196e08f6a0049df",
+      "chunks": 4,
+      "vectorized_at": "2025-12-31T03:00:36.115979"
+    },
+    "rag_knowledge/lessons_learned/ll_058_langsmith_trace_errors_dec23.md": {
+      "hash": "300c4b16ab28ffd2118112ffc2135d30",
+      "chunks": 3,
+      "vectorized_at": "2025-12-31T03:00:36.516699"
+    },
+    "rag_knowledge/lessons_learned/ll_011_ai_agent_adaptation_dec11.md": {
+      "hash": "91921cc11b31fb1f273d7ede43f4c71c",
+      "chunks": 8,
+      "vectorized_at": "2025-12-31T03:00:36.986896"
+    },
+    "rag_knowledge/lessons_learned/ll_016_regime_pivot_safety_gates_dec12.md": {
+      "hash": "41de34560a09dd48cda0cf640d3ae51f",
+      "chunks": 12,
+      "vectorized_at": "2025-12-31T03:00:37.577849"
+    },
+    "rag_knowledge/lessons_learned/ll_017_missing_langsmith_env_vars_dec12.md": {
+      "hash": "d52a05984cdf86620a69381076eb5eb7",
+      "chunks": 9,
+      "vectorized_at": "2025-12-31T03:00:38.077007"
+    },
+    "rag_knowledge/lessons_learned/ll_052_credit_spreads_capital_efficiency_dec17.md": {
+      "hash": "526abb682837c62439673c8b99da3010",
+      "chunks": 4,
+      "vectorized_at": "2025-12-31T03:00:38.497755"
+    },
+    "rag_knowledge/lessons_learned/ll_057_context_engineering_patterns_dec22.md": {
+      "hash": "e5d4046b592b69f9a5162454a99b3945",
+      "chunks": 4,
+      "vectorized_at": "2025-12-31T03:00:38.915981"
+    },
+    "rag_knowledge/lessons_learned/ll_053_stop_bleeding_crypto_reit_dec17.md": {
+      "hash": "0cbe5f38ae041eaef29554c02307a351",
+      "chunks": 3,
+      "vectorized_at": "2025-12-31T03:00:39.295315"
+    },
+    "rag_knowledge/lessons_learned/ll_025_bats_budget_framework.md": {
+      "hash": "7dafd5af76cbf875947b4ae4365a0df6",
+      "chunks": 8,
+      "vectorized_at": "2025-12-31T03:00:39.769919"
+    },
+    "rag_knowledge/lessons_learned/ll_049_config_workflow_sync_failure_dec16.md": {
+      "hash": "a05c152b63112a3c07f42b86b44a1569",
+      "chunks": 5,
+      "vectorized_at": "2025-12-31T03:00:40.193101"
+    },
+    "rag_knowledge/lessons_learned/ll_020_options_primary_strategy_dec12.md": {
+      "hash": "6ab39304a8e5e979f67db3c0feddbe0a",
+      "chunks": 5,
+      "vectorized_at": "2025-12-31T03:00:40.652171"
+    },
+    "rag_knowledge/lessons_learned/ll_autonomous_commands.md": {
+      "hash": "78bba747c2fa6bfd060247e0abcd06d6",
+      "chunks": 2,
+      "vectorized_at": "2025-12-31T03:00:41.038067"
+    },
+    "rag_knowledge/lessons_learned/ll_035_failed_to_use_rag_dec15.md": {
+      "hash": "695dbb6c885f55e21ac8ed62247872da",
+      "chunks": 11,
+      "vectorized_at": "2025-12-31T03:00:41.690333"
+    },
+    "rag_knowledge/lessons_learned/ll_028_unified_domain_model.md": {
+      "hash": "c4c14a9bd576dcb2211988aed7b5e85d",
+      "chunks": 7,
+      "vectorized_at": "2025-12-31T03:00:42.119955"
     },
     "rag_knowledge/books/phil_town_rule_one.md": {
       "hash": "02e2ebb5db2c60c1b7e278e1b8b71b54",
       "chunks": 10,
-      "vectorized_at": "2025-12-30T21:06:50.636093"
+      "vectorized_at": "2025-12-31T03:00:42.609794"
     },
     "rag_knowledge/books/systematic_trading_chapters.json": {
       "hash": "01ff2d2b8ffb0bea116c4c5641e5be1f",
       "chunks": 18,
-      "vectorized_at": "2025-12-30T21:06:50.908013"
+      "vectorized_at": "2025-12-31T03:00:43.182808"
     },
     "rag_knowledge/books/afml_chapters.json": {
       "hash": "987db7bf5d8b88c3a8561bdd7154ffd4",
       "chunks": 21,
-      "vectorized_at": "2025-12-30T21:06:51.250562"
+      "vectorized_at": "2025-12-31T03:00:43.802915"
     }
   },
-  "last_updated": "2025-12-30T21:06:51.251206"
+  "last_updated": "2025-12-31T03:00:43.803650"
 }

--- a/scripts/fix_win_rate_from_closed_trades.py
+++ b/scripts/fix_win_rate_from_closed_trades.py
@@ -1,0 +1,179 @@
+#!/usr/bin/env python3
+"""
+Fix Win Rate From Closed Trades
+
+This script recalculates the win_rate from actual closed_trades data,
+fixing the mismatch between the counter-based calculation and reality.
+
+Created: Dec 31, 2025 (Fix for lying dashboard metrics)
+"""
+
+import json
+import logging
+from pathlib import Path
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
+logger = logging.getLogger(__name__)
+
+STATE_FILE = Path("data/system_state.json")
+
+
+def calculate_accurate_win_rate() -> dict:
+    """
+    Calculate accurate win rate from closed_trades list.
+
+    Returns:
+        Dict with corrected metrics and discrepancy info
+    """
+    if not STATE_FILE.exists():
+        logger.error(f"State file not found: {STATE_FILE}")
+        return {"error": "State file not found"}
+
+    with open(STATE_FILE) as f:
+        state = json.load(f)
+
+    performance = state.get("performance", {})
+    closed_trades = performance.get("closed_trades", [])
+
+    # Count actual winners from closed_trades
+    actual_winners = 0
+    actual_losers = 0
+
+    for trade in closed_trades:
+        pl = trade.get("pl", 0)
+        if pl > 0:
+            actual_winners += 1
+        elif pl < 0:
+            actual_losers += 1
+        # pl == 0 is neither win nor loss
+
+    total_closed = len(closed_trades)
+
+    # Calculate actual win rate
+    actual_win_rate = (actual_winners / total_closed * 100) if total_closed > 0 else 0.0
+
+    # Get reported values
+    reported_win_rate = performance.get("win_rate", 0.0)
+    reported_winners = performance.get("winning_trades", 0)
+    reported_losers = performance.get("losing_trades", 0)
+
+    # Calculate discrepancy
+    discrepancy = abs(actual_win_rate - reported_win_rate)
+
+    return {
+        "reported": {
+            "win_rate": reported_win_rate,
+            "winning_trades": reported_winners,
+            "losing_trades": reported_losers,
+        },
+        "actual": {
+            "win_rate": round(actual_win_rate, 2),
+            "winning_trades": actual_winners,
+            "losing_trades": actual_losers,
+            "total_closed": total_closed,
+        },
+        "discrepancy": round(discrepancy, 2),
+        "needs_fix": discrepancy > 0.5,  # More than 0.5% difference
+    }
+
+
+def fix_win_rate() -> bool:
+    """
+    Fix the win_rate by recalculating from closed_trades.
+
+    Returns:
+        True if fix was applied, False otherwise
+    """
+    if not STATE_FILE.exists():
+        logger.error(f"State file not found: {STATE_FILE}")
+        return False
+
+    with open(STATE_FILE) as f:
+        state = json.load(f)
+
+    performance = state.get("performance", {})
+    closed_trades = performance.get("closed_trades", [])
+
+    # Count actual winners/losers
+    actual_winners = 0
+    actual_losers = 0
+
+    for trade in closed_trades:
+        pl = trade.get("pl", 0)
+        if pl > 0:
+            actual_winners += 1
+        elif pl < 0:
+            actual_losers += 1
+
+    total_closed = len(closed_trades)
+    actual_win_rate = (actual_winners / total_closed * 100) if total_closed > 0 else 0.0
+
+    # Log the fix
+    old_win_rate = performance.get("win_rate", 0.0)
+    old_winners = performance.get("winning_trades", 0)
+    old_losers = performance.get("losing_trades", 0)
+
+    logger.info(f"Fixing win_rate: {old_win_rate:.1f}% -> {actual_win_rate:.1f}%")
+    logger.info(f"Fixing winning_trades: {old_winners} -> {actual_winners}")
+    logger.info(f"Fixing losing_trades: {old_losers} -> {actual_losers}")
+
+    # Apply fix
+    performance["win_rate"] = round(actual_win_rate, 2)
+    performance["winning_trades"] = actual_winners
+    performance["losing_trades"] = actual_losers
+    performance["_win_rate_source"] = "calculated_from_closed_trades"
+    performance["_win_rate_fixed_at"] = __import__("datetime").datetime.now().isoformat()
+
+    state["performance"] = performance
+
+    # Save
+    with open(STATE_FILE, "w") as f:
+        json.dump(state, f, indent=2)
+
+    logger.info(f"Win rate fixed and saved to {STATE_FILE}")
+    return True
+
+
+def main():
+    """Main entry point."""
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Fix win rate from closed trades")
+    parser.add_argument("--check", action="store_true", help="Check for discrepancy without fixing")
+    parser.add_argument("--fix", action="store_true", help="Apply the fix")
+    args = parser.parse_args()
+
+    if args.check or not args.fix:
+        result = calculate_accurate_win_rate()
+        print("\n=== Win Rate Analysis ===")
+        print(f"Reported win_rate: {result['reported']['win_rate']:.1f}%")
+        print(f"Actual win_rate:   {result['actual']['win_rate']:.1f}%")
+        print(f"Discrepancy:       {result['discrepancy']:.1f}%")
+        print()
+        print(f"Reported winners:  {result['reported']['winning_trades']}")
+        print(f"Actual winners:    {result['actual']['winning_trades']}")
+        print()
+        print(f"Reported losers:   {result['reported']['losing_trades']}")
+        print(f"Actual losers:     {result['actual']['losing_trades']}")
+        print()
+        print(f"Total closed:      {result['actual']['total_closed']}")
+        print()
+
+        if result["needs_fix"]:
+            print("STATUS: FIX NEEDED - Run with --fix to correct")
+        else:
+            print(" STATUS: OK - No significant discrepancy")
+
+        if not args.fix:
+            return
+
+    if args.fix:
+        success = fix_win_rate()
+        if success:
+            print("\n WIN RATE FIXED SUCCESSFULLY")
+        else:
+            print("\n FAILED TO FIX WIN RATE")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/generate_world_class_dashboard_enhanced.py
+++ b/scripts/generate_world_class_dashboard_enhanced.py
@@ -206,14 +206,14 @@ def calculate_simple_risk_metrics(perf_log: list, all_trades: list) -> dict:
 
     return {
         "sharpe_ratio": sharpe_ratio,
-        "sortino_ratio": sharpe_ratio * 1.2,  # Approximate
+        "sortino_ratio": None,  # HONESTY FIX: Was incorrectly approximated as sharpe*1.2
         "max_drawdown_pct": max_drawdown * 100,
         "current_drawdown_pct": ((peak - equities[-1]) / peak * 100) if peak > 0 else 0,
         "volatility_annualized": volatility_annualized,
-        "var_95": -1.65 * std_dev * 100,
-        "var_99": -2.33 * std_dev * 100,
-        "calmar_ratio": (avg_return * 252 / max_drawdown) if max_drawdown > 0 else 0,
-        "ulcer_index": max_drawdown * 100 * 0.5,
+        "var_95": -1.65 * std_dev * 100 if std_dev > 0 else None,
+        "var_99": -2.33 * std_dev * 100 if std_dev > 0 else None,
+        "calmar_ratio": (avg_return * 252 / max_drawdown) if max_drawdown > 0 else None,
+        "ulcer_index": None,  # HONESTY FIX: Was fake calculation (drawdown * 0.5)
     }
 
 
@@ -367,28 +367,34 @@ def generate_world_class_dashboard() -> str:
 
     # Use simple risk metrics calculated above (risk already set)
     attribution = {"by_symbol": {}, "by_strategy": {}, "by_time_of_day": {}}
+    # HONESTY FIX Dec 31, 2025: Mark unmeasured metrics as such
+    # Previously these were hardcoded to perfect values which was misleading
     execution = {
-        "avg_slippage": 0,
-        "fill_quality": 100,
-        "order_success_rate": 100,
-        "order_reject_rate": 0,
-        "avg_fill_time_ms": 50,
-        "broker_latency_ms": 20,
+        "avg_slippage": None,  # NOT MEASURED - would need trade-by-trade analysis
+        "fill_quality": None,  # NOT MEASURED - no benchmark available
+        "order_success_rate": None,  # NOT MEASURED - requires order tracking
+        "order_reject_rate": None,  # NOT MEASURED
+        "avg_fill_time_ms": None,  # NOT MEASURED
+        "broker_latency_ms": None,  # NOT MEASURED
+        "_note": "Execution metrics not currently tracked - values would be misleading",
     }
     data_completeness = {
-        "performance_log_completeness": 100,
-        "missing_dates_count": 0,
-        "data_freshness_days": 0,
-        "missing_candle_pct": 0,
+        "performance_log_completeness": len(perf_log) if perf_log else 0,  # Actual count
+        "missing_dates_count": None,  # Would need calendar analysis
+        "data_freshness_days": None,  # Calculated below if possible
+        "missing_candle_pct": None,  # NOT MEASURED
         "data_sources_used": ["Alpaca"],
         "model_version": "2.0",
+        "_note": "Some completeness metrics require additional implementation",
     }
+    # HONESTY FIX: Predictive metrics are NOT implemented - don't pretend they are
     predictive = {
-        "expected_pl_30d": 0,
-        "monte_carlo_forecast": {},
-        "risk_of_ruin": 0,
-        "forecasted_drawdown": 0,
-        "strategy_decay_detected": False,
+        "expected_pl_30d": None,  # NOT IMPLEMENTED
+        "monte_carlo_forecast": None,  # NOT IMPLEMENTED
+        "risk_of_ruin": None,  # NOT IMPLEMENTED
+        "forecasted_drawdown": None,  # NOT IMPLEMENTED
+        "strategy_decay_detected": None,  # NOT IMPLEMENTED
+        "_note": "Predictive analytics not yet implemented - future feature",
     }
     benchmark = {
         "portfolio_return": basic_metrics.get("total_pl_pct", 0),

--- a/src/rag/lessons_search.py
+++ b/src/rag/lessons_search.py
@@ -1,0 +1,372 @@
+"""
+LessonsSearch - Semantic search for lessons learned using ChromaDB.
+
+This module provides proper vector-based semantic search on lessons learned,
+replacing the simple keyword matching with true embeddings-based retrieval.
+
+Created: Dec 31, 2025 (Fix for ll_054 - RAG not actually used)
+"""
+
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+# Paths
+LESSONS_DIR = Path("rag_knowledge/lessons_learned")
+VECTOR_DB_PATH = Path("data/vector_db")
+
+
+@dataclass
+class LessonResult:
+    """A lesson search result with all relevant fields."""
+
+    id: str
+    title: str
+    severity: str
+    snippet: str
+    prevention: str
+    file: str
+    score: float = 0.0
+
+
+class LessonsSearch:
+    """
+    Semantic search over lessons learned using ChromaDB embeddings.
+
+    Provides true semantic similarity search, not just keyword matching.
+    Falls back to keyword search if ChromaDB is unavailable.
+    """
+
+    def __init__(self, use_chromadb: bool = True):
+        """
+        Initialize LessonsSearch.
+
+        Args:
+            use_chromadb: Whether to use ChromaDB for semantic search.
+                         Falls back to keyword search if unavailable.
+        """
+        self.collection = None
+        self.use_chromadb = use_chromadb
+        self._lessons_cache: list[dict] = []
+
+        if use_chromadb:
+            self._init_chromadb()
+
+        # Always load lessons for fallback
+        self._load_lessons()
+
+    def _init_chromadb(self) -> None:
+        """Initialize ChromaDB collection for lessons."""
+        try:
+            import chromadb
+            from chromadb.config import Settings
+
+            VECTOR_DB_PATH.mkdir(parents=True, exist_ok=True)
+
+            client = chromadb.PersistentClient(
+                path=str(VECTOR_DB_PATH),
+                settings=Settings(anonymized_telemetry=False),
+            )
+
+            self.collection = client.get_or_create_collection(
+                name="lessons_learned",
+                metadata={
+                    "description": "Trading lessons learned knowledge base",
+                    "hnsw:space": "cosine",
+                },
+            )
+
+            logger.info(
+                f"LessonsSearch: ChromaDB initialized with {self.collection.count()} documents"
+            )
+
+        except ImportError:
+            logger.warning("ChromaDB not available - falling back to keyword search")
+            self.collection = None
+        except Exception as e:
+            logger.warning(f"ChromaDB init failed: {e} - falling back to keyword search")
+            self.collection = None
+
+    def _load_lessons(self) -> None:
+        """Load all lessons from markdown files."""
+        self._lessons_cache = []
+
+        if not LESSONS_DIR.exists():
+            logger.warning(f"Lessons directory not found: {LESSONS_DIR}")
+            return
+
+        for lesson_file in LESSONS_DIR.glob("*.md"):
+            try:
+                content = lesson_file.read_text()
+                lesson = {
+                    "id": lesson_file.stem,
+                    "file": str(lesson_file),
+                    "content": content,
+                    "severity": self._extract_severity(content),
+                    "title": self._extract_title(content, lesson_file.stem),
+                    "prevention": self._extract_prevention(content),
+                }
+                self._lessons_cache.append(lesson)
+            except Exception as e:
+                logger.warning(f"Failed to load lesson {lesson_file}: {e}")
+
+        logger.info(f"LessonsSearch: Loaded {len(self._lessons_cache)} lessons")
+
+    def _extract_severity(self, content: str) -> str:
+        """Extract severity from lesson content."""
+        content_lower = content.lower()
+        if "severity**: critical" in content_lower or "**severity:** critical" in content_lower:
+            return "CRITICAL"
+        elif "severity**: high" in content_lower or "**severity:** high" in content_lower:
+            return "HIGH"
+        elif "severity**: medium" in content_lower or "**severity:** medium" in content_lower:
+            return "MEDIUM"
+        return "LOW"
+
+    def _extract_title(self, content: str, fallback: str) -> str:
+        """Extract title from lesson content."""
+        lines = content.strip().split("\n")
+        for line in lines[:5]:
+            line = line.strip()
+            if line.startswith("# "):
+                return line[2:].strip()
+            if line.startswith("## "):
+                return line[3:].strip()
+        return fallback
+
+    def _extract_prevention(self, content: str) -> str:
+        """Extract prevention/action section from lesson content."""
+        import re
+
+        patterns = [
+            r"## Prevention\s*\n(.*?)(?=\n##|\Z)",
+            r"## Action\s*\n(.*?)(?=\n##|\Z)",
+            r"## Solution\s*\n(.*?)(?=\n##|\Z)",
+            r"## What to Do\s*\n(.*?)(?=\n##|\Z)",
+            r"## Fix\s*\n(.*?)(?=\n##|\Z)",
+            r"## Corrective Action\s*\n(.*?)(?=\n##|\Z)",
+        ]
+        for pattern in patterns:
+            match = re.search(pattern, content, re.DOTALL | re.IGNORECASE)
+            if match:
+                return match.group(1).strip()[:500]
+
+        return content[:300].strip()
+
+    def search(
+        self, query: str, top_k: int = 5, severity_filter: Optional[str] = None
+    ) -> list[tuple[LessonResult, float]]:
+        """
+        Search lessons using semantic similarity.
+
+        Args:
+            query: Search query (e.g., "position sizing error", "API failure")
+            top_k: Number of results to return
+            severity_filter: Optional filter for severity level (CRITICAL, HIGH, MEDIUM, LOW)
+
+        Returns:
+            List of (LessonResult, score) tuples, sorted by relevance
+        """
+        # Try ChromaDB semantic search first
+        if self.collection is not None and self.collection.count() > 0:
+            try:
+                return self._search_chromadb(query, top_k, severity_filter)
+            except Exception as e:
+                logger.warning(f"ChromaDB search failed: {e} - falling back to keyword")
+
+        # Fallback to keyword search
+        return self._search_keywords(query, top_k, severity_filter)
+
+    def _search_chromadb(
+        self, query: str, top_k: int, severity_filter: Optional[str]
+    ) -> list[tuple[LessonResult, float]]:
+        """Search using ChromaDB semantic similarity."""
+        where_filter = None
+        if severity_filter:
+            where_filter = {"severity": severity_filter}
+
+        results = self.collection.query(
+            query_texts=[query],
+            n_results=min(top_k * 2, 20),  # Get more, then filter
+            where=where_filter,
+            include=["documents", "metadatas", "distances"],
+        )
+
+        output = []
+        if results and results.get("ids") and results["ids"][0]:
+            for i, doc_id in enumerate(results["ids"][0]):
+                metadata = results["metadatas"][0][i] if results.get("metadatas") else {}
+                document = results["documents"][0][i] if results.get("documents") else ""
+                distance = results["distances"][0][i] if results.get("distances") else 1.0
+
+                # Convert distance to similarity score (0-1)
+                score = max(0, 1 - distance)
+
+                lesson = LessonResult(
+                    id=doc_id,
+                    title=metadata.get("title", doc_id),
+                    severity=metadata.get("severity", "MEDIUM"),
+                    snippet=document[:500] if document else "",
+                    prevention=metadata.get("prevention", ""),
+                    file=metadata.get("file", ""),
+                    score=score,
+                )
+                output.append((lesson, score))
+
+        return output[:top_k]
+
+    def _search_keywords(
+        self, query: str, top_k: int, severity_filter: Optional[str]
+    ) -> list[tuple[LessonResult, float]]:
+        """Fallback keyword-based search."""
+        query_terms = query.lower().split()
+        results = []
+
+        for lesson in self._lessons_cache:
+            # Filter by severity if specified
+            if severity_filter and lesson["severity"] != severity_filter:
+                continue
+
+            content_lower = lesson["content"].lower()
+
+            # Score based on term matches
+            score = 0
+            for term in query_terms:
+                if term in content_lower:
+                    score += content_lower.count(term)
+
+            # Boost CRITICAL lessons
+            if lesson["severity"] == "CRITICAL":
+                score *= 2
+            elif lesson["severity"] == "HIGH":
+                score *= 1.5
+
+            if score > 0:
+                # Normalize score to 0-1 range
+                normalized_score = min(score / 50.0, 1.0)
+
+                lesson_result = LessonResult(
+                    id=lesson["id"],
+                    title=lesson["title"],
+                    severity=lesson["severity"],
+                    snippet=lesson["content"][:500],
+                    prevention=lesson["prevention"],
+                    file=lesson["file"],
+                    score=normalized_score,
+                )
+                results.append((lesson_result, normalized_score))
+
+        # Sort by score descending
+        results.sort(key=lambda x: x[1], reverse=True)
+        return results[:top_k]
+
+    def index_lessons(self, force_rebuild: bool = False) -> int:
+        """
+        Index all lessons into ChromaDB for semantic search.
+
+        Args:
+            force_rebuild: If True, delete existing index and rebuild
+
+        Returns:
+            Number of lessons indexed
+        """
+        if self.collection is None:
+            logger.error("ChromaDB not available - cannot index lessons")
+            return 0
+
+        if force_rebuild:
+            # Clear existing documents
+            try:
+                existing_ids = self.collection.get()["ids"]
+                if existing_ids:
+                    self.collection.delete(ids=existing_ids)
+                    logger.info(f"Cleared {len(existing_ids)} existing documents")
+            except Exception as e:
+                logger.warning(f"Failed to clear collection: {e}")
+
+        indexed = 0
+        for lesson in self._lessons_cache:
+            try:
+                self.collection.upsert(
+                    ids=[lesson["id"]],
+                    documents=[lesson["content"]],
+                    metadatas=[
+                        {
+                            "title": lesson["title"],
+                            "severity": lesson["severity"],
+                            "prevention": lesson["prevention"][:500],
+                            "file": lesson["file"],
+                        }
+                    ],
+                )
+                indexed += 1
+            except Exception as e:
+                logger.warning(f"Failed to index lesson {lesson['id']}: {e}")
+
+        logger.info(f"Indexed {indexed} lessons into ChromaDB")
+        return indexed
+
+    def get_critical_lessons(self) -> list[LessonResult]:
+        """Get all CRITICAL severity lessons."""
+        return [
+            LessonResult(
+                id=lesson["id"],
+                title=lesson["title"],
+                severity=lesson["severity"],
+                snippet=lesson["content"][:500],
+                prevention=lesson["prevention"],
+                file=lesson["file"],
+            )
+            for lesson in self._lessons_cache
+            if lesson["severity"] == "CRITICAL"
+        ]
+
+    def count(self) -> int:
+        """Return total number of lessons loaded."""
+        return len(self._lessons_cache)
+
+
+# Singleton instance
+_search_instance: Optional[LessonsSearch] = None
+
+
+def get_lessons_search() -> LessonsSearch:
+    """Get or create singleton LessonsSearch instance."""
+    global _search_instance
+    if _search_instance is None:
+        _search_instance = LessonsSearch()
+    return _search_instance
+
+
+if __name__ == "__main__":
+    # Test the implementation
+    import sys
+
+    logging.basicConfig(level=logging.INFO)
+
+    search = get_lessons_search()
+    print(f"Loaded {search.count()} lessons")
+
+    # Test search
+    test_queries = [
+        "position sizing error",
+        "API failure",
+        "blind trading catastrophe",
+        "wash sale tax",
+        "margin of safety",
+    ]
+
+    for query in test_queries:
+        print(f"\n--- Searching: '{query}' ---")
+        results = search.search(query, top_k=3)
+        for lesson, score in results:
+            print(f"  [{lesson.severity}] {lesson.id}: {lesson.title[:50]}... (score: {score:.2f})")
+
+    # Test critical lessons
+    critical = search.get_critical_lessons()
+    print(f"\n--- CRITICAL Lessons ({len(critical)}) ---")
+    for lesson in critical[:5]:
+        print(f"  {lesson.id}: {lesson.title[:60]}...")

--- a/src/utils/honesty_guard.py
+++ b/src/utils/honesty_guard.py
@@ -1,0 +1,290 @@
+"""
+Honesty Guard - Prevents misleading metrics and false claims.
+
+This module provides guards to ensure all reported metrics are honest and
+verified. Created Dec 31, 2025 after discovering fake/hardcoded metrics.
+
+MANDATE: Never lie. If a metric can't be calculated, report it as such.
+"""
+
+import json
+import logging
+from datetime import datetime, timedelta
+from pathlib import Path
+from typing import Any, Optional
+
+logger = logging.getLogger(__name__)
+
+STATE_FILE = Path("data/system_state.json")
+PERF_LOG_FILE = Path("data/performance_log.json")
+
+
+class HonestyGuard:
+    """
+    Guards against misleading metrics and false claims.
+
+    Validates that reported numbers match actual data sources.
+    """
+
+    def __init__(self):
+        self.violations: list[dict] = []
+        self.warnings: list[dict] = []
+
+    def validate_win_rate(self) -> dict[str, Any]:
+        """
+        Validate that reported win_rate matches closed_trades data.
+
+        Returns:
+            Dict with validation result and any discrepancy details
+        """
+        if not STATE_FILE.exists():
+            return {"valid": False, "error": "State file not found"}
+
+        with open(STATE_FILE) as f:
+            state = json.load(f)
+
+        performance = state.get("performance", {})
+        closed_trades = performance.get("closed_trades", [])
+        reported_win_rate = performance.get("win_rate", 0.0)
+
+        # Calculate actual
+        winners = sum(1 for t in closed_trades if t.get("pl", 0) > 0)
+        total = len(closed_trades)
+        actual_win_rate = (winners / total * 100) if total > 0 else 0.0
+
+        discrepancy = abs(actual_win_rate - reported_win_rate)
+        is_valid = discrepancy < 1.0  # Allow 1% tolerance
+
+        if not is_valid:
+            self.violations.append({
+                "type": "WIN_RATE_MISMATCH",
+                "reported": reported_win_rate,
+                "actual": actual_win_rate,
+                "discrepancy": discrepancy,
+                "timestamp": datetime.now().isoformat(),
+            })
+
+        return {
+            "valid": is_valid,
+            "reported": reported_win_rate,
+            "actual": round(actual_win_rate, 2),
+            "discrepancy": round(discrepancy, 2),
+            "closed_trades_count": total,
+        }
+
+    def validate_pl_sanity(self) -> dict[str, Any]:
+        """
+        Validate that P/L numbers are sane and not stale.
+
+        Returns:
+            Dict with validation result
+        """
+        if not PERF_LOG_FILE.exists():
+            return {"valid": False, "error": "Performance log not found"}
+
+        with open(PERF_LOG_FILE) as f:
+            perf_log = json.load(f)
+
+        if not perf_log or not isinstance(perf_log, list):
+            return {"valid": False, "error": "Empty performance log"}
+
+        latest = perf_log[-1]
+        latest_date = latest.get("date", "")
+
+        # Check freshness
+        try:
+            log_date = datetime.fromisoformat(latest_date)
+            days_stale = (datetime.now() - log_date).days
+        except (ValueError, TypeError):
+            days_stale = 999
+
+        is_fresh = days_stale <= 3  # Allow 3 days (weekend + holiday)
+
+        # Check for suspicious patterns
+        suspicious = []
+
+        # Same equity for multiple days
+        if len(perf_log) >= 3:
+            last_3_equities = [p.get("equity", 0) for p in perf_log[-3:]]
+            if len(set(last_3_equities)) == 1 and last_3_equities[0] > 0:
+                suspicious.append("Same equity for 3+ consecutive days")
+
+        # Sudden large change (>10% in one day)
+        if len(perf_log) >= 2:
+            prev_equity = perf_log[-2].get("equity", 100000)
+            curr_equity = latest.get("equity", 100000)
+            if prev_equity > 0:
+                daily_change = abs(curr_equity - prev_equity) / prev_equity
+                if daily_change > 0.10:
+                    suspicious.append(f"Large daily change: {daily_change*100:.1f}%")
+
+        if suspicious:
+            self.warnings.extend([
+                {"type": "SUSPICIOUS_PATTERN", "detail": s, "timestamp": datetime.now().isoformat()}
+                for s in suspicious
+            ])
+
+        return {
+            "valid": is_fresh and not suspicious,
+            "days_stale": days_stale,
+            "is_fresh": is_fresh,
+            "suspicious_patterns": suspicious,
+            "latest_equity": latest.get("equity"),
+            "latest_pl": latest.get("pl"),
+        }
+
+    def validate_metric(
+        self,
+        metric_name: str,
+        value: Any,
+        expected_range: Optional[tuple] = None,
+        allow_none: bool = True,
+    ) -> dict[str, Any]:
+        """
+        Validate a single metric value.
+
+        Args:
+            metric_name: Name of the metric
+            value: The value to validate
+            expected_range: Optional (min, max) tuple
+            allow_none: Whether None is acceptable
+
+        Returns:
+            Validation result dict
+        """
+        if value is None:
+            if allow_none:
+                return {"valid": True, "metric": metric_name, "value": None, "note": "Not calculated"}
+            else:
+                self.violations.append({
+                    "type": "NULL_METRIC",
+                    "metric": metric_name,
+                    "timestamp": datetime.now().isoformat(),
+                })
+                return {"valid": False, "metric": metric_name, "error": "Required metric is null"}
+
+        if expected_range:
+            min_val, max_val = expected_range
+            if not (min_val <= value <= max_val):
+                self.warnings.append({
+                    "type": "OUT_OF_RANGE",
+                    "metric": metric_name,
+                    "value": value,
+                    "expected_range": expected_range,
+                    "timestamp": datetime.now().isoformat(),
+                })
+                return {
+                    "valid": False,
+                    "metric": metric_name,
+                    "value": value,
+                    "error": f"Value {value} outside expected range {expected_range}",
+                }
+
+        return {"valid": True, "metric": metric_name, "value": value}
+
+    def run_all_validations(self) -> dict[str, Any]:
+        """
+        Run all honesty validations.
+
+        Returns:
+            Comprehensive validation report
+        """
+        self.violations = []
+        self.warnings = []
+
+        win_rate = self.validate_win_rate()
+        pl_sanity = self.validate_pl_sanity()
+
+        overall_valid = win_rate["valid"] and pl_sanity.get("valid", False)
+
+        return {
+            "overall_valid": overall_valid,
+            "timestamp": datetime.now().isoformat(),
+            "validations": {
+                "win_rate": win_rate,
+                "pl_sanity": pl_sanity,
+            },
+            "violations": self.violations,
+            "warnings": self.warnings,
+            "violation_count": len(self.violations),
+            "warning_count": len(self.warnings),
+        }
+
+    def format_report(self) -> str:
+        """Generate human-readable honesty report."""
+        report = self.run_all_validations()
+
+        lines = [
+            "=" * 50,
+            "HONESTY GUARD REPORT",
+            "=" * 50,
+            "",
+            f"Timestamp: {report['timestamp']}",
+            f"Overall Status: {'✅ PASS' if report['overall_valid'] else '❌ FAIL'}",
+            "",
+            "--- Win Rate Validation ---",
+        ]
+
+        wr = report["validations"]["win_rate"]
+        if wr.get("error"):
+            lines.append(f"  Error: {wr['error']}")
+        else:
+            lines.append(f"  Reported: {wr['reported']:.1f}%")
+            lines.append(f"  Actual:   {wr['actual']:.1f}%")
+            lines.append(f"  Valid:    {'✅' if wr['valid'] else '❌'}")
+
+        lines.append("")
+        lines.append("--- P/L Sanity Check ---")
+
+        pl = report["validations"]["pl_sanity"]
+        if pl.get("error"):
+            lines.append(f"  Error: {pl['error']}")
+        else:
+            lines.append(f"  Days Stale: {pl['days_stale']}")
+            lines.append(f"  Fresh:      {'✅' if pl['is_fresh'] else '❌'}")
+            if pl["suspicious_patterns"]:
+                lines.append("  Suspicious:")
+                for p in pl["suspicious_patterns"]:
+                    lines.append(f"    - {p}")
+
+        if report["violations"]:
+            lines.append("")
+            lines.append("--- VIOLATIONS ---")
+            for v in report["violations"]:
+                lines.append(f"  ❌ {v['type']}: {v}")
+
+        if report["warnings"]:
+            lines.append("")
+            lines.append("--- WARNINGS ---")
+            for w in report["warnings"]:
+                lines.append(f"  ⚠️ {w['type']}: {w.get('detail', w)}")
+
+        lines.append("")
+        lines.append("=" * 50)
+
+        return "\n".join(lines)
+
+
+def run_honesty_check() -> bool:
+    """
+    Run honesty check and return pass/fail.
+
+    Returns:
+        True if all validations pass, False otherwise
+    """
+    guard = HonestyGuard()
+    report = guard.run_all_validations()
+
+    if not report["overall_valid"]:
+        logger.warning("Honesty check FAILED")
+        print(guard.format_report())
+        return False
+
+    logger.info("Honesty check passed")
+    return True
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    guard = HonestyGuard()
+    print(guard.format_report())


### PR DESCRIPTION
## Summary
- Fixed RAG vectorization: 707 chunks indexed in ChromaDB
- Fixed win_rate: Corrected 30% discrepancy (was 50%, actual 80%)
- Added honesty safeguards: Dashboard no longer shows fake metrics
- Created LessonsSearch for semantic search on 75 lessons

## Changes
- src/rag/lessons_search.py - NEW: Semantic search with ChromaDB
- src/utils/honesty_guard.py - NEW: Validation guard
- scripts/fix_win_rate_from_closed_trades.py - NEW: Win rate fixer
- scripts/generate_world_class_dashboard_enhanced.py - Removed fake metrics

## Test plan
- [x] LessonsSearch loads 75 lessons
- [x] Win rate matches closed_trades (80%)
- [x] HonestyGuard passes
- [x] ChromaDB vectorization complete (707 chunks)