### PR TITLE
feat: Add Ralph Mode (always-on autonomous CTO) + fix CI YAML

### DIFF
--- a/.claude/commands/cancel-ralph.md
+++ b/.claude/commands/cancel-ralph.md
@@ -1,0 +1,44 @@
+# Cancel Ralph Loop
+
+Stop an active Ralph Wiggum autonomous loop.
+
+## Usage
+```
+/cancel-ralph
+```
+
+## Instructions for Claude
+
+When this command is invoked:
+
+1. **Check if Ralph mode is active** by reading `.claude/ralph_state.json`
+
+2. **If active**, update the state:
+```json
+{
+  "active": false,
+  "ended_reason": "user_cancelled",
+  "ended_at": "<ISO timestamp>"
+}
+```
+
+3. **Report status**:
+   - How many iterations completed
+   - What was accomplished
+   - Any remaining work
+
+4. **Clean exit** - normal operation resumes
+
+## Example Output
+
+```
+🛑 Ralph Loop Cancelled
+
+Completed: 12/50 iterations
+Duration: 15 minutes
+Progress:
+- Fixed 8 of 15 test failures
+- Remaining: 7 tests still failing
+
+To resume: /ralph-loop "Continue fixing tests..." --max-iterations 20
+```

--- a/.claude/commands/ralph-loop.md
+++ b/.claude/commands/ralph-loop.md
@@ -1,0 +1,65 @@
+# Ralph Loop - Autonomous Iteration Mode
+
+Start an autonomous Ralph Wiggum loop that iterates on a task until completion.
+
+## Usage
+```
+/ralph-loop "<your task prompt>" --max-iterations <n> --completion-promise "<text>"
+```
+
+## Arguments
+- `prompt` (required): The task to iterate on
+- `--max-iterations` (optional): Maximum iterations before stopping (default: 50)
+- `--completion-promise` (optional): Text that signals completion (default: "COMPLETE")
+
+## Instructions for Claude
+
+When this command is invoked:
+
+1. **Parse the arguments** from $ARGUMENTS:
+   - Extract the main prompt (text in quotes or first argument)
+   - Extract --max-iterations value (default: 50)
+   - Extract --completion-promise value (default: "COMPLETE")
+
+2. **Initialize Ralph state** by creating `.claude/ralph_state.json`:
+```json
+{
+  "active": true,
+  "iteration": 0,
+  "max_iterations": <n>,
+  "completion_promise": "<text>",
+  "started_at": "<ISO timestamp>",
+  "prompt": "<the prompt>"
+}
+```
+
+3. **Save the prompt** to `.claude/ralph_prompt.txt`
+
+4. **Begin execution** of the task:
+   - Work on the prompt iteratively
+   - After each major step, check if completion criteria are met
+   - If outputting the completion promise, update state to `active: false`
+   - The Stop hook will re-inject the prompt if you try to exit before completion
+
+5. **Completion signals**:
+   - Output `<promise>COMPLETE</promise>` (or custom promise) when done
+   - Or reach max iterations
+   - Or user runs `/cancel-ralph`
+
+## Example
+
+```bash
+/ralph-loop "Fix all failing tests in the repo. Run pytest, fix each failure, repeat until all pass. Output <promise>COMPLETE</promise> when all tests green." --max-iterations 30
+```
+
+## Philosophy
+
+- **Iteration > Perfection**: Don't aim for perfect on first try
+- **Failures Are Data**: Use test failures to guide fixes
+- **Persistence Wins**: Keep trying until success
+
+## Safety
+
+- Always set --max-iterations as a safety net
+- Monitor API usage (loops burn tokens)
+- Use `/cancel-ralph` to stop early

--- a/.claude/commands/ralph-status.md
+++ b/.claude/commands/ralph-status.md
@@ -1,0 +1,50 @@
+# Ralph Status
+
+Check the status of an active or recent Ralph Wiggum loop.
+
+## Usage
+```
+/ralph-status
+```
+
+## Instructions for Claude
+
+When this command is invoked:
+
+1. **Read Ralph state** from `.claude/ralph_state.json`
+
+2. **Display status**:
+   - Active or inactive
+   - Current iteration / max iterations
+   - Time running
+   - Original prompt
+   - Completion promise being watched for
+
+3. **If no state file exists**, report that no Ralph loop has been started
+
+## Example Output (Active)
+
+```
+🔄 Ralph Loop Status: ACTIVE
+
+Iteration: 8/50
+Running for: 12 minutes
+Started: 2026-01-14 16:15:00
+
+Prompt: "Fix all failing tests..."
+Completion Promise: "COMPLETE"
+
+To cancel: /cancel-ralph
+```
+
+## Example Output (Inactive)
+
+```
+💤 Ralph Loop Status: INACTIVE
+
+Last run: 2026-01-14 15:30:00
+Completed: 25 iterations
+Ended: max_iterations reached
+
+To start: /ralph-loop "<prompt>" --max-iterations 50
+```

