### PR TITLE
fix(risk): Add pre-market position protection to daily workflow

### DIFF
--- a/.claude/SESSION_START_CHECKLIST.md
+++ b/.claude/SESSION_START_CHECKLIST.md
@@ -25,12 +25,19 @@ This checklist ensures critical tasks are reviewed at the start of each session.
 - [ ] Convert significant diary entries to formal lessons using `/capture-learning`
 - [ ] Run `/reflect` to generate new rules from patterns
 
+### 4. Position Protection (Phil Town Rule #1)
+- [ ] Check trailing stops status: `python3 -c "import json; s=json.load(open('data/system_state.json')); print(s.get('trailing_stops', 'NOT CONFIGURED'))"`
+- [ ] If NOT CONFIGURED and positions exist, trigger CI: `set-trailing-stops` task
+- [ ] Verify all positions have stop-loss protection before market opens
+
 ## Deferred Items
 
 Track items that need follow-up but aren't blocking:
 
-1. *(Add deferred items here)*
+1. **URGENT (Jan 8, 2026)**: Trigger `set-trailing-stops` workflow before 9:30 AM ET
+   - 5 positions with $1,187.60 unrealized gains currently UNPROTECTED
+   - Command: `gh workflow run claude-agent-utility.yml -f task=set-trailing-stops`
 
 ---
 
-*Last updated: December 29, 2025*
+*Last updated: January 7, 2026*

--- a/.github/workflows/daily-trading.yml
+++ b/.github/workflows/daily-trading.yml
@@ -242,11 +242,54 @@ jobs:
           path: data/rag_pretrade_advice.json
           retention-days: 7
 
+  # ========================================================================
+  # PRE-MARKET POSITION PROTECTION (Phil Town Rule #1)
+  # CEO Directive (Jan 7, 2026): "Losing money is NOT allowed"
+  # This runs BEFORE any new trades to protect existing positions
+  # ========================================================================
+  protect-existing-positions:
+    name: Set Trailing Stops on Existing Positions
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    needs: [validate-and-test]
+    if: needs.validate-and-test.outputs.secrets_valid == 'true'
+    continue-on-error: true  # Don't block trading if stops can't be set
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+          cache: 'pip'
+
+      - name: Install dependencies
+        run: pip install alpaca-py
+
+      - name: Set Trailing Stop-Loss Orders
+        env:
+          ALPACA_API_KEY: ${{ github.event.inputs.trading_mode == 'live' && secrets.ALPACA_BROKERAGE_TRADING_API_KEY || secrets.ALPACA_PAPER_TRADING_API_KEY }}
+          ALPACA_SECRET_KEY: ${{ github.event.inputs.trading_mode == 'live' && secrets.ALPACA_BROKERAGE_TRADING_API_SECRET || secrets.ALPACA_PAPER_TRADING_API_SECRET }}
+          PAPER_TRADING: ${{ github.event.inputs.trading_mode != 'live' && 'true' || 'false' }}
+        run: |
+          echo "🛡️ ========================================"
+          echo "🛡️ PRE-MARKET POSITION PROTECTION"
+          echo "🛡️ Phil Town Rule #1: Don't Lose Money"
+          echo "🛡️ ========================================"
+          echo ""
+          echo "Setting trailing stops BEFORE any new trades..."
+          echo ""
+          python3 scripts/set_trailing_stops.py || {
+            echo "::warning::Could not set trailing stops - positions may be unprotected"
+          }
+
   # Main trading execution job
   execute-trading:
     runs-on: ubuntu-22.04  # Pinned Ubuntu version
     timeout-minutes: 30  # Increased to handle retries
-    needs: [validate-and-test, pretrade-rag-query]
+    needs: [validate-and-test, pretrade-rag-query, protect-existing-positions]
     if: needs.validate-and-test.outputs.secrets_valid == 'true'
     env:
       PYTHONPATH: ${{ github.workspace }}

--- a/rag_knowledge/lessons_learned/ll_112_premarket_position_protection_jan07.md
+++ b/rag_knowledge/lessons_learned/ll_112_premarket_position_protection_jan07.md
@@ -1,0 +1,56 @@
+# Lesson Learned #112: Pre-Market Position Protection Gap
+
+**Date**: January 7, 2026
+**Severity**: CRITICAL
+**Category**: Risk Management, Phil Town Rule #1
+
+## What Happened
+
+CEO review revealed 5 open positions with $1,187.60 in unrealized gains had **ZERO PROTECTION**:
+
+| Position | Unrealized P/L | Stop-Loss |
+|----------|----------------|-----------|
+| SPY | +$74.60 | NONE |
+| INTC260109P00035000 | +$151.00 | NONE |
+| SOFI260123P00024000 | +$56.00 | NONE |
+| AMD260116P00200000 | +$457.00 | NONE |
+| SPY260123P00660000 | +$449.00 | NONE |
+
+## Root Cause
+
+The `daily-trading.yml` workflow only set trailing stops **AFTER** trading activity.
+On days with no new trades, existing positions remained unprotected.
+
+## Evidence
+
+```bash
+$ python3 -c "import json; print(json.load(open('data/system_state.json')).get('trailing_stops', 'NOT CONFIGURED'))"
+NOT CONFIGURED
+```
+
+## Fix Applied
+
+Added `protect-existing-positions` job to `daily-trading.yml` that runs:
+- **BEFORE** any new trades (`needs: [validate-and-test]`)
+- At start of each trading day
+- Sets trailing stops on ALL existing positions
+
+Configuration:
+- Equities: 10% trailing stop
+- Options: 20% trailing stop (more volatile)
+
+## Prevention
+
+1. Session Start Checklist now includes position protection check
+2. Workflow runs protection BEFORE trading, not just after
+3. Added deferred item for manual trigger if needed
+
+## Phil Town Rule #1
+
+> "Rule #1: Don't Lose Money. Rule #2: Don't Forget Rule #1."
+
+A trade without a stop-loss is a hope, not a strategy.
+
+## Tags
+
+trailing-stops, risk-management, phil-town, position-protection, premarket


### PR DESCRIPTION
## Summary

- Add protect-existing-positions job to daily-trading.yml
- Sets trailing stops BEFORE any new trades
- Addresses Phil Town Rule #1 violation: positions had ZERO protection
- Update SESSION_START_CHECKLIST with protection checks
- Add lesson learned ll_112

## CEO Review Finding
5 positions with $1,187.60 unrealized gains were UNPROTECTED.

## Test plan
- [x] Workflow syntax validated
- [ ] Verify trailing stops set on paper account after workflow runs