### PR TITLE
fix: Remove unused imports and reformat with ruff

### DIFF
--- a/src/learning/lancedb_feedback_store.py
+++ b/src/learning/lancedb_feedback_store.py
@@ -172,9 +172,14 @@ class LanceDBFeedbackStore:
 
         # Semantic search
         results = (
-            self.table.search(query_embedding)
-            .where(where_clause) if where_clause else self.table.search(query_embedding)
-        ).limit(limit).to_list()
+            (
+                self.table.search(query_embedding).where(where_clause)
+                if where_clause
+                else self.table.search(query_embedding)
+            )
+            .limit(limit)
+            .to_list()
+        )
 
         logger.debug(
             "Found %d similar contexts (filter_positive=%s)",
@@ -208,8 +213,7 @@ class LanceDBFeedbackStore:
 
         # Query by model checkpoint values
         results = (
-            self.table
-            .search()
+            self.table.search()
             .where(
                 f"model_alpha >= {alpha - tolerance} AND model_alpha <= {alpha + tolerance} "
                 f"AND model_beta >= {beta - tolerance} AND model_beta <= {beta + tolerance}"

--- a/src/learning/rlhf_storage.py
+++ b/src/learning/rlhf_storage.py
@@ -179,7 +179,9 @@ class RLHFStorage:
             return None
 
         try:
-            trajectory_id = f"{episode_id}_{step}_{datetime.now(timezone.utc).strftime('%Y%m%d%H%M%S%f')}"
+            trajectory_id = (
+                f"{episode_id}_{step}_{datetime.now(timezone.utc).strftime('%Y%m%d%H%M%S%f')}"
+            )
 
             # Ensure state_vector is a list of floats
             if isinstance(state_vector, np.ndarray):
@@ -241,8 +243,12 @@ class RLHFStorage:
             episode_id if successful
         """
         if len(states) != len(actions) or len(states) != len(rewards):
-            logger.error("Mismatched lengths: states=%d, actions=%d, rewards=%d",
-                        len(states), len(actions), len(rewards))
+            logger.error(
+                "Mismatched lengths: states=%d, actions=%d, rewards=%d",
+                len(states),
+                len(actions),
+                len(rewards),
+            )
             return None
 
         episode_id = f"{symbol}_{datetime.now(timezone.utc).strftime('%Y%m%d%H%M%S%f')}"
@@ -269,8 +275,12 @@ class RLHFStorage:
                 logger.error("Failed to store episode at step %d", step)
                 return None
 
-        logger.info("Stored episode %s: %d steps, cumulative_reward=%.4f",
-                   episode_id, len(states), cumulative)
+        logger.info(
+            "Stored episode %s: %d steps, cumulative_reward=%.4f",
+            episode_id,
+            len(states),
+            cumulative,
+        )
         return episode_id
 
     def add_user_feedback(
@@ -304,8 +314,7 @@ class RLHFStorage:
                     "feedback_timestamp": feedback_ts,
                 },
             )
-            logger.info("Added feedback %s to episode %s",
-                       "👍" if thumbs_up else "👎", episode_id)
+            logger.info("Added feedback %s to episode %s", "👍" if thumbs_up else "👎", episode_id)
             return True
 
         except Exception as exc:
@@ -390,7 +399,9 @@ class RLHFStorage:
             total = self.table.count_rows()
             # Get unique episodes
             all_data = self.table.search().limit(10000).to_list()
-            episodes = set(r.get("episode_id", "") for r in all_data if r.get("episode_id") != "_init_")
+            episodes = set(
+                r.get("episode_id", "") for r in all_data if r.get("episode_id") != "_init_"
+            )
             with_feedback = sum(1 for r in all_data if r.get("user_feedback", 0) != 0)
 
             return {

--- a/tests/test_lancedb_feedback.py
+++ b/tests/test_lancedb_feedback.py
@@ -9,11 +9,8 @@ Verifies:
 5. Integration with FeedbackTrainer
 """
 
-import json
 import tempfile
 from pathlib import Path
-
-import pytest
 
 
 class TestLanceDBInstallation:


### PR DESCRIPTION
Fixes CI Lint & Format failures:

- Remove unused json and pytest imports in test_lancedb_feedback.py
- Reformat lancedb_feedback_store.py and rlhf_storage.py with ruff

This resolves the lint failures on main branch.