### PR TITLE
docs(rag): Add wheel strategy criticism research (ll_129)

### DIFF
--- a/rag_knowledge/lessons_learned/ll_129_wheel_strategy_criticism_research_jan10.md
+++ b/rag_knowledge/lessons_learned/ll_129_wheel_strategy_criticism_research_jan10.md
@@ -1,0 +1,100 @@
+# Lesson Learned #129: Wheel Strategy Criticism - Deep Research
+
+**Date**: January 10, 2026
+**Severity**: HIGH
+**Category**: Strategy Risk
+
+## Summary
+
+Deep research on the wheel strategy (our Phil Town CSP approach) reveals serious criticisms from quantitative analysts. This must be understood before executing more trades.
+
+## Source
+
+[Early Retirement Now - Why the Wheel Strategy Doesn't Work](https://earlyretirementnow.com/2024/09/17/the-wheel-strategy-doesnt-work-options-series-part-12/)
+
+## Six Key Criticisms
+
+### 1. Ignores Market History
+- Bear markets can last 13+ years (2000-2013)
+- During prolonged downturns, selling calls at original strike generates minimal income
+- Strategy assumes stocks recover quickly - not always true
+
+### 2. Excessive Leverage Risk
+- Assignment creates margin positions
+- A 30% further decline could "wipe out your entire account" with leverage
+- **Our mitigation**: We use cash-secured puts only (no margin)
+
+### 3. Disguised Valuation Betting
+- Strategy inadvertently increases equity exposure as losses mount
+- Shifts from 20 Delta to 100 Delta (full stock ownership)
+- Forces "doubling down" on losing positions
+- **Our mitigation**: 25% stop loss prevents unlimited losses
+
+### 4. Mathematical Inconsistency
+- Two identical investors would have vastly different allocations
+- Starting puts vs holding assigned shares = illogical difference
+- Strategy lacks coherent theoretical foundation
+
+### 5. Enables Fraudulent Reporting
+- YouTube influencers hide unrealized losses
+- Report only "realized" premiums as "returns"
+- Creates misleading 30-60% "return" claims
+- **Warning**: Be skeptical of YouTube profit claims
+
+### 6. Requires Superior Stock Picking
+- Assumes you can identify stocks that "can't fall for extended periods"
+- Even "quality" stocks like PTON, RIDE failed
+- Stock picking is not reliable
+
+## Bogleheads Perspective (Additional Research)
+
+From [Bogleheads Forum](https://www.bogleheads.org/forum/viewtopic.php?t=212858):
+
+> "This strategy is called eating like a bird and pooping like an elephant. With good reason. If it works, you'll keep leveraging up until you blow out."
+
+> "For me it's only play money and for a small number of puts."
+
+The Bogleheads community is generally **skeptical** of options selling for income.
+
+## Impact on Our Strategy
+
+### What We're Doing Right
+- Cash-secured puts (no margin leverage)
+- Quality stock selection (F, SOFI, T, INTC, BAC, VZ)
+- 25% stop loss (prevents unlimited losses)
+- Small position sizes (10% max per position)
+
+### What We Need to Address
+1. **Understand the math**: Our 80% win rate with -6.97% avg return proves the criticism - small wins, big losses
+2. **Don't trust YouTube influencers**: Many hide unrealized losses
+3. **Accept limitations**: With $500, we can only do 1 CSP at a time
+4. **Realistic expectations**: This is not a "get rich quick" strategy
+
+## Recommendations
+
+1. **Keep tight stop losses** (25%) - already implemented
+2. **Don't increase position sizes** when assigned (avoid doubling down)
+3. **Diversify** - don't put all capital in one wheel trade
+4. **Track realized AND unrealized** P/L honestly
+5. **Consider alternatives**: Credit spreads reduce capital requirements
+
+## Honest Assessment
+
+The wheel strategy CAN work, but:
+- It's not magical passive income
+- It requires discipline and risk management
+- It can lose money in extended bear markets
+- YouTube success stories are often misleading
+
+Our current implementation is reasonable with proper risk controls, but we must:
+- Keep expectations realistic
+- Never hide unrealized losses
+- Exit losing positions (don't "wheel" forever hoping for recovery)
+
+## Tags
+`strategy`, `wheel`, `options`, `risk`, `research`, `criticism`
+
+## Prevention
+- Query this lesson before any wheel strategy trade
+- Always report realized AND unrealized P/L
+- Don't trust YouTube "passive income" claims


### PR DESCRIPTION
## Summary
- Deep research on wheel strategy criticism from quantitative analysts
- Source: Early Retirement Now + Bogleheads forum
- Six key criticisms documented with our mitigations

## Test Plan
- Lesson syncs to Vertex AI RAG via CI