### PR TITLE
feat: Add brokerage account verification tasks

### DIFF
--- a/.github/workflows/claude-agent-utility.yml
+++ b/.github/workflows/claude-agent-utility.yml
@@ -33,6 +33,8 @@ on:
           - set-trailing-stops
           - manage-positions
           - verify-alpaca-account
+          - verify-brokerage-account
+          - verify-all-accounts
           - execute-paper-trade
           - custom-command
         default: 'run-tests'
@@ -271,6 +273,136 @@ jobs:
               print('  NO ORDERS')
           "
 
+      - name: Task - Verify Brokerage Account
+        if: github.event.inputs.task == 'verify-brokerage-account'
+        env:
+          ALPACA_API_KEY: ${{ secrets.ALPACA_BROKERAGE_TRADING_API_KEY }}
+          ALPACA_SECRET_KEY: ${{ secrets.ALPACA_BROKERAGE_TRADING_API_SECRET }}
+        run: |
+          echo "=================================================="
+          echo "🔴 VERIFYING ALPACA LIVE BROKERAGE ACCOUNT STATUS"
+          echo "=================================================="
+          pip install alpaca-py
+          python3 -c "
+          import os
+          from alpaca.trading.client import TradingClient
+          from alpaca.trading.requests import GetOrdersRequest
+          from alpaca.trading.enums import QueryOrderStatus
+
+          client = TradingClient(
+              os.environ['ALPACA_API_KEY'],
+              os.environ['ALPACA_SECRET_KEY'],
+              paper=False  # LIVE ACCOUNT
+          )
+
+          account = client.get_account()
+          print('=== 🔴 ALPACA LIVE BROKERAGE ACCOUNT ===')
+          print(f'Equity: \${float(account.equity):,.2f}')
+          print(f'Cash: \${float(account.cash):,.2f}')
+          print(f'Buying Power: \${float(account.buying_power):,.2f}')
+          print(f'Last Equity: \${float(account.last_equity):,.2f}')
+          daily_change = float(account.equity) - float(account.last_equity)
+          print(f'Today P/L: \${daily_change:,.2f}')
+          print(f'Status: {account.status}')
+
+          positions = client.get_all_positions()
+          print(f'\n=== POSITIONS ({len(positions)}) ===')
+          for p in positions:
+              print(f'  {p.symbol}: {p.qty} @ \${float(p.current_price):.2f} | P/L: \${float(p.unrealized_pl):.2f}')
+
+          if not positions:
+              print('  NO POSITIONS')
+
+          orders = client.get_orders(GetOrdersRequest(status=QueryOrderStatus.ALL, limit=10))
+          print(f'\n=== RECENT ORDERS ({len(orders)}) ===')
+          for o in orders[:5]:
+              print(f'  {o.created_at.strftime(\"%Y-%m-%d %H:%M\")} | {o.side} {o.qty} {o.symbol} | {o.status}')
+
+          if not orders:
+              print('  NO ORDERS')
+          "
+
+      - name: Task - Verify All Accounts
+        if: github.event.inputs.task == 'verify-all-accounts'
+        env:
+          PAPER_API_KEY: ${{ secrets.ALPACA_PAPER_TRADING_5K_API_KEY }}
+          PAPER_SECRET_KEY: ${{ secrets.ALPACA_PAPER_TRADING_5K_API_SECRET }}
+          LIVE_API_KEY: ${{ secrets.ALPACA_BROKERAGE_TRADING_API_KEY }}
+          LIVE_SECRET_KEY: ${{ secrets.ALPACA_BROKERAGE_TRADING_API_SECRET }}
+        run: |
+          echo "=================================================="
+          echo "📊 VERIFYING ALL ALPACA ACCOUNTS"
+          echo "=================================================="
+          pip install alpaca-py
+          python3 -c "
+          import os
+          from alpaca.trading.client import TradingClient
+          from alpaca.trading.requests import GetOrdersRequest
+          from alpaca.trading.enums import QueryOrderStatus
+
+          # ========== PAPER ACCOUNT ==========
+          print('=' * 50)
+          print('📝 PAPER TRADING ACCOUNT (\$5K R&D)')
+          print('=' * 50)
+          paper_client = TradingClient(
+              os.environ['PAPER_API_KEY'],
+              os.environ['PAPER_SECRET_KEY'],
+              paper=True
+          )
+
+          paper_acct = paper_client.get_account()
+          paper_equity = float(paper_acct.equity)
+          paper_daily = paper_equity - float(paper_acct.last_equity)
+          print(f'Equity: \${paper_equity:,.2f}')
+          print(f'Cash: \${float(paper_acct.cash):,.2f}')
+          print(f'Today P/L: \${paper_daily:,.2f}')
+          print(f'Total P/L: \${paper_equity - 5000:,.2f} ({((paper_equity/5000)-1)*100:.2f}%)')
+
+          paper_positions = paper_client.get_all_positions()
+          print(f'Positions: {len(paper_positions)}')
+          for p in paper_positions:
+              print(f'  {p.symbol}: {p.qty} @ \${float(p.current_price):.2f} | P/L: \${float(p.unrealized_pl):.2f}')
+
+          # ========== LIVE BROKERAGE ACCOUNT ==========
+          print()
+          print('=' * 50)
+          print('🔴 LIVE BROKERAGE ACCOUNT (Real Money)')
+          print('=' * 50)
+          live_client = TradingClient(
+              os.environ['LIVE_API_KEY'],
+              os.environ['LIVE_SECRET_KEY'],
+              paper=False
+          )
+
+          live_acct = live_client.get_account()
+          live_equity = float(live_acct.equity)
+          live_daily = live_equity - float(live_acct.last_equity)
+          print(f'Equity: \${live_equity:,.2f}')
+          print(f'Cash: \${float(live_acct.cash):,.2f}')
+          print(f'Buying Power: \${float(live_acct.buying_power):,.2f}')
+          print(f'Today P/L: \${live_daily:,.2f}')
+
+          live_positions = live_client.get_all_positions()
+          print(f'Positions: {len(live_positions)}')
+          for p in live_positions:
+              print(f'  {p.symbol}: {p.qty} @ \${float(p.current_price):.2f} | P/L: \${float(p.unrealized_pl):.2f}')
+
+          if not live_positions:
+              print('  NO POSITIONS')
+
+          # ========== SUMMARY ==========
+          print()
+          print('=' * 50)
+          print('📊 COMBINED SUMMARY')
+          print('=' * 50)
+          total_equity = paper_equity + live_equity
+          total_daily = paper_daily + live_daily
+          print(f'Total Equity: \${total_equity:,.2f}')
+          print(f'Combined Today P/L: \${total_daily:,.2f}')
+          print(f'  Paper: \${paper_daily:,.2f}')
+          print(f'  Live:  \${live_daily:,.2f}')
+          "
+
       - name: Task - Execute Paper Trade
         if: github.event.inputs.task == 'execute-paper-trade' || github.event_name == 'push'
         env:
