### PR TITLE
docs(claude): Add LangSmith ML directive to CLAUDE.md (#1335)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -148,7 +148,8 @@ This is non-negotiable. Every trading decision must:
 - **Vertex AI RAG**: SSL-blocked in sandbox, use CI workflows to sync
 - **Local JSON**: Primary recording system in sandbox (always works)
 - CI (GitHub Actions) can write to Vertex AI RAG with proper credentials
-- **NOTE**: LangSmith/LangChain REMOVED (Jan 9, 2026) - not essential for trading
+- **LangSmith ML**: Use for trade observability and ML training (via `LANGCHAIN_API_KEY`)
+- **NOTE**: ChromaDB deprecated (Dec 2025) - do NOT use or mention
 
 ### Sandbox Environment (CRITICAL)
 - This is a sandboxed web environment - packages do NOT persist between sessions
@@ -288,7 +289,7 @@ RIGHT: "Deployment succeeded, please test Dialogflow and confirm it works"
 - See: `rag_knowledge/lessons_learned/ll_109_bidirectional_rag_learning_jan07.md`
 
 ### Continuous Learning System (CEO Directive Jan 9, 2026)
-- **ALWAYS** learn from mistakes - record in Vertex AI RAG
+- **ALWAYS** learn from mistakes - record in Vertex AI RAG AND LangSmith ML
 - Continuously synthesize lessons from:
   - YouTube (top options traders, especially those who started with nothing)
   - Blogs and publications
@@ -296,6 +297,7 @@ RIGHT: "Deployment succeeded, please test Dialogflow and confirm it works"
   - Bogleheads forum wisdom
 - System must CONSTANTLY be learning and improving via orchestration
 - Use `weekend-learning.yml` workflow to ingest new content
+- LangSmith provides ML observability - use for tracking agent decisions
 
 ### PR Completion Protocol
 - When done merging all PRs, confirm with: **"done merging PRs"**


### PR DESCRIPTION
Per CEO directive: Add LangSmith ML for trade observability and ML training.

Changes:
- Re-added LangSmith ML directive
- Updated continuous learning section
- Clarified ChromaDB deprecated, not LangSmith