### PR TITLE
fix(analyst): Re-apply BiasProvider freshness argument fix

### DIFF
--- a/src/analyst/bias_store.py
+++ b/src/analyst/bias_store.py
@@ -2,7 +2,7 @@
 
 import json
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Optional
 
@@ -34,7 +34,12 @@ class BiasSnapshot:
 class BiasProvider:
     """Provides market bias signals."""
 
-    def __init__(self):
+    def __init__(self, bias_store: "BiasStore" = None, freshness: timedelta = None):
+        # Accept bias_store and freshness for compatibility with TradingOrchestrator
+        # CEO FIX Jan 15, 2026: Orchestrator passes these args
+        # RE-APPLIED Jan 16, 2026: Was accidentally reverted
+        self.bias_store = bias_store
+        self.freshness = freshness
         self.current_bias = "neutral"
         self.confidence = 0.5
 


### PR DESCRIPTION
## Summary
Re-applies the fix from PR #1900 (ee690861) which was accidentally reverted during PR #1910 merge conflicts.

## Problem
TradingOrchestrator crashes on startup:
```
TypeError: BiasProvider.__init__() got an unexpected keyword argument 'freshness'
```

This broke the Daily Trading Execution workflow (run 21072719140).

## Root Cause
- PR #1900 added `bias_store` and `freshness` parameters to BiasProvider
- PR #1910 had merge conflicts and accidentally reverted to the old signature
- TradingOrchestrator passes these args but BiasProvider didn't accept them

## Fix
BiasProvider now accepts optional `bias_store` and `freshness` arguments with defaults for backward compatibility.

## Test Plan
- [x] Verified BiasProvider works without args (backward compat)
- [x] Verified BiasProvider works with args (TradingOrchestrator style)
- [x] Pre-push tests pass (17 unit, 5 integration)

🤖 Generated with [Claude Code](https://claude.com/claude-code)