### PR TITLE
fix(rag): Add actionable 2026 trading rules - CRISIS FIX

### DIFF
--- a/rag_knowledge/trading_rules_2026.md
+++ b/rag_knowledge/trading_rules_2026.md
@@ -1,0 +1,81 @@
+# Trading Rules 2026 - Actionable Guidance
+
+**Last Updated**: January 11, 2026
+**Status**: ACTIVE
+**Priority**: HIGH - Query this first for trading decisions
+
+## Current Capital Situation
+
+- **Brokerage**: $30 (accumulating via $10/day deposits)
+- **Paper Trading**: $5,000 (practice account)
+- **Target**: $100/day requires ~$20,000 capital
+
+## Active Trading Strategy (January 2026)
+
+### For Accounts Under $500: CREDIT SPREADS
+- Use put credit spreads on F, SOFI, T (low-price stocks)
+- 50/25 delta rule: Sell 30 delta, buy 15 delta
+- 33% rule: Collect minimum 33% of spread width as premium
+- Take profit at 50%, stop loss at 100%
+- Collateral: $5 wide spread = $500
+
+### For Accounts $500-$2,000: CSPs + CREDIT SPREADS
+- Cash-secured puts on F ($5 strike), SOFI ($10 strike)
+- 30-45 DTE for optimal theta decay
+- Max 10% of portfolio per position
+
+### For Accounts $2,000+: FULL WHEEL STRATEGY
+- CSPs on BAC, INTC, T, VZ
+- If assigned, sell covered calls at cost basis
+- Target 0.5% weekly premium
+
+## Risk Management Rules (NEVER VIOLATE)
+
+1. **Stop Loss**: 50% max loss on any position (was 200% - FIXED Jan 9)
+2. **Position Size**: Max 10% of portfolio per trade
+3. **Delta**: Sell 30 delta puts (70% probability OTM)
+4. **DTE**: 30-45 days to expiration
+
+## Phil Town Rule #1 Investing
+
+- Only buy wonderful companies at attractive prices
+- Margin of Safety: Buy at 50% of intrinsic value
+- 4Ms: Meaning, Moat, Management, Margin of Safety
+- "Getting Paid to Wait" - sell puts at MOS price
+
+## Watchlist (Affordable for Small Accounts)
+
+| Symbol | Price Range | Strategy | Min Capital |
+|--------|-------------|----------|-------------|
+| F | $9-12 | CSP/Spread | $500 |
+| SOFI | $12-18 | CSP/Spread | $1,000 |
+| T | $18-22 | CSP/Spread | $1,500 |
+| INTC | $18-25 | CSP/Spread | $2,000 |
+| BAC | $32-38 | CSP/Spread | $3,500 |
+
+## What NOT to Do
+
+- ❌ Chase 50% daily returns (impossible without extreme risk)
+- ❌ Trade meme stocks (GME, AMC)
+- ❌ Use 200% stop loss (lose 2x before exiting)
+- ❌ Trade without defined risk
+- ❌ Trade crypto (we do NOT trade crypto - US equities only)
+
+## North Star Goal
+
+- Ultimate: $100/day after-tax
+- Requires: ~$20,000 capital with credit spreads
+- Timeline: June 2026 with $10/day deposits + compounding
+
+## Trading Hours
+
+- US Markets: Mon-Fri 9:30 AM - 4:00 PM ET
+- Options: Same as underlying
+- NO TRADING on weekends
+
+## Sources (2026 Best Practices)
+
+- https://alpaca.markets/learn/credit-spreads
+- https://www.optionsplay.com/blogs/how-to-grow-a-small-account
+- https://thetradinganalyst.com/put-credit-spread/
+- Phil Town's Rule #1 Investing book


### PR DESCRIPTION
RAG was returning Dec 2025 incidents instead of useful guidance. Added trading_rules_2026.md with current strategies.