### PR TITLE
fix: Use GetOrdersRequest for alpaca-py get_orders API

### DIFF
--- a/scripts/cancel_stale_orders.py
+++ b/scripts/cancel_stale_orders.py
@@ -28,6 +28,8 @@ def main() -> int:
     """Cancel stale orders to free buying power."""
     try:
         from alpaca.trading.client import TradingClient
+        from alpaca.trading.enums import QueryOrderStatus
+        from alpaca.trading.requests import GetOrdersRequest
     except ImportError:
         logger.error("alpaca-py not installed")
         return 1
@@ -43,8 +45,9 @@ def main() -> int:
 
     client = TradingClient(api_key, secret_key, paper=paper)
 
-    # Get all open orders
-    orders = client.get_orders(status="open")
+    # Get all open orders using GetOrdersRequest (alpaca-py API)
+    request_params = GetOrdersRequest(status=QueryOrderStatus.OPEN)
+    orders = client.get_orders(filter=request_params)
 
     if not orders:
         logger.info("No open orders found")


### PR DESCRIPTION
## Summary
- Use `GetOrdersRequest` object instead of keyword arguments for `get_orders()`
- Import `QueryOrderStatus` and `GetOrdersRequest` from alpaca-py

## Fixes
- Cancel Stale Orders workflow failing with: `TypeError: TradingClient.get_orders() got an unexpected keyword argument 'status'`
- The alpaca-py SDK requires a request object, not keyword arguments

## Test plan
- [x] Syntax validation passed
- [x] Pre-push validation passed all checks
- [ ] Cancel Stale Orders workflow should pass after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)