### PR TITLE
fix: Skip RLHF storage tests when lancedb not installed

### DIFF
--- a/tests/test_rlhf_storage.py
+++ b/tests/test_rlhf_storage.py
@@ -27,6 +27,9 @@ import pytest
 # Add project root to path
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
+# Skip all tests if lancedb is not installed
+pytest.importorskip("lancedb", reason="lancedb not installed - skipping RLHF storage tests")
+
 
 class TestRLHFStorageInitialization:
     """Test RLHFStorage initialization."""


### PR DESCRIPTION
## Summary
- Tests were failing because lancedb is not a required dependency
- Added pytest.importorskip to gracefully skip these tests