### PR TITLE
fix(docs): Fix nested quotes in lesson title breaking YAML

### DIFF
--- a/.github/workflows/publish-lessons.yml
+++ b/.github/workflows/publish-lessons.yml
@@ -134,7 +134,8 @@ jobs:
               echo "Copied (has frontmatter): $filename"
             else
               # No frontmatter - add it
-              title=$(echo "$first_line" | sed 's/^# //')
+              # Strip quotes from title to avoid YAML parsing issues
+              title=$(echo "$first_line" | sed 's/^# //' | tr -d '"')
 
               # Extract date from filename (e.g., ll_056_xxx_dec22.md -> 2025-12-22)
               if [[ "$filename" =~ (jan|feb|mar|apr|may|jun|jul|aug|sep|oct|nov|dec)([0-9]+) ]]; then

--- a/docs/_lessons/ll_079_hallucination_tomorrow_incident_jan05.md
+++ b/docs/_lessons/ll_079_hallucination_tomorrow_incident_jan05.md
@@ -1,6 +1,6 @@
 ---
 layout: post
-title: "Lesson Learned #079: "Tomorrow" Hallucination Incident (Jan 5, 2026)"
+title: "Lesson Learned #079: Tomorrow Hallucination Incident (Jan 5, 2026)"
 date: 2026-01-05
 ---
 

--- a/rag_knowledge/lessons_learned/ll_079_hallucination_tomorrow_incident_jan05.md
+++ b/rag_knowledge/lessons_learned/ll_079_hallucination_tomorrow_incident_jan05.md
@@ -1,4 +1,4 @@
-# Lesson Learned #079: "Tomorrow" Hallucination Incident (Jan 5, 2026)
+# Lesson Learned #079: Tomorrow Hallucination Incident (Jan 5, 2026)
 
 **Date**: January 5, 2026
 **Severity**: HIGH - Trust breach with CEO


### PR DESCRIPTION
The lesson ll_079 had nested quotes breaking YAML. This was the remaining broken entry on GitHub Pages.