### PR TITLE
fix: Update dashboard to reflect $20 portfolio reset

### DIFF
--- a/data/system_state.json
+++ b/data/system_state.json
@@ -16,15 +16,16 @@
     "phase": "R&D Phase - Month 2 (Days 31-60)"
   },
   "account": {
-    "starting_balance": 100000.0,
-    "current_equity": 100942.23,
-    "cash": 86629.95,
-    "positions_value": 17695.12,
-    "total_pl": 942.23,
-    "total_pl_pct": 0.94,
-    "buying_power": 1341.99,
+    "starting_balance": 20.0,
+    "current_equity": 20.0,
+    "cash": 20.0,
+    "positions_value": 0.0,
+    "total_pl": 0.0,
+    "total_pl_pct": 0.0,
+    "buying_power": 20.0,
     "daily_change_pct": 0.0,
-    "positions_count": 15
+    "positions_count": 0,
+    "reset_note": "Fresh start Jan 3, 2026 - Real brokerage with $10/day deposits"
   },
   "investments": {
     "total_invested": 1621.93,

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,7 +1,7 @@
 ---
 layout: home
 title: "AI Trading Journey - Autonomous Options Trading with Claude"
-description: "90-day experiment building an AI trading system. 80% overall win rate (+$942.23 profit). Full transparency on what works and what doesn't."
+description: "90-day experiment building an AI trading system. Fresh start with real brokerage. Full transparency on what works and what doesn't."
 ---
 
 # AI Trading Journey
@@ -17,9 +17,11 @@ A 90-day experiment building an autonomous AI trading system with Claude Opus 4.
 | Metric | Value | Trend |
 |--------|-------|-------|
 | **Day** | 50/90 | R&D Phase |
-| **Portfolio** | $100,942.23 | +0.94% |
-| **Win Rate** | 80% | Improved |
+| **Portfolio** | $20.00 | Fresh Start |
+| **Win Rate** | 80% | Historic |
 | **Lessons** | 75+ | Growing |
+
+> **Jan 3, 2026**: Fresh start with real brokerage account. $10/day deposits to reach $100/day profit goal.
 
 ---
 
@@ -27,9 +29,9 @@ A 90-day experiment building an autonomous AI trading system with Claude Opus 4.
 
 | Strategy | Win Rate | P/L | Status |
 |----------|----------|-----|--------|
-| **Options Theta** | 80% | +$942.23 | Primary Edge |
+| **Options Theta** | 80% | Historic | Primary Edge |
 | Credit Spreads | Testing | TBD | 10x Capital Efficient |
-| Core ETFs (SPY) | 80% | +$942.23 | Working |
+| Core ETFs (SPY) | 80% | Starting | Active |
 
 ---
 


### PR DESCRIPTION
## Summary
- Updated docs/index.md with correct portfolio value ($20 fresh start)
- Updated system_state.json account section to reflect reset
- Added note about $10/day deposit plan to reach $100/day profit goal

## Problem
Dashboard was showing stale data from December 31, 2025 ($100,942.23) instead of the current reset value ($20).

## Solution
Manually updated dashboard and system_state.json with correct values reflecting the fresh start.

## Test Plan
- [x] GitHub Pages will update after merge