### PR TITLE
fix(lint): Fix import sorting and remove unused imports

### DIFF
--- a/mcp/client.py
+++ b/mcp/client.py
@@ -170,7 +170,7 @@ def get_alpaca_trader(paper: bool = True) -> AlpacaTrader:
 import asyncio
 import logging
 from enum import Enum
-from typing import Callable, TypeVar
+from typing import TypeVar
 
 logger = logging.getLogger(__name__)
 
@@ -398,8 +398,8 @@ class UnifiedMCPClient:
         timeout: int,
     ) -> dict[str, Any]:
         """Call an HTTP-based MCP server."""
-        import urllib.request
         import urllib.error
+        import urllib.request
 
         # Server endpoint mapping
         endpoints = {

--- a/tests/unit/test_budget_enforcement.py
+++ b/tests/unit/test_budget_enforcement.py
@@ -6,11 +6,11 @@ Verifies runtime budget enforcement prevents overspending.
 """
 
 import pytest
+
 from src.utils.model_selector import (
+    MODEL_REGISTRY,
     ModelSelector,
     ModelTier,
-    TaskComplexity,
-    MODEL_REGISTRY,
 )
 
 
@@ -195,7 +195,7 @@ class TestToolDefinitions:
 
     def test_tool_registry(self):
         """Test tool registry operations."""
-        from src.utils.tool_definitions import ToolRegistry, ToolDefinition
+        from src.utils.tool_definitions import ToolDefinition, ToolRegistry
 
         registry = ToolRegistry()
         tool = ToolDefinition(name="my_tool", description="Test")
@@ -244,7 +244,7 @@ class TestUnifiedMCPClient:
 
     def test_mcp_tool_result_failure(self):
         """Test MCPToolResult for failed calls."""
-        from mcp.client import MCPToolResult, MCPError
+        from mcp.client import MCPError, MCPToolResult
 
         result = MCPToolResult(
             success=False,


### PR DESCRIPTION
## Summary

Fixes lint errors introduced in PR #1261.

## Changes
- Remove unused TaskComplexity import from test_budget_enforcement.py (F401)
- Remove unused Callable import from mcp/client.py (F401)
- Sort imports alphabetically per ruff I001 requirements

## Test plan
- [x] Lint errors identified from CI annotations
- [ ] CI Lint & Format check passes