### PR TITLE
feat(ci): Add workflow to update Alpaca API secrets

### DIFF
--- a/.github/workflows/update-alpaca-secrets.yml
+++ b/.github/workflows/update-alpaca-secrets.yml
@@ -1,0 +1,104 @@
+name: Update Alpaca Secrets
+
+on:
+  workflow_dispatch:
+    inputs:
+      api_key:
+        description: 'Alpaca Paper Trading API Key'
+        required: true
+        type: string
+      api_secret:
+        description: 'Alpaca Paper Trading API Secret'
+        required: true
+        type: string
+
+jobs:
+  update-secrets:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: pip install requests pynacl alpaca-py
+
+      - name: Verify credentials first
+        env:
+          ALPACA_API_KEY: ${{ github.event.inputs.api_key }}
+          ALPACA_SECRET_KEY: ${{ github.event.inputs.api_secret }}
+        run: |
+          python3 -c "
+          import os
+          from alpaca.trading.client import TradingClient
+
+          client = TradingClient(
+              os.environ['ALPACA_API_KEY'],
+              os.environ['ALPACA_SECRET_KEY'],
+              paper=True
+          )
+          account = client.get_account()
+          print(f'Connected! Equity: \${float(account.equity):,.2f}')
+          print(f'Account Status: {account.status}')
+          "
+
+      - name: Update GitHub secrets
+        env:
+          GH_PAT: ${{ secrets.GH_PAT }}
+          NEW_API_KEY: ${{ github.event.inputs.api_key }}
+          NEW_API_SECRET: ${{ github.event.inputs.api_secret }}
+        run: |
+          python3 << 'EOF'
+          import os
+          import requests
+          from base64 import b64decode, b64encode
+          from nacl import public
+
+          def encrypt_secret(public_key: str, secret_value: str) -> str:
+              public_key_bytes = b64decode(public_key)
+              sealed_box = public.SealedBox(public.PublicKey(public_key_bytes))
+              encrypted = sealed_box.encrypt(secret_value.encode("utf-8"))
+              return b64encode(encrypted).decode("utf-8")
+
+          def update_secret(secret_name: str, secret_value: str):
+              token = os.environ["GH_PAT"]
+              repo = "IgorGanapolsky/trading"
+              headers = {
+                  "Authorization": f"token {token}",
+                  "Accept": "application/vnd.github+json",
+              }
+
+              # Get public key
+              key_resp = requests.get(
+                  f"https://api.github.com/repos/{repo}/actions/secrets/public-key",
+                  headers=headers
+              )
+              key_data = key_resp.json()
+
+              # Encrypt and update
+              encrypted = encrypt_secret(key_data["key"], secret_value)
+              requests.put(
+                  f"https://api.github.com/repos/{repo}/actions/secrets/{secret_name}",
+                  headers=headers,
+                  json={"encrypted_value": encrypted, "key_id": key_data["key_id"]}
+              )
+              print(f"Updated: {secret_name}")
+
+          update_secret("ALPACA_PAPER_TRADING_5K_API_KEY", os.environ["NEW_API_KEY"])
+          update_secret("ALPACA_PAPER_TRADING_5K_API_SECRET", os.environ["NEW_API_SECRET"])
+          print("All secrets updated!")
+          EOF
+
+      - name: Trigger daily trading test
+        env:
+          GH_PAT: ${{ secrets.GH_PAT }}
+        run: |
+          curl -X POST \
+            -H "Authorization: token $GH_PAT" \
+            -H "Accept: application/vnd.github+json" \
+            "https://api.github.com/repos/IgorGanapolsky/trading/actions/workflows/daily-trading.yml/dispatches" \
+            -d '{"ref":"main","inputs":{"trading_mode":"paper"}}'
+          echo "Triggered daily trading workflow"

--- a/scripts/update_alpaca_secrets.py
+++ b/scripts/update_alpaca_secrets.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""
+Update Alpaca API secrets in GitHub.
+
+This script must be run in GitHub Actions where nacl is available.
+"""
+
+import os
+import sys
+from base64 import b64decode, b64encode
+
+import requests
+
+try:
+    from nacl import encoding, public
+except ImportError:
+    print("ERROR: nacl library not available. Run in GitHub Actions.")
+    sys.exit(1)
+
+
+def encrypt_secret(public_key: str, secret_value: str) -> str:
+    """Encrypt a secret using the repository's public key."""
+    public_key_bytes = b64decode(public_key)
+    sealed_box = public.SealedBox(public.PublicKey(public_key_bytes))
+    encrypted = sealed_box.encrypt(secret_value.encode("utf-8"))
+    return b64encode(encrypted).decode("utf-8")
+
+
+def update_secret(repo: str, secret_name: str, secret_value: str, token: str) -> bool:
+    """Update a GitHub Actions secret."""
+    # Get the public key
+    headers = {
+        "Authorization": f"token {token}",
+        "Accept": "application/vnd.github+json",
+    }
+
+    key_response = requests.get(
+        f"https://api.github.com/repos/{repo}/actions/secrets/public-key",
+        headers=headers,
+    )
+
+    if key_response.status_code != 200:
+        print(f"Failed to get public key: {key_response.text}")
+        return False
+
+    key_data = key_response.json()
+    encrypted_value = encrypt_secret(key_data["key"], secret_value)
+
+    # Update the secret
+    update_response = requests.put(
+        f"https://api.github.com/repos/{repo}/actions/secrets/{secret_name}",
+        headers=headers,
+        json={"encrypted_value": encrypted_value, "key_id": key_data["key_id"]},
+    )
+
+    if update_response.status_code in (201, 204):
+        print(f"Updated secret: {secret_name}")
+        return True
+    else:
+        print(f"Failed to update {secret_name}: {update_response.text}")
+        return False
+
+
+def main():
+    """Update Alpaca API secrets."""
+    repo = "IgorGanapolsky/trading"
+    token = os.environ.get("GH_PAT") or os.environ.get("GITHUB_TOKEN")
+
+    if not token:
+        print("ERROR: GH_PAT or GITHUB_TOKEN environment variable required")
+        sys.exit(1)
+
+    # Get credentials from environment
+    api_key = os.environ.get("NEW_ALPACA_API_KEY")
+    api_secret = os.environ.get("NEW_ALPACA_API_SECRET")
+
+    if not api_key or not api_secret:
+        print("ERROR: NEW_ALPACA_API_KEY and NEW_ALPACA_API_SECRET required")
+        sys.exit(1)
+
+    # Update both secrets
+    success = True
+    success &= update_secret(repo, "ALPACA_PAPER_TRADING_5K_API_KEY", api_key, token)
+    success &= update_secret(
+        repo, "ALPACA_PAPER_TRADING_5K_API_SECRET", api_secret, token
+    )
+
+    if success:
+        print("\nAll secrets updated successfully!")
+    else:
+        print("\nSome secrets failed to update")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Root Cause
Daily trading failing with: `Alpaca API: unauthorized`

## Fix
- Workflow to update ALPACA_PAPER_TRADING_5K secrets
- Verifies credentials before updating
- Triggers daily trading after update