### PR TITLE
fix(options): Correct delta/theta ratio calculation

### DIFF
--- a/src/utils/options_analysis.py
+++ b/src/utils/options_analysis.py
@@ -499,8 +499,10 @@ def validate_delta_theta_ratio(
     warnings = []
 
     # Use absolute values for calculation
-    abs_delta = abs(delta) * 100  # Convert to dollars per $1 move
-    abs_theta = abs(theta)  # Already in dollars per day
+    # Both delta and theta are per-share, so the 100x multiplier cancels out
+    # Delta 0.45 / Theta 0.10 = 4.5 ratio (per Giannino's example)
+    abs_delta = abs(delta)
+    abs_theta = abs(theta)
 
     # Calculate ratio
     ratio = abs_delta / abs_theta if abs_theta > 0 else float("inf")


### PR DESCRIPTION
## Summary
- Fixes CI failure in `test_bad_ratio_fails`
- Delta/theta ratio was incorrectly multiplying delta by 100 but not theta
- Both greeks are per-share, so the multipliers cancel out

## Before
```
abs(delta) * 100 / abs(theta) = 0.20 * 100 / 0.15 = 133.33 (falsely passes)
```

## After
```
abs(delta) / abs(theta) = 0.20 / 0.15 = 1.33 (correctly fails < 3)
```

## Test plan
- [ ] CI passes with test_bad_ratio_fails
- [ ] All 950 tests pass