### PR TITLE
fix(ci): Fix octal number parsing bug in publish-lessons workflow

### DIFF
--- a/.github/workflows/publish-lessons.yml
+++ b/.github/workflows/publish-lessons.yml
@@ -140,8 +140,8 @@ jobs:
                 nov) month_num="11"; year="2025" ;;
                 dec) month_num="12"; year="2025" ;;
               esac
-              # Pad day with leading zero if needed
-              day=$(printf "%02d" "$day")
+              # Pad day with leading zero if needed (use 10# to force decimal interpretation)
+              day=$(printf "%02d" "$((10#$day))")
               date="${year}-${month_num}-${day}"
             else
               date=$(date +%Y-%m-%d)


### PR DESCRIPTION
## Summary
Fix printf octal number error that was preventing Jan 9 lessons from publishing to blog.

## Root Cause
Bash interprets numbers with leading zeros as octal. Days 08 and 09 caused the workflow to fail with:
```
printf: 08: invalid octal number
```

## Fix
Use `$((10#$day))` to force decimal interpretation before printf.

## Test Plan
- [x] Workflow should now handle all days including 08 and 09
- [ ] Jan 9 lessons should publish after merge