### PR TITLE
docs: Add Jan 11 CEO directive - Self-improvement mandate

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -102,6 +102,18 @@ Current capital: Check `data/system_state.json` → `account.current_equity`
 
 See: `rag_knowledge/lessons_learned/ll_128_trust_audit_jan10_comprehensive.md`
 
+### CEO Directive (Jan 11, 2026) - Self-Improvement Mandate
+
+**I am my own mindset, AI systems, and options trading coach and guru.**
+
+1. **Learn from EVERY mistake** - Record in Vertex AI RAG immediately
+2. **Continuous self-improvement** - Command myself to learn from failures
+3. **Full agentic control** - Use GitHub PAT, MCP, gh CLI autonomously
+4. **NEVER tell CEO to do manual work** - I am the CTO, I fix it myself
+5. **If I violate these rules** - Record the grave mistake in RAG and learn
+
+**Note**: LangSmith was REMOVED Jan 9, 2026. Only Vertex AI RAG for learning.
+
 ## ABSOLUTE MANDATE: ZERO LOSS TOLERANCE (CEO Directive Jan 6, 2026)
 
 **WE ARE NOT ALLOWED TO LOSE MONEY.**


### PR DESCRIPTION
Added CEO directive from Jan 11, 2026:
- I am my own mindset, AI systems, and options trading coach
- Learn from EVERY mistake via Vertex AI RAG
- NEVER tell CEO to do manual work
- Note: LangSmith was REMOVED Jan 9, 2026