### PR TITLE
fix: Force DialogFlow webhook redeployment with Alpaca credentials

### DIFF
--- a/.claude/prd.json
+++ b/.claude/prd.json
@@ -58,16 +58,16 @@
       "category": "learning",
       "title": "Query RAG for pending lessons",
       "description": "Check Vertex AI RAG for any unimplemented lessons",
-      "passes": false,
+      "passes": true,
       "priority": 6,
       "acceptance_criteria": "RAG lessons reviewed"
     }
   ],
   "completed_tasks": [],
   "metadata": {
-    "total_iterations": 0,
-    "tasks_completed_this_session": 0,
-    "last_task_completed": null,
-    "last_iteration_at": null
+    "total_iterations": 53,
+    "tasks_completed_this_session": 6,
+    "last_task_completed": "T006",
+    "last_iteration_at": "2026-01-16T04:20:00Z"
   }
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -142,14 +142,14 @@
         "filename": ".github/workflows/daily-trading.yml",
         "hashed_secret": "a5d7160f05c143168de136e41b8fe6458e1ed0c6",
         "is_verified": false,
-        "line_number": 111
+        "line_number": 139
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/daily-trading.yml",
         "hashed_secret": "5ffe533b830f08a0326348a9160afafc8ada44db",
         "is_verified": false,
-        "line_number": 159
+        "line_number": 187
       }
     ],
     ".github/workflows/emergency-close-options.yml": [
@@ -2246,5 +2246,5 @@
       }
     ]
   },
-  "generated_at": "2026-01-15T18:56:02Z"
+  "generated_at": "2026-01-16T04:01:54Z"
 }

--- a/data/system_state.json
+++ b/data/system_state.json
@@ -1,99 +1,97 @@
 {
-  "last_updated": "2026-01-16T15:27:26.459418",
+  "last_updated": "2026-01-16T09:35:04.439788",
   "portfolio": {
-    "equity": 4988.68,
-    "cash": 4302.08
+    "equity": 4989.98,
+    "cash": 4260.12
   },
   "paper_account": {
-    "equity": 4988.68,
-    "cash": 4302.08,
-    "buying_power": 9002.76,
-    "total_pl": -11.319999999999709,
-    "total_pl_pct": -0.23,
-    "positions_count": 8,
-    "daily_change": 29.5
+    "equity": 4989.98,
+    "cash": 4260.12,
+    "buying_power": 8919.91,
+    "total_pl": -10.020000000000437,
+    "total_pl_pct": -0.2,
+    "positions_count": 6,
+    "daily_change": 30.799999999999272,
+    "current_equity": 4959.79
   },
   "positions": [
     {
       "symbol": "SPY",
       "qty": 0.576037269,
-      "price": 691.97,
-      "value": 398.600509,
-      "pnl": -1.35949,
+      "price": 692.42,
+      "value": 398.859726,
+      "pnl": -1.100273,
       "type": "stock"
     },
     {
       "symbol": "SPY260220P00565000",
       "qty": 1.0,
-      "price": 0.48,
-      "value": 48.0,
-      "pnl": 1.0,
+      "price": 0.5,
+      "value": 50.0,
+      "pnl": 3.0,
       "type": "option"
     },
     {
       "symbol": "SPY260220P00570000",
       "qty": -1.0,
-      "price": 0.53,
-      "value": -53.0,
-      "pnl": -3.0,
+      "price": 0.54,
+      "value": -54.0,
+      "pnl": -4.0,
       "type": "option"
     },
     {
       "symbol": "SPY260220P00595000",
       "qty": 1.0,
-      "price": 0.77,
-      "value": 77.0,
-      "pnl": 4.0,
+      "price": 0.78,
+      "value": 78.0,
+      "pnl": 5.0,
       "type": "option"
     },
     {
       "symbol": "SPY260220P00600000",
       "qty": -1.0,
-      "price": 0.85,
-      "value": -85.0,
-      "pnl": -7.0,
-      "type": "option"
-    },
-    {
-      "symbol": "SPY260220P00653000",
-      "qty": 1.0,
-      "price": 2.83,
-      "value": 283.0,
-      "pnl": 4.0,
-      "type": "option"
-    },
-    {
-      "symbol": "SPY260220P00658000",
-      "qty": -1.0,
-      "price": 3.29,
-      "value": -329.0,
+      "price": 0.86,
+      "value": -86.0,
       "pnl": -8.0,
       "type": "option"
     },
     {
       "symbol": "SPY260220P00660000",
       "qty": 1.0,
-      "price": 3.47,
-      "value": 347.0,
-      "pnl": 40.0,
+      "price": 3.43,
+      "value": 343.0,
+      "pnl": 36.0,
       "type": "option"
     }
   ],
   "trades": {
-    "last_trade_date": "2026-01-16",
+    "last_trade_date": "2026-01-15",
     "today_trades": "synced",
     "total_trades_today": 0,
     "last_trade_symbol": "SPY"
   },
   "risk": {
     "status": "WARNING - NEGATIVE P/L",
-    "total_pl": -11.319999999999709,
-    "unrealized_pl": 29.64051
+    "total_pl": -10.020000000000437,
+    "unrealized_pl": 30.899727
   },
   "account": {
-    "current_equity": 4988.68,
-    "total_pl": -11.319999999999709,
-    "total_pl_pct": -0.23,
-    "positions_count": 8
+    "current_equity": 4989.98,
+    "total_pl": -10.020000000000437,
+    "total_pl_pct": -0.2,
+    "positions_count": 6
+  },
+  "trailing_stops": {
+    "last_set": "2026-01-16T10:00:07.890359",
+    "stops_active": 1,
+    "positions_skipped": 0,
+    "value_protected": 500.0,
+    "default_trail_pct": 0.1,
+    "options_trail_pct": 0.2
+  },
+  "meta": {
+    "last_updated": "2026-01-16T09:35:04.439788",
+    "last_sync": "2026-01-16T09:35:04.439795",
+    "sync_mode": "paper_account"
   }
 }

