### PR TITLE
fix: Calculate R&D day dynamically from start date

### DIFF
--- a/data/system_state.json
+++ b/data/system_state.json
@@ -10,10 +10,10 @@
   },
   "challenge": {
     "start_date": "2025-10-29",
-    "current_day": 50,
+    "current_day": 69,
     "total_days": 90,
     "status": "active",
-    "phase": "R&D Phase - Month 2 (Days 31-60)"
+    "phase": "R&D Phase - Month 3 (Days 61-90)"
   },
   "account": {
     "type": "live",

--- a/docs/index.md
+++ b/docs/index.md
@@ -12,7 +12,7 @@ Building an autonomous AI trading system with Claude Opus 4.5.
 
 ---
 
-## Live Status (Day 50/90)
+## Live Status (Day 69/90)
 
 | Metric | Value |
 |--------|-------|

--- a/scripts/generate_world_class_dashboard_enhanced.py
+++ b/scripts/generate_world_class_dashboard_enhanced.py
@@ -83,9 +83,16 @@ def calculate_basic_metrics():
     total_trades = performance.get("total_trades", 0)
 
     challenge = system_state.get("challenge", {})
-    current_day = challenge.get("current_day", days_elapsed)
+    # Always calculate current_day dynamically from start_date
+    current_day = days_elapsed  # Use calculated value, not hardcoded
     total_days = challenge.get("total_days", 90)
-    phase = challenge.get("phase", "R&D Phase - Month 1 (Days 1-30)")
+    # Calculate phase dynamically
+    if current_day <= 30:
+        phase = "R&D Phase - Month 1 (Days 1-30)"
+    elif current_day <= 60:
+        phase = "R&D Phase - Month 2 (Days 31-60)"
+    else:
+        phase = "R&D Phase - Month 3 (Days 61-90)"
 
     automation = system_state.get("automation", {})
     automation_status = automation.get("workflow_status", "UNKNOWN")


### PR DESCRIPTION
## Summary
- Day is now 69/90 (was hardcoded as 50 since Dec 22)
- Dashboard generator calculates day from 2025-10-29 start date
- Phase calculated dynamically (Month 1/2/3)