### PR TITLE
docs: Update blog with real portfolio data + RAG lesson

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -20,9 +20,12 @@ Building an autonomous AI trading system with Claude Opus 4.5.
 
 | Metric | Value |
 |--------|-------|
-| **Capital** | $30 |
-| **Trades** | 0 |
-| **Target** | $500 for first CSP |
+| **Brokerage Capital** | $4,998.98 |
+| **Paper Account** | $5,002.98 |
+| **Open Positions** | 1 (SOFI $25 Put, Jan 30 exp) |
+| **Pending Orders** | 1 (SOFI $24 Put, Feb 20 exp) |
+| **Day of Journey** | 74/90 |
+| **Next Goal** | Execute more CSPs on F, BAC |
 
 ---
 

--- a/rag_knowledge/lessons_learned/ll_134_options_buying_power_zero_jan12.md
+++ b/rag_knowledge/lessons_learned/ll_134_options_buying_power_zero_jan12.md
@@ -1,0 +1,20 @@
+# Lesson Learned: Alpaca Paper Trading Options Buying Power Shows $0 Despite Cash Available
+
+**ID**: ll_134_options_buying_power_zero_jan12
+**Date**: 2026-01-12
+**Severity**: HIGH
+
+## Problem
+Alpaca paper trading account shows options_buying_power=$0 even with $5K cash and options_approved_level=3. This blocks new CSP orders.
+
+## Root Cause
+Pending sell-to-open orders AND existing short put positions consume buying power as collateral. Paper trading may have margin calculation bugs.
+
+## Solution
+1) Check open orders before placing new ones. 2) Cancel stale orders to free buying power. 3) Use credit spreads when buying power is tight. 4) Consider closing existing positions before opening new ones.
+
+## Impact
+Blocked BAC, F, and other CSP trades despite STRONG BUY signals.
+
+## Prevention
+Add buying_power check BEFORE submitting options orders. Auto-cancel stale orders older than 1 day.


### PR DESCRIPTION
## Summary
- Updated docs/index.md with actual account values ($4,998.98 brokerage, $5,002.98 paper)
- Added RAG lesson ll_134: Root cause analysis of options_buying_power=$0 issue

## Root Cause Found
Alpaca paper account shows `options_buying_power: $0` because:
1. Pending sell-to-open orders consume collateral
2. Existing short put positions reserve buying power
3. Need to cancel stale orders before placing new CSPs

## Test plan
- [x] Blog renders correctly with new data
- [x] RAG lesson file is valid markdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)