### PR TITLE
feat(security): Add ask/deny permission tiers for defense in depth

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -19,6 +19,28 @@
       "Bash(ls:*)",
       "Bash(wc:*)",
       "Skill"
+    ],
+    "ask": [
+      "Bash(git push:*)",
+      "Bash(git commit:*)",
+      "Bash(git rebase:*)",
+      "Bash(git reset:*)",
+      "Bash(git checkout -B:*)",
+      "Edit(.github/workflows/**)",
+      "Edit(.claude/settings.json)"
+    ],
+    "deny": [
+      "Bash(sudo:*)",
+      "Bash(rm -rf /:*)",
+      "Bash(rm -rf /*:*)",
+      "Bash(chmod 777:*)",
+      "Bash(git push --force:*)",
+      "Bash(git push -f:*)",
+      "Bash(curl|bash:*)",
+      "Bash(wget|bash:*)",
+      "Read(.env)",
+      "Edit(.env)",
+      "Edit(.git/**)"
     ]
   },
   "hooks": {


### PR DESCRIPTION
## Summary
- Implements all 3 Claude Code permission tiers (allow, ask, deny)
- Provides defense in depth - even if hooks fail, permission tiers catch dangerous operations

## Changes

### ASK tier (requires confirmation)
- git push/commit/rebase/reset
- Editing CI workflows and settings.json

### DENY tier (blocked completely)
- sudo, rm -rf /, chmod 777
- git force push
- curl/wget piped to bash
- Reading/editing .env
- Editing .git internals