### PR TITLE
feat(ci): Add Claude Agent Utility workflow for sandbox-escaped tasks

### DIFF
--- a/.github/workflows/claude-agent-utility.yml
+++ b/.github/workflows/claude-agent-utility.yml
@@ -1,0 +1,214 @@
+# Claude Agent Utility Workflow
+# Purpose: Execute tasks that cannot be done in the Claude sandbox
+# Triggered via API: curl -X POST with workflow_dispatch
+#
+# Created: Jan 7, 2026
+# Reason: CEO directive - "Don't tell me sandbox can't do it, create CI workflows"
+
+name: Claude Agent Utility
+
+on:
+  workflow_dispatch:
+    inputs:
+      task:
+        description: 'Task to execute'
+        required: true
+        type: choice
+        options:
+          - run-tests
+          - run-lint
+          - verify-rag
+          - sync-trades-to-rag
+          - system-health-check
+          - verify-chromadb
+          - dry-run-trading
+          - deploy-webhook
+          - custom-command
+        default: 'run-tests'
+      custom_command:
+        description: 'Custom Python command (only if task=custom-command)'
+        required: false
+        type: string
+        default: ''
+      test_pattern:
+        description: 'Test pattern for pytest (e.g., tests/test_*.py)'
+        required: false
+        type: string
+        default: 'tests/'
+      verbose:
+        description: 'Enable verbose output'
+        required: false
+        type: boolean
+        default: true
+
+env:
+  PYTHON_VERSION: '3.11'
+
+jobs:
+  execute-task:
+    name: Execute ${{ github.event.inputs.task }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+          cache: 'pip'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install pytest pytest-cov ruff black chromadb
+
+      - name: Task - Run Tests
+        if: github.event.inputs.task == 'run-tests'
+        run: |
+          echo "Running pytest with pattern: ${{ github.event.inputs.test_pattern }}"
+          python -m pytest ${{ github.event.inputs.test_pattern }} \
+            -v \
+            --tb=short \
+            --color=yes \
+            2>&1 | tee test-output.txt
+
+          echo "::notice::Test run complete. Check output above."
+
+      - name: Task - Run Lint
+        if: github.event.inputs.task == 'run-lint'
+        run: |
+          echo "Running ruff check..."
+          python -m ruff check src/ scripts/ --fix --show-fixes || true
+
+          echo "Running black check..."
+          python -m black src/ scripts/ --check --diff || true
+
+          echo "::notice::Lint check complete."
+
+      - name: Task - Verify RAG
+        if: github.event.inputs.task == 'verify-rag'
+        run: |
+          echo "Verifying RAG systems..."
+          python3 -c "
+          from src.rag.lessons_learned_rag import LessonsLearnedRAG
+          rag = LessonsLearnedRAG()
+          print(f'Lessons loaded: {len(rag.lessons)}')
+          results = rag.query('trading risk', top_k=3)
+          print(f'Query test returned {len(results)} results')
+          for r in results:
+              print(f'  - {r.get(\"id\", \"unknown\")}: {r.get(\"severity\", \"\")}')
+          print('RAG verification: PASSED')
+          "
+
+      - name: Task - Sync Trades to RAG
+        if: github.event.inputs.task == 'sync-trades-to-rag'
+        env:
+          GOOGLE_APPLICATION_CREDENTIALS_JSON: ${{ secrets.GOOGLE_APPLICATION_CREDENTIALS_JSON }}
+        run: |
+          echo "Syncing trades to Vertex AI RAG and ChromaDB..."
+          python3 scripts/sync_trades_to_rag.py || {
+            echo "::warning::RAG sync had issues - check logs"
+          }
+          echo "::notice::Trade sync complete."
+
+      - name: Task - System Health Check
+        if: github.event.inputs.task == 'system-health-check'
+        run: |
+          echo "Running full system health check..."
+          python3 scripts/system_health_check.py 2>&1 | tee health-check.txt
+
+          # Check for critical failures
+          if grep -q "SOME CHECKS FAILED" health-check.txt; then
+            echo "::warning::Some health checks failed - review output"
+          else
+            echo "::notice::All health checks passed!"
+          fi
+
+      - name: Task - Verify ChromaDB
+        if: github.event.inputs.task == 'verify-chromadb'
+        run: |
+          echo "Verifying ChromaDB setup..."
+          python3 -c "
+          import chromadb
+          from chromadb.config import Settings
+
+          # Test persistent client
+          client = chromadb.PersistentClient(
+              path='data/chromadb_test',
+              settings=Settings(anonymized_telemetry=False)
+          )
+
+          # Create test collection
+          collection = client.get_or_create_collection('test_trades')
+
+          # Add test document
+          collection.upsert(
+              documents=['Test trade document'],
+              ids=['test_001'],
+              metadatas=[{'type': 'test', 'symbol': 'TEST'}]
+          )
+
+          # Query
+          results = collection.query(query_texts=['trade'], n_results=1)
+          print(f'ChromaDB test query returned: {len(results[\"documents\"][0])} docs')
+
+          # Cleanup
+          client.delete_collection('test_trades')
+          print('ChromaDB verification: PASSED')
+          "
+
+      - name: Task - Dry Run Trading
+        if: github.event.inputs.task == 'dry-run-trading'
+        env:
+          ALPACA_API_KEY: ${{ secrets.ALPACA_PAPER_KEY }}
+          ALPACA_SECRET_KEY: ${{ secrets.ALPACA_PAPER_SECRET }}
+          ALPACA_PAPER: "true"
+        run: |
+          echo "Running trading system dry run..."
+          python3 -c "
+          import os
+          os.environ['ALPACA_SIMULATED'] = 'true'
+
+          # Import core modules
+          from src.orchestrator.main import TradingOrchestrator
+          print('TradingOrchestrator: importable')
+
+          from src.execution.alpaca_executor import AlpacaExecutor
+          print('AlpacaExecutor: importable')
+
+          from src.safety.mandatory_trade_gate import validate_trade_mandatory
+          print('MandatoryTradeGate: importable')
+
+          from src.learning.trade_memory import TradeMemory
+          print('TradeMemory: importable')
+
+          print('Dry run: ALL CORE MODULES IMPORTABLE')
+          "
+
+      - name: Task - Deploy Webhook
+        if: github.event.inputs.task == 'deploy-webhook'
+        run: |
+          echo "Triggering webhook deployment..."
+          echo "::notice::Use the dedicated deploy-dialogflow-webhook workflow for full deployment"
+          # This is a placeholder - actual deployment uses dedicated workflow
+          python3 -c "from src.agents.dialogflow_webhook import app; print(f'Webhook app version: {app.version}')"
+
+      - name: Task - Custom Command
+        if: github.event.inputs.task == 'custom-command' && github.event.inputs.custom_command != ''
+        run: |
+          echo "Executing custom command..."
+          echo "Command: ${{ github.event.inputs.custom_command }}"
+          python3 -c "${{ github.event.inputs.custom_command }}"
+
+      - name: Summary
+        run: |
+          echo "## Task Execution Summary" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "- **Task**: ${{ github.event.inputs.task }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Triggered by**: ${{ github.actor }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Timestamp**: $(date -u +"%Y-%m-%d %H:%M:%S UTC")" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "Task completed. Check logs above for details." >> $GITHUB_STEP_SUMMARY

--- a/data/system_state.json
+++ b/data/system_state.json
@@ -2,10 +2,10 @@
   "meta": {
     "version": "1.0",
     "created": "2025-10-29T09:35:00",
-    "last_updated": "2026-01-07T03:36:07.583443",
+    "last_updated": "2026-01-07T14:16:59.577199",
     "last_audit": "2026-01-06T16:38:45",
     "audit_notes": "Updated after trades synced - Jan 6 2026 paper trades executed",
-    "last_sync": "2026-01-07T03:36:07.583450",
+    "last_sync": "2026-01-07T14:16:59.577209",
     "sync_mode": "skipped_no_keys"
   },
   "challenge": {

--- a/scripts/trigger_ci_task.py
+++ b/scripts/trigger_ci_task.py
@@ -1,0 +1,238 @@
+#!/usr/bin/env python3
+"""
+Trigger CI Tasks from Sandbox
+
+CEO Directive (Jan 7, 2026): "Don't tell me sandbox can't do it, create CI workflows"
+
+This script allows Claude to trigger GitHub Actions workflows from the sandbox
+to accomplish tasks that cannot be done locally (tests, RAG sync, etc.)
+
+Usage:
+    python3 scripts/trigger_ci_task.py --task run-tests
+    python3 scripts/trigger_ci_task.py --task verify-rag
+    python3 scripts/trigger_ci_task.py --task sync-trades-to-rag
+    python3 scripts/trigger_ci_task.py --task system-health-check
+
+Or via curl:
+    curl -X POST \
+      -H "Authorization: token $GITHUB_TOKEN" \
+      -H "Accept: application/vnd.github.v3+json" \
+      https://api.github.com/repos/IgorGanapolsky/trading/actions/workflows/claude-agent-utility.yml/dispatches \
+      -d '{"ref":"main","inputs":{"task":"run-tests"}}'
+"""
+
+import argparse
+import json
+import os
+import sys
+import time
+import urllib.request
+import urllib.error
+
+# Configuration
+REPO_OWNER = "IgorGanapolsky"
+REPO_NAME = "trading"
+WORKFLOW_FILE = "claude-agent-utility.yml"
+
+VALID_TASKS = [
+    "run-tests",
+    "run-lint",
+    "verify-rag",
+    "sync-trades-to-rag",
+    "system-health-check",
+    "verify-chromadb",
+    "dry-run-trading",
+    "deploy-webhook",
+    "custom-command",
+]
+
+
+def get_github_token() -> str | None:
+    """Get GitHub token from environment."""
+    return os.environ.get("GITHUB_TOKEN") or os.environ.get("GH_TOKEN")
+
+
+def trigger_workflow(
+    task: str,
+    token: str,
+    ref: str = "main",
+    custom_command: str = "",
+    test_pattern: str = "tests/",
+    verbose: bool = True,
+) -> dict:
+    """Trigger the claude-agent-utility workflow via GitHub API."""
+    url = f"https://api.github.com/repos/{REPO_OWNER}/{REPO_NAME}/actions/workflows/{WORKFLOW_FILE}/dispatches"
+
+    payload = {
+        "ref": ref,
+        "inputs": {
+            "task": task,
+            "custom_command": custom_command,
+            "test_pattern": test_pattern,
+            "verbose": str(verbose).lower(),
+        },
+    }
+
+    headers = {
+        "Authorization": f"token {token}",
+        "Accept": "application/vnd.github.v3+json",
+        "Content-Type": "application/json",
+    }
+
+    data = json.dumps(payload).encode("utf-8")
+    req = urllib.request.Request(url, data=data, headers=headers, method="POST")
+
+    try:
+        with urllib.request.urlopen(req, timeout=30) as response:  # noqa: S310
+            # 204 No Content is success for this endpoint
+            return {"success": True, "status": response.status}
+    except urllib.error.HTTPError as e:
+        error_body = e.read().decode("utf-8") if e.fp else ""
+        return {"success": False, "status": e.code, "error": error_body}
+    except urllib.error.URLError as e:
+        return {"success": False, "error": str(e)}
+
+
+def get_latest_run(token: str, wait_for_new: bool = True) -> dict | None:
+    """Get the latest workflow run status."""
+    url = f"https://api.github.com/repos/{REPO_OWNER}/{REPO_NAME}/actions/workflows/{WORKFLOW_FILE}/runs?per_page=1"
+
+    headers = {
+        "Authorization": f"token {token}",
+        "Accept": "application/vnd.github.v3+json",
+    }
+
+    req = urllib.request.Request(url, headers=headers)
+
+    try:
+        with urllib.request.urlopen(req, timeout=30) as response:  # noqa: S310
+            data = json.loads(response.read().decode("utf-8"))
+            runs = data.get("workflow_runs", [])
+            if runs:
+                return runs[0]
+    except Exception as e:
+        print(f"Error fetching run status: {e}")
+
+    return None
+
+
+def wait_for_completion(token: str, timeout: int = 600) -> dict:
+    """Wait for the triggered workflow to complete."""
+    print("Waiting for workflow to start...")
+    time.sleep(5)  # Give it time to start
+
+    start_time = time.time()
+    last_status = None
+
+    while time.time() - start_time < timeout:
+        run = get_latest_run(token)
+        if run:
+            status = run.get("status")
+            conclusion = run.get("conclusion")
+
+            if status != last_status:
+                print(f"  Status: {status} | Conclusion: {conclusion or 'pending'}")
+                last_status = status
+
+            if status == "completed":
+                return {
+                    "completed": True,
+                    "conclusion": conclusion,
+                    "run_id": run.get("id"),
+                    "html_url": run.get("html_url"),
+                }
+
+        time.sleep(10)
+
+    return {"completed": False, "error": "Timeout waiting for completion"}
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Trigger CI tasks from sandbox",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__,
+    )
+    parser.add_argument(
+        "--task",
+        required=True,
+        choices=VALID_TASKS,
+        help="Task to execute",
+    )
+    parser.add_argument(
+        "--token",
+        help="GitHub token (or set GITHUB_TOKEN env var)",
+    )
+    parser.add_argument(
+        "--ref",
+        default="main",
+        help="Git ref to run on (default: main)",
+    )
+    parser.add_argument(
+        "--custom-command",
+        default="",
+        help="Custom Python command (for custom-command task)",
+    )
+    parser.add_argument(
+        "--test-pattern",
+        default="tests/",
+        help="Test pattern for pytest (default: tests/)",
+    )
+    parser.add_argument(
+        "--wait",
+        action="store_true",
+        help="Wait for workflow completion",
+    )
+    parser.add_argument(
+        "--timeout",
+        type=int,
+        default=600,
+        help="Timeout in seconds when waiting (default: 600)",
+    )
+
+    args = parser.parse_args()
+
+    # Get token
+    token = args.token or get_github_token()
+    if not token:
+        print("Error: GitHub token required. Set GITHUB_TOKEN or use --token")
+        sys.exit(1)
+
+    print(f"Triggering task: {args.task}")
+    print(f"Repository: {REPO_OWNER}/{REPO_NAME}")
+    print(f"Ref: {args.ref}")
+
+    # Trigger workflow
+    result = trigger_workflow(
+        task=args.task,
+        token=token,
+        ref=args.ref,
+        custom_command=args.custom_command,
+        test_pattern=args.test_pattern,
+    )
+
+    if result.get("success"):
+        print(f"Workflow triggered successfully (HTTP {result.get('status', 204)})")
+
+        if args.wait:
+            print("\nWaiting for completion...")
+            completion = wait_for_completion(token, args.timeout)
+
+            if completion.get("completed"):
+                conclusion = completion.get("conclusion")
+                print(f"\nWorkflow completed: {conclusion}")
+                print(f"Run URL: {completion.get('html_url')}")
+                sys.exit(0 if conclusion == "success" else 1)
+            else:
+                print(f"\nWorkflow did not complete: {completion.get('error')}")
+                sys.exit(1)
+        else:
+            print("\nTo monitor progress:")
+            print(f"  https://github.com/{REPO_OWNER}/{REPO_NAME}/actions")
+    else:
+        print(f"Failed to trigger workflow: {result.get('error')}")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## CEO Directive (Jan 7, 2026)
> "Don't tell me sandbox can't do it, create CI workflows"

## What this adds
1. **claude-agent-utility.yml** - workflow_dispatch workflow with tasks:
   - run-tests
   - run-lint
   - verify-rag
   - sync-trades-to-rag
   - system-health-check
   - verify-chromadb
   - dry-run-trading
   - custom-command

2. **trigger_ci_task.py** - Helper to trigger via API

## Usage
```bash
curl -X POST -H "Authorization: token $PAT" \
  https://api.github.com/repos/IgorGanapolsky/trading/actions/workflows/claude-agent-utility.yml/dispatches \
  -d '{"ref":"main","inputs":{"task":"run-tests"}}''```