### PR TITLE
fix(critical): Enable Vertex AI in Dialogflow webhook

### DIFF
--- a/.github/workflows/deploy-dialogflow-webhook.yml
+++ b/.github/workflows/deploy-dialogflow-webhook.yml
@@ -63,6 +63,7 @@ jobs:
       - name: Deploy to Cloud Run
         run: |
           IMAGE=${{ env.REGION }}-docker.pkg.dev/${{ env.PROJECT_ID }}/cloud-run-source-deploy/${{ env.SERVICE_NAME }}:${{ github.sha }}
+          # CRITICAL: Set GOOGLE_CLOUD_PROJECT for Vertex AI RAG initialization
           gcloud run deploy ${{ env.SERVICE_NAME }} \
             --image $IMAGE \
             --region ${{ env.REGION }} \
@@ -72,7 +73,8 @@ jobs:
             --cpu 1 \
             --min-instances 0 \
             --max-instances 3 \
-            --timeout 60s
+            --timeout 60s \
+            --set-env-vars "GOOGLE_CLOUD_PROJECT=${{ env.PROJECT_ID }},VERTEX_AI_LOCATION=${{ env.REGION }}"
 
       - name: Get service URL
         run: |

--- a/Dockerfile.webhook
+++ b/Dockerfile.webhook
@@ -1,5 +1,5 @@
-# Dockerfile for Dialogflow Webhook
-# Minimal dependencies for fast deployment (~2 min vs ~10 min)
+# Dockerfile for Dialogflow Webhook with Vertex AI RAG
+# FIXED Jan 13, 2026: Now includes Vertex AI for semantic search
 FROM python:3.11-slim
 
 # Cache bust to force fresh build on deploy
@@ -7,13 +7,14 @@ ARG CACHE_BUST=1
 
 WORKDIR /app
 
-# Install ONLY what webhook actually needs (no chromadb/sentence-transformers)
-# This reduces build time from ~10 min to ~2 min
-# ChromaDB was REMOVED per CLAUDE.md directive (Jan 7, 2026)
+# Install webhook dependencies INCLUDING Vertex AI for semantic search
+# Build time ~3-4 min but enables real RAG answers
 RUN pip install --no-cache-dir \
     fastapi==0.128.0 \
     uvicorn==0.40.0 \
-    requests==2.32.5
+    requests==2.32.5 \
+    google-cloud-aiplatform>=1.72.0 \
+    vertexai>=1.72.0
 
 # Create required package structure
 RUN mkdir -p src/agents src/rag rag_knowledge/lessons_learned data
@@ -21,10 +22,11 @@ RUN mkdir -p src/agents src/rag rag_knowledge/lessons_learned data
 # Create empty __init__.py files for Python packages
 RUN touch src/__init__.py src/agents/__init__.py src/rag/__init__.py
 
-# Copy ONLY the specific RAG files needed (not vertex_rag.py which needs google.cloud)
+# Copy RAG files INCLUDING vertex_rag.py for semantic search
 COPY src/agents/dialogflow_webhook.py src/agents/
 COPY src/rag/lessons_learned_rag.py src/rag/
 COPY src/rag/lessons_search.py src/rag/
+COPY src/rag/vertex_rag.py src/rag/
 COPY rag_knowledge/lessons_learned/ rag_knowledge/lessons_learned/
 
 # Copy system state for portfolio data (fallback to GitHub raw if stale)

--- a/rag_knowledge/lessons_learned/ll_166_dialogflow_vertex_ai_missing_jan13.md
+++ b/rag_knowledge/lessons_learned/ll_166_dialogflow_vertex_ai_missing_jan13.md
@@ -1,0 +1,40 @@
+# Lesson Learned: Dialogflow Webhook Missing Vertex AI - Only Local Keyword Search
+
+**ID**: ll_166_dialogflow_vertex_ai_missing_jan13
+**Date**: 2026-01-13
+**Severity**: HIGH
+
+## Problem
+Dialogflow webhook was falling back to local keyword search instead of using Vertex AI semantic search. CEO saw "Based on our lessons learned (local search):" instead of synthesized answers from Gemini.
+
+## Root Cause
+1. **Dockerfile.webhook** explicitly excluded Vertex AI:
+   - No `google-cloud-aiplatform` or `vertexai` packages
+   - Did NOT copy `src/rag/vertex_rag.py`
+   - Comment said: "not vertex_rag.py which needs google.cloud"
+
+2. **deploy-dialogflow-webhook.yml** missing environment variables:
+   - No `GOOGLE_CLOUD_PROJECT` set
+   - No `VERTEX_AI_LOCATION` set
+   - Without these, Vertex AI RAG cannot initialize
+
+## Fix
+1. Updated Dockerfile.webhook:
+   - Added `google-cloud-aiplatform>=1.72.0` and `vertexai>=1.72.0`
+   - Added `COPY src/rag/vertex_rag.py src/rag/`
+
+2. Updated deploy-dialogflow-webhook.yml:
+   - Added `--set-env-vars "GOOGLE_CLOUD_PROJECT=...,VERTEX_AI_LOCATION=..."`
+
+## Impact
+- Dialogflow was useless for answering CEO questions
+- Only dumped keyword-matched lessons instead of synthesizing answers
+- No semantic search capability despite Vertex AI being available
+
+## Prevention
+1. Always verify Cloud Run environment variables after deployment
+2. Test Dialogflow responses show "Vertex AI RAG" not "local search"
+3. Include Vertex AI deps in Dockerfile when semantic search is required
+
+## Tags
+dialogflow, vertex-ai, rag, cloud-run, deployment, semantic-search


### PR DESCRIPTION
## Problem
Dialogflow was falling back to LOCAL keyword search instead of Vertex AI semantic search.

## Root Cause
1. Dockerfile.webhook excluded Vertex AI packages
2. deploy-dialogflow-webhook.yml missing env vars

## Fix
- Add google-cloud-aiplatform and vertexai to Dockerfile
- Copy vertex_rag.py to container
- Set GOOGLE_CLOUD_PROJECT and VERTEX_AI_LOCATION env vars

## Impact
Dialogflow will use Gemini to synthesize answers instead of dumping lessons.