### PR TITLE
fix: Remove unused imports to pass ruff linter

### DIFF
--- a/src/rag/lessons_search.py
+++ b/src/rag/lessons_search.py
@@ -343,8 +343,6 @@ def get_lessons_search() -> LessonsSearch:
 
 if __name__ == "__main__":
     # Test the implementation
-    import sys
-
     logging.basicConfig(level=logging.INFO)
 
     search = get_lessons_search()

--- a/src/utils/honesty_guard.py
+++ b/src/utils/honesty_guard.py
@@ -9,7 +9,7 @@ MANDATE: Never lie. If a metric can't be calculated, report it as such.
 
 import json
 import logging
-from datetime import datetime, timedelta
+from datetime import datetime
 from pathlib import Path
 from typing import Any, Optional
 


### PR DESCRIPTION
## Summary
- Remove unused `sys` import from lessons_search.py
- Remove unused `timedelta` import from honesty_guard.py

## Test plan
- [x] Ruff linter passes locally
- [ ] CI should pass after merge