### PR TITLE
fix(webhook): Update .dockerignore to include files needed by webhook

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -37,7 +37,9 @@ htmlcov/
 
 # Documentation
 docs/
+# Exclude .md but keep lessons learned files for webhook
 *.md
+!rag_knowledge/lessons_learned/*.md
 README*
 LICENSE
 
@@ -56,7 +58,9 @@ docker-compose*.yml
 .env.*
 
 # Data and logs (mounted as volumes)
-data/
+# Exclude data dir but keep system_state.json for webhook
+data/*
+!data/system_state.json
 logs/
 *.log
 


### PR DESCRIPTION
## Summary
The Docker build was failing because .dockerignore was excluding files needed by the webhook.

## Changes
- Added exception for `data/system_state.json`
- Added exception for `rag_knowledge/lessons_learned/*.md`

## Test plan
- [ ] Merge and verify Docker build succeeds
- [ ] Verify webhook deploys with version 2.8.0