### PR TITLE
fix(lint): Sort imports and remove unused imports

### DIFF
--- a/scripts/small_capital_csp.py
+++ b/scripts/small_capital_csp.py
@@ -263,8 +263,8 @@ def execute_csp(option: dict, capital: float) -> dict:
 
     try:
         from alpaca.trading.client import TradingClient
-        from alpaca.trading.requests import LimitOrderRequest
         from alpaca.trading.enums import OrderSide, TimeInForce
+        from alpaca.trading.requests import LimitOrderRequest
 
         api_key = os.getenv("ALPACA_API_KEY")
         secret_key = os.getenv("ALPACA_SECRET_KEY")

--- a/tests/test_small_capital_csp.py
+++ b/tests/test_small_capital_csp.py
@@ -2,9 +2,6 @@
 
 import json
 from pathlib import Path
-from unittest.mock import MagicMock, patch
-
-import pytest
 
 
 class TestCapitalTiers:


### PR DESCRIPTION
Fixes CI lint failure:
- Sort alpaca imports alphabetically
- Remove unused imports from test file