### PR TITLE
fix(lint): Remove unused OrderSide import

### DIFF
--- a/scripts/verify_trade_execution.py
+++ b/scripts/verify_trade_execution.py
@@ -27,7 +27,7 @@ from pathlib import Path
 # Try to import Alpaca - graceful fallback if not available
 try:
     from alpaca.trading.client import TradingClient
-    from alpaca.trading.enums import OrderSide, QueryOrderStatus
+    from alpaca.trading.enums import QueryOrderStatus
     from alpaca.trading.requests import GetOrdersRequest
 
     ALPACA_AVAILABLE = True


### PR DESCRIPTION
## Summary
- Remove unused `OrderSide` import from `verify_trade_execution.py`
- Fixes F401 lint error causing CI failure

## Test plan
- [x] `ruff check .` passes locally
- [ ] CI passes after merge