### PR TITLE
fix: Resolve ruff lint errors in test files

### DIFF
--- a/tests/test_rlhf_storage.py
+++ b/tests/test_rlhf_storage.py
@@ -19,7 +19,7 @@ Tests:
 import sys
 import tempfile
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import numpy as np
 import pytest
@@ -245,7 +245,7 @@ class TestStoreTrajectory:
         with tempfile.TemporaryDirectory() as tmpdir:
             storage = RLHFStorage(db_path=tmpdir)
 
-            result = storage.store_trajectory(
+            storage.store_trajectory(
                 episode_id="test_case",
                 step=0,
                 state_vector=[0.0] * 10,
@@ -670,10 +670,9 @@ class TestSingletonPattern:
 
     def test_get_rlhf_storage_singleton(self):
         """Should return the same instance."""
-        from src.learning.rlhf_storage import get_rlhf_storage
-
         # Reset singleton for test
         import src.learning.rlhf_storage as module
+        from src.learning.rlhf_storage import get_rlhf_storage
 
         module._rlhf_storage = None
 
@@ -810,9 +809,8 @@ class TestLanceDBNotAvailable:
         """Storage should be disabled gracefully without LanceDB."""
         with patch.dict("sys.modules", {"lancedb": None}):
             # Force reimport with mocked module
-            from src.learning.rlhf_storage import RLHFStorage
 
-            with tempfile.TemporaryDirectory() as tmpdir:
+            with tempfile.TemporaryDirectory():
                 # This tests the fallback behavior
                 # The actual behavior depends on how import is handled
                 pass

--- a/tests/test_trade_sync.py
+++ b/tests/test_trade_sync.py
@@ -18,7 +18,7 @@ import sys
 import tempfile
 from datetime import datetime, timezone
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import pytest
 
@@ -36,17 +36,14 @@ class TestTradeSyncInitialization:
 
     def test_init_creates_trades_dir(self):
         """Initialization should create trades directory."""
-        from src.observability.trade_sync import TradeSync
-
         # Reset singleton
         import src.observability.trade_sync as module
+        from src.observability.trade_sync import TradeSync
 
         module._trade_sync = None
 
-        with tempfile.TemporaryDirectory() as tmpdir:
-            with patch.object(
-                Path, "mkdir", return_value=None
-            ) as mock_mkdir:
+        with tempfile.TemporaryDirectory():
+            with patch.object(Path, "mkdir", return_value=None):
                 sync = TradeSync()
                 # Should have called mkdir at least once
                 assert sync is not None
@@ -406,10 +403,9 @@ class TestSingleton:
 
     def test_get_trade_sync_singleton(self):
         """Should return same instance."""
-        from src.observability.trade_sync import get_trade_sync
-
         # Reset singleton
         import src.observability.trade_sync as module
+        from src.observability.trade_sync import get_trade_sync
 
         module._trade_sync = None
 


### PR DESCRIPTION
## Summary
- Remove unused imports (MagicMock, RLHFStorage)
- Remove unused local variables (result, tmpdir, mock_mkdir)
- Sort import blocks correctly

## Test plan
- [x] Ruff linter passes locally
- [ ] CI passes