### PR TITLE
fix(ci): Add retry logic to screenshot push workflow

### DIFF
--- a/.github/workflows/capture-trading-screenshots.yml
+++ b/.github/workflows/capture-trading-screenshots.yml
@@ -56,18 +56,25 @@ jobs:
           path: data/screenshots/
           retention-days: 30
 
-      - name: Commit screenshots to repo
+      - name: Commit and push screenshots
         run: |
           git config --local user.email "github-actions[bot]@users.noreply.github.com"
           git config --local user.name "github-actions[bot]"
           git add data/screenshots/
-          git diff-index --quiet HEAD || git commit -m "chore: Add trading screenshots (automated capture)"
-
-      - name: Push screenshots
-        uses: ad-m/github-push-action@master
-        with:
-          github_token: ${{ secrets.GH_PAT }}
-          branch: ${{ github.ref }}
+          if git diff-index --quiet HEAD; then
+            echo "No changes to commit"
+          else
+            git commit -m "chore: Add trading screenshots (automated capture)"
+            # Retry push with rebase to handle race conditions
+            for i in 1 2 3; do
+              git pull --rebase origin ${{ github.ref_name }} && \
+              git push origin HEAD:${{ github.ref_name }} && break
+              echo "Push attempt $i failed, retrying..."
+              sleep $((i * 2))
+            done
+          fi
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_PAT }}
 
       - name: Notify on failure
         if: failure()


### PR DESCRIPTION
## Problem
Screenshot workflow failing on push step due to race conditions with other workflows.

## Solution
- Replace github-push-action with direct git commands
- Add pull --rebase before push
- Retry up to 3 times with exponential backoff

## Test Plan
- [ ] CI passes
- [ ] Next scheduled screenshot workflow succeeds