### PR TITLE
fix: Parse GCP SA key from file instead of shell variable

### DIFF
--- a/.github/workflows/vertex-rag-pretrade.yml
+++ b/.github/workflows/vertex-rag-pretrade.yml
@@ -91,8 +91,8 @@ jobs:
             export GOOGLE_APPLICATION_CREDENTIALS=/tmp/gcp_sa_key.json
             echo "GOOGLE_APPLICATION_CREDENTIALS=/tmp/gcp_sa_key.json" >> $GITHUB_ENV
 
-            # Extract project ID from SA key
-            PROJECT_ID=$(python3 -c "import json; print(json.loads('''$GCP_SA_KEY''').get('project_id', 'igor-trading-2025-v2'))")
+            # Extract project ID from SA key file (safer than shell variable parsing)
+            PROJECT_ID=$(python3 -c "import json; print(json.load(open('/tmp/gcp_sa_key.json')).get('project_id', 'igor-trading-2025-v2'))")
             echo "GOOGLE_CLOUD_PROJECT=$PROJECT_ID" >> $GITHUB_ENV
             echo "Authenticated with project: $PROJECT_ID"
           else


### PR DESCRIPTION
## Problem
Vertex AI RAG Pre-Trade Query workflow failing at GCP authentication step.

## Root Cause
Line 95 was parsing JSON directly from shell variable `$GCP_SA_KEY` using triple quotes, which breaks on special characters.

## Fix
Read from `/tmp/gcp_sa_key.json` which was already written on line 90.

## Test Plan
- [ ] Workflow passes after merge