### PR TITLE
fix: CRITICAL - Options orders DAY->GTC time_in_force

### DIFF
--- a/scripts/execute_credit_spread.py
+++ b/scripts/execute_credit_spread.py
@@ -452,13 +452,15 @@ def execute_bull_put_spread(
         from alpaca.trading.requests import LimitOrderRequest
 
         # SELL the higher strike put (short leg)
+        # NOTE: Options orders require GTC (Good Til Canceled), not DAY
+        # Alpaca error: "order_time_in_force provided not supported for options trading"
         short_order = LimitOrderRequest(
             symbol=spread["short_put"]["symbol"],
             qty=1,
             side=OrderSide.SELL,
             type="limit",
             limit_price=round(spread["short_put"]["mid"], 2),
-            time_in_force=TimeInForce.DAY,
+            time_in_force=TimeInForce.GTC,
         )
 
         # BUY the lower strike put (long leg)
@@ -468,7 +470,7 @@ def execute_bull_put_spread(
             side=OrderSide.BUY,
             type="limit",
             limit_price=round(spread["long_put"]["mid"], 2),
-            time_in_force=TimeInForce.DAY,
+            time_in_force=TimeInForce.GTC,
         )
 
         # Submit orders

--- a/scripts/execute_options_trade.py
+++ b/scripts/execute_options_trade.py
@@ -477,7 +477,7 @@ def execute_cash_secured_put(trading_client, options_client, symbol: str, dry_ru
             side=OrderSide.SELL,
             type="limit",
             limit_price=limit_price,
-            time_in_force=TimeInForce.DAY,
+            time_in_force=TimeInForce.GTC,  # Options require GTC, not DAY
         )
 
         order = trading_client.submit_order(order_request)

--- a/scripts/iron_condor_trader.py
+++ b/scripts/iron_condor_trader.py
@@ -288,7 +288,7 @@ class IronCondorStrategy:
                                 side=side,
                                 type="limit",
                                 limit_price=0.50,  # Will need real pricing
-                                time_in_force=TimeInForce.DAY,
+                                time_in_force=TimeInForce.GTC,  # Options require GTC
                             )
                             order = client.submit_order(order_req)
                             order_ids.append({"leg": leg_name, "order_id": str(order.id)})


### PR DESCRIPTION
## CRITICAL BUG FIX

Options orders were being REJECTED by Alpaca with:
```
order_time_in_force provided not supported for options trading
```

No trades have executed since Jan 13 because orders were silently skipped.

## Fix
Change `TimeInForce.DAY` to `TimeInForce.GTC` for all options orders.

Files: execute_credit_spread.py, execute_options_trade.py, iron_condor_trader.py