### PR TITLE
fix: Fix 404.html links for GitHub Pages baseurl

### DIFF
--- a/docs/404.md
+++ b/docs/404.md
@@ -16,8 +16,7 @@ We consolidated lesson files into our Vertex AI RAG knowledge base.
 
 ## Where to go instead:
 
-- [Home](/) - Current trading status
-- [Trading Rules](/lessons/) - Essential rules
+- [Home]({{ '/' | relative_url }}) - Current trading status
 - [GitHub Repo](https://github.com/IgorGanapolsky/trading) - Source code
 
 ---


### PR DESCRIPTION
- Use relative_url filter for home link
- Remove /lessons/ link (lessons in RAG)
- Fixes Deploy GitHub Pages workflow