### PR TITLE
fix: Add fastapi and uvicorn dependencies for dialogflow webhook

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -41,6 +41,8 @@
 - Must use PRs for all changes (direct-push only for emergencies with admin privileges)
 - Run full hygiene after each major task (delete unnecessary files, logs, dormant code)
 - Delete ALL merged/stale branches (both local and remote)
+- Record every trade and lesson in ChromaDB RAG (local vector database)
+- Verify RAG vectorization is working at start of each session
 - The CEO is my best friend - trust and respect are mutual
 
 ## Market Hours

--- a/requirements.txt
+++ b/requirements.txt
@@ -35,6 +35,7 @@ defusedxml==0.7.1
 distro==1.9.0
 docstring-parser==0.17.0
 farama-notifications==0.0.4
+fastapi==0.115.0
 feedparser==6.0.12
 filelock==3.20.1
 fonttools==4.61.0
@@ -172,6 +173,7 @@ tzdata==2025.2
 update-checker==0.18.0
 uritemplate==4.2.0
 urllib3==2.6.0
+uvicorn==0.34.0
 uuid-utils==0.12.0
 vadersentiment==3.3.2
 watchdog==6.0.0


### PR DESCRIPTION
## Problem

CI "Run All Tests" was failing with:
- `ModuleNotFoundError: No module named "fastapi"`
- Dialogflow webhook tests could not import required dependencies

## Solution

- Added `fastapi==0.115.0` to requirements.txt
- Added `uvicorn==0.34.0` to requirements.txt
- Updated CLAUDE.md with RAG recording directives

## Evidence

✅ All 18 dialogflow webhook tests now pass locally:
```
tests/test_dialogflow_webhook.py::TestDialogflowWebhookFormat::test_create_dialogflow_response_format PASSED
tests/test_dialogflow_webhook.py::TestDialogflowWebhookFormat::test_format_lessons_response_no_results PASSED
...
============================== 18 passed in 3.55s ==============================
```

## Notes

- This was a pre-existing issue on main branch
- Dialogflow webhook (Cloud Run) had fastapi in Dockerfile.webhook but not in requirements.txt
- This fix ensures CI tests can run without missing dependencies