--- a/src/agents/dialogflow_webhook.py
+++ b/src/agents/dialogflow_webhook.py
@@ -14,6 +14,7 @@ Version History:
 - v3.3.0 Jan 13, 2026: Fix direct P/L queries - conversational "How much money" answers
 - v3.4.0 Jan 14, 2026: Fix stale P/L data - use GitHub API instead of raw URL (bypass CDN cache)
 - v3.5.0 Jan 15, 2026: Query Alpaca API DIRECTLY for real-time P/L (fixes stale data issue)
+- v3.5.1 Jan 16, 2026: Force redeployment to ensure Alpaca credentials are loaded
 
 Architecture (v3.0.0):
 - Primary: Vertex AI RAG (cloud semantic search with text-embedding-004)
@@ -192,7 +193,11 @@ def query_alpaca_api_direct() -> dict | None:
     api_secret = os.environ.get("ALPACA_PAPER_TRADING_5K_API_SECRET", "")
 
     if not api_key or not api_secret:
-        logger.warning("Alpaca API credentials not available in environment")
+        logger.warning(
+            f"Alpaca API credentials not available in environment. "
+            f"API_KEY present: {bool(api_key)}, API_SECRET present: {bool(api_secret)}. "
+            f"Env vars: {[k for k in os.environ if 'ALPACA' in k]}"
+        )
         return None
 
     try:


### PR DESCRIPTION
## Summary
- Force redeployment of DialogFlow webhook to ensure Alpaca API credentials are loaded
- Add better logging when credentials are missing to help debug

## Problem
CEO reported DialogFlow showing stale P/L data:
- **DialogFlow said**: -$14.95 (-0.30%)
- **Alpaca (actual)**: +$26.85 (+0.54%)

The webhook was falling back to cached system_state.json because Alpaca credentials weren't available in the Cloud Run environment.

## Fix
- Bump version to v3.5.1 to trigger redeployment
- Add detailed logging for credential availability

🤖 Generated with [Claude Code](https://claude.com/claude-code)