### PR TITLE
fix(lint): Fix F541 and F401 ruff errors

### DIFF
--- a/scripts/pre_market_health_check.py
+++ b/scripts/pre_market_health_check.py
@@ -71,7 +71,7 @@ def check_alpaca_api() -> bool:
     api_key = os.getenv("ALPACA_API_KEY", "")
     secret_key = os.getenv("ALPACA_SECRET_KEY", "")
 
-    print(f"🔍 Alpaca API Configuration:")
+    print("🔍 Alpaca API Configuration:")
     print(f"   Mode: {'PAPER' if paper_mode else 'LIVE'}")
     print(f"   API Key: {api_key[:8] if len(api_key) >= 8 else 'MISSING'}...{api_key[-4:] if len(api_key) >= 4 else ''}")
     print(f"   Secret: {secret_key[:8] if len(secret_key) >= 8 else 'MISSING'}...{secret_key[-4:] if len(secret_key) >= 4 else ''}")

--- a/scripts/test_alpaca_credentials_local.py
+++ b/scripts/test_alpaca_credentials_local.py
@@ -31,10 +31,10 @@ def test_credentials():
         print("   Set ALPACA_API_KEY and ALPACA_SECRET_KEY environment variables")
         return False
 
-    print(f"Testing credentials:")
+    print("Testing credentials:")
     print(f"  API Key: {api_key[:8]}...{api_key[-4:]}")
     print(f"  Secret:  {secret_key[:8]}...{secret_key[-4:]}")
-    print(f"  Mode:    PAPER")
+    print("  Mode:    PAPER")
     print()
 
     try:

--- a/src/observability/trade_sync.py
+++ b/src/observability/trade_sync.py
@@ -10,7 +10,6 @@ Simplified: Jan 9, 2026 - Removed LangSmith (not essential for trading).
 
 import json
 import logging
-import os
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Optional

--- a/tests/test_introspective_council.py
+++ b/tests/test_introspective_council.py
@@ -124,7 +124,7 @@ class TestCouncilValidationWithAnonymization:
             "confidence": 0.7,
             "individual_scores": {"claude": 0.6, "gpt4": 0.7}
         }
-        result = await council._get_council_validation(
+        _result = await council._get_council_validation(
             symbol="SPY",
             ensemble=ensemble,
             introspection=mock_introspection,


### PR DESCRIPTION
Fix pre-existing lint errors:
- F541: f-string without placeholders
- F401: unused import
- F841: unused variable