### PR TITLE
fix: Resolve Ruff linter errors (CI was failing)

### DIFF
--- a/scripts/generate_world_class_dashboard_enhanced.py
+++ b/scripts/generate_world_class_dashboard_enhanced.py
@@ -128,7 +128,6 @@ def calculate_basic_metrics():
             yesterday_account_type = yesterday_perf.get("account_type", "live")
             # Only calculate P/L if comparing same account type
             if yesterday_account_type == "live":
-                yesterday_equity = yesterday_perf.get("equity", starting_balance)
                 today_equity = current_equity
                 # Avoid negative P/L from deposits - use stored P/L or 0
                 today_pl = live_pl  # Use stored P/L from system_state instead of calculating

--- a/scripts/simple_daily_trader.py
+++ b/scripts/simple_daily_trader.py
@@ -217,8 +217,8 @@ def execute_cash_secured_put(client, option: dict, config: dict) -> Optional[dic
     logger.info("RAG checks passed - proceeding with execution")
 
     try:
-        from alpaca.trading.requests import MarketOrderRequest
         from alpaca.trading.enums import OrderSide, TimeInForce
+        from alpaca.trading.requests import MarketOrderRequest
 
         logger.info(f"Executing cash-secured put: {option['symbol']}")
         logger.info(f"  Strike: ${option['strike']}")


### PR DESCRIPTION
## Summary
- Remove unused variable yesterday_equity in dashboard generator
- Sort imports alphabetically in simple_daily_trader.py

**URGENT**: CI on main is failing due to these lint errors.

## Test plan
- [x] Ran ruff locally - all checks passed