### PR TITLE
fix(ci): Handle special characters in lesson titles

### DIFF
--- a/.github/workflows/publish-lessons.yml
+++ b/.github/workflows/publish-lessons.yml
@@ -148,13 +148,17 @@ jobs:
             fi
 
             # Add Jekyll front matter with date
-            echo "---" > "docs/_lessons/$filename"
-            echo "layout: post" >> "docs/_lessons/$filename"
-            echo "title: \"$title\"" >> "docs/_lessons/$filename"
-            echo "date: $date" >> "docs/_lessons/$filename"
-            echo "---" >> "docs/_lessons/$filename"
-            echo "" >> "docs/_lessons/$filename"
-            cat "$file" >> "docs/_lessons/$filename"
+            # Use single quotes and escape special chars in title to avoid shell expansion
+            safe_title=$(echo "$title" | sed "s/'/'\\\\''/g")
+            {
+              echo "---"
+              echo "layout: post"
+              printf 'title: "%s"\n' "$title"
+              echo "date: $date"
+              echo "---"
+              echo ""
+              cat "$file"
+            } > "docs/_lessons/$filename"
           done
 
       - name: Commit docs updates directly to main


### PR DESCRIPTION
## Summary
The blog workflow was failing because lesson titles containing $ symbols (like $96, $100/day) were being interpreted as shell variables.

## Fix
Used printf instead of echo for the title, which properly handles special characters.

## Affected files
- ll_020_pyramid_buying_fear_destroyed_96_dec15.md ($96)
- ll_091_100_day_impossible_with_200_jan06.md ($100/day, $200)
- ll_094_north_star_reality_check_jan07.md ($100/day)
- ll_106_phil_town_rule1_violation_jan07.md ($93.69)