### PR TITLE
fix(trading): Use 30-45 DTE for credit spreads per CLAUDE.md

### DIFF
--- a/.github/workflows/execute-credit-spread.yml
+++ b/.github/workflows/execute-credit-spread.yml
@@ -124,10 +124,11 @@ jobs:
           from alpaca.trading.requests import GetOptionContractsRequest
           from alpaca.trading.enums import AssetStatus, ContractType
 
-          # Find expiration 7-14 days out
+          # BUGFIX Jan 14, 2026: Use 30-45 DTE per CLAUDE.md strategy
+          # 7-14 days had insufficient options liquidity for F/T
           today = datetime.now()
-          min_expiry = (today + timedelta(days=3)).strftime("%Y-%m-%d")
-          max_expiry = (today + timedelta(days=21)).strftime("%Y-%m-%d")
+          min_expiry = (today + timedelta(days=25)).strftime("%Y-%m-%d")
+          max_expiry = (today + timedelta(days=50)).strftime("%Y-%m-%d")
 
           try:
               req = GetOptionContractsRequest(


### PR DESCRIPTION
## Summary
Auto-generated PR from branch: `claude/fix-credit-spread-dte-VD682`

## Changes
e340484c fix(trading): Use 30-45 DTE for credit spreads per CLAUDE.md

## Test Plan
- [ ] CI passes
- [ ] Manual verification if needed