### PR TITLE
fix: Use GH_PAT for weekend-learning PR creation

### DIFF
--- a/.github/workflows/weekend-learning.yml
+++ b/.github/workflows/weekend-learning.yml
@@ -294,7 +294,7 @@ jobs:
         if: steps.check_changes.outputs.has_changes == 'true'
         uses: peter-evans/create-pull-request@v8
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.GH_PAT }}
           commit-message: "feat(weekend): Learning pipeline update ${{ github.run_id }}"
           title: "feat(weekend): Learning pipeline update"
           body: |
@@ -320,7 +320,7 @@ jobs:
       - name: "Self-Healing: Auto-merge weekend learning PR"
         if: steps.check_changes.outputs.has_changes == 'true'
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GH_PAT }}
         run: |
           echo "🔄 Self-Healing: Attempting auto-merge..."
 


### PR DESCRIPTION
## Summary
- Fix PR creation failure in weekend-learning workflow
- Switch from GITHUB_TOKEN to GH_PAT for peter-evans/create-pull-request
- GH_PAT has full repo access needed for PR creation

## Test Plan
- [ ] Trigger weekend-learning workflow manually after merge