### PR TITLE
fix: Add PYTHONPATH to daily blog post workflow

### DIFF
--- a/.github/workflows/daily-blog-post.yml
+++ b/.github/workflows/daily-blog-post.yml
@@ -69,6 +69,8 @@ jobs:
 
       - name: Update performance log
         if: steps.market_check.outputs.skip != 'true'
+        env:
+          PYTHONPATH: ${{ github.workspace }}
         run: |
           python3 scripts/update_performance_log.py
 
@@ -80,6 +82,8 @@ jobs:
       - name: Generate blog post
         id: generate
         if: steps.market_check.outputs.skip != 'true'
+        env:
+          PYTHONPATH: ${{ github.workspace }}
         run: |
           python3 scripts/generate_daily_blog_post.py 2>&1 | tee /tmp/blog_output.txt
 


### PR DESCRIPTION
## Summary
The Daily Revenue Blog Post workflow was failing with:
```
ModuleNotFoundError: No module named 'src'
```

Added `PYTHONPATH: ${{ github.workspace }}` to steps that import from `src/`.

## Test plan
- [x] YAML is valid
- [ ] Workflow succeeds after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)