### PR TITLE
fix(lint): Remove unused imports and fix import sorting

### DIFF
--- a/scripts/small_capital_csp.py
+++ b/scripts/small_capital_csp.py
@@ -80,10 +80,7 @@ def get_tier_for_capital(capital: float) -> dict:
 
     for tier_capital in reversed(sorted_tiers):
         if capital >= tier_capital:
-            return {
-                "tier_capital": tier_capital,
-                **CAPITAL_TIERS[tier_capital]
-            }
+            return {"tier_capital": tier_capital, **CAPITAL_TIERS[tier_capital]}
 
     return {
         "tier_capital": 0,
@@ -104,6 +101,7 @@ def calculate_sticker_price(symbol: str) -> Optional[dict]:
         # Try yfinance first
         try:
             from src.utils import yfinance_wrapper as yf
+
             ticker = yf.Ticker(symbol)
             info = ticker.info
 
@@ -156,7 +154,9 @@ def get_recommendation(current: float, sticker: float, mos: float) -> str:
         return "OVERVALUED - Avoid"
 
 
-def find_csp_opportunity(symbol: str, mos_price: float, max_strike: float, capital: float) -> Optional[dict]:
+def find_csp_opportunity(
+    symbol: str, mos_price: float, max_strike: float, capital: float
+) -> Optional[dict]:
     """
     Find a CSP opportunity for the given symbol.
 
@@ -360,17 +360,16 @@ def run_small_capital_csp():
         # Find CSP opportunity
         if "BUY" in valuation["recommendation"] or "STRONG" in valuation["recommendation"]:
             option = find_csp_opportunity(
-                symbol,
-                valuation["mos_price"],
-                tier["max_strike"],
-                capital
+                symbol, valuation["mos_price"], tier["max_strike"], capital
             )
 
             if option:
-                opportunities.append({
-                    "valuation": valuation,
-                    "option": option,
-                })
+                opportunities.append(
+                    {
+                        "valuation": valuation,
+                        "option": option,
+                    }
+                )
                 logger.info(f"  ✅ Found CSP: {option['symbol']} @ ${option['strike']:.2f}")
 
     logger.info(f"\n{'=' * 60}")

--- a/scripts/sync_trades_to_rag.py
+++ b/scripts/sync_trades_to_rag.py
@@ -16,14 +16,11 @@ Usage:
 
 import json
 import logging
-import os
 import sys
 from datetime import datetime, timezone
 from pathlib import Path
 
-logging.basicConfig(
-    level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s"
-)
+logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
 logger = logging.getLogger(__name__)
 
 
@@ -62,7 +59,8 @@ def sync_to_vertex_rag(trades: list[dict]) -> bool:
             try:
                 # Format trade as document for RAG
                 doc_content = format_trade_document(trade)
-                doc_id = f"trade_{trade.get('symbol', 'UNK')}_{trade.get('timestamp', datetime.now().isoformat())}"
+                timestamp_val = trade.get("timestamp", datetime.now().isoformat())
+                doc_id = f"trade_{trade.get('symbol', 'UNK')}_{timestamp_val}"
 
                 # Add to RAG corpus
                 rag.add_document(
@@ -105,18 +103,21 @@ def sync_to_chromadb(trades: list[dict]) -> bool:
         for trade in trades:
             try:
                 doc_content = format_trade_document(trade)
-                doc_id = f"trade_{trade.get('symbol', 'UNK')}_{trade.get('timestamp', datetime.now().isoformat())}"
+                timestamp_val = trade.get("timestamp", datetime.now().isoformat())
+                doc_id = f"trade_{trade.get('symbol', 'UNK')}_{timestamp_val}"
 
                 collection.upsert(
                     documents=[doc_content],
                     ids=[doc_id],
-                    metadatas=[{
-                        "type": "trade",
-                        "symbol": str(trade.get("symbol", "")),
-                        "date": str(trade.get("timestamp", ""))[:10],
-                        "strategy": str(trade.get("strategy", "unknown")),
-                        "pnl": str(trade.get("pnl", 0)),
-                    }],
+                    metadatas=[
+                        {
+                            "type": "trade",
+                            "symbol": str(trade.get("symbol", "")),
+                            "date": str(trade.get("timestamp", ""))[:10],
+                            "strategy": str(trade.get("strategy", "unknown")),
+                            "pnl": str(trade.get("pnl", 0)),
+                        }
+                    ],
                 )
                 synced += 1
             except Exception as e:

--- a/src/execution/alpaca_executor.py
+++ b/src/execution/alpaca_executor.py
@@ -437,7 +437,9 @@ class AlpacaExecutor:
                         f"Consider reducing position size."
                     )
             else:
-                logger.info(f"📊 PATTERN CHECK: No history for {strategy}_{entry_reason} - proceeding with caution")
+                logger.info(
+                    f"📊 PATTERN CHECK: No history for {strategy}_{entry_reason} - proceeding with caution"
+                )
 
         except ImportError:
             logger.debug("TradeMemory not available - skipping pattern check")

--- a/tests/test_small_capital_csp.py
+++ b/tests/test_small_capital_csp.py
@@ -11,6 +11,7 @@ class TestCapitalTiers:
         """Verify tier configuration is properly defined."""
         # Import after patching potential dependencies
         import sys
+
         sys.path.insert(0, str(Path(__file__).parent.parent))
 
         from scripts.small_capital_csp import CAPITAL_TIERS
@@ -23,6 +24,7 @@ class TestCapitalTiers:
     def test_tier_500_has_cheap_stocks(self):
         """$500 tier should only have cheap stocks."""
         import sys
+
         sys.path.insert(0, str(Path(__file__).parent.parent))
 
         from scripts.small_capital_csp import CAPITAL_TIERS
@@ -34,6 +36,7 @@ class TestCapitalTiers:
     def test_get_tier_for_insufficient_capital(self):
         """$200 should return insufficient tier."""
         import sys
+
         sys.path.insert(0, str(Path(__file__).parent.parent))
 
         from scripts.small_capital_csp import get_tier_for_capital
@@ -46,6 +49,7 @@ class TestCapitalTiers:
     def test_get_tier_for_500(self):
         """$500 should return tier 500."""
         import sys
+
         sys.path.insert(0, str(Path(__file__).parent.parent))
 
         from scripts.small_capital_csp import get_tier_for_capital
@@ -57,6 +61,7 @@ class TestCapitalTiers:
     def test_get_tier_for_750(self):
         """$750 should still use tier 500."""
         import sys
+
         sys.path.insert(0, str(Path(__file__).parent.parent))
 
         from scripts.small_capital_csp import get_tier_for_capital
@@ -67,6 +72,7 @@ class TestCapitalTiers:
     def test_get_tier_for_5000(self):
         """$5000 should use tier 5000."""
         import sys
+
         sys.path.insert(0, str(Path(__file__).parent.parent))
 
         from scripts.small_capital_csp import get_tier_for_capital
@@ -82,6 +88,7 @@ class TestRecommendation:
     def test_strong_buy_below_mos(self):
         """Price below MOS should be STRONG BUY."""
         import sys
+
         sys.path.insert(0, str(Path(__file__).parent.parent))
 
         from scripts.small_capital_csp import get_recommendation
@@ -92,6 +99,7 @@ class TestRecommendation:
     def test_buy_below_sticker(self):
         """Price below sticker but above MOS should be BUY."""
         import sys
+
         sys.path.insert(0, str(Path(__file__).parent.parent))
 
         from scripts.small_capital_csp import get_recommendation
@@ -102,6 +110,7 @@ class TestRecommendation:
     def test_hold_near_fair_value(self):
         """Price near sticker should be HOLD."""
         import sys
+
         sys.path.insert(0, str(Path(__file__).parent.parent))
 
         from scripts.small_capital_csp import get_recommendation
@@ -112,6 +121,7 @@ class TestRecommendation:
     def test_overvalued(self):
         """Price well above sticker should be OVERVALUED."""
         import sys
+
         sys.path.insert(0, str(Path(__file__).parent.parent))
 
         from scripts.small_capital_csp import get_recommendation

--- a/tests/test_sync_trades_to_rag.py
+++ b/tests/test_sync_trades_to_rag.py
@@ -1,16 +1,16 @@
 """Tests for sync_trades_to_rag.py - Post-trade RAG sync functionality."""
 
 import json
-import pytest
-from pathlib import Path
-from unittest.mock import patch, MagicMock
-
-# Import the functions we're testing
 import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
 sys.path.insert(0, str(Path(__file__).parent.parent))
 from scripts.sync_trades_to_rag import (
-    load_todays_trades,
     format_trade_document,
+    load_todays_trades,
 )
 
 
@@ -30,7 +30,7 @@ class TestLoadTodaysTrades:
 
         with patch("scripts.sync_trades_to_rag.Path") as mock_path:
             mock_path.return_value = trades_file
-            trades = load_todays_trades("2026-01-06")
+            _trades = load_todays_trades("2026-01-06")  # noqa: F841
 
         # Function uses hardcoded path, so just test the real file
         # This is an integration test using actual data


### PR DESCRIPTION
## Summary
- Remove unused `os` import from sync_trades_to_rag.py
- Sort imports properly in test_sync_trades_to_rag.py
- Remove unused `MagicMock` import
- Mark intentionally unused variable with underscore prefix

## Test Plan
- [x] CI lint check should pass