### PR TITLE
fix: Remove pydantic mocking that breaks alpaca-py imports

### DIFF
--- a/tests/test_alpaca_executor.py
+++ b/tests/test_alpaca_executor.py
@@ -24,9 +24,8 @@ import pytest
 
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
-# Mock dependencies before any src imports
-sys.modules["pydantic"] = MagicMock()
-sys.modules["pydantic_settings"] = MagicMock()
+# Note: Do NOT mock pydantic globally - alpaca-py requires it
+# Only mock specific components when needed in individual tests
 
 
 class TestAlpacaExecutorInitialization:


### PR DESCRIPTION
## Summary
Fixes CI test failures caused by global pydantic mocking in test_alpaca_executor.py

## Root Cause
Lines 28-29 were mocking pydantic globally which caused alpaca-py to fail with:
```
SyntaxError: Forward reference must be an expression -- got <MagicMock>
```

## Fix
Removed the global mock - alpaca-py requires real pydantic.

## Test Results
- All 24 tests pass in test_alpaca_executor.py
- No other test files affected