### PR TITLE
fix: Add list_all() to StrategyRegistry and allow heartbeat.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,6 +76,7 @@ build/
 !data/watchlist_4ms_small_capital.json
 !data/performance_log.json
 !data/trades_*.json
+!data/heartbeat.json
 data/google_sheets_credentials.json
 
 # Local CI/CD

--- a/src/strategies/registry.py
+++ b/src/strategies/registry.py
@@ -82,6 +82,10 @@ class StrategyRegistry:
         """List all registered strategies."""
         return list(self._strategies.keys())
 
+    def list_all(self) -> list[str]:
+        """List all registered strategies (alias for list_strategies)."""
+        return self.list_strategies()
+
 
 # Global registry instance
 _registry: StrategyRegistry | None = None


### PR DESCRIPTION
## Summary
- Add `list_all()` method to `StrategyRegistry` stub as alias for `list_strategies()` to fix Agent Health Check workflow `AttributeError`
- Add `!data/heartbeat.json` to `.gitignore` to allow Pre-Market Sync workflow to commit heartbeat data

## Fixes
- Agent Health Check workflow failing with: `AttributeError: 'StrategyRegistry' object has no attribute 'list_all'`
- Pre-Market Sync workflow failing to commit `data/heartbeat.json` (blocked by gitignore)

## Test plan
- [x] Verified `list_all()` method works locally: returns empty list as expected
- [x] Pre-push validation passed all checks
- [ ] CI should pass after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)