### PR TITLE
chore: Update paper account to $5,000 (CEO reset complete)

### DIFF
--- a/data/system_state.json
+++ b/data/system_state.json
@@ -132,34 +132,25 @@
   },
   "paper_account": {
     "type": "paper",
-    "purpose": "Test Phil Town Rule #1 strategies before live deployment",
-    "CRITICAL_WARNING": "INVALID SIMULATION - $100k paper tests strategies impossible with real capital",
-    "simulation_mismatch": {
-      "paper_capital": 100000,
-      "recommended_paper_capital": 5000,
-      "real_target_capital": 500,
-      "mismatch_ratio": "20x (should be testing at $5k, not $100k)",
-      "invalid_strategies_tested": ["AMD $200 CSPs", "SPY $660 CSPs", "INTC $35 CSPs"],
-      "valid_strategies_at_5000": ["CSPs on stocks with strike ≤$50", "1-2 positions max"],
-      "recommendation": "Reset Alpaca paper to $5,000 - realistic 6-month milestone",
-      "how_to_reset": "Alpaca Dashboard → Account → Reset Account → Set balance to $5,000",
-      "lesson_learned": "rag_knowledge/lessons_learned/ll_111_paper_capital_must_match_real_jan07.md"
-    },
-    "starting_balance": 100000.0,
-    "current_equity": 117967.66,
-    "cash": 92704.96,
-    "positions_value": 25262.7,
-    "total_pl": 17967.66,
-    "total_pl_pct": 17.97,
-    "buying_power": 209600.0,
-    "positions_count": 4,
-    "win_rate": 80.0,
-    "win_rate_sample_size": 5,
-    "win_rate_warning": "STATISTICALLY INSIGNIFICANT - Only 5 closed trades. Need 30+ for confidence.",
-    "last_sync": "2026-01-07T10:50:00",
-    "sync_source": "CEO screenshot Jan 7 2026 10:50 AM ET",
-    "todays_pl": 16661.2,
-    "todays_pl_pct": 16.45,
+    "purpose": "Test Phil Town Rule #1 strategies - REALISTIC capital for CSP testing",
+    "RESET_COMPLETED": "CEO reset paper account Jan 7 2026 - now matches brokerage strategy",
+    "simulation_mismatch": "RESOLVED - Paper now at $5K matching 6-month brokerage milestone",
+    "starting_balance": 5000.0,
+    "current_equity": 5000.0,
+    "cash": 5000.0,
+    "positions_value": 0.0,
+    "total_pl": 0.0,
+    "total_pl_pct": 0.0,
+    "buying_power": 5000.0,
+    "positions_count": 0,
+    "win_rate": 0.0,
+    "win_rate_sample_size": 0,
+    "win_rate_warning": "FRESH START - Build 30+ trade track record at realistic capital level",
+    "last_sync": "2026-01-07T22:11:00",
+    "sync_source": "CEO reset paper account Jan 7 2026",
+    "todays_pl": 0.0,
+    "todays_pl_pct": 0.0,
+    "reset_note": "Jan 7 2026: Reset from $100K to $5K for REALISTIC CSP testing matching brokerage strategy",
     "phil_town_strategy": {
       "enabled": true,
       "purpose": "Validate Phil Town Rule #1 approach before live trading",
@@ -275,48 +266,8 @@
         "tier": "unknown"
       }
     ],
-    "open_positions": [
-      {
-        "symbol": "SPY",
-        "price": 685.03,
-        "quantity": 21.62,
-        "market_value": 14810.93,
-        "unrealized_pl": 74.6,
-        "side": "long"
-      },
-      {
-        "symbol": "INTC260109P00035000",
-        "price": 0.06,
-        "quantity": -2,
-        "market_value": -12.0,
-        "unrealized_pl": 151.0,
-        "side": "short"
-      },
-      {
-        "symbol": "SOFI260123P00024000",
-        "price": 0.23,
-        "quantity": -1,
-        "market_value": -23.0,
-        "unrealized_pl": 56.0,
-        "side": "short"
-      },
-      {
-        "symbol": "AMD260116P00200000",
-        "price": 1.33,
-        "quantity": -1,
-        "market_value": -133.0,
-        "unrealized_pl": 457.0,
-        "side": "short"
-      },
-      {
-        "symbol": "SPY260123P00660000",
-        "price": 1.89,
-        "quantity": -1,
-        "market_value": -189.0,
-        "unrealized_pl": 449.0,
-        "side": "short"
-      }
-    ],
+    "open_positions": [],
+    "open_positions_note": "Jan 7 2026: Paper account RESET to $5,000 - all positions closed",
     "_win_rate_source": "calculated_from_closed_trades",
     "_win_rate_fixed_at": "2025-12-31T02:57:09.901650"
   },


### PR DESCRIPTION
## Summary
CEO reset Alpaca paper trading from $100K to $5K for realistic CSP testing.

## Changes
- starting_balance: $100,000 → $5,000
- current_equity: $117,967 → $5,000
- positions_count: 4 → 0 (all positions closed)
- total_pl: 17.97% → 0% (fresh start)
- RESET_COMPLETED flag added
- simulation_mismatch: RESOLVED

## Why
This resolves the capital mismatch identified in LL-111. Paper account now matches 6-month brokerage milestone for realistic CSP testing at $5K capital tier.