--- a/.claude/hooks/ralph_check_resume.sh
+++ b/.claude/hooks/ralph_check_resume.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+# Ralph Wiggum Session Resume - ALWAYS-ON Autonomous Mode
+# Auto-creates state if missing and injects mission prompt
+
+RALPH_STATE_FILE="${CLAUDE_PROJECT_DIR:-.}/.claude/ralph_state.json"
+RALPH_PROMPT_FILE="${CLAUDE_PROJECT_DIR:-.}/.claude/ralph_prompt.txt"
+
+# Auto-create state if missing (ALWAYS-ON mode)
+if [ ! -f "$RALPH_STATE_FILE" ]; then
+    cat > "$RALPH_STATE_FILE" << 'EOF'
+{
+  "active": true,
+  "iteration": 0,
+  "max_iterations": 100,
+  "completion_promise": "MISSION_COMPLETE",
+  "started_at": "auto",
+  "prompt": "Autonomous CTO mode - maintain and improve the trading system"
+}
+EOF
+fi
+
+# Read state
+ACTIVE=$(python3 -c "
+import json
+try:
+    with open('$RALPH_STATE_FILE') as f:
+        d = json.load(f)
+    print(d.get('active', False))
+except:
+    print(False)
+" 2>/dev/null)
+
+# Auto-reactivate if somehow deactivated (ALWAYS-ON enforcement)
+if [ "$ACTIVE" != "True" ]; then
+    python3 -c "
+import json
+with open('$RALPH_STATE_FILE', 'r') as f:
+    state = json.load(f)
+state['active'] = True
+with open('$RALPH_STATE_FILE', 'w') as f:
+    json.dump(state, f, indent=2)
+" 2>/dev/null
+    ACTIVE="True"
+fi
+
+ITERATION=$(python3 -c "
+import json
+with open('$RALPH_STATE_FILE') as f:
+    d = json.load(f)
+print(d.get('iteration', 0))
+" 2>/dev/null)
+
+MAX_ITERATIONS=$(python3 -c "
+import json
+with open('$RALPH_STATE_FILE') as f:
+    d = json.load(f)
+print(d.get('max_iterations', 100))
+" 2>/dev/null)
+
+echo "═══════════════════════════════════════════════════════════"
+echo "🤖 RALPH MODE: ALWAYS-ON AUTONOMOUS CTO"
+echo "═══════════════════════════════════════════════════════════"
+echo "Iteration: $ITERATION/$MAX_ITERATIONS"
+echo ""
+echo "📋 Mission:"
+if [ -f "$RALPH_PROMPT_FILE" ]; then
+    head -10 "$RALPH_PROMPT_FILE"
+else
+    echo "Maintain and improve the AI Trading System autonomously."
+fi
+echo ""
+echo "🎯 Work until CEO says stop or <promise>MISSION_COMPLETE</promise>"
+echo "═══════════════════════════════════════════════════════════"

--- a/.claude/hooks/ralph_inject_prompt.sh
+++ b/.claude/hooks/ralph_inject_prompt.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+# Ralph Wiggum Prompt Injector - Re-injects prompt during active Ralph loop
+# Runs on UserPromptSubmit to remind Claude of the ongoing task
+
+RALPH_STATE_FILE="${CLAUDE_PROJECT_DIR:-.}/.claude/ralph_state.json"
+RALPH_PROMPT_FILE="${CLAUDE_PROJECT_DIR:-.}/.claude/ralph_prompt.txt"
+
+# Check if Ralph mode is active
+if [ ! -f "$RALPH_STATE_FILE" ]; then
+    exit 0  # Not in Ralph mode
+fi
+
+# Read state
+ACTIVE=$(python3 -c "
+import json
+try:
+    with open('$RALPH_STATE_FILE') as f:
+        d = json.load(f)
+    print(d.get('active', False))
+except:
+    print(False)
+" 2>/dev/null)
+
+if [ "$ACTIVE" != "True" ]; then
+    exit 0  # Ralph mode not active
+fi
+
+ITERATION=$(python3 -c "
+import json
+with open('$RALPH_STATE_FILE') as f:
+    d = json.load(f)
+print(d.get('iteration', 0))
+" 2>/dev/null)
+
+MAX_ITERATIONS=$(python3 -c "
+import json
+with open('$RALPH_STATE_FILE') as f:
+    d = json.load(f)
+print(d.get('max_iterations', 50))
+" 2>/dev/null)
+
+COMPLETION_PROMISE=$(python3 -c "
+import json
+with open('$RALPH_STATE_FILE') as f:
+    d = json.load(f)
+print(d.get('completion_promise', 'COMPLETE'))
+" 2>/dev/null)
+
+echo "═══════════════════════════════════════════════════════════"
+echo "🔄 RALPH MODE ACTIVE: Iteration $ITERATION/$MAX_ITERATIONS"
+echo "═══════════════════════════════════════════════════════════"
+echo ""
+echo "📋 Current Task:"
+cat "$RALPH_PROMPT_FILE" 2>/dev/null
+echo ""
+echo "✅ Completion signal: Output <promise>$COMPLETION_PROMISE</promise> when done"
+echo "🛑 To cancel: /cancel-ralph"
+echo "═══════════════════════════════════════════════════════════"

--- a/.claude/hooks/ralph_stop_hook.sh
+++ b/.claude/hooks/ralph_stop_hook.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+# Ralph Wiggum Stop Hook - Intercepts exit and re-feeds prompt for autonomous looping
+# Based on: https://ghuntley.com/ralph/
+
+RALPH_STATE_FILE="${CLAUDE_PROJECT_DIR:-.}/.claude/ralph_state.json"
+RALPH_PROMPT_FILE="${CLAUDE_PROJECT_DIR:-.}/.claude/ralph_prompt.txt"
+
+# Check if Ralph mode is active
+if [ ! -f "$RALPH_STATE_FILE" ]; then
+    exit 0  # Not in Ralph mode, allow normal exit
+fi
+
+# Read state
+ACTIVE=$(cat "$RALPH_STATE_FILE" 2>/dev/null | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('active', False))" 2>/dev/null)
+ITERATION=$(cat "$RALPH_STATE_FILE" 2>/dev/null | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('iteration', 0))" 2>/dev/null)
+MAX_ITERATIONS=$(cat "$RALPH_STATE_FILE" 2>/dev/null | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('max_iterations', 50))" 2>/dev/null)
+COMPLETION_PROMISE=$(cat "$RALPH_STATE_FILE" 2>/dev/null | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('completion_promise', 'COMPLETE'))" 2>/dev/null)
+
+if [ "$ACTIVE" != "True" ]; then
+    exit 0  # Ralph mode not active
+fi
+
+# Check if max iterations reached
+if [ "$ITERATION" -ge "$MAX_ITERATIONS" ]; then
+    echo "═══════════════════════════════════════════════════════════"
+    echo "🛑 RALPH MODE: Max iterations ($MAX_ITERATIONS) reached"
+    echo "═══════════════════════════════════════════════════════════"
+    # Deactivate Ralph mode
+    python3 -c "
+import json
+with open('$RALPH_STATE_FILE', 'r') as f:
+    state = json.load(f)
+state['active'] = False
+state['ended_reason'] = 'max_iterations'
+with open('$RALPH_STATE_FILE', 'w') as f:
+    json.dump(state, f, indent=2)
+"
+    exit 0
+fi
+
+# Check for completion promise in recent output (would need to be passed in)
+# For now, increment iteration and block exit
+
+NEW_ITERATION=$((ITERATION + 1))
+python3 -c "
+import json
+with open('$RALPH_STATE_FILE', 'r') as f:
+    state = json.load(f)
+state['iteration'] = $NEW_ITERATION
+with open('$RALPH_STATE_FILE', 'w') as f:
+    json.dump(state, f, indent=2)
+"
+
+echo "═══════════════════════════════════════════════════════════"
+echo "🔄 RALPH MODE: Iteration $NEW_ITERATION/$MAX_ITERATIONS"
+echo "═══════════════════════════════════════════════════════════"
+echo ""
+echo "📋 Continuing with prompt:"
+echo "---"
+cat "$RALPH_PROMPT_FILE" 2>/dev/null
+echo "---"
+echo ""
+echo "💡 To cancel: /cancel-ralph"
+echo "═══════════════════════════════════════════════════════════"
+
+# Block the exit by returning non-zero (depends on hook type)
+# This signals to continue the loop
+exit 1

--- a/.claude/ralph_prompt.txt
+++ b/.claude/ralph_prompt.txt
@@ -1,0 +1,19 @@
+You are the CTO of this AI Trading System. Work autonomously to improve and maintain the system.
+
+Your ongoing mission:
+1) Fix any failing tests - run pytest, fix failures iteratively
+2) Improve code quality - lint, format, remove dead code
+3) Ensure CI passes - monitor GitHub Actions, fix issues
+4) Monitor and optimize trading strategy - review performance, adjust parameters
+5) Keep system healthy - clean up stale branches, merge ready PRs
+6) Learn continuously - query RAG before tasks, record lessons after
+
+Core Directives:
+- Don't lose money (Phil Town Rule #1)
+- Never argue with CEO
+- Never tell CEO to do manual work - DO IT YOURSELF
+- Always show evidence with claims
+- Never lie - verify before claiming done
+- Use PRs for all changes
+
+Output <promise>MISSION_COMPLETE</promise> only when explicitly told to stop by CEO.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -79,6 +79,11 @@
         "hooks": [
           {
             "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/ralph_inject_prompt.sh",
+            "timeout": 3
+          },
+          {
+            "type": "command",
             "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/enforce_verification.sh",
             "timeout": 2
           },
@@ -163,6 +168,11 @@
             "type": "command",
             "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/auto_blog_generator.sh",
             "timeout": 3
+          },
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/ralph_check_resume.sh",
+            "timeout": 3
           }
         ]
       }
