### PR TITLE
docs(rag): Add self-healing gap lesson #131

### DIFF
--- a/rag_knowledge/lessons_learned/ll_131_self_healing_gap_blog_sync_jan11.md
+++ b/rag_knowledge/lessons_learned/ll_131_self_healing_gap_blog_sync_jan11.md
@@ -1,0 +1,75 @@
+# Lesson Learned #131: Self-Healing Gap - Blog Lesson Sync
+
+**ID**: LL-131
+**Date**: January 11, 2026
+**Severity**: MEDIUM
+**Category**: self-healing, automation, blog
+
+## What Happened
+
+The GitHub Pages blog showed "Jan 11:" with no content because:
+1. Lessons created during Claude sessions are on feature branches
+2. Feature branches require manual PR creation and merge
+3. The blog only shows lessons that are merged to `main`
+
+## Root Cause
+
+**Gap in self-healing**: The weekend-learning workflow auto-merges RAG content, but session-created lessons don't have the same automation.
+
+Current workflow:
+1. Claude creates lesson → Feature branch
+2. Claude creates PR → Manual step
+3. PR merge → Manual or requires API call
+4. Blog sync → Automatic (after merge)
+
+## Evidence
+
+```
+Jan 11 blog entry empty because:
+- ll_130_investment_strategy_review_jan11.md was on branch
+- Branch not merged to main
+- Blog builds from main only
+```
+
+## Fix Applied
+
+Used GitHub PAT to:
+1. Create PR #1408 programmatically
+2. Merge PR #1408 automatically
+3. Triggered auto-sync PR #1409 (lessons → docs/_lessons)
+
+## Prevention (Self-Healing Improvement Needed)
+
+### Option A: Auto-merge safe lesson PRs
+Add to CI workflow that auto-merges PRs that only change:
+- `rag_knowledge/lessons_learned/*.md`
+- `docs/_lessons/*.md`
+
+### Option B: Direct push for lessons (with safeguards)
+Allow direct push to main for lesson files only if:
+- File matches `ll_*.md` pattern
+- Content passes schema validation
+- No code files changed
+
+### Option C: Session-end hook
+Create hook that auto-creates and merges lesson PRs at session end.
+
+## Self-Healing Status
+
+| Component | Self-Healing? |
+|-----------|---------------|
+| Weekend learning RAG | ✅ YES - auto-merge |
+| Daily trading | ✅ YES - scheduled |
+| Session lessons | ❌ NO - requires manual PR |
+| Branch cleanup | ✅ YES - weekend-learning cleans |
+| Blog sync | ✅ YES - after merge |
+
+## Action Items
+
+1. [ ] Implement Option A: Auto-merge lesson PRs in CI
+2. [ ] Add session-end hook for lesson PR creation
+3. [ ] Monitor for similar gaps in other components
+
+## Tags
+
+`self-healing`, `automation`, `blog`, `github-pages`, `lessons-learned`, `operational-gap`


### PR DESCRIPTION
## Summary
- Documents the self-healing gap where session-created lessons dont auto-merge
- Proposes fix: auto-merge lesson PRs in CI

## Test Plan
- [x] Lesson file created
- [ ] Blog shows Jan 11 entries after merge