### PR TITLE
docs: Add LL-093 automation stale incident + fix system state

### DIFF
--- a/data/system_state.json
+++ b/data/system_state.json
@@ -529,14 +529,18 @@
   "automation": {
     "github_actions_enabled": true,
     "workflow_name": "Daily Trading Execution",
-    "workflow_status": "OPERATIONAL",
+    "workflow_status": "NEEDS_VERIFICATION",
+    "workflow_status_reason": "Jan 7 2026: No trades_2026-01-07.json file exists - automation may not be creating trade files",
     "last_execution_attempt": "2025-12-16T19:27:00.000000",
+    "last_execution_attempt_note": "WARNING: This timestamp is stale (3+ weeks old) - not being updated by workflow",
     "last_successful_execution": "2025-12-15T18:18:15.595991",
     "execution_count": 3,
     "failures": 0,
     "failure_reasons": [],
     "fix_applied": "2025-12-16: Fixed stale automation metadata, manually triggered combined-trading workflow",
-    "next_scheduled_execution": "2025-12-17T09:35:00"
+    "next_scheduled_execution": "2025-12-17T09:35:00",
+    "incident_jan07_2026": "No trade file created today despite workflow being scheduled. Jan 6 trades were MANUAL triggers.",
+    "verification_needed": "Check GitHub Actions logs to see if daily-trading workflow actually executed and what blocked trade file creation"
   },
   "video_analysis": {
     "enabled": true,

--- a/rag_knowledge/lessons_learned/ll_093_automation_metadata_stale_jan07.md
+++ b/rag_knowledge/lessons_learned/ll_093_automation_metadata_stale_jan07.md
@@ -1,0 +1,62 @@
+# Lesson Learned #093: Automation Metadata Stale - No Trades Executed Jan 7
+
+**Date**: January 7, 2026
+**Severity**: CRITICAL
+**Category**: Automation, Trading System, Verification
+
+## Incident Summary
+
+CEO asked why paper trading didn't execute today. Investigation revealed:
+- No `trades_2026-01-07.json` file exists
+- `automation.last_execution_attempt` shows `2025-12-16` (3+ weeks stale)
+- Jan 6 trades were from MANUAL triggers, not scheduled automation
+
+## Evidence
+
+```
+File: trades_2026-01-07.json → DOES NOT EXIST
+automation.last_execution_attempt: 2025-12-16 (STALE)
+automation.next_scheduled_execution: 2025-12-17 (IN THE PAST)
+paper_account.last_sync: 2026-01-06T17:27:00 (CEO screenshot, manual)
+Jan 6 trades source: immediate-trade workflow + test_sync (MANUAL)
+```
+
+## Root Cause
+
+The `automation` metadata in `system_state.json` is NOT being updated by the daily-trading GitHub Actions workflow. This created a false sense of automation being operational.
+
+## What Went Wrong
+
+1. **Assumption**: Assumed scheduled workflow was executing and recording trades
+2. **Reality**: The workflow may run, but isn't updating system_state.json or creating trade files
+3. **Verification Gap**: Did not verify trade file existence AFTER workflow supposedly ran
+
+## Corrective Actions
+
+1. Daily-trading workflow MUST:
+   - Create `trades_YYYY-MM-DD.json` file
+   - Update `automation.last_execution_attempt` timestamp
+   - Update `automation.next_scheduled_execution` timestamp
+
+2. Session start verification MUST check:
+   - Trade file exists for previous trading day
+   - `automation.last_execution_attempt` is recent (< 2 trading days)
+
+3. Never claim automation is working without:
+   - Trade file evidence from today/yesterday
+   - Fresh automation timestamps
+
+## Never Again
+
+- NEVER assume scheduled automation ran without checking trade files
+- NEVER claim "system ready" when automation metadata is 3+ weeks old
+- ALWAYS verify trade file creation, not just workflow trigger
+
+## Related Lessons
+
+- LL-092: Compounding strategy mandatory
+- LL-074: ChromaDB must be verified
+
+## Tags
+
+automation, stale_data, verification, trading_system, incident_jan07


### PR DESCRIPTION
## Summary

- Created LL-093: Automation metadata stale - no trades executed Jan 7
- Updated system_state.json automation status to NEEDS_VERIFICATION
- Added warnings about 3+ week stale timestamps

## Test Plan

- [x] Verify LL-093 is correctly formatted
- [x] Check system_state.json has warnings