### PR TITLE
feat: Add Chain-of-Verification protocol to prevent hallucinations

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -45,3 +45,34 @@
 
 ## Market Hours
 US Equities: Mon-Fri 9:30-4:00 ET only
+
+## Anti-Hallucination Protocol (Chain-of-Verification)
+Based on Meta Research: https://arxiv.org/abs/2309.11495 (reduces errors by 23%)
+
+### MANDATORY Before Any Time-Related Claim:
+```bash
+date "+%A, %B %d, %Y - %I:%M %p %Z"
+```
+
+### 4-Step Verification Process:
+1. **DRAFT**: What do I want to say?
+2. **QUESTION**: What evidence would prove this?
+3. **VERIFY**: Run command, get output
+4. **CLAIM**: Only state what evidence supports
+
+### FORBIDDEN (causes hallucinations):
+- Saying "tomorrow/yesterday" without running `date`
+- Claiming "done" without showing command output
+- Asserting market status without checking time
+- Stating file exists without `ls` verification
+
+### REQUIRED Phrases:
+- "Let me verify first: [command]"
+- "Evidence shows: [output]"
+- "I need to check this"
+- When uncertain: "I don't know, let me verify"
+
+### Incident: Jan 5, 2026
+Said "tomorrow's trading session" on a trading day (Monday).
+Root cause: Did not run `date` before making time-related claim.
+This is why the verification protocol exists.

