### PR TITLE
fix(webhook): Use Cloud Build with --no-cache to fix deployment

### DIFF
--- a/.github/workflows/deploy-dialogflow-webhook.yml
+++ b/.github/workflows/deploy-dialogflow-webhook.yml
@@ -9,6 +9,7 @@ on:
       - 'src/rag/**'
       - 'rag_knowledge/lessons_learned/**'
       - 'Dockerfile.webhook'
+      - 'cloudbuild-webhook.yaml'
       - '.github/workflows/deploy-dialogflow-webhook.yml'
   workflow_dispatch:  # Manual trigger
 
@@ -41,34 +42,27 @@ jobs:
       - name: Prepare Dockerfile
         run: |
           cp Dockerfile.webhook Dockerfile
-          # Inject dynamic cache bust to force fresh Docker build
-          CACHE_BUST=$(date +%Y%m%d%H%M%S)
-          sed -i "s/CACHE_BUST=1/CACHE_BUST=$CACHE_BUST/" Dockerfile
-          echo "Cache bust value: $CACHE_BUST"
-          grep CACHE_BUST Dockerfile
-
-      - name: Deploy to Cloud Run (source-based)
-        run: |
-          # Show what files will be uploaded
-          echo "=== Files being uploaded (after .gcloudignore) ==="
+          echo "=== Dockerfile contents ==="
+          cat Dockerfile
+          echo ""
+          echo "=== Files to be uploaded ==="
           find . -type f ! -path './.git/*' | head -50
-          echo "=== Starting deployment ==="
-          gcloud run deploy ${{ env.SERVICE_NAME }} \
-            --source . \
-            --region ${{ env.REGION }} \
-            --platform managed \
-            --allow-unauthenticated \
-            --memory 512Mi \
-            --cpu 1 \
-            --min-instances 0 \
-            --max-instances 3 \
-            --timeout 60s \
-            --verbosity=debug \
-            --set-env-vars="BUILD_DATE=$(date +%Y%m%d%H%M%S)" 2>&1 || {
-              echo "=== Deployment failed, fetching Cloud Build logs ==="
-              BUILD_ID=$(gcloud builds list --limit=1 --format='value(id)' --filter="source.storageSource.bucket~trading")
+
+      - name: Build and Deploy with Cloud Build (no-cache)
+        run: |
+          # Use Cloud Build with explicit --no-cache to prevent stale images
+          SHORT_SHA=$(echo ${{ github.sha }} | cut -c1-7)
+          echo "Building with SHA: $SHORT_SHA"
+
+          gcloud builds submit \
+            --config=cloudbuild-webhook.yaml \
+            --substitutions=SHORT_SHA=$SHORT_SHA \
+            --project=${{ env.PROJECT_ID }} \
+            . 2>&1 || {
+              echo "=== Build failed, fetching Cloud Build logs ==="
+              BUILD_ID=$(gcloud builds list --limit=1 --format='value(id)' --project=${{ env.PROJECT_ID }})
               if [ -n "$BUILD_ID" ]; then
-                gcloud builds log $BUILD_ID --stream || true
+                gcloud builds log $BUILD_ID --project=${{ env.PROJECT_ID }} || true
               fi
               exit 1
             }

--- a/cloudbuild-webhook.yaml
+++ b/cloudbuild-webhook.yaml
@@ -1,0 +1,59 @@
+# Cloud Build configuration for Dialogflow Webhook
+# Forces --no-cache to prevent stale image deployments
+
+steps:
+  # Build Docker image with --no-cache to force fresh build
+  - name: 'gcr.io/cloud-builders/docker'
+    args:
+      - 'build'
+      - '--no-cache'
+      - '-t'
+      - 'us-central1-docker.pkg.dev/$PROJECT_ID/cloud-run-source-deploy/trading-dialogflow-webhook:$SHORT_SHA'
+      - '-t'
+      - 'us-central1-docker.pkg.dev/$PROJECT_ID/cloud-run-source-deploy/trading-dialogflow-webhook:latest'
+      - '-f'
+      - 'Dockerfile'
+      - '.'
+
+  # Push the image to Artifact Registry
+  - name: 'gcr.io/cloud-builders/docker'
+    args:
+      - 'push'
+      - '--all-tags'
+      - 'us-central1-docker.pkg.dev/$PROJECT_ID/cloud-run-source-deploy/trading-dialogflow-webhook'
+
+  # Deploy to Cloud Run
+  - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
+    entrypoint: 'gcloud'
+    args:
+      - 'run'
+      - 'deploy'
+      - 'trading-dialogflow-webhook'
+      - '--image'
+      - 'us-central1-docker.pkg.dev/$PROJECT_ID/cloud-run-source-deploy/trading-dialogflow-webhook:$SHORT_SHA'
+      - '--region'
+      - 'us-central1'
+      - '--platform'
+      - 'managed'
+      - '--allow-unauthenticated'
+      - '--memory'
+      - '512Mi'
+      - '--cpu'
+      - '1'
+      - '--min-instances'
+      - '0'
+      - '--max-instances'
+      - '3'
+      - '--timeout'
+      - '60s'
+
+images:
+  - 'us-central1-docker.pkg.dev/$PROJECT_ID/cloud-run-source-deploy/trading-dialogflow-webhook:$SHORT_SHA'
+  - 'us-central1-docker.pkg.dev/$PROJECT_ID/cloud-run-source-deploy/trading-dialogflow-webhook:latest'
+
+options:
+  logging: CLOUD_LOGGING_ONLY
+  dynamicSubstitutions: true
+
+substitutions:
+  _REGION: us-central1


### PR DESCRIPTION
## Summary
- Adds `cloudbuild-webhook.yaml` with explicit `--no-cache` flag
- Updates workflow to use `gcloud builds submit` instead of `--source`
- Uses explicit image tagging with SHORT_SHA for traceability

## Problem
Previous deployments were failing because Cloud Build was using cached Docker layers from old builds. The webhook remained at version 2.5.0 despite code changes.

## Solution
Force fresh Docker builds by using `docker build --no-cache` in the Cloud Build configuration.

## Test plan
- [ ] Merge and verify deployment workflow succeeds
- [ ] Verify webhook version is 2.8.0
- [ ] Verify Dialogflow shows correct readiness assessment