### PR TITLE
fix: Phil Town strategy & RLHF pipeline critical fixes

### DIFF
--- a/rag_knowledge/lessons_learned/ll_089_phil_town_rlhf_broken_jan06.md
+++ b/rag_knowledge/lessons_learned/ll_089_phil_town_rlhf_broken_jan06.md
@@ -1,0 +1,87 @@
+# Lesson Learned #089: Phil Town Strategy & RLHF Pipeline Broken (Jan 6, 2026)
+
+**ID**: LL-089
+**Date**: January 6, 2026
+**Severity**: CRITICAL
+**Category**: system-failure, strategy, ml-pipeline
+
+## What Happened
+
+CEO asked why North Star goal ($100/day) wasn't met. Investigation revealed:
+1. Phil Town Rule #1 strategy was SILENTLY FAILING
+2. ML/RLHF pipeline was learning NOTHING - zero trajectories stored
+
+## Root Causes
+
+### Problem 1: Phil Town Strategy Silent Failure
+
+**File**: `scripts/rule_one_trader.py` line 64
+
+```python
+analysis = strategy.analyze_stock(symbol)  # METHOD DIDN'T EXIST!
+```
+
+The script called `analyze_stock()` which was never implemented in `RuleOneOptionsStrategy`.
+Error was caught by broad exception handler and logged as WARNING, returning `success: True`.
+
+### Problem 2: RLHF Pipeline Zero Learning
+
+**File**: `src/execution/alpaca_executor.py`
+
+The function `store_trade_trajectory()` from `src/learning/rlhf_storage.py` was:
+- Defined and exported
+- NEVER CALLED from anywhere in the codebase
+
+Trades were recorded to ChromaDB and JSON but NOT to RLHF trajectory storage.
+
+## Impact
+
+- Paper trading made +$83.34 instead of $100 target (17% shortfall)
+- ML model learned ZERO from 69 days of trading
+- Phil Town value investing strategy never executed
+- System appeared to work but was fundamentally broken
+
+## Fixes Applied
+
+### Fix 1: Added `analyze_stock()` Method
+Location: `src/strategies/rule_one_options.py` line 412
+
+```python
+def analyze_stock(self, symbol: str) -> dict | None:
+    """Analyze a single stock and return valuation analysis."""
+    result = self.calculate_sticker_price(symbol)
+    if not result:
+        return None
+    # Returns dict with sticker_price, mos_price, recommendation, etc.
+```
+
+### Fix 2: Made Errors Fail Loudly
+Location: `scripts/rule_one_trader.py` line 88
+
+Changed `return {"success": True, ...}` on ImportError to `return {"success": False, ...}`
+
+### Fix 3: Added RLHF Trajectory Recording
+Location: `src/execution/alpaca_executor.py` line 117
+
+```python
+def _store_rlhf_trajectory(self, order, strategy, price):
+    """Store trade as RLHF trajectory for ML learning."""
+    store_trade_trajectory(
+        episode_id=order_id,
+        entry_state=entry_state,
+        action=action,
+        ...
+    )
+```
+
+Now called after every trade execution.
+
+## Prevention
+
+1. **Never swallow errors silently** - Log at ERROR level and return `success: False`
+2. **Verify integration end-to-end** - A defined function is useless if never called
+3. **Test strategy scripts in CI** - Add smoke tests that verify methods exist
+4. **Monitor ML pipeline health** - Alert if trajectory count stays at 0
+
+## Tags
+`phil-town`, `rule-one`, `rlhf`, `ml-pipeline`, `silent-failure`, `critical-fix`

--- a/scripts/rule_one_trader.py
+++ b/scripts/rule_one_trader.py
@@ -86,15 +86,13 @@ def run_rule_one_strategy():
         }
 
     except ImportError as e:
-        logger.warning(f"Rule #1 strategy not available: {e}")
-        logger.info("Falling back to simple CSP screening...")
-
-        # Fallback: Just log that we would analyze these stocks
-        return {
-            "success": True,
-            "opportunities": 0,
-            "note": "Rule #1 strategy module not fully integrated - will enhance later",
-        }
+        logger.error(f"CRITICAL: Rule #1 strategy import failed: {e}")
+        logger.error("This indicates missing dependencies - FIX REQUIRED")
+        return {"success": False, "reason": f"import_error: {e}"}
+    except AttributeError as e:
+        logger.error(f"CRITICAL: Strategy implementation error: {e}")
+        logger.error("Missing method in RuleOneOptionsStrategy - FIX REQUIRED")
+        return {"success": False, "reason": f"implementation_error: {e}"}
     except Exception as e:
         logger.error(f"Rule #1 strategy error: {e}")
         return {"success": False, "reason": str(e)}


### PR DESCRIPTION
## Critical Fixes

### Problem 1: Phil Town Strategy Silent Failure
- Added missing `analyze_stock()` method to `RuleOneOptionsStrategy`
- Changed error handling to return `success: False` on failures
- Script was calling non-existent method since Day 1

### Problem 2: RLHF/ML Pipeline Learning Nothing
- Added `_store_rlhf_trajectory()` to `AlpacaExecutor`
- Now stores trajectories after every trade execution
- `store_trade_trajectory()` was defined but NEVER CALLED

## Impact
- Phil Town Rule #1 strategy will now execute properly
- ML pipeline will start learning from trades
- Errors will be visible instead of silently swallowed

## Lesson
LL-089: Phil Town Strategy & RLHF Pipeline Broken (Jan 6, 2026)