### PR TITLE
style: Apply Ruff formatter to pass CI checks

### DIFF
--- a/scripts/train_from_feedback.py
+++ b/scripts/train_from_feedback.py
@@ -114,8 +114,7 @@ def main():
         result = train_from_logs(days_back=args.days)
         if result["trained"]:
             logger.info(
-                "Training complete: %d samples (%.1f%% positive). "
-                "Posterior: %.3f ± %.3f",
+                "Training complete: %d samples (%.1f%% positive). Posterior: %.3f ± %.3f",
                 result["samples"],
                 100 * result["positive"] / result["samples"],
                 result["posterior_mean"],

--- a/scripts/verify_rag_operational.py
+++ b/scripts/verify_rag_operational.py
@@ -21,6 +21,7 @@ def verify_chromadb_installed() -> tuple[bool, str]:
     """Verify chromadb package is actually installed."""
     try:
         import chromadb
+
         return True, f"chromadb v{chromadb.__version__}"
     except ImportError:
         return False, "chromadb NOT INSTALLED - run: pip install chromadb"
@@ -86,8 +87,7 @@ def verify_semantic_search_works() -> tuple[bool, str]:
         docs = results.get("documents", [[]])[0]
         relevant_keywords = ["money", "loss", "capital", "protect", "rule", "don't lose"]
         found_relevant = any(
-            any(kw.lower() in doc.lower() for kw in relevant_keywords)
-            for doc in docs if doc
+            any(kw.lower() in doc.lower() for kw in relevant_keywords) for doc in docs if doc
         )
 
         if not found_relevant:
@@ -124,7 +124,7 @@ def verify_lessons_search_class() -> tuple[bool, str]:
 
         # Verify results have correct format
         lesson, score = results[0]
-        if not hasattr(lesson, 'id') or not hasattr(lesson, 'severity'):
+        if not hasattr(lesson, "id") or not hasattr(lesson, "severity"):
             return False, "LessonsSearch results have wrong format"
 
         return True, f"LessonsSearch OK ({ls.count()} lessons, {doc_count} vectors)"

--- a/src/learning/feedback_trainer.py
+++ b/src/learning/feedback_trainer.py
@@ -113,8 +113,7 @@ class FeedbackTrainer:
         }
 
         logger.info(
-            "Feedback training complete: %d samples, %.1f%% positive, "
-            "posterior=%.3f±%.3f",
+            "Feedback training complete: %d samples, %.1f%% positive, posterior=%.3f±%.3f",
             len(feedback_samples),
             100 * positive_count / len(feedback_samples),
             posterior_mean,
@@ -271,9 +270,7 @@ class FeedbackTrainer:
             neg = negative_features.get(feature, 0) + 1
             self.feature_weights[feature] = math.log(pos / neg)
 
-    def _update_feature_weights_single(
-        self, context: dict[str, Any], is_positive: bool
-    ) -> None:
+    def _update_feature_weights_single(self, context: dict[str, Any], is_positive: bool) -> None:
         """Update feature weights from single feedback."""
         features = self._extract_features_from_context(str(context))
         adjustment = 0.1 if is_positive else -0.1

--- a/src/learning/reward_shaper.py
+++ b/src/learning/reward_shaper.py
@@ -96,11 +96,7 @@ class BinaryRewardShaper:
 
         # Final shaped reward
         shaped_reward = (
-            binary_reward
-            + risk_penalty
-            + holding_bonus
-            + vol_adjustment
-            + pattern_adjustment
+            binary_reward + risk_penalty + holding_bonus + vol_adjustment + pattern_adjustment
         )
 
         logger.debug(

--- a/tests/test_feedback_pipeline.py
+++ b/tests/test_feedback_pipeline.py
@@ -186,7 +186,7 @@ class TestFeedbackTrainer:
         assert result["is_positive"] is True
         assert trainer.alpha == 2.0
         assert trainer.beta == 1.0
-        assert result["posterior_mean"] == 2/3
+        assert result["posterior_mean"] == 2 / 3
 
     def test_record_negative_feedback(self, temp_feedback_dir):
         """Test recording negative feedback."""
@@ -202,7 +202,7 @@ class TestFeedbackTrainer:
         assert result["is_positive"] is False
         assert trainer.alpha == 1.0
         assert trainer.beta == 2.0
-        assert result["posterior_mean"] == 1/3
+        assert result["posterior_mean"] == 1 / 3
 
     def test_get_model_stats(self, temp_feedback_dir):
         """Test getting model statistics."""
@@ -272,8 +272,7 @@ class TestFeedbackTrainer:
         # Create feedback file with only 2 samples
         feedback_file = feedback_dir / "feedback_2026-01-01.jsonl"
         feedback_file.write_text(
-            '{"type": "positive", "score": 1}\n'
-            '{"type": "negative", "score": -1}\n'
+            '{"type": "positive", "score": 1}\n{"type": "negative", "score": -1}\n'
         )
 
         trainer = FeedbackTrainer(
@@ -295,7 +294,9 @@ class TestFeedbackTrainer:
         lines = []
         for i in range(10):
             feedback_type = "positive" if i % 3 != 0 else "negative"
-            lines.append(f'{{"type": "{feedback_type}", "score": {1 if feedback_type == "positive" else -1}}}')
+            lines.append(
+                f'{{"type": "{feedback_type}", "score": {1 if feedback_type == "positive" else -1}}}'
+            )
 
         feedback_file = feedback_dir / "feedback_2026-01-01.jsonl"
         feedback_file.write_text("\n".join(lines))
@@ -337,14 +338,8 @@ class TestFeedbackTrainer:
         )
 
         # Record feedback with context to build feature weights
-        trainer.record_feedback(
-            is_positive=True,
-            context={"raw_context": "profit trade momentum"}
-        )
-        trainer.record_feedback(
-            is_positive=False,
-            context={"raw_context": "loss trade risk"}
-        )
+        trainer.record_feedback(is_positive=True, context={"raw_context": "profit trade momentum"})
+        trainer.record_feedback(is_positive=False, context={"raw_context": "loss trade risk"})
 
         # Check feature weights were updated
         assert len(trainer.feature_weights) > 0
@@ -376,9 +371,9 @@ class TestIntegration:
         # 2. Simulate trade outcomes
         trades = [
             {"pnl": 100, "holding_period_days": 2},  # Quick win
-            {"pnl": -50, "holding_period_days": 5},   # Loss
-            {"pnl": 200, "holding_period_days": 1},   # Quick win
-            {"pnl": 75, "holding_period_days": 3},    # Win
+            {"pnl": -50, "holding_period_days": 5},  # Loss
+            {"pnl": 200, "holding_period_days": 1},  # Quick win
+            {"pnl": 75, "holding_period_days": 3},  # Win
         ]
 
         total_shaped_reward = 0
@@ -389,7 +384,7 @@ class TestIntegration:
         # 3. Record user feedback
         trainer.record_feedback(is_positive=True)  # 👍
         trainer.record_feedback(is_positive=True)  # 👍
-        trainer.record_feedback(is_positive=False) # 👎
+        trainer.record_feedback(is_positive=False)  # 👎
 
         # 4. Get prediction
         stats = trainer.get_model_stats()

--- a/tests/test_rag_operational.py
+++ b/tests/test_rag_operational.py
@@ -23,6 +23,7 @@ class TestRAGOperational:
         """Verify chromadb package is installed."""
         try:
             import chromadb
+
             assert chromadb.__version__, "chromadb version should be set"
         except ImportError:
             pytest.fail(

--- a/tests/test_trading_context_hook.py
+++ b/tests/test_trading_context_hook.py
@@ -36,9 +36,9 @@ class TestTimezoneHandling:
         )
 
         actual_date = result.stdout.strip()
-        assert (
-            actual_date == expected_date
-        ), f"TODAY should be {expected_date} (ET), got {actual_date}"
+        assert actual_date == expected_date, (
+            f"TODAY should be {expected_date} (ET), got {actual_date}"
+        )
 
     def test_hook_file_contains_et_timezone_for_today(self):
         """Verify the hook file has TZ=America/New_York for TODAY variable."""
@@ -54,9 +54,9 @@ class TestTimezoneHandling:
             content = f.read()
 
         # Check that TODAY uses ET timezone
-        assert (
-            "TODAY=$(TZ=America/New_York date" in content
-        ), "TODAY variable must use TZ=America/New_York"
+        assert "TODAY=$(TZ=America/New_York date" in content, (
+            "TODAY variable must use TZ=America/New_York"
+        )
 
     def test_hook_file_contains_et_timezone_for_days_old(self):
         """Verify the hook file has TZ=America/New_York for DAYS_OLD calculation."""
@@ -72,9 +72,9 @@ class TestTimezoneHandling:
             content = f.read()
 
         # Check that DAYS_OLD calculation uses ET timezone
-        assert (
-            "DAYS_OLD=$(( ($(TZ=America/New_York date" in content
-        ), "DAYS_OLD calculation must use TZ=America/New_York"
+        assert "DAYS_OLD=$(( ($(TZ=America/New_York date" in content, (
+            "DAYS_OLD calculation must use TZ=America/New_York"
+        )
 
     def test_day_of_week_uses_et_timezone(self):
         """Verify DAY_OF_WEEK uses America/New_York timezone."""
@@ -89,9 +89,9 @@ class TestTimezoneHandling:
         with open(hook_path) as f:
             content = f.read()
 
-        assert (
-            "DAY_OF_WEEK=$(TZ=America/New_York date" in content
-        ), "DAY_OF_WEEK must use TZ=America/New_York"
+        assert "DAY_OF_WEEK=$(TZ=America/New_York date" in content, (
+            "DAY_OF_WEEK must use TZ=America/New_York"
+        )
 
     def test_full_date_uses_et_timezone(self):
         """Verify FULL_DATE uses America/New_York timezone."""
@@ -106,9 +106,9 @@ class TestTimezoneHandling:
         with open(hook_path) as f:
             content = f.read()
 
-        assert (
-            "FULL_DATE=$(TZ=America/New_York date" in content
-        ), "FULL_DATE must use TZ=America/New_York"
+        assert "FULL_DATE=$(TZ=America/New_York date" in content, (
+            "FULL_DATE must use TZ=America/New_York"
+        )
 
 
 class TestDateCalculations:
@@ -140,9 +140,7 @@ class TestDateCalculations:
         et_tz = ZoneInfo("America/New_York")
         expected = datetime.now(et_tz).strftime("%Y-%m-%d")
 
-        assert (
-            result.stdout.strip() == expected
-        ), f"Bash TZ command should return {expected}"
+        assert result.stdout.strip() == expected, f"Bash TZ command should return {expected}"
 
 
 class TestHookSmokeTests:
@@ -169,9 +167,7 @@ class TestHookSmokeTests:
             "inject_trading_context.sh",
         )
 
-        result = subprocess.run(
-            ["bash", "-n", hook_path], capture_output=True, text=True
-        )
+        result = subprocess.run(["bash", "-n", hook_path], capture_output=True, text=True)
 
         assert result.returncode == 0, f"Hook has syntax errors: {result.stderr}"
 
@@ -203,9 +199,7 @@ class TestHookSmokeTests:
         with open(hook_path) as f:
             content = f.read()
 
-        assert (
-            "set -euo pipefail" in content
-        ), "Hook should use strict mode: set -euo pipefail"
+        assert "set -euo pipefail" in content, "Hook should use strict mode: set -euo pipefail"
 
 
 class TestMarketHoursAwareness:


### PR DESCRIPTION
## Summary
- Format 7 files to pass Ruff formatter CI check
- Fixes the 'Run Ruff formatter check' failure in CI

## Files formatted
- scripts/train_from_feedback.py
- scripts/verify_rag_operational.py
- src/learning/feedback_trainer.py
- src/learning/reward_shaper.py
- tests/test_feedback_pipeline.py
- tests/test_rag_operational.py
- tests/test_trading_context_hook.py

## Test Plan
- [x] `ruff format --check .` passes locally
- [x] `ruff check .` passes locally