### PR TITLE
fix(lint): Fix ruff linting errors for CI

### DIFF
--- a/scripts/manage_positions.py
+++ b/scripts/manage_positions.py
@@ -50,7 +50,6 @@ def main(dry_run: bool = False):
         from src.risk.position_manager import (
             ExitConditions,
             PositionManager,
-            PositionInfo,
         )
     except ImportError as e:
         logger.error(f"Cannot import PositionManager: {e}")

--- a/src/analytics/profit_target_tracker.py
+++ b/src/analytics/profit_target_tracker.py
@@ -39,7 +39,7 @@ class ProfitTargetTracker:
             account = trader.get_account_info()
             # Calculate today's P/L
             current_profit = float(account.get("unrealized_pl", 0) or 0)
-            
+
             return ProfitTargetResult(
                 daily_target=self.daily_target,
                 current_profit=current_profit,

--- a/src/strategies/precious_metals_strategy.py
+++ b/src/strategies/precious_metals_strategy.py
@@ -44,6 +44,6 @@ class PreciousMetalsStrategy:
                 "trades_executed": 0,
                 "reason": "Strategy disabled"
             }
-        
+
         # TODO: Implement actual trading logic when enabled
         return {"success": True, "trades_executed": 0}

--- a/tests/test_feature_flags.py
+++ b/tests/test_feature_flags.py
@@ -13,8 +13,9 @@ These tests verify that feature flags:
 """
 
 import os
-import pytest
 from unittest.mock import patch
+
+import pytest
 
 
 class TestFeatureFlagsDefaults:
@@ -32,8 +33,8 @@ class TestFeatureFlagsDefaults:
             os.environ.pop("ENABLE_REIT_STRATEGY", None)
 
             # Import after clearing env to get fresh state
-            from importlib import reload
             import scripts.autonomous_trader as trader
+            from importlib import reload
             reload(trader)
 
             # CRITICAL: Must be False by default
@@ -47,8 +48,8 @@ class TestFeatureFlagsDefaults:
         with patch.dict(os.environ, {}, clear=True):
             os.environ.pop("ENABLE_PRECIOUS_METALS", None)
 
-            from importlib import reload
             import scripts.autonomous_trader as trader
+            from importlib import reload
             reload(trader)
 
             assert trader.precious_metals_enabled() is False, (
@@ -70,8 +71,8 @@ class TestFeatureFlagsEnvOverride:
     def test_reit_enabled_via_env(self, value):
         """REIT can be enabled via environment variable."""
         with patch.dict(os.environ, {"ENABLE_REIT_STRATEGY": value}):
-            from importlib import reload
             import scripts.autonomous_trader as trader
+            from importlib import reload
             reload(trader)
 
             assert trader.reit_enabled() is True, (
@@ -82,8 +83,8 @@ class TestFeatureFlagsEnvOverride:
     def test_reit_disabled_via_env(self, value):
         """REIT stays disabled with falsy values."""
         with patch.dict(os.environ, {"ENABLE_REIT_STRATEGY": value}):
-            from importlib import reload
             import scripts.autonomous_trader as trader
+            from importlib import reload
             reload(trader)
 
             assert trader.reit_enabled() is False, (
@@ -94,8 +95,8 @@ class TestFeatureFlagsEnvOverride:
     def test_precious_metals_enabled_via_env(self, value):
         """Precious Metals can be enabled via environment variable."""
         with patch.dict(os.environ, {"ENABLE_PRECIOUS_METALS": value}):
-            from importlib import reload
             import scripts.autonomous_trader as trader
+            from importlib import reload
             reload(trader)
 
             assert trader.precious_metals_enabled() is True, (
@@ -111,8 +112,8 @@ class TestFeatureFlagsIntegration:
         with patch.dict(os.environ, {}, clear=True):
             os.environ.pop("ENABLE_REIT_STRATEGY", None)
 
-            from importlib import reload
             import scripts.autonomous_trader as trader
+            from importlib import reload
             reload(trader)
 
             # Verify disabled

--- a/tests/test_manage_positions.py
+++ b/tests/test_manage_positions.py
@@ -9,9 +9,6 @@ This tests the position management script that enforces stop-losses.
 
 import sys
 from pathlib import Path
-from unittest.mock import MagicMock, patch
-
-import pytest
 
 # Add src to path
 sys.path.insert(0, str(Path(__file__).parent.parent))
@@ -47,13 +44,14 @@ class TestManagePositions:
 
     def test_stop_loss_triggers(self):
         """Test that stop-loss correctly triggers on losing position."""
+        from datetime import datetime
+
         from src.risk.position_manager import (
             ExitConditions,
             ExitReason,
             PositionInfo,
             PositionManager,
         )
-        from datetime import datetime
 
         conditions = ExitConditions(stop_loss_pct=0.08)
         manager = PositionManager(conditions=conditions)
@@ -77,13 +75,14 @@ class TestManagePositions:
 
     def test_take_profit_triggers(self):
         """Test that take-profit correctly triggers on winning position."""
+        from datetime import datetime
+
         from src.risk.position_manager import (
             ExitConditions,
             ExitReason,
             PositionInfo,
             PositionManager,
         )
-        from datetime import datetime
 
         conditions = ExitConditions(take_profit_pct=0.15)
         manager = PositionManager(conditions=conditions)
@@ -107,12 +106,13 @@ class TestManagePositions:
 
     def test_hold_when_no_exit_condition(self):
         """Test that position is held when no exit conditions met."""
+        from datetime import datetime
+
         from src.risk.position_manager import (
             ExitConditions,
             PositionInfo,
             PositionManager,
         )
-        from datetime import datetime
 
         conditions = ExitConditions(stop_loss_pct=0.08, take_profit_pct=0.15)
         manager = PositionManager(conditions=conditions)

--- a/tests/test_position_enforcer.py
+++ b/tests/test_position_enforcer.py
@@ -5,8 +5,7 @@ Created: Jan 7, 2026
 Purpose: 100% test coverage for position_enforcer.py
 """
 
-import pytest
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 from src.safety.position_enforcer import (
     EnforcementResult,


### PR DESCRIPTION
## Summary
- Remove unused imports (pytest, patch, MagicMock, PositionInfo)
- Fix import sorting (I001) in test files
- Remove trailing whitespace (W293)
- Reorder stdlib imports before local imports

## Test plan
- CI Lint & Format job should pass