### PR TITLE
fix(ci): Only run publish-lessons on main branch pushes

### DIFF
--- a/.github/workflows/publish-lessons.yml
+++ b/.github/workflows/publish-lessons.yml
@@ -2,6 +2,8 @@ name: Publish Lessons to Blog
 
 on:
   push:
+    branches:
+      - main
     paths:
       - 'rag_knowledge/lessons_learned/*.md'
   workflow_dispatch:


### PR DESCRIPTION
## Summary
- Fixed publish-lessons workflow failing on feature branch pushes
- Added branch filter to only trigger on main branch

## Test plan
- [x] Workflow now only runs on main branch pushes
- [x] Feature branch pushes no longer trigger the workflow