### PR TITLE
fix(ci): Handle missing .claude/skills directory gracefully

### DIFF
--- a/scripts/validate_skills.py
+++ b/scripts/validate_skills.py
@@ -82,8 +82,9 @@ def main():
     args = parser.parse_args()
 
     if not SKILLS_DIR.exists():
-        print("ERROR: .claude/skills directory not found")
-        sys.exit(1)
+        print("INFO: .claude/skills directory not found - no skills to validate")
+        print("✅ Skill validation passed (no skills defined)")
+        sys.exit(0)
 
     all_errors = []
     skills_checked = 0


### PR DESCRIPTION
## Summary
- Fixed validate_skills.py to exit 0 when no skills directory exists
- No skills = nothing to validate = success

## Root Cause
Skill validation was failing because .claude/skills directory does not exist in this repo.