### PR TITLE
fix(hooks): Add GitHub secrets anti-hallucination hook (LL-124)

### DIFF
--- a/.claude/hooks/github_secrets_reminder.sh
+++ b/.claude/hooks/github_secrets_reminder.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+# GitHub Secrets Anti-Hallucination Reminder
+# Created: Jan 9, 2026
+# Purpose: Stop Claude from claiming secrets are missing when they ARE configured
+
+cat << 'EOF'
+═══════════════════════════════════════════════════════════
+🔑 GITHUB SECRETS REMINDER - STOP HALLUCINATING!
+═══════════════════════════════════════════════════════════
+ALL ALPACA SECRETS ARE CONFIGURED:
+✅ ALPACA_PAPER_TRADING_5K_API_KEY
+✅ ALPACA_PAPER_TRADING_5K_API_SECRET
+✅ ALPACA_BROKERAGE_TRADING_API_KEY
+✅ ALPACA_BROKERAGE_TRADING_API_SECRET
+✅ GCP_SA_KEY, GOOGLE_API_KEY, LANGCHAIN_API_KEY, GH_PAT
+
+⚠️  IF WORKFLOW FAILS:
+1. Check the actual workflow LOGS for the real error
+2. DO NOT assume missing secrets
+3. The real error is in GitHub Actions run details
+
+🔗 Check workflow logs: https://github.com/IgorGanapolsky/trading/actions
+═══════════════════════════════════════════════════════════
+EOF

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -153,6 +153,11 @@
             "type": "command",
             "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/cost_circuit_breaker.sh",
             "timeout": 5
+          },
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/github_secrets_reminder.sh",
+            "timeout": 2
           }
         ]
       }

--- a/rag_knowledge/lessons_learned/ll_124_github_secrets_are_configured_jan09.md
+++ b/rag_knowledge/lessons_learned/ll_124_github_secrets_are_configured_jan09.md
@@ -1,0 +1,46 @@
+# Lesson Learned #124: GitHub Secrets ARE Configured - Stop Hallucinating
+
+**Date**: January 9, 2026
+**Severity**: CRITICAL
+**Category**: Anti-Hallucination / Operations
+
+## The Lie I Told
+
+I claimed: "Paper trading broken because GitHub secrets may not be configured"
+
+## The Truth
+
+**ALL SECRETS ARE CONFIGURED.** Evidence from CEO screenshot (Jan 9, 2026):
+
+| Secret Name | Status |
+|-------------|--------|
+| `ALPACA_PAPER_TRADING_5K_API_KEY` | ✅ CONFIGURED |
+| `ALPACA_PAPER_TRADING_5K_API_SECRET` | ✅ CONFIGURED |
+| `ALPACA_PAPER_TRADING_API_KEY` | ✅ CONFIGURED |
+| `ALPACA_PAPER_TRADING_API_SECRET` | ✅ CONFIGURED |
+| `ALPACA_BROKERAGE_TRADING_API_KEY` | ✅ CONFIGURED |
+| `ALPACA_BROKERAGE_TRADING_API_SECRET` | ✅ CONFIGURED |
+| `GCP_SA_KEY` | ✅ CONFIGURED |
+| `GOOGLE_API_KEY` | ✅ CONFIGURED |
+| `LANGCHAIN_API_KEY` | ✅ CONFIGURED |
+| `GH_PAT` | ✅ CONFIGURED |
+
+## Real Issue
+
+The `Daily Trading Execution` workflow is **FAILING** - not because of missing secrets, but for a different reason that needs investigation.
+
+## Prevention
+
+**BEFORE claiming secrets are missing:**
+1. Check the actual GitHub workflow run logs
+2. Look for the REAL error message
+3. NEVER assume missing secrets without evidence
+
+## Session Start Check
+
+Add to session start hooks:
+- "GitHub secrets ARE configured - if workflow fails, check logs for REAL error"
+
+## Tags
+
+`anti-hallucination`, `github-secrets`, `workflow-failure`, `critical`


### PR DESCRIPTION
## Summary
CEO caught me lying about missing secrets when they ARE configured.

## Changes
- SessionStart hook: Reminds ALL SECRETS ARE CONFIGURED
- LL-124: Documents the hallucination and prevention
- If workflow fails, check logs for REAL error

## Test plan
- [x] Hook created and executable
- [x] Settings.json updated
- [x] Lesson learned documented