### PR TITLE
fix: Remove duplicate lesson numbers from GitHub Pages

### DIFF
--- a/docs/_lessons/ll_073_feedback_training_pipeline_jan03.md
+++ b/docs/_lessons/ll_073_feedback_training_pipeline_jan03.md
@@ -1,3 +1,8 @@
+---
+title: "Lesson Learned #073: Feedback Training Pipeline Implementation"
+date: 2026-01-03
+---
+
 # Lesson Learned #073: Feedback Training Pipeline Implementation
 
 **Date**: 2026-01-03

--- a/docs/_lessons/ll_081_hallucination_tomorrow_incident_jan05.md
+++ b/docs/_lessons/ll_081_hallucination_tomorrow_incident_jan05.md
@@ -1,10 +1,10 @@
 ---
 layout: post
-title: "Lesson Learned #079: "Tomorrow" Hallucination Incident (Jan 5, 2026)"
+title: "Lesson Learned #081: "Tomorrow" Hallucination Incident (Jan 5, 2026)"
 date: 2026-01-05
 ---
 
-# Lesson Learned #079: "Tomorrow" Hallucination Incident (Jan 5, 2026)
+# Lesson Learned #081: "Tomorrow" Hallucination Incident (Jan 5, 2026)
 
 **Date**: January 5, 2026
 **Severity**: HIGH - Trust breach with CEO

--- a/docs/_lessons/ll_082_lancedb_rlhf_integration_jan05.md
+++ b/docs/_lessons/ll_082_lancedb_rlhf_integration_jan05.md
@@ -1,10 +1,10 @@
 ---
 layout: post
-title: "Lesson Learned #080: LanceDB Integration for RLHF"
+title: "Lesson Learned #082: LanceDB Integration for RLHF"
 date: 2026-01-05
 ---
 
-# Lesson Learned #080: LanceDB Integration for RLHF
+# Lesson Learned #082: LanceDB Integration for RLHF
 
 **Date**: 2026-01-05
 **Category**: RLHF, Machine Learning, Infrastructure, Vector Database


### PR DESCRIPTION
## Summary
Remove duplicate lesson numbers from GitHub Pages to improve readability.

## Test plan
- [x] Verified no duplicate lesson numbers in output