### PR TITLE
fix: Add missing methods to MomentumAgent stub

### DIFF
--- a/src/agents/momentum_agent.py
+++ b/src/agents/momentum_agent.py
@@ -5,7 +5,16 @@ class MomentumAgent:
     """Stub for MomentumAgent - not used in Phil Town strategy."""
 
     def __init__(self, *args, **kwargs):
-        pass
+        self._regime_config = {}
 
-    def analyze(self, *args, **kwargs):
-        return {"signal": "neutral", "confidence": 0.0}
+    def analyze(self, symbol: str = None, *args, **kwargs) -> dict:
+        """Return neutral momentum signal."""
+        return {"signal": "hold", "confidence": 0.0, "recommendation": "neutral"}
+
+    def configure_regime(self, overrides: dict = None) -> None:
+        """Configure momentum regime - stub does nothing."""
+        self._regime_config = overrides or {}
+
+    def _fetch_history(self, ticker: str) -> list:
+        """Return empty history - stub."""
+        return []


### PR DESCRIPTION
Add `configure_regime()` and `_fetch_history()` methods that main.py expects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)