### PR TITLE
fix: Update brokerage equity to $60 (verified from Alpaca)

### DIFF
--- a/data/performance_log.json
+++ b/data/performance_log.json
@@ -49,5 +49,16 @@
     "pl_pct": 0.0,
     "account_type": "live",
     "note": "Day 70/90 - Live account: Accumulation phase. Paper account: +$16,661.20 today (+16.45%)"
+  },
+  {
+    "date": "2026-01-12",
+    "timestamp": "2026-01-12T15:10:00.000000",
+    "equity": 60.0,
+    "cash": 60.0,
+    "buying_power": 60.0,
+    "pl": 0.0,
+    "pl_pct": 0.0,
+    "account_type": "live",
+    "note": "Day 74/90 - Accumulation phase. $30 deposited since Jan 7. 44 days to first CSP."
   }
 ]

--- a/data/system_state.json
+++ b/data/system_state.json
@@ -1,8 +1,8 @@
 {
-  "last_updated": "2026-01-12T13:43:53.823674",
+  "last_updated": "2026-01-12T15:10:00.000000",
   "portfolio": {
-    "equity": 30.0,
-    "cash": 30.0
+    "equity": 60.0,
+    "cash": 60.0
   },
   "total_trades": 0,
   "win_rate": 0,
@@ -11,5 +11,5 @@
   "strategy": "CSP on F/SOFI at $5 strike when capital >= $500",
   "capital_needed": 500,
   "daily_deposit": 10,
-  "days_to_first_trade": 47
+  "days_to_first_trade": 44
 }


### PR DESCRIPTION
CEO verified Alpaca shows $60 equity but system state showed $30.

Updated:
- system_state.json: equity $30 → $60
- performance_log.json: added Jan 12 entry
- days_to_first_trade: 47 → 44