### PR TITLE
fix(security): Add chmod 600 to GCP key files (LL-146)

### DIFF
--- a/.github/workflows/cleanup-vertex-rag.yml
+++ b/.github/workflows/cleanup-vertex-rag.yml
@@ -36,6 +36,7 @@ jobs:
       - name: Authenticate to Google Cloud
         run: |
           echo '${{ secrets.GCP_SA_KEY }}' > /tmp/gcp-key.json
+          chmod 600 /tmp/gcp-key.json  # Security fix Jan 13, 2026
           export GOOGLE_APPLICATION_CREDENTIALS=/tmp/gcp-key.json
           echo "GOOGLE_APPLICATION_CREDENTIALS=/tmp/gcp-key.json" >> $GITHUB_ENV
           echo "GCP_SA_KEY=${{ secrets.GCP_SA_KEY }}" >> $GITHUB_ENV

--- a/.github/workflows/daily-trading.yml
+++ b/.github/workflows/daily-trading.yml
@@ -190,9 +190,10 @@ jobs:
           echo "=" * 70
           echo ""
 
-          # Set up GCP auth
+          # Set up GCP auth (chmod 600 for security - Jan 13, 2026 fix)
           if [ -n "$GCP_SA_KEY" ]; then
             echo "$GCP_SA_KEY" > /tmp/gcp_sa_key.json
+            chmod 600 /tmp/gcp_sa_key.json
             export GOOGLE_APPLICATION_CREDENTIALS=/tmp/gcp_sa_key.json
           fi
 

--- a/.github/workflows/vertex-rag-pretrade.yml
+++ b/.github/workflows/vertex-rag-pretrade.yml
@@ -88,6 +88,7 @@ jobs:
           echo "Setting up GCP authentication..."
           if [ -n "$GCP_SA_KEY" ]; then
             echo "$GCP_SA_KEY" > /tmp/gcp_sa_key.json
+            chmod 600 /tmp/gcp_sa_key.json  # Security fix Jan 13, 2026
             export GOOGLE_APPLICATION_CREDENTIALS=/tmp/gcp_sa_key.json
             echo "GOOGLE_APPLICATION_CREDENTIALS=/tmp/gcp_sa_key.json" >> $GITHUB_ENV
 

--- a/rag_knowledge/lessons_learned/ll_146_gcp_key_security_fix_jan13.md
+++ b/rag_knowledge/lessons_learned/ll_146_gcp_key_security_fix_jan13.md
@@ -1,0 +1,36 @@
+# LL-146: GCP Service Account Key Security Fix
+
+**Date**: January 13, 2026
+**Category**: Security
+**Severity**: CRITICAL
+
+## Summary
+
+Fixed security vulnerability where GCP service account keys were written to `/tmp/` with world-readable permissions (644 default). Added `chmod 600` to restrict access to owner only.
+
+## Affected Workflows
+- daily-trading.yml (line 196)
+- vertex-rag-pretrade.yml (line 91)
+- cleanup-vertex-rag.yml (line 39)
+
+## Root Cause
+
+Default file creation permissions in shell allow read access to all users. On GitHub Actions runners, this is less critical (ephemeral VMs), but follows security best practices and prevents any process on the runner from reading credentials.
+
+## Fix Applied
+
+```bash
+# Before (insecure)
+echo "$GCP_SA_KEY" > /tmp/gcp_sa_key.json
+
+# After (secure)
+echo "$GCP_SA_KEY" > /tmp/gcp_sa_key.json
+chmod 600 /tmp/gcp_sa_key.json
+```
+
+## Prevention
+
+When writing secrets to files:
+1. Always `chmod 600` immediately after creation
+2. Delete secret files after use (`rm -f /tmp/secret.json`)
+3. Prefer environment variables over files when possible


### PR DESCRIPTION
## Summary
Security fix: GCP service account keys written to /tmp now have 600 permissions (owner-only read/write).

## Changes
- daily-trading.yml
- vertex-rag-pretrade.yml
- cleanup-vertex-rag.yml

## Test plan
- [x] Workflow syntax valid
- [x] Lesson recorded (LL-146)