### PR TITLE
feat(strategy): Add ticker hierarchy, earnings blackouts, trade plan

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -21,6 +21,19 @@ CTO: Claude | CEO: Igor Ganapolsky
 - Scale decisions based on REAL data, not projections
 - If win rate <60% after 30 trades: reassess strategy
 
+### Ticker Hierarchy (Jan 2026 Research)
+| Priority | Ticker | Rationale | Blackout |
+|----------|--------|-----------|----------|
+| 1 | SPY | Best liquidity, tightest spreads | None |
+| 2 | IWM | Small cap exposure, good vol | None |
+| 3 | F | Undervalued, 4.2% div support | Feb 3-10 (earnings Feb 10) |
+| 4 | T | Stable, low IV = lower premiums | TBD earnings |
+| 5 | SOFI | **AVOID until Feb 1** | Jan 23-30 (earnings Jan 30, IV 55%) |
+
+### Phil Town Alignment Note
+Credit spreads conflict with Rule #1 (risk $400 to make $100).
+Mitigations: Use 30-delta (not ATM) for margin of safety, strict stops, small position sizes.
+
 ## Core Directives (PERMANENT)
 1. **Don't lose money** - Rule #1 always
 2. **Never argue with CEO** - Follow directives immediately

--- a/data/trade_plans/jan14_2026_trade_plan.md
+++ b/data/trade_plans/jan14_2026_trade_plan.md
@@ -1,0 +1,57 @@
+# Trade Plan: January 14, 2026
+
+**Generated:** Jan 13, 2026 by CTO Claude
+**Market Status:** Markets open 9:30 AM ET
+**Trade Window:** 9:35 AM - 3:30 PM ET
+
+## Pre-Market Checklist
+
+- [ ] Check VIX level (currently ~15, low IV environment)
+- [ ] Verify no unexpected overnight news on target tickers
+- [ ] Confirm account balance: $5,017.76
+- [ ] Max positions today: 1-2 (conservative)
+
+## Primary Targets (Priority Order)
+
+### 1. SPY Bull Put Spread
+- **Why**: Best liquidity, tightest bid/ask
+- **Setup**:
+  - Sell 30-delta put (~$580 strike area, verify live)
+  - Buy put $5 below
+  - 30-45 DTE (Feb 14-21 expiration)
+- **Target premium**: $60-80
+- **Max position size**: 1 spread
+- **Collateral required**: $500
+
+### 2. IWM Bull Put Spread (Backup)
+- **Why**: Small caps undervalued, good IV
+- **Setup**:
+  - Sell 30-delta put (verify strike live)
+  - Buy put $5 below
+  - 30-45 DTE
+- **Target premium**: $50-70
+- **Collateral required**: $500
+
+## DO NOT TRADE
+
+- **SOFI**: BLACKOUT until Feb 1 (earnings Jan 30, IV 55%)
+- **F**: Use caution, earnings Feb 10
+- Any ticker with earnings < 7 days away
+
+## Exit Rules
+
+| Condition | Action |
+|-----------|--------|
+| 50% of max profit | Close and bank gains |
+| 25% of max loss | Close and cut losses |
+| 7 DTE remaining | Close regardless of P/L |
+
+## End-of-Day Review
+
+- [ ] Record all trades to RAG
+- [ ] Update performance log
+- [ ] Note any lessons learned
+
+---
+
+**Paper trading phase:** Day N/A of 90

--- a/rag_knowledge/lessons_learned/ll_188_jan2026_strategy_research_jan13.md
+++ b/rag_knowledge/lessons_learned/ll_188_jan2026_strategy_research_jan13.md
@@ -1,0 +1,57 @@
+# Strategic Research: January 2026 Credit Spread Optimization
+
+**ID:** LL-188
+**Date:** January 13, 2026
+**Severity:** HIGH
+**Category:** strategy-research
+
+## Research Summary
+
+Deep research conducted on January 2026 best practices for credit spreads on small accounts ($5K).
+
+## Key Findings
+
+### 1. Ticker Selection Priority
+- **SPY/IWM** superior to F/SOFI/T due to liquidity
+- SOFI: BLACKOUT until Feb 1 (earnings Jan 30, IV at 55%)
+- F: Caution Feb 3-10 (earnings Feb 10)
+- T: Safest but lowest premiums (weak moat per research)
+
+### 2. Strike Selection
+- Use 30-delta puts (not ATM) for margin of safety
+- ATM = zero cushion, violates Phil Town principles
+
+### 3. Premium Reality Check
+- VIX at 15 = low IV environment
+- $100/spread may be unrealistic; $60-80 achievable
+- Accept lower returns in low IV periods
+
+### 4. Phil Town Conflict
+Credit spreads inherently violate Rule #1 (risk $400 to make $100).
+Mitigation: Use OTM strikes, strict stops, conservative position sizes.
+
+## Ticker Analysis
+
+| Ticker | Moat | Management | Rule #1? |
+|--------|------|------------|----------|
+| F | Narrow/Declining | Mixed | Maybe |
+| SOFI | Emerging | Strong | Promising |
+| T | Weak | Concerning | NO |
+
+## Prevention
+
+Before any trade:
+1. Check earnings calendar (avoid 7 days before)
+2. Verify IV environment (VIX level)
+3. Use 30-delta strikes (not ATM)
+4. Respect position limits
+
+## Sources
+
+- OptionsPlay, Schwab, Fidelity, MarketBeat
+- arXiv market analysis papers
+- Phil Town Rule #1 Investing
+
+## Tags
+
+`strategy`, `research`, `credit-spreads`, `earnings-risk`, `phil-town`


### PR DESCRIPTION
## Summary
- Added ticker hierarchy: SPY/IWM prioritized over F/SOFI/T
- Added earnings blackouts: SOFI until Feb 1, F Feb 3-10
- Added Phil Town alignment note with mitigations
- Added trade plan template for Jan 14
- Logged research findings (ll_188)

## Test plan
- [ ] Verify CLAUDE.md renders correctly
- [ ] Verify trade plan is actionable