### PR TITLE
feat: Implement realistic North Star targets scaled to capital

### DIFF
--- a/data/system_state.json
+++ b/data/system_state.json
@@ -27,8 +27,20 @@
     "daily_change_pct": 50.0,
     "positions_count": 0,
     "daily_deposit": 10.0,
-    "target_daily_profit": 100.0,
     "reset_note": "Fresh start Jan 3, 2026 - Real brokerage with $10/day deposits",
+    "north_star": {
+      "ultimate_target": 100.0,
+      "current_target": 5.0,
+      "target_explanation": "Target scales with capital: $5/day at $200, $100/day at $2000",
+      "capital_tiers": [
+        {"capital": 200, "daily_target": 5, "strategy": "Single CSP on SPY", "return_pct": 2.5},
+        {"capital": 500, "daily_target": 15, "strategy": "2 CSPs or 1 Iron Condor", "return_pct": 3.0},
+        {"capital": 1000, "daily_target": 30, "strategy": "Wheel strategy on SPY", "return_pct": 3.0},
+        {"capital": 2000, "daily_target": 60, "strategy": "Multiple wheels + 0DTE", "return_pct": 3.0},
+        {"capital": 5000, "daily_target": 100, "strategy": "Full Phil Town portfolio", "return_pct": 2.0}
+      ],
+      "rule_1_reminder": "Don't lose money - 50% daily returns are IMPOSSIBLE without extreme risk"
+    },
     "deposit_strategy": {
       "amount_per_day": 10.0,
       "start_date": "2026-01-03",
@@ -37,12 +49,18 @@
       "purpose": "Accumulate capital for defined-risk options spreads (~$100-200 minimum)",
       "target_for_first_trade": 200.0,
       "estimated_days_to_target": 17,
+      "accelerated_plan": {
+        "option_1": {"deposit": 20, "days_to_200": 9, "days_to_2000": 99},
+        "option_2": {"deposit": 50, "days_to_200": 4, "days_to_2000": 40},
+        "option_3": {"deposit": 100, "days_to_200": 2, "days_to_2000": 20},
+        "recommendation": "Increase to $50/day to reach trading capital faster"
+      },
       "tax_strategy": "Section 475 MTM election + Section 1256 index options (60/40 treatment)"
     }
   },
   "paper_account": {
     "type": "paper",
-    "purpose": "R&D and RAG knowledge building",
+    "purpose": "Test Phil Town Rule #1 strategies before live deployment",
     "starting_balance": 100000.0,
     "current_equity": 101167.20,
     "cash": 86629.93,
@@ -54,11 +72,30 @@
     "win_rate": 80.0,
     "win_rate_sample_size": 5,
     "win_rate_warning": "STATISTICALLY INSIGNIFICANT - Only 5 closed trades. Need 30+ for confidence.",
-    "note": "Continue paper trading at night to build RAG knowledge",
     "last_sync": "2026-01-06T17:27:00",
     "sync_source": "CEO screenshot Jan 6 2026",
     "todays_pl": 83.34,
-    "todays_pl_pct": 0.08
+    "todays_pl_pct": 0.08,
+    "phil_town_strategy": {
+      "enabled": true,
+      "purpose": "Validate Phil Town Rule #1 approach before live trading",
+      "primary_strategy": "Cash Secured Puts on 4Ms stocks",
+      "four_ms_watchlist": ["AAPL", "MSFT", "GOOGL", "AMZN", "BRK.B"],
+      "rules": {
+        "rule_1": "Don't lose money - use stop losses",
+        "entry": "Only sell CSPs when stock is at MOS (Margin of Safety) price",
+        "delta": "0.20 to 0.30 (70-80% probability OTM)",
+        "dte": "30-45 days to expiration",
+        "position_size": "Max 10% of buying power per position",
+        "exit": "Close at 50% profit or roll if challenged"
+      },
+      "target_metrics": {
+        "win_rate_target": 70,
+        "min_trades_for_confidence": 30,
+        "max_drawdown_allowed": 5
+      },
+      "note": "Build track record of 30+ trades before deploying to live account"
+    }
   },
   "investments": {
     "total_invested": 1621.93,

--- a/rag_knowledge/lessons_learned/ll_090_north_star_capital_requirements_jan06.md
+++ b/rag_knowledge/lessons_learned/ll_090_north_star_capital_requirements_jan06.md
@@ -1,0 +1,67 @@
+# Lesson Learned #090: North Star Must Scale with Capital
+
+**Date**: January 6, 2026
+**Severity**: CRITICAL
+**Category**: Strategy, Capital Management
+
+## Summary
+
+The $100/day North Star target is IMPOSSIBLE with $200 capital. This would require 50% daily returns - a guaranteed path to losing money (violating Phil Town Rule #1).
+
+## The Math
+
+| Capital | Required Return for $100/day |
+|---------|------------------------------|
+| $200 | 50% daily (IMPOSSIBLE) |
+| $500 | 20% daily (EXTREMELY RISKY) |
+| $1,000 | 10% daily (VERY RISKY) |
+| $2,000 | 5% daily (AGGRESSIVE) |
+| $5,000 | 2% daily (REALISTIC) |
+
+## Realistic Targets by Capital Tier
+
+| Capital | Daily Target | Strategy | Return % |
+|---------|--------------|----------|----------|
+| $200 | $5 | Single CSP on SPY | 2.5% |
+| $500 | $15 | 2 CSPs or 1 Iron Condor | 3.0% |
+| $1,000 | $30 | Wheel strategy on SPY | 3.0% |
+| $2,000 | $60 | Multiple wheels + 0DTE | 3.0% |
+| $5,000 | $100 | Full Phil Town portfolio | 2.0% |
+
+## Phil Town Rule #1 Reminder
+
+> "Rule #1: Don't lose money. Rule #2: Don't forget Rule #1."
+
+Chasing unrealistic returns is the fastest way to LOSE money.
+
+## Accelerated Path to $100/day
+
+To reach the capital needed for $100/day:
+
+| Daily Deposit | Days to $200 | Days to $2,000 | Days to $5,000 |
+|---------------|--------------|----------------|----------------|
+| $10 (current) | 17 | 197 | 497 |
+| $20 | 9 | 99 | 249 |
+| $50 | 4 | 40 | 100 |
+| $100 | 2 | 20 | 50 |
+
+**Recommendation**: Increase deposits to $50/day to reach trading capital in ~40 days.
+
+## Changes Made
+
+1. Updated `system_state.json` with tiered North Star targets
+2. Added Phil Town strategy configuration to paper account
+3. Created accelerated deposit plan options
+4. Paper account will validate strategy before live deployment
+
+## Key Insight
+
+The paper account ($101K) should be used to:
+- Test Phil Town Rule #1 strategies
+- Build 30+ trade track record
+- Validate 70%+ win rate
+- THEN deploy proven strategy to live account
+
+## Tags
+
+north_star, capital_requirements, phil_town, rule_1, realistic_targets


### PR DESCRIPTION
## Summary
- Fixed unrealistic $100/day target for $200 capital
- Added tiered North Star: $5/day at $200, scaling to $100/day at $5000
- Created accelerated deposit plan options
- Configured paper account for Phil Town Rule #1 strategy testing

## Evidence
$100/day from $200 = 50% daily return = IMPOSSIBLE

## Test Plan
- [x] Lesson LL-090 recorded in ChromaDB
- [x] system_state.json updated with capital tiers