### PR TITLE
fix(tests): Resolve 5 failing CI tests

### DIFF
--- a/src/core/introspective_council.py
+++ b/src/core/introspective_council.py
@@ -282,7 +282,7 @@ class IntrospectiveCouncil:
         anonymized = {}
         labels = ["A", "B", "C", "D", "E", "F", "G", "H"]
         for i, (model_name, score) in enumerate(individual_scores.items()):
-            label = labels[i] if i < len(labels) else f"Response_{i+1}"
+            label = labels[i] if i < len(labels) else str(i + 1)
             anonymized[f"Response_{label}"] = score
             # Store mapping for internal logging only (not sent to peer review)
             logger.debug(f"Anonymized {model_name} -> Response_{label}")

--- a/tests/test_dialogflow_webhook.py
+++ b/tests/test_dialogflow_webhook.py
@@ -414,47 +414,46 @@ class TestTradeQueryFallbackBehavior:
                 {"id": "ll_001", "severity": "INFO", "content": "Test lesson"}
             ]
 
-            with patch("src.agents.dialogflow_webhook.trade_collection", None):
-                with patch(
-                    "src.agents.dialogflow_webhook.get_current_portfolio_status"
-                ) as mock_portfolio:
-                    mock_portfolio.return_value = {
-                        "live": {
-                            "equity": 100,
-                            "total_pl": 5,
-                            "total_pl_pct": 5.0,
-                            "positions_count": 0,
-                        },
-                        "paper": {
-                            "equity": 100000,
-                            "total_pl": 1000,
-                            "total_pl_pct": 1.0,
-                            "positions_count": 2,
-                            "win_rate": 80.0,
-                        },
-                        "last_trade_date": "2026-01-05",
-                        "trades_today": 0,
-                        "challenge_day": 69,
-                    }
+            with patch(
+                "src.agents.dialogflow_webhook.get_current_portfolio_status"
+            ) as mock_portfolio:
+                mock_portfolio.return_value = {
+                    "live": {
+                        "equity": 100,
+                        "total_pl": 5,
+                        "total_pl_pct": 5.0,
+                        "positions_count": 0,
+                    },
+                    "paper": {
+                        "equity": 100000,
+                        "total_pl": 1000,
+                        "total_pl_pct": 1.0,
+                        "positions_count": 2,
+                        "win_rate": 80.0,
+                    },
+                    "last_trade_date": "2026-01-05",
+                    "trades_today": 0,
+                    "challenge_day": 69,
+                }
 
-                    from fastapi.testclient import TestClient
-                    from src.agents.dialogflow_webhook import app
+                from fastapi.testclient import TestClient
+                from src.agents.dialogflow_webhook import app
 
-                    client = TestClient(app)
+                client = TestClient(app)
 
-                    response = client.post(
-                        "/webhook",
-                        json={"text": "How much money did we make today?"},
-                    )
+                response = client.post(
+                    "/webhook",
+                    json={"text": "How much money did we make today?"},
+                )
 
-                    assert response.status_code == 200
-                    data = response.json()
-                    text = data["fulfillmentResponse"]["messages"][0]["text"]["text"][0]
+                assert response.status_code == 200
+                data = response.json()
+                text = data["fulfillmentResponse"]["messages"][0]["text"]["text"][0]
 
-                    # Should return portfolio status, NOT lessons
-                    assert "Portfolio" in text or "Equity" in text or "P/L" in text
-                    # Should NOT contain lesson references
-                    assert "ll_001" not in text
+                # Should return portfolio status, NOT lessons
+                assert "Portfolio" in text or "Equity" in text or "P/L" in text
+                # Should NOT contain lesson references
+                assert "ll_001" not in text
 
     def test_trade_query_unavailable_portfolio_returns_clear_message(self):
         """Verify P/L queries don't dump lessons when portfolio unavailable."""
@@ -466,31 +465,30 @@ class TestTradeQueryFallbackBehavior:
                 {"id": "ll_001", "severity": "INFO", "content": "Test lesson"}
             ]
 
-            with patch("src.agents.dialogflow_webhook.trade_collection", None):
-                with patch(
-                    "src.agents.dialogflow_webhook.get_current_portfolio_status"
-                ) as mock_portfolio:
-                    mock_portfolio.return_value = {}  # No portfolio data
+            with patch(
+                "src.agents.dialogflow_webhook.get_current_portfolio_status"
+            ) as mock_portfolio:
+                mock_portfolio.return_value = {}  # No portfolio data
 
-                    from fastapi.testclient import TestClient
-                    from src.agents.dialogflow_webhook import app
+                from fastapi.testclient import TestClient
+                from src.agents.dialogflow_webhook import app
 
-                    client = TestClient(app)
+                client = TestClient(app)
 
-                    response = client.post(
-                        "/webhook",
-                        json={"text": "What's my balance?"},
-                    )
+                response = client.post(
+                    "/webhook",
+                    json={"text": "What's my balance?"},
+                )
 
-                    assert response.status_code == 200
-                    data = response.json()
-                    text = data["fulfillmentResponse"]["messages"][0]["text"]["text"][0]
+                assert response.status_code == 200
+                data = response.json()
+                text = data["fulfillmentResponse"]["messages"][0]["text"]["text"][0]
 
-                    # Should return clear unavailable message
-                    assert "Unavailable" in text or "couldn't retrieve" in text
-                    # Should NOT dump lessons
-                    assert "ll_001" not in text
-                    assert "Based on our lessons" not in text
+                # Should return clear unavailable message
+                assert "Unavailable" in text or "couldn't retrieve" in text
+                # Should NOT dump lessons
+                assert "ll_001" not in text
+                assert "Based on our lessons" not in text
 
 
 class TestPortfolioStatusFunction:

--- a/tests/test_options_risk_monitor.py
+++ b/tests/test_options_risk_monitor.py
@@ -249,7 +249,7 @@ class TestIronCondorStopLoss:
             side="short",
             quantity=1,
             entry_price=2.00,  # Received $2.00 credit
-            current_price=5.00,  # Loss = $3.00 < 2.2x=$4.40 but > 2.0x=$4.00
+            current_price=6.00,  # Loss = $4.00 = 2.0x, triggers IC stop (< 2.2x=$4.40)
             delta=0.0,
             gamma=0.02,
             theta=0.04,
@@ -259,7 +259,7 @@ class TestIronCondorStopLoss:
             opened_at=datetime.now(),
         )
         monitor.add_position(position)
-        exits = monitor.check_stop_losses({"SPY_IC": 5.00})
+        exits = monitor.check_stop_losses({"SPY_IC": 6.00})
 
         assert len(exits) == 1, "Iron condor should trigger stop at 2.0x"
         assert exits[0]["position_type"] == "iron_condor"


### PR DESCRIPTION
## Summary
- Fix test_dialogflow_webhook: Remove patches for non-existent trade_collection
- Fix test_introspective_council: Response_9/10 naming bug in _anonymize_responses
- Fix test_introspective_council: Convert async test to use asyncio.run()
- Fix test_options_risk_monitor: Iron condor stop test math (current_price 5->6)

## Test plan
- [x] All modified files pass lint
- [x] Syntax valid
- [ ] CI passes