### PR TITLE
fix(orchestrator): Disable dormant RL filter to reduce complexity

### DIFF
--- a/src/orchestrator/main.py
+++ b/src/orchestrator/main.py
@@ -177,12 +177,11 @@ class TradingOrchestrator:
             min_score=float(_os.getenv("MOMENTUM_MIN_SCORE", "0.0"))
         )
 
-        # Dec 30, 2025: RE-ENABLED ML INTEGRATION
-        # CEO mandate: "Put all powers into fixing ML integration"
-        # RLFilter was disabled during simplification but ML must be active for learning.
-        # Previous: disabled due to Sharpe -7 to -72 (backtest overfitting concern)
-        # Now: enabled to collect data and learn, with safety gates in place
-        self.rl_filter_enabled = _os.getenv("RL_FILTER_ENABLED", "true").lower() in {
+        # Jan 10, 2026: DISABLED RL FILTER (CEO directive - reduce complexity)
+        # Evidence: 1,601 lines of RL code, 0 trades using it
+        # With $30 portfolio, RL has nothing to learn from
+        # Re-enable when: portfolio >= $500 AND trades being executed
+        self.rl_filter_enabled = _os.getenv("RL_FILTER_ENABLED", "false").lower() in {
             "1",
             "true",
             "yes",


### PR DESCRIPTION
CEO directive Jan 10, 2026: Disable RL system

Evidence:
- 1,601 lines of RL code
- 0 trades using RL filter
- $30 portfolio (need $500+ for first trade)

Change: RL_FILTER_ENABLED default false