### PR TITLE
fix: Verify .md transcript files instead of .json

### DIFF
--- a/scripts/ingest_phil_town_youtube.py
+++ b/scripts/ingest_phil_town_youtube.py
@@ -833,7 +833,7 @@ def main():
         results["silent_failure"] = True
     else:
         # Verify files actually exist
-        transcript_files = list(RAG_TRANSCRIPTS.glob("*.json")) if RAG_TRANSCRIPTS.exists() else []
+        transcript_files = list(RAG_TRANSCRIPTS.glob("*.md")) if RAG_TRANSCRIPTS.exists() else []
         if results["success"] > 0 and len(transcript_files) == 0:
             logger.error(
                 "⛔ OUTPUT VERIFICATION FAILED: Claimed success but no transcript files exist!"


### PR DESCRIPTION
## Summary
Fixes the output verification bug where the workflow was checking for `*.json` files but transcripts are actually saved as `*.md` files, causing false-negative verification failures.

## Root Cause
The `save_to_rag()` function saves transcripts as Markdown files:
```python
transcript_file = RAG_TRANSCRIPTS / f"{video_id}_{safe_title}.md"
```

But the output verification was checking for JSON files:
```python
transcript_files = list(RAG_TRANSCRIPTS.glob("*.json"))  # Wrong!
```

## Fix
Changed verification to check for `.md` files:
```python
transcript_files = list(RAG_TRANSCRIPTS.glob("*.md"))  # Correct!
```

## Test Plan
- [ ] CI passes
- [ ] Re-run phil-town-ingestion workflow
- [ ] Verify curated fallback now shows proper output verification

Fixes #1995