### PR TITLE
fix: Restore working PositionManager with stop-loss protection

### DIFF
--- a/src/risk/position_manager.py
+++ b/src/risk/position_manager.py
@@ -1,16 +1,33 @@
-# Position manager stub - original deleted in cleanup PR #1445
-# Minimal implementation to prevent import errors
+"""
+Position Manager - Real Implementation for Stop-Loss Protection
 
-from dataclasses import dataclass
+CEO Directive: "Don't lose money" - Phil Town Rule 1
+
+CRITICAL: This replaces the stub that was accidentally left after PR #1445 cleanup.
+The stub returned empty exit lists, meaning NO STOP-LOSSES EVER TRIGGERED!
+
+This implementation:
+- Evaluates all positions against exit conditions
+- Triggers stop-loss at 8% loss (configurable)
+- Triggers take-profit at 15% gain (configurable)
+- Supports time-based exits
+- Works for both long and short positions (including sold options)
+"""
+
+import logging
+from dataclasses import dataclass, field
+from datetime import datetime
 from typing import Any
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass
 class ExitConditions:
     """Exit conditions for positions."""
 
-    take_profit_pct: float = 0.15
-    stop_loss_pct: float = 0.08
+    take_profit_pct: float = 0.15  # 15% profit target
+    stop_loss_pct: float = 0.08  # 8% stop-loss (Phil Town Rule 1)
     max_holding_days: int = 30
     enable_momentum_exit: bool = False
     enable_atr_stop: bool = True
@@ -18,28 +35,133 @@ class ExitConditions:
     trailing_stop_pct: float = 0.0
 
 
+@dataclass
+class Position:
+    """Position data class."""
+
+    symbol: str
+    quantity: float
+    entry_price: float
+    current_price: float
+    unrealized_pl: float = 0.0
+    unrealized_plpc: float = 0.0
+    entry_date: datetime = field(default_factory=datetime.now)
+
+
 class PositionManager:
-    """Stub position manager - not used in Phil Town strategy."""
+    """
+    Real position manager with working stop-loss protection.
 
-    def __init__(self, *args, **kwargs):
-        self.positions: dict[str, Any] = {}
-        self.exit_conditions = ExitConditions()
+    This is NOT a stub - it actually evaluates positions and triggers exits.
+    """
 
-    def add_position(self, symbol: str, qty: float, price: float) -> bool:
-        """Stub add position."""
-        return True
+    def __init__(self, conditions: ExitConditions | None = None):
+        self.conditions = conditions or ExitConditions()
+        self.entries: dict[str, datetime] = {}  # Track entry dates
 
-    def remove_position(self, symbol: str) -> bool:
-        """Stub remove position."""
-        return True
+    def record_entry(self, symbol: str, entry_date: datetime | None = None) -> None:
+        """Record when a position was entered."""
+        self.entries[symbol] = entry_date or datetime.now()
 
-    def get_positions(self) -> dict[str, Any]:
-        """Return empty positions."""
-        return {}
+    def clear_entry(self, symbol: str) -> None:
+        """Clear entry tracking after exit."""
+        self.entries.pop(symbol, None)
 
-    def check_exits(self) -> list[str]:
-        """Return empty exit list."""
-        return []
+    def should_exit(self, position: Position) -> tuple[bool, str, str]:
+        """
+        Determine if a position should be exited.
+
+        Returns:
+            tuple: (should_exit: bool, reason: str, details: str)
+        """
+        symbol = position.symbol
+        pl_pct = position.unrealized_plpc
+
+        # For short positions (like sold puts), the P/L calculation is inverted
+        # A short put profits when the put price decreases
+        is_short = position.quantity < 0
+
+        # Stop-loss check - MOST IMPORTANT
+        if pl_pct <= -self.conditions.stop_loss_pct:
+            return (
+                True,
+                "STOP_LOSS",
+                f"Loss of {pl_pct * 100:.2f}% exceeds {self.conditions.stop_loss_pct * 100:.1f}% threshold",
+            )
+
+        # Take-profit check
+        if pl_pct >= self.conditions.take_profit_pct:
+            return (
+                True,
+                "TAKE_PROFIT",
+                f"Gain of {pl_pct * 100:.2f}% exceeds {self.conditions.take_profit_pct * 100:.1f}% target",
+            )
+
+        # Time-based exit
+        if symbol in self.entries:
+            days_held = (datetime.now() - self.entries[symbol]).days
+            if days_held >= self.conditions.max_holding_days:
+                return (
+                    True,
+                    "MAX_HOLDING_TIME",
+                    f"Position held for {days_held} days (max: {self.conditions.max_holding_days})",
+                )
+
+        return (False, "HOLD", "No exit conditions met")
+
+    def manage_all_positions(
+        self, positions: list[dict[str, Any]]
+    ) -> list[dict[str, Any]]:
+        """
+        Evaluate all positions and return those that should exit.
+
+        Args:
+            positions: List of position dicts from Alpaca API
+
+        Returns:
+            List of exit recommendations with position details
+        """
+        exits = []
+
+        for pos_dict in positions:
+            try:
+                # Convert to Position object
+                qty = float(pos_dict.get("qty", 0))
+                entry_price = float(pos_dict.get("avg_entry_price", 0))
+                current_price = float(pos_dict.get("current_price", 0))
+                unrealized_pl = float(pos_dict.get("unrealized_pl", 0))
+                unrealized_plpc = float(pos_dict.get("unrealized_plpc", 0))
+
+                position = Position(
+                    symbol=pos_dict["symbol"],
+                    quantity=qty,
+                    entry_price=entry_price,
+                    current_price=current_price,
+                    unrealized_pl=unrealized_pl,
+                    unrealized_plpc=unrealized_plpc,
+                )
+
+                should_exit, reason, details = self.should_exit(position)
+
+                if should_exit:
+                    logger.info(
+                        f"EXIT SIGNAL: {position.symbol} - {reason} - {details}"
+                    )
+                    exits.append(
+                        {
+                            "symbol": position.symbol,
+                            "reason": reason,
+                            "details": details,
+                            "position": position,
+                        }
+                    )
+                else:
+                    logger.debug(f"HOLD: {position.symbol} - {details}")
+
+            except Exception as e:
+                logger.error(f"Error evaluating position {pos_dict}: {e}")
+
+        return exits
 
 
 # Default instance for imports

