### PR TITLE
fix: Skip dialogflow webhook tests when fastapi not installed

### DIFF
--- a/tests/test_dialogflow_webhook.py
+++ b/tests/test_dialogflow_webhook.py
@@ -12,6 +12,9 @@ from unittest.mock import patch
 
 import pytest
 
+# Skip all tests if fastapi is not installed
+pytest.importorskip("fastapi", reason="fastapi not installed - skipping webhook tests")
+
 
 class TestDialogflowWebhookFormat:
     """Test Dialogflow response format."""


### PR DESCRIPTION
## Summary
- Tests were failing because fastapi is not a required dependency
- Added pytest.importorskip to gracefully skip these tests

## Test Plan
- [x] Tests now skip instead of fail when fastapi is not installed