### PR TITLE
fix: Update workflows to use correct Alpaca secret names

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -317,8 +317,9 @@ jobs:
       - name: Run reference backtest
         env:
           PYTHONPATH: ${{ github.workspace }}
-          ALPACA_API_KEY: ${{ secrets.ALPACA_API_KEY }}
-          ALPACA_SECRET_KEY: ${{ secrets.ALPACA_SECRET_KEY }}
+          # Use paper trading keys for CI backtests
+          ALPACA_API_KEY: ${{ secrets.ALPACA_PAPER_TRADING_API_KEY }}
+          ALPACA_SECRET_KEY: ${{ secrets.ALPACA_PAPER_TRADING_API_SECRET }}
         run: |
           python scripts/run_core_strategy_reference_backtest.py || {
             echo "::error::Core strategy metrics degraded. Add 'ACCEPT_METRIC_DEGRADATION' to PR description if intentional."

--- a/.github/workflows/daily-blog-post.yml
+++ b/.github/workflows/daily-blog-post.yml
@@ -17,8 +17,9 @@ permissions:
   contents: write
 
 env:
-  ALPACA_API_KEY: ${{ secrets.ALPACA_API_KEY }}
-  ALPACA_SECRET_KEY: ${{ secrets.ALPACA_SECRET_KEY }}
+  # Use paper trading keys for blog post data (PAPER_TRADING=true)
+  ALPACA_API_KEY: ${{ secrets.ALPACA_PAPER_TRADING_API_KEY }}
+  ALPACA_SECRET_KEY: ${{ secrets.ALPACA_PAPER_TRADING_API_SECRET }}
   DEVTO_API_KEY: ${{ secrets.DEVTO_API_KEY }}
   FRED_API_KEY: ${{ secrets.FRED_API_KEY }}
   PAPER_TRADING: "true"

--- a/.github/workflows/daily-trading.yml
+++ b/.github/workflows/daily-trading.yml
@@ -87,8 +87,8 @@ jobs:
       - name: Validate secrets
         id: validate_secrets
         env:
-          ALPACA_API_KEY: ${{ secrets.ALPACA_API_KEY }}
-          ALPACA_SECRET_KEY: ${{ secrets.ALPACA_SECRET_KEY }}
+          ALPACA_API_KEY: ${{ github.event.inputs.trading_mode == 'live' && secrets.ALPACA_BROKERAGE_TRADING_API_KEY || secrets.ALPACA_PAPER_TRADING_API_KEY }}
+          ALPACA_SECRET_KEY: ${{ github.event.inputs.trading_mode == 'live' && secrets.ALPACA_BROKERAGE_TRADING_API_SECRET || secrets.ALPACA_PAPER_TRADING_API_SECRET }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
           ALPHA_VANTAGE_API_KEY: ${{ secrets.ALPHA_VANTAGE_API_KEY }}
@@ -154,8 +154,8 @@ jobs:
 
       - name: Start Alpaca MCP server
         env:
-          ALPACA_API_KEY: ${{ secrets.ALPACA_API_KEY }}
-          ALPACA_SECRET_KEY: ${{ secrets.ALPACA_SECRET_KEY }}
+          ALPACA_API_KEY: ${{ github.event.inputs.trading_mode == 'live' && secrets.ALPACA_BROKERAGE_TRADING_API_KEY || secrets.ALPACA_PAPER_TRADING_API_KEY }}
+          ALPACA_SECRET_KEY: ${{ github.event.inputs.trading_mode == 'live' && secrets.ALPACA_BROKERAGE_TRADING_API_SECRET || secrets.ALPACA_PAPER_TRADING_API_SECRET }}
           # Determine trading mode from input or secret
           TRADING_MODE: ${{ github.event.inputs.trading_mode || 'paper' }}
           PAPER_TRADING_SECRET: ${{ secrets.PAPER_TRADING }}
@@ -443,8 +443,8 @@ jobs:
         if: steps.check_execution.outputs.skip != 'true'
         timeout-minutes: 5  # Increased from 1 to allow efficient API checks
         env:
-          ALPACA_API_KEY: ${{ secrets.ALPACA_API_KEY }}
-          ALPACA_SECRET_KEY: ${{ secrets.ALPACA_SECRET_KEY }}
+          ALPACA_API_KEY: ${{ github.event.inputs.trading_mode == 'live' && secrets.ALPACA_BROKERAGE_TRADING_API_KEY || secrets.ALPACA_PAPER_TRADING_API_KEY }}
+          ALPACA_SECRET_KEY: ${{ github.event.inputs.trading_mode == 'live' && secrets.ALPACA_BROKERAGE_TRADING_API_SECRET || secrets.ALPACA_PAPER_TRADING_API_SECRET }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           FINNHUB_API_KEY: ${{ secrets.FINNHUB_API_KEY || secrets.FINHUB_API_KEY }}
         run: |
@@ -475,8 +475,8 @@ jobs:
         id: execute_trading
         if: steps.check_execution.outputs.skip != 'true' && steps.health_check.outputs.health_check_passed == 'true'
         env:
-          ALPACA_API_KEY: ${{ secrets.ALPACA_API_KEY }}
-          ALPACA_SECRET_KEY: ${{ secrets.ALPACA_SECRET_KEY }}
+          ALPACA_API_KEY: ${{ github.event.inputs.trading_mode == 'live' && secrets.ALPACA_BROKERAGE_TRADING_API_KEY || secrets.ALPACA_PAPER_TRADING_API_KEY }}
+          ALPACA_SECRET_KEY: ${{ github.event.inputs.trading_mode == 'live' && secrets.ALPACA_BROKERAGE_TRADING_API_SECRET || secrets.ALPACA_PAPER_TRADING_API_SECRET }}
           OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
           HELICONE_API_KEY: ${{ secrets.HELICONE_API_KEY }}
           # LangSmith tracing (observability)
@@ -703,8 +703,8 @@ jobs:
         continue-on-error: false  # CRITICAL: Options failures must be visible (Dec 16 fix)
         timeout-minutes: 15
         env:
-          ALPACA_API_KEY: ${{ secrets.ALPACA_API_KEY }}
-          ALPACA_SECRET_KEY: ${{ secrets.ALPACA_SECRET_KEY }}
+          ALPACA_API_KEY: ${{ github.event.inputs.trading_mode == 'live' && secrets.ALPACA_BROKERAGE_TRADING_API_KEY || secrets.ALPACA_PAPER_TRADING_API_KEY }}
+          ALPACA_SECRET_KEY: ${{ github.event.inputs.trading_mode == 'live' && secrets.ALPACA_BROKERAGE_TRADING_API_SECRET || secrets.ALPACA_PAPER_TRADING_API_SECRET }}
           PAPER_TRADING: ${{ github.event.inputs.trading_mode == 'live' && 'false' || secrets.PAPER_TRADING || 'true' }}
           PYTHONPATH: ${{ github.workspace }}
         run: |
@@ -859,8 +859,8 @@ jobs:
         if: steps.execute_trading.outcome == 'success'
         # FIXED Dec 30, 2025: Removed continue-on-error - trading failures must be visible
         env:
-          ALPACA_API_KEY: ${{ secrets.ALPACA_API_KEY }}
-          ALPACA_SECRET_KEY: ${{ secrets.ALPACA_SECRET_KEY }}
+          ALPACA_API_KEY: ${{ github.event.inputs.trading_mode == 'live' && secrets.ALPACA_BROKERAGE_TRADING_API_KEY || secrets.ALPACA_PAPER_TRADING_API_KEY }}
+          ALPACA_SECRET_KEY: ${{ github.event.inputs.trading_mode == 'live' && secrets.ALPACA_BROKERAGE_TRADING_API_SECRET || secrets.ALPACA_PAPER_TRADING_API_SECRET }}
         run: |
           echo ""
           echo "🦅 ========================================"
@@ -880,8 +880,8 @@ jobs:
         if: steps.execute_trading.outcome == 'success'
         # FIXED Dec 30, 2025: Removed continue-on-error - trading failures must be visible
         env:
-          ALPACA_API_KEY: ${{ secrets.ALPACA_API_KEY }}
-          ALPACA_SECRET_KEY: ${{ secrets.ALPACA_SECRET_KEY }}
+          ALPACA_API_KEY: ${{ github.event.inputs.trading_mode == 'live' && secrets.ALPACA_BROKERAGE_TRADING_API_KEY || secrets.ALPACA_PAPER_TRADING_API_KEY }}
+          ALPACA_SECRET_KEY: ${{ github.event.inputs.trading_mode == 'live' && secrets.ALPACA_BROKERAGE_TRADING_API_SECRET || secrets.ALPACA_PAPER_TRADING_API_SECRET }}
         run: |
           echo ""
           echo "💰 ========================================"
@@ -901,8 +901,8 @@ jobs:
         if: steps.execute_trading.outcome == 'success'
         # FIXED Dec 30, 2025: Removed continue-on-error - trading failures must be visible
         env:
-          ALPACA_API_KEY: ${{ secrets.ALPACA_API_KEY }}
-          ALPACA_SECRET_KEY: ${{ secrets.ALPACA_SECRET_KEY }}
+          ALPACA_API_KEY: ${{ github.event.inputs.trading_mode == 'live' && secrets.ALPACA_BROKERAGE_TRADING_API_KEY || secrets.ALPACA_PAPER_TRADING_API_KEY }}
+          ALPACA_SECRET_KEY: ${{ github.event.inputs.trading_mode == 'live' && secrets.ALPACA_BROKERAGE_TRADING_API_SECRET || secrets.ALPACA_PAPER_TRADING_API_SECRET }}
         run: |
           echo ""
           echo "📚 ========================================"
@@ -923,8 +923,8 @@ jobs:
         if: steps.execute_trading.outcome == 'success'
         continue-on-error: true  # Non-fatal - trading succeeded
         env:
-          ALPACA_API_KEY: ${{ secrets.ALPACA_API_KEY }}
-          ALPACA_SECRET_KEY: ${{ secrets.ALPACA_SECRET_KEY }}
+          ALPACA_API_KEY: ${{ github.event.inputs.trading_mode == 'live' && secrets.ALPACA_BROKERAGE_TRADING_API_KEY || secrets.ALPACA_PAPER_TRADING_API_KEY }}
+          ALPACA_SECRET_KEY: ${{ github.event.inputs.trading_mode == 'live' && secrets.ALPACA_BROKERAGE_TRADING_API_SECRET || secrets.ALPACA_PAPER_TRADING_API_SECRET }}
           PAPER_TRADING: ${{ github.event.inputs.trading_mode == 'live' && 'false' || secrets.PAPER_TRADING || 'true' }}
         run: |
           echo "📊 Updating performance log with current account data..."
@@ -935,8 +935,8 @@ jobs:
         if: steps.execute_trading.outcome == 'success'
         continue-on-error: true  # Non-fatal - trading succeeded, sync issues shouldn't fail workflow
         env:
-          ALPACA_API_KEY: ${{ secrets.ALPACA_API_KEY }}
-          ALPACA_SECRET_KEY: ${{ secrets.ALPACA_SECRET_KEY }}
+          ALPACA_API_KEY: ${{ github.event.inputs.trading_mode == 'live' && secrets.ALPACA_BROKERAGE_TRADING_API_KEY || secrets.ALPACA_PAPER_TRADING_API_KEY }}
+          ALPACA_SECRET_KEY: ${{ github.event.inputs.trading_mode == 'live' && secrets.ALPACA_BROKERAGE_TRADING_API_SECRET || secrets.ALPACA_PAPER_TRADING_API_SECRET }}
         run: |
           echo "🔍 Verifying positions match between Alpaca and local state..."
           python3 scripts/verify_positions.py || {
@@ -949,8 +949,8 @@ jobs:
         if: steps.execute_trading.outcome == 'success'
         continue-on-error: true  # Non-fatal - Alpaca is source of truth
         env:
-          ALPACA_API_KEY: ${{ secrets.ALPACA_API_KEY }}
-          ALPACA_SECRET_KEY: ${{ secrets.ALPACA_SECRET_KEY }}
+          ALPACA_API_KEY: ${{ github.event.inputs.trading_mode == 'live' && secrets.ALPACA_BROKERAGE_TRADING_API_KEY || secrets.ALPACA_PAPER_TRADING_API_KEY }}
+          ALPACA_SECRET_KEY: ${{ github.event.inputs.trading_mode == 'live' && secrets.ALPACA_BROKERAGE_TRADING_API_SECRET || secrets.ALPACA_PAPER_TRADING_API_SECRET }}
         run: |
           echo "🔍 Verifying orders in Alpaca match our trade logs..."
           python3 scripts/verify_orders.py || {
@@ -962,8 +962,8 @@ jobs:
         id: sanity_check
         if: always()
         env:
-          ALPACA_API_KEY: ${{ secrets.ALPACA_API_KEY }}
-          ALPACA_SECRET_KEY: ${{ secrets.ALPACA_SECRET_KEY }}
+          ALPACA_API_KEY: ${{ github.event.inputs.trading_mode == 'live' && secrets.ALPACA_BROKERAGE_TRADING_API_KEY || secrets.ALPACA_PAPER_TRADING_API_KEY }}
+          ALPACA_SECRET_KEY: ${{ github.event.inputs.trading_mode == 'live' && secrets.ALPACA_BROKERAGE_TRADING_API_SECRET || secrets.ALPACA_PAPER_TRADING_API_SECRET }}
         run: |
           echo "🔍 Running P/L sanity check..."
           echo "   This detects zombie mode (system running but not trading)"
@@ -1257,8 +1257,8 @@ jobs:
         if: always()
         continue-on-error: true
         env:
-          ALPACA_API_KEY: ${{ secrets.ALPACA_API_KEY }}
-          ALPACA_SECRET_KEY: ${{ secrets.ALPACA_SECRET_KEY }}
+          ALPACA_API_KEY: ${{ github.event.inputs.trading_mode == 'live' && secrets.ALPACA_BROKERAGE_TRADING_API_KEY || secrets.ALPACA_PAPER_TRADING_API_KEY }}
+          ALPACA_SECRET_KEY: ${{ github.event.inputs.trading_mode == 'live' && secrets.ALPACA_BROKERAGE_TRADING_API_SECRET || secrets.ALPACA_PAPER_TRADING_API_SECRET }}
         run: |
           echo "📊 Running daily verification..."
           python3 scripts/daily_verification.py

--- a/.github/workflows/immediate-trade.yml
+++ b/.github/workflows/immediate-trade.yml
@@ -15,8 +15,9 @@ jobs:
     runs-on: ubuntu-22.04
     timeout-minutes: 15
     env:
-      ALPACA_API_KEY: ${{ secrets.ALPACA_API_KEY }}
-      ALPACA_SECRET_KEY: ${{ secrets.ALPACA_SECRET_KEY }}
+      # Uses paper trading keys (paper=True in code)
+      ALPACA_API_KEY: ${{ secrets.ALPACA_PAPER_TRADING_API_KEY }}
+      ALPACA_SECRET_KEY: ${{ secrets.ALPACA_PAPER_TRADING_API_SECRET }}
       LANGCHAIN_API_KEY: ${{ secrets.LANGCHAIN_API_KEY }}
       LANGCHAIN_PROJECT: 'igor-trading-system'
       LANGCHAIN_TRACING_V2: 'true'

--- a/.github/workflows/pre-market-sync.yml
+++ b/.github/workflows/pre-market-sync.yml
@@ -25,10 +25,11 @@ jobs:
 
       - name: Sync Alpaca State
         env:
-          ALPACA_API_KEY: ${{ secrets.ALPACA_API_KEY }}
-          ALPACA_SECRET_KEY: ${{ secrets.ALPACA_SECRET_KEY }}
-          APCA_API_KEY_ID: ${{ secrets.ALPACA_API_KEY }}
-          APCA_API_SECRET_KEY: ${{ secrets.ALPACA_SECRET_KEY }}
+          # Use paper trading keys for data sync (read-only operations)
+          ALPACA_API_KEY: ${{ secrets.ALPACA_PAPER_TRADING_API_KEY }}
+          ALPACA_SECRET_KEY: ${{ secrets.ALPACA_PAPER_TRADING_API_SECRET }}
+          APCA_API_KEY_ID: ${{ secrets.ALPACA_PAPER_TRADING_API_KEY }}
+          APCA_API_SECRET_KEY: ${{ secrets.ALPACA_PAPER_TRADING_API_SECRET }}
         run: |
           python scripts/sync_alpaca_state.py
 

--- a/docs/LIVE_TRADING_SETUP.md
+++ b/docs/LIVE_TRADING_SETUP.md
@@ -13,31 +13,55 @@ This system supports both **paper trading** (simulation) and **live trading** (r
 | Paper | `paper-api.alpaca.markets` | Paper-specific keys |
 | Live | `api.alpaca.markets` | Live-specific keys |
 
-## How to Generate Live API Keys
+## Required GitHub Secrets
 
+The system uses **separate secrets** for paper and live trading:
+
+| Secret Name | Description |
+|-------------|-------------|
+| `ALPACA_PAPER_TRADING_API_KEY` | Paper trading API key |
+| `ALPACA_PAPER_TRADING_API_SECRET` | Paper trading secret |
+| `ALPACA_BROKERAGE_TRADING_API_KEY` | Live brokerage API key |
+| `ALPACA_BROKERAGE_TRADING_API_SECRET` | Live brokerage secret |
+
+## How to Generate API Keys
+
+### Paper Trading Keys
 1. Log into [Alpaca Dashboard](https://app.alpaca.markets)
 2. Click the dropdown in the **top-left corner**
-3. Select **"Live Trading"** account (not Paper)
+3. Select **"Paper Trading"** account
 4. Click **"Generate New Keys"**
-5. Save both the API Key and Secret Key securely
+5. Add to GitHub secrets as `ALPACA_PAPER_TRADING_API_KEY` and `ALPACA_PAPER_TRADING_API_SECRET`
+
+### Live Trading Keys
+1. Log into [Alpaca Dashboard](https://app.alpaca.markets)
+2. Click the dropdown in the **top-left corner**
+3. Select **"Live Trading"** account
+4. Click **"Generate New Keys"**
+5. Add to GitHub secrets as `ALPACA_BROKERAGE_TRADING_API_KEY` and `ALPACA_BROKERAGE_TRADING_API_SECRET`
 
 ## How to Enable Live Trading
 
-### Option 1: GitHub Secrets (Recommended for production)
-
-1. Go to your repository: Settings → Secrets → Actions
-2. Update these secrets with your **LIVE** keys:
-   - `ALPACA_API_KEY` - Your live API key
-   - `ALPACA_SECRET_KEY` - Your live secret key
-3. Add a new secret:
-   - `PAPER_TRADING` = `false`
-
-### Option 2: Manual Workflow Dispatch
+### Option 1: Workflow Dispatch (Recommended for first test)
 
 1. Go to Actions → Daily Trading Execution
 2. Click "Run workflow"
 3. Select `trading_mode: live`
 4. This will use live mode for that single run only
+
+### Option 2: Scheduled Live Trading
+
+To make the scheduled workflow use live trading:
+1. Add secret: `PAPER_TRADING` = `false`
+
+## How Trading Mode Selection Works
+
+The workflow automatically selects the correct API keys:
+
+```yaml
+# If trading_mode=live → Uses ALPACA_BROKERAGE_TRADING_API_KEY
+# If trading_mode=paper (default) → Uses ALPACA_PAPER_TRADING_API_KEY
+```
 
 ## Safety Checks
 
@@ -46,12 +70,13 @@ The system includes multiple safety checks:
 - Pre-trade smoke tests verify account connectivity
 - P/L sanity checks detect zombie mode
 - All trades are logged and can be audited
+- Live mode displays: "LIVE TRADING MODE - Real money at risk!"
 
 ## Switching Back to Paper Trading
 
 To return to paper trading:
-1. Update `PAPER_TRADING` secret to `true` (or delete it - defaults to paper)
-2. Update `ALPACA_API_KEY` and `ALPACA_SECRET_KEY` with paper keys
+1. Delete `PAPER_TRADING` secret (or set to `true`)
+2. Run workflow manually with `trading_mode: paper`
 
 ## Troubleshooting
 
@@ -62,6 +87,10 @@ To return to paper trading:
 ### Error: 403 Access Denied
 - API keys may have been revoked or are invalid
 - Solution: Generate new keys from Alpaca dashboard
+
+### Credentials Missing Error
+- One or more required secrets is not set
+- Solution: Verify all 4 Alpaca secrets are configured in GitHub
 
 ## References
 


### PR DESCRIPTION
## Summary
- Updated all workflows to use the new secret naming convention
- `ALPACA_PAPER_TRADING_API_KEY` / `ALPACA_PAPER_TRADING_API_SECRET` for paper
- `ALPACA_BROKERAGE_TRADING_API_KEY` / `ALPACA_BROKERAGE_TRADING_API_SECRET` for live
- daily-trading.yml dynamically selects based on `trading_mode` input

## Secrets Required
| Secret | Purpose |
|--------|--------|
| ALPACA_PAPER_TRADING_API_KEY | Paper trading API key |
| ALPACA_PAPER_TRADING_API_SECRET | Paper trading secret |
| ALPACA_BROKERAGE_TRADING_API_KEY | Live brokerage API key |
| ALPACA_BROKERAGE_TRADING_API_SECRET | Live brokerage secret |

## Test plan
- [x] Workflow syntax validated
- [ ] Test paper mode (default) on Monday
- [ ] Test live mode via workflow_dispatch