### PR TITLE
fix(webhook): Use local Docker build to bypass Cloud Build caching

### DIFF
--- a/.github/workflows/deploy-dialogflow-webhook.yml
+++ b/.github/workflows/deploy-dialogflow-webhook.yml
@@ -9,7 +9,6 @@ on:
       - 'src/rag/**'
       - 'rag_knowledge/lessons_learned/**'
       - 'Dockerfile.webhook'
-      - 'cloudbuild-webhook.yaml'
       - '.github/workflows/deploy-dialogflow-webhook.yml'
   workflow_dispatch:  # Manual trigger
 
@@ -39,33 +38,41 @@ jobs:
         with:
           project_id: ${{ env.PROJECT_ID }}
 
+      - name: Configure Docker auth
+        run: gcloud auth configure-docker ${{ env.REGION }}-docker.pkg.dev --quiet
+
       - name: Prepare Dockerfile
         run: |
           cp Dockerfile.webhook Dockerfile
-          echo "=== Dockerfile contents ==="
+          # Add timestamp to force Docker cache invalidation
+          echo "# Build timestamp: $(date -u +%Y%m%d%H%M%S)" >> Dockerfile
+          echo "=== Final Dockerfile ==="
           cat Dockerfile
-          echo ""
-          echo "=== Files to be uploaded ==="
-          find . -type f ! -path './.git/*' | head -50
 
-      - name: Build and Deploy with Cloud Build (no-cache)
+      - name: Build Docker image locally
         run: |
-          # Use Cloud Build with explicit --no-cache to prevent stale images
-          SHORT_SHA=$(echo ${{ github.sha }} | cut -c1-7)
-          echo "Building with SHA: $SHORT_SHA"
+          IMAGE=${{ env.REGION }}-docker.pkg.dev/${{ env.PROJECT_ID }}/cloud-run-source-deploy/${{ env.SERVICE_NAME }}:${{ github.sha }}
+          echo "Building image: $IMAGE"
+          docker build --no-cache -t $IMAGE -f Dockerfile .
 
-          gcloud builds submit \
-            --config=cloudbuild-webhook.yaml \
-            --substitutions=SHORT_SHA=$SHORT_SHA \
-            --project=${{ env.PROJECT_ID }} \
-            . 2>&1 || {
-              echo "=== Build failed, fetching Cloud Build logs ==="
-              BUILD_ID=$(gcloud builds list --limit=1 --format='value(id)' --project=${{ env.PROJECT_ID }})
-              if [ -n "$BUILD_ID" ]; then
-                gcloud builds log $BUILD_ID --project=${{ env.PROJECT_ID }} || true
-              fi
-              exit 1
-            }
+      - name: Push to Artifact Registry
+        run: |
+          IMAGE=${{ env.REGION }}-docker.pkg.dev/${{ env.PROJECT_ID }}/cloud-run-source-deploy/${{ env.SERVICE_NAME }}:${{ github.sha }}
+          docker push $IMAGE
+
+      - name: Deploy to Cloud Run
+        run: |
+          IMAGE=${{ env.REGION }}-docker.pkg.dev/${{ env.PROJECT_ID }}/cloud-run-source-deploy/${{ env.SERVICE_NAME }}:${{ github.sha }}
+          gcloud run deploy ${{ env.SERVICE_NAME }} \
+            --image $IMAGE \
+            --region ${{ env.REGION }} \
+            --platform managed \
+            --allow-unauthenticated \
+            --memory 512Mi \
+            --cpu 1 \
+            --min-instances 0 \
+            --max-instances 3 \
+            --timeout 60s
 
       - name: Get service URL
         run: |


### PR DESCRIPTION
## Summary
- Builds Docker image locally in GitHub Actions with --no-cache
- Pushes directly to Artifact Registry
- Deploys to Cloud Run using the specific image SHA

## Problem
Cloud Build caching was preventing fresh builds, causing stale version 2.5.0 to remain deployed.

## Solution
Use local Docker build in GitHub Actions, giving us full control over the build process.

## Test plan
- [ ] Merge and verify deployment succeeds
- [ ] Verify webhook version is 2.8.0