### PR TITLE
fix(docs): Add relative_url filter to fix GitHub Pages links

### DIFF
--- a/docs/RETROSPECTIVE.md
+++ b/docs/RETROSPECTIVE.md
@@ -59,7 +59,7 @@ feat: Add world's simplest learning system (~250 lines)
 
 We built a beautiful RAG system with ChromaDB, 400+ vectorized chunks, semantic search... and then **never actually queried it**.
 
-From [LL-054](/rag_knowledge/lessons_learned/ll_054_rag_not_actually_used_dec17.md):
+From [LL-054](https://github.com/IgorGanapolsky/trading/blob/main/rag_knowledge/lessons_learned/ll_054_rag_not_actually_used_dec17.md):
 > "The RAG system exists but is not integrated into any decision-making process. We have knowledge but don't use it."
 
 ### The Friday Problem
@@ -243,7 +243,7 @@ trading/
 ## Connect
 
 - **GitHub**: [IgorGanapolsky/trading](https://github.com/IgorGanapolsky/trading)
-- **llms.txt**: [/llms.txt](/llms.txt) - For AI agents
+- **llms.txt**: [/llms.txt]({{ '/llms.txt' | relative_url }}) - For AI agents
 - **Issues**: Open an issue if you have questions
 
 ---

--- a/docs/index.md
+++ b/docs/index.md
@@ -96,7 +96,7 @@ Building an autonomous AI trading system with Claude Opus 4.5.
 - **{{ lesson.date | date: "%b %d" }}**: [{{ lesson.title }}]({{ lesson.url | relative_url }})
 {% endfor %}
 
-[View All 90+ Lessons](/lessons/)
+[View All 90+ Lessons]({{ '/lessons/' | relative_url }})
 
 ---
 
@@ -107,7 +107,7 @@ Building an autonomous AI trading system with Claude Opus 4.5.
 - **{{ report.date | date: "%b %d" }}**: [{{ report.title }}]({{ report.url | relative_url }})
 {% endfor %}
 
-[View All Reports](/reports/)
+[View All Reports]({{ '/reports/' | relative_url }})
 
 ---
 
@@ -120,9 +120,9 @@ If you're an AI agent exploring this codebase: [/llms.txt](https://raw.githubuse
 ## Links
 
 - [Full Dashboard (Wiki)](https://github.com/IgorGanapolsky/trading/wiki/Progress-Dashboard)
-- [50-Day Retrospective](/RETROSPECTIVE/)
+- [50-Day Retrospective]({{ '/RETROSPECTIVE/' | relative_url }})
 - [GitHub Repository](https://github.com/IgorGanapolsky/trading)
-- [RSS Feed](/feed.xml)
+- [RSS Feed]({{ '/feed.xml' | relative_url }})
 
 ---
 


### PR DESCRIPTION
## Summary

- Fix broken internal links causing deploy-pages workflow to fail
- Links were missing /trading/ baseurl prefix
- This is why GitHub Pages shows Day 69 instead of Day 70

## Test Plan

- [ ] deploy-pages workflow succeeds
- [ ] GitHub Pages shows Day 70/90