### PR TITLE
fix: Add missing get_macro_context() to MacroeconomicAgent

### DIFF
--- a/src/agents/macro_agent.py
+++ b/src/agents/macro_agent.py
@@ -9,3 +9,13 @@ class MacroeconomicAgent:
 
     def analyze(self, *args, **kwargs):
         return {"signal": "neutral", "confidence": 0.0}
+
+    def get_macro_context(self) -> dict:
+        """Return empty macro context - not used in Phil Town strategy."""
+        return {
+            "market_regime": "neutral",
+            "vix_level": 15.0,
+            "interest_rate_trend": "stable",
+            "economic_outlook": "neutral",
+            "recommendation": "proceed_normal",
+        }


### PR DESCRIPTION
## Summary
Add missing `get_macro_context()` method to MacroeconomicAgent stub.

## Error Fixed
```
AttributeError: 'MacroeconomicAgent' object has no attribute 'get_macro_context'
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)