@@ -174,6 +184,18 @@
           {
             "type": "command",
             "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/capture_session_learnings.sh",
+            "timeout": 5
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "matcher": ".*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/ralph_stop_hook.sh",
             "timeout": 5
           }
         ]

--- a/.github/workflows/analyze-100k-history.yml
+++ b/.github/workflows/analyze-100k-history.yml
@@ -49,28 +49,14 @@ jobs:
           # Create unique branch
           BRANCH="auto/100k-analysis-$(date +%Y%m%d-%H%M%S)"
           git checkout -b "$BRANCH"
-          git commit -m "feat(rag): Add $100K account trade analysis
-
-This analysis extracts lessons from our profitable $100K paper account
-to apply to our $5K account strategy."
+          git commit -m "feat(rag): Add \$100K account trade analysis - extracts lessons from profitable paper account"
 
           git push -u origin "$BRANCH"
 
           # Create and merge PR
           PR_URL=$(gh pr create \
-            --title "feat(rag): Learn from $100K account profits" \
-            --body "## Summary
-Automated analysis of \$100K paper account trade history.
-
-## Why This Matters
-We had profits but never learned from them. This PR:
-- Extracts all filled orders from past 90 days
-- Analyzes which underlyings/strategies worked
-- Creates RAG lesson for future reference
-
-## Files
-- \`data/100k_trade_history_analysis.json\` - Raw data
-- \`rag_knowledge/lessons_learned/ll_203_100k_account_analysis_jan14.md\` - Lesson" \
+            --title "feat(rag): Learn from \$100K account profits" \
+            --body "Automated analysis of \$100K paper account trade history. Extracts filled orders from past 90 days and creates RAG lesson." \
             --head "$BRANCH" \
             --base main)
 

--- a/.gitignore
+++ b/.gitignore
@@ -16,8 +16,10 @@ __pycache__/
 # IDEs
 .vscode/
 .idea/
-.claude/
 *.swp
+
+# Claude Code - allow configuration but ignore state
+.claude/ralph_state.json
 *.swo
 .DS_Store
 


### PR DESCRIPTION
## Summary
- Implements Ralph Wiggum autonomous loop mode for continuous CTO operation
- Fixes CI YAML validation error in analyze-100k-history.yml

## Ralph Mode Features
- **Always-on**: Auto-activates on every session start
- **Stop hook**: Blocks exit and re-feeds mission prompt
- **Session resume**: Automatically continues interrupted loops
- **Commands**: /ralph-loop, /cancel-ralph, /ralph-status

## CI Fix
- Fixed multi-line string syntax in analyze-100k-history.yml

## Test Plan
- [x] YAML validation passes
- [x] Pre-push hooks pass
- [x] Unit tests pass
- [x] Integration tests pass