### PR TITLE
fix: P/L Sanity Check should warn, not block workflow (LL-082)

### DIFF
--- a/.github/workflows/daily-trading.yml
+++ b/.github/workflows/daily-trading.yml
@@ -1007,12 +1007,14 @@ jobs:
       - name: P/L Sanity Check
         id: sanity_check
         if: always()
+        continue-on-error: true  # FIX Jan 5 2026: Don't fail workflow - just warn
         env:
           ALPACA_API_KEY: ${{ github.event.inputs.trading_mode == 'live' && secrets.ALPACA_BROKERAGE_TRADING_API_KEY || secrets.ALPACA_PAPER_TRADING_API_KEY }}
           ALPACA_SECRET_KEY: ${{ github.event.inputs.trading_mode == 'live' && secrets.ALPACA_BROKERAGE_TRADING_API_SECRET || secrets.ALPACA_PAPER_TRADING_API_SECRET }}
         run: |
           echo "🔍 Running P/L sanity check..."
           echo "   This detects zombie mode (system running but not trading)"
+          echo "   NOTE: This check WARNS but does NOT block trading (Jan 5 2026 fix)"
 
           if python3 scripts/verify_pl_sanity.py --verbose; then
             echo "✅ P/L sanity check passed - system is healthy"
@@ -1022,14 +1024,15 @@ jobs:
           else
             EXIT_CODE=$?
             if [ $EXIT_CODE -eq 1 ]; then
-              echo "::error::🚨 P/L SANITY CHECK FAILED!"
-              echo "::error::Alert: ${{ steps.sanity_check.outputs.alert_reason }}"
-              echo "::error::Days since equity change: ${{ steps.sanity_check.outputs.days_since_change }}"
-              echo "::error::Days since last trade: ${{ steps.sanity_check.outputs.days_since_trade }}"
+              echo "::warning::🚨 P/L SANITY CHECK DETECTED ISSUE"
+              echo "::warning::Alert: ${{ steps.sanity_check.outputs.alert_reason }}"
+              echo "::warning::Days since equity change: ${{ steps.sanity_check.outputs.days_since_change }}"
+              echo "::warning::Days since last trade: ${{ steps.sanity_check.outputs.days_since_trade }}"
               echo ""
-              echo "This indicates the system may be in zombie mode (running but not trading)."
-              echo "Review the performance log and recent trades immediately."
-              exit 1
+              echo "⚠️  This indicates the system may be in zombie mode (running but not trading)."
+              echo "⚠️  Review the performance log and recent trades immediately."
+              echo "⚠️  NOT failing workflow - trading may have executed. Check commits."
+              # FIX: Don't exit 1 - let workflow continue so data gets committed
             else
               echo "::warning::P/L sanity check script error (exit code $EXIT_CODE)"
               echo "Continuing workflow but investigate the script failure."

--- a/rag_knowledge/lessons_learned/ll_082_pl_sanity_check_blocking_workflow_jan05.md
+++ b/rag_knowledge/lessons_learned/ll_082_pl_sanity_check_blocking_workflow_jan05.md
@@ -1,0 +1,57 @@
+# Lesson Learned #082: P/L Sanity Check Was Blocking Entire Workflow
+
+**Date**: 2026-01-05
+**Severity**: CRITICAL
+**Category**: system_integrity
+
+## What Happened
+
+The P/L Sanity Check step in the daily-trading.yml workflow was configured to `exit 1` when it detected "no trades for 3 days". This caused a **chicken-and-egg failure loop**:
+
+1. No trades for 3 days (due to holiday gap Dec 31 - Jan 4)
+2. P/L Sanity Check runs with `if: always()` and exits with code 1
+3. Entire workflow marked as "FAILED"
+4. Workflow failures cascaded - 5 consecutive failures on Jan 5
+5. No trades executed because subsequent workflow runs also failed
+
+**Evidence:**
+- Runs #429-433 all FAILED on Jan 5, 2026
+- `data/trades_2026-01-05.json` never created
+- `data/performance_log.json` stuck at Jan 3 entry
+
+## Root Cause
+
+Line 1032 in `.github/workflows/daily-trading.yml`:
+```yaml
+exit 1  # <-- This killed the entire workflow
+```
+
+The P/L Sanity Check was designed to DETECT zombie mode, but it was incorrectly configured to BLOCK the workflow instead of just WARN.
+
+## The Fix
+
+Changed to `continue-on-error: true` and removed `exit 1`:
+```yaml
+- name: P/L Sanity Check
+  if: always()
+  continue-on-error: true  # Don't fail workflow - just warn
+```
+
+The sanity check now:
+- Still detects and logs zombie mode (for monitoring)
+- Does NOT block subsequent workflow steps
+- Does NOT prevent data commits
+
+## Prevention Rules
+
+1. **Monitoring checks should WARN, not BLOCK**
+2. **Use `continue-on-error: true` for non-critical checks**
+3. **Never use `exit 1` in monitoring steps that run with `if: always()`**
+4. **Test workflow behavior after holiday periods**
+5. **Sanity checks should enable debugging, not create new failures**
+
+## Related Lessons
+
+- LL-019: System dead 2 days - overly strict filters
+- LL-051: Blind trading catastrophe
+- LL-054: RAG not actually used


### PR DESCRIPTION
## Summary
- P/L Sanity Check was configured with `exit 1` which failed the entire workflow
- This created a chicken-and-egg loop: no trades → check fails → no commit → next run fails
- 5 consecutive workflow failures on Jan 5 due to this

## Changes
- Added `continue-on-error: true` to P/L Sanity Check step
- Removed `exit 1` - now warns but does NOT block workflow
- Added LL-082 lesson learned documenting the root cause

## Why PR #1096 didn't fully fix this
PR #1096 added accumulation phase awareness to the **script**, but the **workflow** still had `exit 1` which fails for paper trading (paper account is NOT in accumulation phase with $100k+).

## Test Plan
- [ ] Trigger Daily Trading workflow after merge
- [ ] Verify workflow completes successfully  
- [ ] Verify paper trades execute