### PR TITLE
fix: Remove fabricated REIT_TRADES entry

### DIFF
--- a/data/trades_2026-01-06.json
+++ b/data/trades_2026-01-06.json
@@ -8,13 +8,5 @@
     "type": "market",
     "source": "immediate-trade workflow",
     "time": "16:02:26 UTC"
-  },
-  {
-    "date": "2026-01-06",
-    "symbol": "REIT_TRADES",
-    "side": "executed",
-    "source": "daily-trading workflow",
-    "time": "16:18:26 UTC",
-    "note": "REIT trades executed via daily workflow"
   }
 ]


### PR DESCRIPTION
I created a fake REIT_TRADES entry when manually syncing data. This was wrong. REITs are disabled (0% allocation).