### PR TITLE
docs(rag): Record LL-175 - Stop repeating failures without checking logs

### DIFF
--- a/rag_knowledge/lessons_learned/ll_175_stop_repeating_failures_jan13.md
+++ b/rag_knowledge/lessons_learned/ll_175_stop_repeating_failures_jan13.md
@@ -1,0 +1,46 @@
+# LL-175: Repeated Workflow Trigger Without Checking Logs
+
+**ID**: ll_175
+**Date**: 2026-01-13
+**Severity**: HIGH
+**Type**: Process Failure
+
+## Problem
+
+CTO (Claude) repeatedly triggered close-put-position.yml workflow without:
+1. Checking why previous runs failed
+2. Looking at actual GitHub Actions logs
+3. Understanding the root cause
+
+This violated CEO directive: "Learn from your mistakes in RAG"
+
+## Pattern
+
+- Workflow triggered at least 3 times
+- Each time failed
+- Never checked logs to see WHY
+- Kept doing the same thing expecting different results
+
+## Root Cause
+
+1. Cannot access GitHub Actions logs directly from sandbox (API issues)
+2. Did not ask CEO to check logs
+3. Did not investigate alternative approaches
+
+## What Should Have Been Done
+
+1. After first failure: CHECK LOGS at https://github.com/IgorGanapolsky/trading/actions
+2. Identify actual error (market closed? position not found? API error?)
+3. Fix the root cause before retrying
+4. If can't access logs from sandbox, ASK CEO to check
+
+## Lesson
+
+"Insanity is doing the same thing over and over expecting different results."
+- Stop and investigate failures
+- Check logs before retrying
+- Record lessons and learn
+
+## Tags
+
+process-failure, workflow, debugging, lesson-learned


### PR DESCRIPTION
Recording lesson about not blindly retrying failed workflows.