### PR TITLE
fix(ci): Add requests dependency to publish-lessons workflow

### DIFF
--- a/.github/workflows/publish-lessons.yml
+++ b/.github/workflows/publish-lessons.yml
@@ -24,6 +24,9 @@ jobs:
         with:
           python-version: '3.11'
 
+      - name: Install dependencies
+        run: pip install requests
+
       - name: Find new lessons
         id: find_lessons
         run: |


### PR DESCRIPTION
The workflow was failing because requests was not installed.