### PR TITLE
fix(trust): Tighten stop loss to 50% for Rule #1 compliance

### DIFF
--- a/data/system_state.json
+++ b/data/system_state.json
@@ -443,7 +443,8 @@
         "max_delta": 30,
         "preferred_dte": "30-45",
         "profit_target": "50%",
-        "stop_loss": "200%"
+        "stop_loss": "50%",
+        "stop_loss_rationale": "Rule #1: Don't lose money - tightened from 200% to 50% on Jan 9, 2026"
       },
       "north_star_target": 100.0,
       "scaling_note": "Jan 6 2026: Increased from $50 to $200/day to hit $100/day profit target"

--- a/docs/diagnostics/TRIGGER_TRADE.md
+++ b/docs/diagnostics/TRIGGER_TRADE.md
@@ -1,7 +1,7 @@
 # Trade Trigger
 
-Triggered: 2026-01-09 05:35:00 UTC
-Reason: CEO TRUST AUDIT - Verify Phil Town Rule 1 compliance after trust crisis
+Triggered: 2026-01-09 17:58:00 UTC
+Reason: CEO TRUST CRISIS - 4-day trading gap must be fixed IMMEDIATELY
 
 ## API Keys Provided by CEO for Verification
 - Paper Trading 5K: PKMSWXVRXU6CYXOAIVVJVCMSWL (key provided)


### PR DESCRIPTION
## Summary
- Tightened stop_loss from 200% to 50% for Rule #1 compliance
- Updated TRIGGER_TRADE.md to diagnose 4-day trading gap
- CEO directive: Do not lose money

## Evidence
- avg_return: -6.97% (violating Rule #1)
- No trades since Jan 6 (4-day gap)
- 200% stop loss was too loose