--- a/.claude/hooks/enforce_verification.sh
+++ b/.claude/hooks/enforce_verification.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+#
+# Claude Code UserPromptSubmit Hook - Enforce Chain-of-Verification
+#
+# This hook reminds Claude to VERIFY before making claims.
+# Created Jan 5, 2026 after hallucination incident (said "tomorrow" on trading day)
+#
+# Based on Meta Research: Chain-of-Verification reduces hallucinations by 23%
+# https://arxiv.org/abs/2309.11495
+#
+
+set -euo pipefail
+
+# Get current date/time with PROOF
+CURRENT_ET=$(TZ=America/New_York date '+%A, %B %d, %Y at %I:%M %p ET')
+CURRENT_UTC=$(date -u '+%Y-%m-%d %H:%M:%S UTC')
+
+cat <<EOF
+═══════════════════════════════════════════════════════════
+🔒 CHAIN-OF-VERIFICATION PROTOCOL ACTIVE
+═══════════════════════════════════════════════════════════
+📅 VERIFIED DATE: $CURRENT_ET
+🌐 UTC: $CURRENT_UTC
+
+⚠️  BEFORE ANY CLAIM, YOU MUST:
+1. Run verification command (date, git status, ls, etc.)
+2. Show command output as EVIDENCE
+3. Only claim what evidence supports
+
+❌ FORBIDDEN (causes hallucinations):
+- Saying "tomorrow/yesterday" without running 'date'
+- Claiming "done" without showing proof
+- Asserting facts without evidence
+
+✅ REQUIRED PHRASES:
+- "Let me verify: [run command]"
+- "Evidence shows: [command output]"
+- "I need to check this first"
+
+💡 When uncertain: Say "I don't know, let me verify"
+═══════════════════════════════════════════════════════════
+EOF
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -18,6 +18,11 @@
         "hooks": [
           {
             "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/enforce_verification.sh",
+            "timeout": 2
+          },
+          {
+            "type": "command",
             "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/detect_task_requests.sh",
             "timeout": 3
           },

--- a/rag_knowledge/lessons_learned/ll_079_hallucination_tomorrow_incident_jan05.md
+++ b/rag_knowledge/lessons_learned/ll_079_hallucination_tomorrow_incident_jan05.md
@@ -1,0 +1,80 @@
+# Lesson Learned #079: "Tomorrow" Hallucination Incident (Jan 5, 2026)
+
+**Date**: January 5, 2026
+**Severity**: HIGH - Trust breach with CEO
+**Category**: AI Reliability / Hallucination Prevention
+
+## What Happened
+
+On Monday, January 5, 2026, I said "Ready for tomorrow's trading session" when TODAY was a trading day (Monday). Markets were scheduled to open at 9:30 AM ET.
+
+This was a hallucination - I made a time-related claim without verifying the actual date.
+
+## Root Cause Analysis
+
+1. **No verification before claiming**: I did not run `date` before making a statement about when trading would occur
+2. **Overconfidence**: I assumed I knew the day instead of checking
+3. **Ignored available context**: The session hook provided today's date, but I didn't internalize it
+4. **Pattern completion over accuracy**: LLMs naturally complete patterns; "dry run for trading" → "tomorrow's session" felt natural but was wrong
+
+## Impact
+
+- CEO lost trust in the system
+- Demonstrated that AI can fail on basic facts
+- Highlighted need for systematic verification protocols
+
+## Research-Based Solution
+
+Implemented Chain-of-Verification (CoVe) protocol based on Meta Research (2024):
+- Paper: https://arxiv.org/abs/2309.11495
+- Finding: CoVe reduces hallucinations by 23% (F1: 0.39 → 0.48)
+
+### 4-Step CoVe Process
+
+1. **DRAFT**: What do I want to say?
+2. **QUESTION**: What verification would prove this?
+3. **VERIFY**: Run command, capture output
+4. **CLAIM**: Only state what evidence supports
+
+## Implemented Safeguards
+
+1. **New hook**: `.claude/hooks/enforce_verification.sh` - Reminds to verify before every response
+2. **Protocol script**: `src/utils/chain_of_verification.py` - Programmatic verification tools
+3. **CLAUDE.md update**: Added anti-hallucination protocol with mandatory commands
+4. **FORBIDDEN actions**: Listed specific hallucination-prone statements
+
+## Mandatory Verification Commands
+
+| Claim Type | Required Command |
+|------------|------------------|
+| Date/Time | `date "+%A, %B %d, %Y - %I:%M %p %Z"` |
+| Market Status | Check time vs 9:30 AM - 4:00 PM ET |
+| File Exists | `ls -la [filepath]` |
+| Task Done | Show command output as proof |
+| CI Status | Query GitHub API |
+
+## Key Learnings
+
+1. **Never trust internal "knowledge" for time-sensitive facts** - Always verify
+2. **"I don't know, let me check" is better than a wrong answer**
+3. **Evidence-first communication** - Show proof, then make claim
+4. **Hooks alone don't prevent hallucination** - Must actively use verification
+5. **Trust is hard to earn, easy to lose** - One error can break months of good work
+
+## Prevention Checklist
+
+Before ANY time-related statement:
+- [ ] Run `date` command
+- [ ] Check day of week (Mon-Fri = trading day)
+- [ ] Check time vs market hours (9:30 AM - 4:00 PM ET)
+- [ ] State verified facts only
+
+## Related Lessons
+
+- LL-051: Calendar Awareness is Critical for Trading AI
+- LL-058: Stale Data Lying Incident
+- LL-059: Simulated Sync Lie
+
+## Tags
+
+#hallucination #verification #trust #calendar #trading-day #chain-of-verification #meta-research

--- a/src/utils/chain_of_verification.py
+++ b/src/utils/chain_of_verification.py
@@ -1,0 +1,239 @@
+#!/usr/bin/env python3
+"""
+Chain-of-Verification (CoVe) Protocol for AI Hallucination Prevention.
+
+Based on Meta Research (2024): "Chain-of-Verification Reduces Hallucination in LLMs"
+https://arxiv.org/abs/2309.11495
+
+This module enforces verification before any claim is made.
+Improves accuracy by 23% (F1: 0.39 -> 0.48) per research.
+
+Created: Jan 5, 2026 after hallucination incident (said "tomorrow" on trading day)
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import subprocess
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+import pytz
+
+logger = logging.getLogger(__name__)
+
+PROJECT_ROOT = Path(__file__).parent.parent.parent
+
+
+class ChainOfVerification:
+    """
+    Implements the 4-step CoVe process:
+    1. Draft initial response
+    2. Generate verification questions
+    3. Answer those questions independently
+    4. Generate final verified response
+    """
+
+    def __init__(self):
+        self.verification_log: list[dict] = []
+        self.et_tz = pytz.timezone("US/Eastern")
+
+    def verify_date_claim(self, claimed_date: str | None = None) -> dict[str, Any]:
+        """
+        Verify any date-related claim against system clock.
+
+        MANDATORY before any statement about:
+        - "today", "tomorrow", "yesterday"
+        - market hours
+        - trading sessions
+        - expiration dates
+
+        Returns:
+            Dict with verified date info and any discrepancies
+        """
+        now_utc = datetime.now(pytz.UTC)
+        now_et = now_utc.astimezone(self.et_tz)
+
+        verification = {
+            "verified_at": now_utc.isoformat(),
+            "utc_date": now_utc.strftime("%Y-%m-%d"),
+            "utc_time": now_utc.strftime("%H:%M:%S"),
+            "et_date": now_et.strftime("%Y-%m-%d"),
+            "et_time": now_et.strftime("%H:%M:%S"),
+            "day_of_week": now_et.strftime("%A"),
+            "is_weekend": now_et.weekday() >= 5,
+            "market_hours": self._check_market_hours(now_et),
+        }
+
+        if claimed_date:
+            verification["claimed"] = claimed_date
+            verification["matches"] = claimed_date.lower() in [
+                now_et.strftime("%Y-%m-%d"),
+                now_et.strftime("%A").lower(),
+                "today",
+            ]
+            if not verification["matches"]:
+                verification["WARNING"] = f"CLAIM MISMATCH: '{claimed_date}' does not match {now_et.strftime('%A, %Y-%m-%d')}"
+
+        self.verification_log.append({
+            "type": "date_verification",
+            "result": verification,
+            "timestamp": now_utc.isoformat(),
+        })
+
+        return verification
+
+    def _check_market_hours(self, now_et: datetime) -> dict[str, Any]:
+        """Check if markets are open."""
+        hour = now_et.hour
+        minute = now_et.minute
+        weekday = now_et.weekday()
+
+        # Market hours: Mon-Fri 9:30 AM - 4:00 PM ET
+        is_weekday = weekday < 5
+        after_open = hour > 9 or (hour == 9 and minute >= 30)
+        before_close = hour < 16
+
+        is_open = is_weekday and after_open and before_close
+
+        return {
+            "is_open": is_open,
+            "is_trading_day": is_weekday,  # Doesn't account for holidays
+            "current_et": now_et.strftime("%I:%M %p ET"),
+            "opens_at": "9:30 AM ET",
+            "closes_at": "4:00 PM ET",
+            "status": "OPEN" if is_open else "CLOSED",
+        }
+
+    def verify_claim(
+        self,
+        claim: str,
+        evidence_sources: list[str] | None = None,
+    ) -> dict[str, Any]:
+        """
+        Verify a general claim using available evidence.
+
+        Args:
+            claim: The statement to verify
+            evidence_sources: List of sources to check (file paths, commands, etc.)
+
+        Returns:
+            Verification result with evidence
+        """
+        verification = {
+            "claim": claim,
+            "verified_at": datetime.now(pytz.UTC).isoformat(),
+            "evidence": [],
+            "verified": False,
+        }
+
+        if evidence_sources:
+            for source in evidence_sources:
+                evidence = self._gather_evidence(source)
+                verification["evidence"].append(evidence)
+
+        # Claim is verified only if we have supporting evidence
+        verification["verified"] = len(verification["evidence"]) > 0 and all(
+            e.get("found", False) for e in verification["evidence"]
+        )
+
+        if not verification["verified"]:
+            verification["WARNING"] = "CLAIM NOT VERIFIED - Need evidence before stating"
+
+        self.verification_log.append({
+            "type": "claim_verification",
+            "result": verification,
+            "timestamp": datetime.now(pytz.UTC).isoformat(),
+        })
+
+        return verification
+
+    def _gather_evidence(self, source: str) -> dict[str, Any]:
+        """Gather evidence from a source (file or command)."""
+        evidence = {"source": source, "found": False}
+
+        if source.startswith("file:"):
+            filepath = Path(source[5:])
+            if filepath.exists():
+                evidence["found"] = True
+                evidence["type"] = "file"
+                # Don't read entire file, just confirm existence
+                evidence["exists"] = True
+                evidence["modified"] = datetime.fromtimestamp(
+                    filepath.stat().st_mtime
+                ).isoformat()
+
+        elif source.startswith("cmd:"):
+            cmd = source[4:]
+            try:
+                result = subprocess.run(
+                    cmd, shell=True, capture_output=True, text=True, timeout=10
+                )
+                evidence["found"] = result.returncode == 0
+                evidence["type"] = "command"
+                evidence["output"] = result.stdout[:500] if result.stdout else None
+                evidence["exit_code"] = result.returncode
+            except Exception as e:
+                evidence["error"] = str(e)
+
+        return evidence
+
+    def must_verify_before_claiming(self, claim_type: str) -> str:
+        """
+        Return the verification command that MUST be run before making a claim.
+
+        This enforces the "verify before claiming" mandate.
+        """
+        verifications = {
+            "date": "date '+%A, %B %d, %Y'",
+            "time": "date '+%I:%M %p %Z'",
+            "market_status": "python3 -c \"import pytz; from datetime import datetime; et=pytz.timezone('US/Eastern'); now=datetime.now(et); print(f'{now.strftime(\"%A %I:%M %p ET\")} - Market {\"OPEN\" if (now.weekday()<5 and ((now.hour>9 or (now.hour==9 and now.minute>=30)) and now.hour<16)) else \"CLOSED\"}')\""  ,
+            "file_exists": "ls -la {filepath}",
+            "git_status": "git status --short",
+            "ci_status": "curl -s https://api.github.com/repos/IgorGanapolsky/trading/commits/main/check-runs | python3 -c \"import json,sys; d=json.load(sys.stdin); print(f'CI: {sum(1 for r in d.get(\\\"check_runs\\\",[]) if r.get(\\\"conclusion\\\")==\\\"success\\\")}/{d.get(\\\"total_count\\\",0)} passed')\"",
+        }
+        return verifications.get(claim_type, f"# No verification defined for: {claim_type}")
+
+    def get_verification_protocol(self) -> str:
+        """Return the full verification protocol as a string."""
+        return """
+=== CHAIN-OF-VERIFICATION PROTOCOL ===
+
+Before ANY claim, follow these 4 steps:
+
+1. DRAFT: What do I want to say?
+2. VERIFY: What evidence supports this?
+3. CHECK: Run verification command, capture output
+4. CLAIM: Only state what evidence supports
+
+MANDATORY VERIFICATIONS:
+- Date/time claims: Run `date` command
+- Market status: Check actual time vs market hours
+- File changes: Run `git status` or `ls -la`
+- CI status: Query GitHub API
+- Task completion: Show command output as proof
+
+FORBIDDEN:
+- Saying "tomorrow" without checking today's date
+- Claiming "done" without showing evidence
+- Stating market status without time check
+- Asserting file exists without verification
+
+When uncertain: Say "I need to verify this first"
+"""
+
+
+def verify_now() -> dict[str, Any]:
+    """Quick verification of current date/time/market status."""
+    cov = ChainOfVerification()
+    return cov.verify_date_claim()
+
+
+if __name__ == "__main__":
+    # Self-test
+    cov = ChainOfVerification()
+    result = cov.verify_date_claim()
+    print(json.dumps(result, indent=2))
+    print("\n" + cov.get_verification_protocol())


### PR DESCRIPTION
## Summary
- Implements anti-hallucination safeguards based on Meta Research (2024)
- Created after 'tomorrow' incident on Jan 5, 2026 (said 'tomorrow' on trading day)
- Reduces errors by 23% per research

## Changes
| File | Purpose |
|------|--------|
| `src/utils/chain_of_verification.py` | 4-step CoVe verification process |
| `.claude/hooks/enforce_verification.sh` | Hook to remind verification |
| `.claude/settings.json` | Added enforce_verification hook |
| `.claude/CLAUDE.md` | Anti-Hallucination Protocol section |
| `ll_079_hallucination_tomorrow_incident_jan05.md` | Incident documentation |

## Key Rules Enforced
- MUST run `date` before any time-related claim
- MUST show evidence before claiming completion
- Say "I don't know, let me verify" when uncertain

## Reference
https://arxiv.org/abs/2309.11495

## Test Plan
- [x] Hook runs on UserPromptSubmit
- [x] Protocol documented in CLAUDE.md
- [x] Lesson learned vectorized for RAG