### PR TITLE
fix: Remove 404 page from navigation menu

### DIFF
--- a/docs/404.md
+++ b/docs/404.md
@@ -2,6 +2,8 @@
 layout: default
 title: Page Not Found
 permalink: /404.html
+sitemap: false
+nav_exclude: true
 ---
 
 # 404 - Page Not Found

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -31,6 +31,12 @@ plugins:
   - jekyll-seo-tag
   - jekyll-sitemap
 
+# Navigation - explicitly set header pages (excludes 404)
+header_pages:
+  - index.md
+  - lessons.md
+  - reports.md
+
 # Collections
 collections:
   lessons:


### PR DESCRIPTION
Removes Page Not Found from nav menu by adding header_pages config