### PR TITLE
chore: Trigger trading workflow after max_positions fix

### DIFF
--- a/TRIGGER_TRADE.md
+++ b/TRIGGER_TRADE.md
@@ -1,1 +1,14 @@
-# Trade Trigger\nTriggered: 2026-01-05 15:15:27 UTC\nReason: Update stale wiki dashboard after PR #1078 fix
+# Trade Trigger
+
+Triggered: 2026-01-05 20:00:00 UTC
+Reason: URGENT - Manual trigger after max_positions fix (PR #1123)
+
+## Context
+- max_positions changed from 3 to 10
+- Previous workflow ran BEFORE fix was merged
+- This trigger will test the fix with the corrected code
+
+## Evidence
+- Last trade: 2025-12-23 (13 days ago)
+- Root cause: max_positions=3 blocked 4 options positions
+- Fix: PR #1123 merged 2026-01-05 14:26:26 ET


### PR DESCRIPTION
## Purpose
Manually trigger the daily trading workflow to test the max_positions fix.

## Context
- max_positions was 3, blocking all trades since Dec 23 (13 days)
- Fixed to 10 in PR #1123
- Need to trigger workflow to verify fix works

## Action Required
**Merge this PR to trigger the trading workflow NOW**