### PR TITLE
chore: Update system state sync timestamp

### DIFF
--- a/data/system_state.json
+++ b/data/system_state.json
@@ -2,10 +2,10 @@
   "meta": {
     "version": "1.0",
     "created": "2025-10-29T09:35:00",
-    "last_updated": "2025-12-30T22:42:30.311309",
+    "last_updated": "2025-12-31T15:15:33.784628",
     "last_audit": "2025-12-29T09:46:00.000000",
     "audit_notes": "Updated from live Alpaca screenshot - Dec 30 10:28 AM EST",
-    "last_sync": "2025-12-30T22:42:30.311317",
+    "last_sync": "2025-12-31T15:15:33.784636",
     "sync_mode": "skipped_no_keys"
   },
   "challenge": {


### PR DESCRIPTION
Auto-sync hook ran at session start. Win rate fix preserved.