### PR TITLE
fix: Resolve 3 ruff lint errors

### DIFF
--- a/scripts/budget_burn_report.py
+++ b/scripts/budget_burn_report.py
@@ -148,7 +148,6 @@ def analyze_api_costs(budget_data: dict[str, Any]) -> dict[str, Any]:
 
 def calculate_cost_per_trade(budget_data: dict[str, Any], trade_count: int) -> dict[str, Any]:
     """Calculate LLM cost per trade."""
-    spent = budget_data.get("spent_this_month", 0.0)
     api_calls = budget_data.get("api_calls", {})
 
     # LLM-specific costs

--- a/tests/test_alpaca_executor.py
+++ b/tests/test_alpaca_executor.py
@@ -263,8 +263,9 @@ class TestPlaceOrder:
 
     def test_place_order_via_broker(self):
         """Should place order via broker in live mode."""
-        from src.brokers.multi_broker import BrokerType, OrderResult
         from datetime import datetime
+
+        from src.brokers.multi_broker import BrokerType, OrderResult
 
         with patch.dict(os.environ, {"ALPACA_SIMULATED": "true"}):
             with patch("src.observability.trade_sync.sync_trade"):

--- a/tests/test_pl_sanity.py
+++ b/tests/test_pl_sanity.py
@@ -327,8 +327,8 @@ class TestEdgeCases:
             # Clear import cache
             if "alpaca.trading.client" in sys.modules:
                 del sys.modules["alpaca.trading.client"]
-            result = module._get_trading_client()
-            # May return mock or None depending on test environment
+            # Call to verify no exception is raised
+            module._get_trading_client()
 
     def test_initialize_api_without_credentials(self, mock_alpaca):
         """Test API initialization fails gracefully without credentials."""


### PR DESCRIPTION
## Summary
- Remove unused "spent" variable in budget_burn_report.py
- Sort imports in test_alpaca_executor.py
- Remove unused "result" variable in test_pl_sanity.py

## Test plan
- [x] Ruff check passes locally
- [x] No functional changes