### PR TITLE
fix: Remove src module dependency from cancel_stale_orders.py

### DIFF
--- a/scripts/cancel_stale_orders.py
+++ b/scripts/cancel_stale_orders.py
@@ -32,9 +32,9 @@ def main() -> int:
         logger.error("alpaca-py not installed")
         return 1
 
-    from src.utils.alpaca_client import get_alpaca_credentials
-
-    api_key, secret_key = get_alpaca_credentials()
+    # Get credentials directly from environment (CI workflow sets these)
+    api_key = os.getenv("ALPACA_API_KEY")
+    secret_key = os.getenv("ALPACA_SECRET_KEY")
     paper = os.getenv("PAPER_TRADING", "true").lower() == "true"
 
     if not api_key or not secret_key:


### PR DESCRIPTION
## Summary
- Get credentials directly from environment variables instead of importing from `src.utils.alpaca_client`

## Fixes
- Cancel Stale Orders workflow failing with: `ModuleNotFoundError: No module named 'src'`
- The workflow only installs `alpaca-py`, not project dependencies

## Test plan
- [x] Syntax validation passed
- [x] Pre-push validation passed all checks
- [ ] CI should pass after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)