### PR TITLE
fix: BiasStore accepts both str and Path

### DIFF
--- a/src/analyst/bias_store.py
+++ b/src/analyst/bias_store.py
@@ -51,8 +51,14 @@ class BiasProvider:
 class BiasStore:
     """Persists bias snapshots to disk."""
 
-    def __init__(self, bias_dir: Optional[Path] = None):
-        self.bias_dir = bias_dir or Path("data/bias")
+    def __init__(self, bias_dir: Optional[Path | str] = None):
+        # Handle both str and Path inputs (CEO FIX Jan 15, 2026)
+        if bias_dir is None:
+            self.bias_dir = Path("data/bias")
+        elif isinstance(bias_dir, str):
+            self.bias_dir = Path(bias_dir)
+        else:
+            self.bias_dir = bias_dir
         self.bias_dir.mkdir(parents=True, exist_ok=True)
         self.snapshots: list[BiasSnapshot] = []
 


### PR DESCRIPTION
## Summary
Fixes AttributeError in TradingOrchestrator initialization when BiasStore receives a string instead of Path.

## Error
```
AttributeError: 'str' object has no attribute 'mkdir'
```

## Root Cause
`TradingOrchestrator.__init__` passes a string to `BiasStore.__init__`, which then called `.mkdir()` on the string.

## Fix
BiasStore now accepts both `str` and `Path` inputs, converting strings to Path internally.

## Test plan
- [ ] Workflow completes without BiasStore error
- [ ] TradingOrchestrator initializes successfully

Generated with Claude Code