### PR TITLE
fix: Sort imports and add LanceDB fallback for CI

### DIFF
--- a/src/agents/rl_agent.py
+++ b/src/agents/rl_agent.py
@@ -542,8 +542,9 @@ class RLFilter:
         """
         # Store in LanceDB for RLHF
         try:
-            from src.learning.rlhf_storage import store_trade_trajectory
             from datetime import datetime, timezone
+
+            from src.learning.rlhf_storage import store_trade_trajectory
 
             episode_id = f"{symbol}_{datetime.now(timezone.utc).strftime('%Y%m%d%H%M%S')}"
             store_trade_trajectory(


### PR DESCRIPTION
## Summary
- Fix ruff I001 error in rl_agent.py (unsorted imports)
- Add LanceDB import fallback in lancedb_feedback_store.py for CI environments

## Root Cause
CI fails because lancedb is not in requirements-minimal.txt

## Test Plan
- [x] ruff check passes
- [ ] CI passes