### PR TITLE
fix: Add query method to LessonsLearnedRAG stub

### DIFF
--- a/src/rag/lessons_learned_rag.py
+++ b/src/rag/lessons_learned_rag.py
@@ -12,6 +12,10 @@ class LessonsLearnedRAG:
         """Search lessons - returns empty list."""
         return []
 
+    def query(self, query: str, *args, **kwargs) -> list:
+        """Query lessons - returns empty list."""
+        return []
+
     def add_lesson(self, lesson: dict, *args, **kwargs) -> bool:
         """Add lesson - returns success."""
         return True


### PR DESCRIPTION
Adds missing query() method