### PR TITLE
chore: Update system state timestamp from session sync

### DIFF
--- a/data/system_state.json
+++ b/data/system_state.json
@@ -2,10 +2,10 @@
   "meta": {
     "version": "1.0",
     "created": "2025-10-29T09:35:00",
-    "last_updated": "2026-01-04T17:00:19.834327",
+    "last_updated": "2026-01-04T23:20:04.331850",
     "last_audit": "2025-12-29T09:46:00.000000",
     "audit_notes": "Updated from live Alpaca screenshot - Dec 30 10:28 AM EST",
-    "last_sync": "2026-01-04T17:00:19.834338",
+    "last_sync": "2026-01-04T23:20:04.331857",
     "sync_mode": "skipped_no_keys"
   },
   "challenge": {


### PR DESCRIPTION
## Summary
- Auto-sync timestamp update from session start (skipped_no_keys mode)

## Test plan
- [x] Timestamp update only, no functional changes