### PR TITLE
feat: Add PostToolUse auto-formatting and expanded permissions

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,26 @@
 {
+  "permissions": {
+    "allow": [
+      "Bash(python3 -m pytest:*)",
+      "Bash(python3 -m black:*)",
+      "Bash(python3 -m ruff:*)",
+      "Bash(python3 -c:*)",
+      "Bash(python3 scripts/*)",
+      "Bash(git status:*)",
+      "Bash(git diff:*)",
+      "Bash(git log:*)",
+      "Bash(git branch:*)",
+      "Bash(git fetch:*)",
+      "Bash(gh pr:*)",
+      "Bash(gh issue:*)",
+      "Bash(pip show:*)",
+      "Bash(pip list:*)",
+      "Bash(date:*)",
+      "Bash(ls:*)",
+      "Bash(wc:*)",
+      "Skill"
+    ]
+  },
   "hooks": {
     "PreToolUse": [
       {
@@ -7,6 +29,18 @@
           {
             "type": "command",
             "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/protect_critical_files.sh",
+            "timeout": 5
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Write|Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "if [[ \"$CLAUDE_FILE_PATH\" == *.py ]]; then ruff format --quiet \"$CLAUDE_FILE_PATH\" 2>/dev/null || true; fi",
             "timeout": 5
           }
         ]


### PR DESCRIPTION
## Summary
- PostToolUse hook runs ruff format on Python files after Write/Edit
- Pre-approved safe commands: pytest, git read ops, gh CLI, pip read ops
- Reduces permission prompts and prevents CI formatting failures

Inspired by Boris Cherny Claude Code best practices research.

## Test Plan
- [x] Valid JSON syntax verified
- [x] Hook will silently fail if file not Python (safe)