### PR TITLE
fix: Add permissions to screenshot workflow

### DIFF
--- a/.claude/prd.json
+++ b/.claude/prd.json
@@ -8,7 +8,7 @@
       "category": "testing",
       "title": "Run pytest and fix failures",
       "description": "Run full test suite, identify failures, fix them iteratively",
-      "passes": false,
+      "passes": true,
       "priority": 1,
       "command": "pytest tests/ -q --tb=short",
       "acceptance_criteria": "All tests pass with 0 failures"

--- a/.github/workflows/capture-trading-screenshots.yml
+++ b/.github/workflows/capture-trading-screenshots.yml
@@ -17,6 +17,9 @@ on:
           - alpaca
           - progress
 
+permissions:
+  contents: write
+
 jobs:
   capture-screenshots:
     name: Capture Trading Dashboards


### PR DESCRIPTION
## Summary
- Screenshot workflow was failing with 403 permission denied
- Added `permissions: contents: write` to enable push access
- Also marked T001 (pytest) as passed in prd.json

## Test plan
- [x] YAML syntax valid
- [ ] Workflow succeeds after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)