--- a/tests/test_position_manager.py
+++ b/tests/test_position_manager.py
@@ -1,0 +1,103 @@
+"""Tests for Position Manager stop-loss functionality."""
+
+import pytest
+from src.risk.position_manager import ExitConditions, Position, PositionManager
+
+
+class TestPositionManager:
+    """Test position manager exit logic."""
+
+    def test_stop_loss_triggers_on_loss(self):
+        """Stop-loss should trigger when loss exceeds threshold."""
+        pm = PositionManager()
+        test_positions = [
+            {
+                "symbol": "TEST",
+                "qty": -1,
+                "avg_entry_price": 0.75,
+                "current_price": 1.04,
+                "unrealized_pl": -29.0,
+                "unrealized_plpc": -0.387,  # 38.7% loss
+            }
+        ]
+        exits = pm.manage_all_positions(test_positions)
+        assert len(exits) == 1
+        assert exits[0]["reason"] == "STOP_LOSS"
+
+    def test_no_exit_when_within_threshold(self):
+        """No exit should trigger when loss is within threshold."""
+        pm = PositionManager()
+        test_positions = [
+            {
+                "symbol": "TEST",
+                "qty": 100,
+                "avg_entry_price": 10.0,
+                "current_price": 9.50,
+                "unrealized_pl": -50.0,
+                "unrealized_plpc": -0.05,  # 5% loss (under 8% threshold)
+            }
+        ]
+        exits = pm.manage_all_positions(test_positions)
+        assert len(exits) == 0
+
+    def test_take_profit_triggers_on_gain(self):
+        """Take-profit should trigger when gain exceeds threshold."""
+        pm = PositionManager()
+        test_positions = [
+            {
+                "symbol": "WINNER",
+                "qty": 100,
+                "avg_entry_price": 10.0,
+                "current_price": 12.0,
+                "unrealized_pl": 200.0,
+                "unrealized_plpc": 0.20,  # 20% gain (over 15% target)
+            }
+        ]
+        exits = pm.manage_all_positions(test_positions)
+        assert len(exits) == 1
+        assert exits[0]["reason"] == "TAKE_PROFIT"
+
+    def test_custom_thresholds(self):
+        """Custom exit conditions should be respected."""
+        conditions = ExitConditions(
+            stop_loss_pct=0.05,  # 5% stop-loss
+            take_profit_pct=0.10,  # 10% take-profit
+        )
+        pm = PositionManager(conditions=conditions)
+
+        # 6% loss should trigger with 5% threshold
+        test_positions = [
+            {
+                "symbol": "TIGHT_STOP",
+                "qty": 100,
+                "avg_entry_price": 10.0,
+                "current_price": 9.40,
+                "unrealized_pl": -60.0,
+                "unrealized_plpc": -0.06,  # 6% loss
+            }
+        ]
+        exits = pm.manage_all_positions(test_positions)
+        assert len(exits) == 1
+        assert exits[0]["reason"] == "STOP_LOSS"
+
+    def test_position_dataclass(self):
+        """Position dataclass should hold correct values."""
+        pos = Position(
+            symbol="TEST",
+            quantity=-1,
+            entry_price=0.75,
+            current_price=1.04,
+            unrealized_pl=-29.0,
+            unrealized_plpc=-0.387,
+        )
+        assert pos.symbol == "TEST"
+        assert pos.quantity == -1
+        assert pos.entry_price == 0.75
+        assert pos.current_price == 1.04
+
+    def test_exit_conditions_defaults(self):
+        """Exit conditions should have sensible defaults."""
+        conditions = ExitConditions()
+        assert conditions.stop_loss_pct == 0.08
+        assert conditions.take_profit_pct == 0.15
+        assert conditions.max_holding_days == 30


### PR DESCRIPTION
CRITICAL FIX: Position manager was stub since PR #1445. No stop-losses ever triggered! Now fixed with 8% stop-loss, 15% take-profit, 6 tests passing.