@@ -352,3 +484,4 @@ jobs:
           echo "- **Timestamp**: $(date -u +"%Y-%m-%d %H:%M:%S UTC")" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "Task completed. Check logs above for details." >> $GITHUB_STEP_SUMMARY
+


### PR DESCRIPTION
## Summary
This PR adds two new tasks to the Claude Agent Utility workflow:

### New Tasks

1. **`verify-brokerage-account`** - Query LIVE brokerage account only
   - Uses `ALPACA_BROKERAGE_TRADING_API_KEY` and `ALPACA_BROKERAGE_TRADING_API_SECRET`
   - Shows equity, cash, buying power, today's P/L
   - Lists all positions (e.g., VOO fractional shares)
   - Shows recent orders

2. **`verify-all-accounts`** - Query BOTH paper AND live accounts
   - Shows paper account ($5K R&D)
   - Shows live brokerage account
   - Provides combined summary with total equity and combined daily P/L

### Why
- Live brokerage account was not queryable via workflow
- Need to track VOO position and daily deposits ($25/day)
- Enables accurate daily P/L reporting for both accounts

### Usage
```bash
# Query live brokerage only
gh workflow run claude-agent-utility.yml -f task=verify-brokerage-account

# Query both accounts with combined summary
gh workflow run claude-agent-utility.yml -f task=verify-all-accounts
```

### Testing
- [x] YAML syntax validated
- [ ] Workflow runs successfully (will test after merge)
