### PR TITLE
fix: Add write permissions to pre-market sync workflow

### DIFF
--- a/.github/workflows/pre-market-sync.yml
+++ b/.github/workflows/pre-market-sync.yml
@@ -6,6 +6,9 @@ on:
     - cron: '25 14 * * 1-5'
   workflow_dispatch:  # Allow manual trigger
 
+permissions:
+  contents: write  # Required to push commits
+
 jobs:
   sync:
     runs-on: ubuntu-latest
@@ -60,3 +63,4 @@ jobs:
           git add data/system_state.json data/heartbeat.json
           git diff --staged --quiet || git commit -m "chore: Pre-market data sync [skip ci]"
           git push
+


### PR DESCRIPTION
## Bug Fix

**Error**: `fatal: unable to access 'https://github.com/...': The requested URL returned error: 403`

### Root Cause
The pre-market sync workflow lacked the `permissions: contents: write` declaration, preventing it from pushing commits with the synced Alpaca state.

### Fix
Added permissions block:
```yaml
permissions:
  contents: write  # Required to push commits
```

### Workflows Fixed
- Pre-Market Data Sync