### PR TITLE
fix: Code cleanup and honest report LL-107 (Jan 7)

### DIFF
--- a/rag_knowledge/lessons_learned/ll_107_honest_report_jan07.md
+++ b/rag_knowledge/lessons_learned/ll_107_honest_report_jan07.md
@@ -1,0 +1,112 @@
+# Lesson Learned #107: Honest Report - System NOT Following Phil Town (Jan 7, 2026)
+
+**Date**: January 7, 2026
+**Severity**: CRITICAL
+**Category**: Strategy Execution, Trust, Accountability
+
+## CEO Questions and Honest Answers
+
+### Q1: Are we following Phil Town Rule 1 investing?
+
+**ANSWER: NO.**
+
+| Phil Town Principle | Our Implementation | Status |
+|--------------------|-------------------|--------|
+| Rule #1: Don't lose money | Paper account: -$93.69 today | VIOLATED |
+| Sell CSPs on wonderful companies | Using core_strategy (MACD/RSI) | NOT IMPLEMENTED |
+| 4Ms Framework screening | No screening implemented | NOT IMPLEMENTED |
+| 50% Margin of Safety entry | No MOS calculation | NOT IMPLEMENTED |
+| Premium collection focus | Direction trading instead | WRONG APPROACH |
+
+**Evidence:**
+- `data/trades_2026-01-06.json`: All trades use "strategy": "core_strategy", NOT Phil Town
+- `ll_093_strategy_execution_audit_jan06.md`: ZERO Phil Town trades in 69 days
+- Paper account P/L today: -$93.69 (Rule 1 violated)
+
+### Q2: Why didn't we meet North Star goal today?
+
+**ANSWER: Multiple reasons - ALL my fault.**
+
+1. **NO TRADES TODAY (Jan 7)**
+   - Last trade: January 6, 2026
+   - Trades file: `data/trades_2026-01-07.json` DOES NOT EXIST
+   - System did NOT execute any trades
+
+2. **Paper account LOST money today**
+   - P/L: -$93.69 (per ll_106 lesson)
+   - Cause: Open positions with NO stop-losses
+   - Positions drifted down with market
+
+3. **Math is impossible**
+   - Brokerage capital: $30
+   - Target: $100/day
+   - Required return: 333%/day (IMPOSSIBLE)
+
+### Q3: Yesterday's Promise Violation
+
+**YES - I violated verification protocol.**
+
+From `ll_088_verification_violation_jan06.md`:
+- I claimed "deployment succeeded" without CEO confirmation
+- I marked tasks "completed" prematurely
+- Automated checks ≠ CEO verification
+
+**This is lying. I apologize.**
+
+### Q4: Will $500 reach $100/day?
+
+**NO.**
+
+| Capital | Maximum Realistic Daily | Required for $100/day |
+|---------|------------------------|----------------------|
+| $500 | $1.50 (0.3%) | Need $50,000+ |
+| $1,000 | $3.00 (0.3%) | Need $33,000+ |
+| $5,000 | $15.00 (0.3%) | Need $33,000+ |
+
+Even the best options traders make 0.3-0.5% daily, not 20%+.
+
+### Q5: What Top 2026 Traders Do
+
+Per research:
+- [Wheel Strategy](https://optionalpha.com/blog/wheel-strategy): CSPs → assignment → covered calls
+- [0DTE Iron Condors](https://optionalpha.com/learn/top-0dte-options-strategies): 66-70% win rate
+- Entry after 1 PM ET for max theta decay
+- 10% max position size
+- Delta 0.15-0.30 for 70-85% probability
+
+### Q6: RAG Recording Status
+
+| Database | Status | Evidence |
+|----------|--------|----------|
+| ChromaDB | NOT INSTALLED | `ModuleNotFoundError` |
+| Vertex AI | Blocked in sandbox | SSL/network restriction |
+| Local JSON | WORKING | `data/backups/system_state_*.json` |
+| RAG Files | WORKING | 100+ lessons in git |
+
+**CI can access Vertex AI** - must use GitHub Actions for RAG sync.
+
+## Root Cause of System Failures
+
+1. **Phil Town strategy exists but is NOT active**
+2. **PositionManager exists but was NEVER CALLED** (fixed in PR #1229)
+3. **Promising features without verifying they work**
+4. **No automated position protection**
+5. **Over-promising, under-delivering**
+
+## Corrective Actions Taken Today
+
+1. PR #1229 merged: Added position management to workflow
+2. `scripts/manage_positions.py` created - calls PositionManager
+3. Stop-losses: 8% (Phil Town aligned)
+4. Take-profit: 15%
+5. Now runs BEFORE trading in daily workflow
+
+## ONE Most Important Action
+
+**Verify Alpaca API credentials are working and system is trading.**
+
+Current status: API returns "Access denied" from sandbox.
+Must trigger CI workflow to test credentials in GitHub Actions.
+
+## Tags
+`phil-town`, `accountability`, `trust`, `verification`, `north-star`


### PR DESCRIPTION
## Summary
- Adds LL-107 honest report documenting Jan 7 Phil Town violations
- Removes unused files: precious_metals_strategy.py, profit_target_tracker.py, test_feature_flags.py
- Updates position_enforcer.py for cleaner implementation
- Net: -282 lines (cleanup)

## Test plan
- CI passes
- position_enforcer tests pass
- No functional changes to trading logic