### PR TITLE
fix: Add mandatory time verification rule to prevent hallucinations

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -28,6 +28,7 @@
 - When user gives thumbs down, IMMEDIATELY ask what went wrong
 - Check CI coverage thresholds, not just test pass/fail
 - Say "I believe this is done, verifying now..." instead of "Done!"
+- NEVER mention time words (today/tomorrow/Monday/etc) without FIRST running `date` command and showing output in SAME message
 - Query RAG lessons before starting tasks AND update RAG after finishing tasks
 - Do dry runs every time we merge into main to prepare for next day's trading
 - Never argue with the CEO - follow directives without question


### PR DESCRIPTION
## Problem

Hallucinated 'tomorrow's trading session' when it was actually today (Monday).

## Solution

**1. Updated CLAUDE.md** - Added explicit rule:
- NEVER mention time words (today/tomorrow/Monday/etc) without FIRST running `date` command and showing output in SAME message

**2. Created stop hook** (`.claude/hooks/stop-hook-time-verification.sh` - not in this PR as `.claude/` is in .gitignore):
- Scans responses for time-related words
- Blocks response if time mentioned without date verification
- Tested and working

## Evidence

Stop hook test results:
```
✅ All tests passed - hook is working correctly!
```

This prevents the exact error that occurred.