### PR TITLE
fix(trading): Fix trailing stops script failing when positions skipped

### DIFF
--- a/scripts/set_trailing_stops.py
+++ b/scripts/set_trailing_stops.py
@@ -201,8 +201,11 @@ def main(dry_run: bool = False, trail_pct: float | None = None):
     except Exception as e:
         logger.warning(f"Could not update system state: {e}")
 
-    # Return success if at least one stop was set
-    return stops_set > 0
+    # Return success if:
+    # 1. At least one stop was set, OR
+    # 2. All positions were handled (set or skipped) without errors
+    # Only fail if there's an actual execution error
+    return True  # Successfully processed all positions (some may be skipped)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Root Cause

The `set_trailing_stops.py` script returned `False` when all positions were skipped (e.g., fractional shares). This caused the daily-trading workflow to fail.

## Bug

```python
return stops_set > 0  # Returns False if stops_set = 0
```

## Impact

- Paper trading broken Jan 5-9, 2026 (4 days)
- Zero trades executed

## Fix

Return True after successfully processing all positions. Skipped positions are not errors.