### PR TITLE
fix: Remove nested quotes breaking YAML title in ll_081

### DIFF
--- a/docs/_lessons/ll_081_hallucination_tomorrow_incident_jan05.md
+++ b/docs/_lessons/ll_081_hallucination_tomorrow_incident_jan05.md
@@ -1,6 +1,6 @@
 ---
 layout: post
-title: "Lesson Learned #081: "Tomorrow" Hallucination Incident (Jan 5, 2026)"
+title: "Lesson Learned #081: Tomorrow Hallucination Incident (Jan 5, 2026)"
 date: 2026-01-05
 ---
 


### PR DESCRIPTION
The title had nested double quotes that broke YAML parsing, causing empty Jan 05 entry on GitHub Pages.