### PR TITLE
style: Add blank line after import per ruff format

### DIFF
--- a/scripts/self_heal_data.py
+++ b/scripts/self_heal_data.py
@@ -121,6 +121,7 @@ def fix_index_md(docs_path: Path, current_day: int) -> list[str]:
 
         # Fix "Live Status (Day XX/90)"
         import re
+
         old_status = re.search(r"Live Status \(Day \d+/90\)", content)
         if old_status:
             new_status = f"Live Status (Day {current_day}/90)"


### PR DESCRIPTION
## Summary
- Fixes CI lint failure
- ruff format requires blank line after import statement at line 123

## Test plan
- [ ] CI passes (lint job)