### PR TITLE
feat: Auto-sync closed positions for accurate win rate tracking

### DIFF
--- a/.github/workflows/daily-trading.yml
+++ b/.github/workflows/daily-trading.yml
@@ -1570,6 +1570,9 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          echo "📊 Syncing closed positions for accurate win rate..."
+          python3 scripts/sync_closed_positions.py || echo "⚠️ Closed positions sync failed"
+
           echo "📊 Generating enhanced world-class progress dashboard..."
           python3 scripts/generate_world_class_dashboard_enhanced.py || python3 scripts/generate_world_class_dashboard.py
 

--- a/.github/workflows/update-progress-dashboard.yml
+++ b/.github/workflows/update-progress-dashboard.yml
@@ -47,6 +47,12 @@ jobs:
             python3 scripts/sync_trades_from_alpaca.py || echo "⚠️ Trade sync failed - dashboard may show stale data"
           }
 
+      - name: Sync closed positions for win rate
+        run: |
+          echo "📊 Syncing closed positions for win rate calculation..."
+          python3 scripts/sync_closed_positions.py || echo "⚠️ Closed positions sync failed - win rate may be stale"
+          echo "✅ Closed positions synced"
+
       - name: Generate Progress Dashboard
         run: |
           echo "📊 Generating enhanced progress dashboard..."

--- a/data/trades.json
+++ b/data/trades.json
@@ -7,25 +7,31 @@
     "paper_phase_days_required": 90,
     "decision_thresholds": {
       "reassess_below": 75,
-      "marginal_range": [75, 80],
+      "marginal_range": [
+        75,
+        80
+      ],
       "profitable_above": 80,
       "min_trades_for_decision": 30
-    }
+    },
+    "last_sync": "2026-01-18T22:17:34.052034+00:00",
+    "sync_source": "sync_closed_positions.py"
   },
   "stats": {
-    "total_trades": 3,
-    "closed_trades": 0,
+    "total_trades": 9,
+    "closed_trades": 6,
     "open_trades": 3,
-    "wins": 0,
-    "losses": 0,
+    "wins": 1,
+    "losses": 5,
     "breakeven": 0,
-    "win_rate_pct": null,
-    "avg_win": null,
-    "avg_loss": null,
-    "profit_factor": null,
-    "total_pnl": 0.0,
-    "paper_phase_days": 0,
-    "last_updated": "2026-01-16T15:39:00Z"
+    "win_rate_pct": 16.7,
+    "avg_win": 31.0,
+    "avg_loss": 8.33,
+    "profit_factor": 0.74,
+    "total_pnl": -10.65,
+    "paper_phase_start": "2026-01-15",
+    "paper_phase_days": 3,
+    "last_updated": "2026-01-18T22:17:34.052030+00:00"
   },
   "trades": [
     {
@@ -44,7 +50,7 @@
           "symbol": "SPY260220P00570000",
           "side": "short",
           "qty": 1,
-          "entry_price": 0.50,
+          "entry_price": 0.5,
           "current_price": 0.57
         }
       ],
@@ -104,6 +110,138 @@
       "status": "open",
       "current_pnl": 67.0,
       "notes": "ORPHAN - Created without matching short leg. Crisis position - see LL-221. Currently profitable but violates strategy."
+    },
+    {
+      "id": "closed_SPY260220P00660000_20260115",
+      "symbol": "SPY260220P00660000",
+      "type": "option",
+      "side": "long",
+      "qty": 1.0,
+      "entry_date": "2026-01-15",
+      "exit_date": "2026-01-16",
+      "entry_cost": 3.07,
+      "exit_proceeds": 3.38,
+      "status": "closed",
+      "realized_pnl": 31.0,
+      "outcome": "win",
+      "multiplier": 100,
+      "strategy": "alpaca_synced",
+      "trades": {
+        "buys": 1,
+        "sells": 1,
+        "buy_qty": 1.0,
+        "sell_qty": 1.0
+      }
+    },
+    {
+      "id": "closed_SPY_20260115",
+      "symbol": "SPY",
+      "type": "stock",
+      "side": "long",
+      "qty": 0.576037269,
+      "entry_date": "2026-01-15",
+      "exit_date": "2026-01-16",
+      "entry_cost": 399.959998613132,
+      "exit_proceeds": 398.665025204058,
+      "status": "closed",
+      "realized_pnl": -1.29,
+      "outcome": "loss",
+      "multiplier": 1,
+      "strategy": "alpaca_synced",
+      "trades": {
+        "buys": 4,
+        "sells": 1,
+        "buy_qty": 0.576037269,
+        "sell_qty": 0.576037269
+      }
+    },
+    {
+      "id": "closed_SOFI260206P00024000_20260113",
+      "symbol": "SOFI260206P00024000",
+      "type": "option",
+      "side": "short",
+      "qty": 2.0,
+      "entry_date": "2026-01-13",
+      "exit_date": "2026-01-14",
+      "entry_cost": 1.74,
+      "exit_proceeds": 1.57,
+      "status": "closed",
+      "realized_pnl": -17.0,
+      "outcome": "loss",
+      "multiplier": 100,
+      "strategy": "alpaca_synced",
+      "trades": {
+        "buys": 1,
+        "sells": 2,
+        "buy_qty": 2.0,
+        "sell_qty": 2.0
+      }
+    },
+    {
+      "id": "closed_SOFI_20260113",
+      "symbol": "SOFI",
+      "type": "stock",
+      "side": "long",
+      "qty": 54.777554687999995,
+      "entry_date": "2026-01-13",
+      "exit_date": "2026-01-14",
+      "entry_cost": 1453.4000034258538,
+      "exit_proceeds": 1452.0404762852054,
+      "status": "closed",
+      "realized_pnl": -1.36,
+      "outcome": "loss",
+      "multiplier": 1,
+      "strategy": "alpaca_synced",
+      "trades": {
+        "buys": 15,
+        "sells": 4,
+        "buy_qty": 54.777554688,
+        "sell_qty": 54.777554687999995
+      }
+    },
+    {
+      "id": "closed_SOFI260220P00024000_20260112",
+      "symbol": "SOFI260220P00024000",
+      "type": "option",
+      "side": "short",
+      "qty": 1.0,
+      "entry_date": "2026-01-12",
+      "exit_date": "2026-01-13",
+      "entry_cost": 1.04,
+      "exit_proceeds": 0.95,
+      "status": "closed",
+      "realized_pnl": -9.0,
+      "outcome": "loss",
+      "multiplier": 100,
+      "strategy": "alpaca_synced",
+      "trades": {
+        "buys": 1,
+        "sells": 1,
+        "buy_qty": 1.0,
+        "sell_qty": 1.0
+      }
+    },
+    {
+      "id": "closed_SOFI260130P00025000_20260112",
+      "symbol": "SOFI260130P00025000",
+      "type": "option",
+      "side": "short",
+      "qty": 1.0,
+      "entry_date": "2026-01-12",
+      "exit_date": "2026-01-13",
+      "entry_cost": 0.95,
+      "exit_proceeds": 0.82,
+      "status": "closed",
+      "realized_pnl": -13.0,
+      "outcome": "loss",
+      "multiplier": 100,
+      "strategy": "alpaca_synced",
+      "trades": {
+        "buys": 1,
+        "sells": 1,
+        "buy_qty": 1.0,
+        "sell_qty": 1.0
+      }
     }
   ]
 }

--- a/scripts/sync_closed_positions.py
+++ b/scripts/sync_closed_positions.py
@@ -1,0 +1,330 @@
+#!/usr/bin/env python3
+"""
+Sync Closed Positions - Auto-detect and record closed trades for win rate tracking.
+
+CEO Directive: "I want our system to be self-healing"
+
+BUG FOUND (Jan 18, 2026): Win rate showed 0% because:
+1. Trades executed on Alpaca but never recorded in trades.json
+2. No automatic detection of closed positions (matching BUY + SELL)
+3. trades.json only had 3 manually added entries that were never closed
+
+This script:
+1. Reads trade history from system_state.json (synced from Alpaca)
+2. Identifies closed positions (matching BUY + SELL pairs)
+3. Calculates P/L for each closed position
+4. Updates trades.json with closed trades and win rate stats
+
+Usage:
+    python3 scripts/sync_closed_positions.py
+    python3 scripts/sync_closed_positions.py --dry-run  # Preview without saving
+"""
+
+import json
+import logging
+import sys
+from collections import defaultdict
+from datetime import datetime, timezone
+from pathlib import Path
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s - %(levelname)s - %(message)s",
+)
+logger = logging.getLogger(__name__)
+
+PROJECT_ROOT = Path(__file__).parent.parent
+DATA_DIR = PROJECT_ROOT / "data"
+SYSTEM_STATE_FILE = DATA_DIR / "system_state.json"
+TRADES_FILE = DATA_DIR / "trades.json"
+
+
+def load_system_state() -> dict:
+    """Load system state with trade history from Alpaca."""
+    if not SYSTEM_STATE_FILE.exists():
+        logger.error(f"System state file not found: {SYSTEM_STATE_FILE}")
+        return {}
+    with open(SYSTEM_STATE_FILE) as f:
+        return json.load(f)
+
+
+def load_trades_ledger() -> dict:
+    """Load the master trades ledger."""
+    if not TRADES_FILE.exists():
+        return {
+            "meta": {
+                "version": "1.0",
+                "created": datetime.now(timezone.utc).isoformat(),
+                "purpose": "Master ledger for win rate tracking per CLAUDE.md",
+            },
+            "stats": {},
+            "trades": [],
+        }
+    with open(TRADES_FILE) as f:
+        return json.load(f)
+
+
+def identify_closed_positions(trade_history: list[dict]) -> list[dict]:
+    """
+    Identify closed positions from trade history.
+
+    A position is closed when there's matching BUY and SELL activity.
+    """
+    # Group trades by symbol
+    by_symbol: dict[str, list[dict]] = defaultdict(list)
+    for t in trade_history:
+        sym = t.get("symbol")
+        if sym and sym != "None":  # Skip null symbols
+            by_symbol[sym].append(t)
+
+    closed_positions = []
+
+    for symbol, trades in by_symbol.items():
+        buys = [t for t in trades if "BUY" in str(t.get("side", ""))]
+        sells = [t for t in trades if "SELL" in str(t.get("side", ""))]
+
+        if not buys or not sells:
+            continue  # Not a closed position
+
+        # Calculate totals
+        buy_qty = sum(float(t.get("qty", 0)) for t in buys)
+        sell_qty = sum(float(t.get("qty", 0)) for t in sells)
+        total_buy = sum(float(t.get("qty", 0)) * float(t.get("price", 0)) for t in buys)
+        total_sell = sum(float(t.get("qty", 0)) * float(t.get("price", 0)) for t in sells)
+
+        # Determine if this is an options contract (longer symbol = option)
+        is_option = len(symbol) > 10
+        multiplier = 100 if is_option else 1
+
+        # Determine position type from first trade
+        first_trade = min(trades, key=lambda x: x.get("filled_at", "9999"))
+        first_side = str(first_trade.get("side", ""))
+        is_short_first = "SELL" in first_side
+
+        # Calculate P/L
+        # For options: (sell price - buy price) * 100
+        raw_pl = total_sell - total_buy
+        pl = raw_pl * multiplier
+
+        # Determine outcome
+        if pl > 0.01:
+            outcome = "win"
+        elif pl < -0.01:
+            outcome = "loss"
+        else:
+            outcome = "breakeven"
+
+        # Get dates
+        entry_date = min(t.get("filled_at", "")[:10] for t in trades if t.get("filled_at"))
+        exit_date = max(t.get("filled_at", "")[:10] for t in trades if t.get("filled_at"))
+
+        closed_positions.append(
+            {
+                "id": f"closed_{symbol}_{entry_date.replace('-', '')}",
+                "symbol": symbol,
+                "type": "option" if is_option else "stock",
+                "side": "short" if is_short_first else "long",
+                "qty": min(buy_qty, sell_qty),  # Closed quantity
+                "entry_date": entry_date,
+                "exit_date": exit_date,
+                "entry_cost": total_buy,
+                "exit_proceeds": total_sell,
+                "status": "closed",
+                "realized_pnl": round(pl, 2),
+                "outcome": outcome,
+                "multiplier": multiplier,
+                "strategy": "alpaca_synced",
+                "trades": {
+                    "buys": len(buys),
+                    "sells": len(sells),
+                    "buy_qty": buy_qty,
+                    "sell_qty": sell_qty,
+                },
+            }
+        )
+
+    return closed_positions
+
+
+def calculate_stats(trades: list[dict], paper_phase_start: str | None = None) -> dict:
+    """Calculate win rate statistics from closed trades."""
+    closed = [t for t in trades if t.get("status") == "closed"]
+    open_trades = [t for t in trades if t.get("status") == "open"]
+
+    # Calculate paper phase days
+    paper_phase_days = 0
+    if paper_phase_start:
+        try:
+            start_date = datetime.fromisoformat(paper_phase_start).date()
+            paper_phase_days = (datetime.now(timezone.utc).date() - start_date).days
+        except (ValueError, TypeError):
+            pass
+
+    if not closed:
+        return {
+            "total_trades": len(trades),
+            "closed_trades": 0,
+            "open_trades": len(open_trades),
+            "wins": 0,
+            "losses": 0,
+            "breakeven": 0,
+            "win_rate_pct": None,
+            "avg_win": None,
+            "avg_loss": None,
+            "profit_factor": None,
+            "total_pnl": 0.0,
+            "paper_phase_start": paper_phase_start,
+            "paper_phase_days": paper_phase_days,
+            "last_updated": datetime.now(timezone.utc).isoformat(),
+        }
+
+    wins = [t for t in closed if t.get("outcome") == "win"]
+    losses = [t for t in closed if t.get("outcome") == "loss"]
+    breakeven = [t for t in closed if t.get("outcome") == "breakeven"]
+
+    win_amounts = [t.get("realized_pnl", 0) for t in wins if t.get("realized_pnl")]
+    loss_amounts = [abs(t.get("realized_pnl", 0)) for t in losses if t.get("realized_pnl")]
+
+    total_wins = sum(win_amounts) if win_amounts else 0
+    total_losses = sum(loss_amounts) if loss_amounts else 0
+
+    return {
+        "total_trades": len(trades),
+        "closed_trades": len(closed),
+        "open_trades": len(open_trades),
+        "wins": len(wins),
+        "losses": len(losses),
+        "breakeven": len(breakeven),
+        "win_rate_pct": round(len(wins) / len(closed) * 100, 1) if closed else None,
+        "avg_win": round(total_wins / len(wins), 2) if wins else None,
+        "avg_loss": round(total_losses / len(losses), 2) if losses else None,
+        "profit_factor": round(total_wins / total_losses, 2) if total_losses > 0 else None,
+        "total_pnl": round(total_wins - total_losses, 2),
+        "paper_phase_start": paper_phase_start,
+        "paper_phase_days": paper_phase_days,
+        "last_updated": datetime.now(timezone.utc).isoformat(),
+    }
+
+
+def sync_closed_positions(dry_run: bool = False) -> dict:
+    """
+    Main sync function - identify closed positions and update trades.json.
+
+    Returns:
+        dict with sync results
+    """
+    logger.info("=" * 60)
+    logger.info("SYNC CLOSED POSITIONS - Auto Win Rate Calculation")
+    logger.info("=" * 60)
+
+    # Load data
+    system_state = load_system_state()
+    trade_history = system_state.get("trade_history", [])
+
+    if not trade_history:
+        logger.warning("No trade history found in system_state.json")
+        return {"success": False, "error": "No trade history"}
+
+    logger.info(f"Found {len(trade_history)} trades in history")
+
+    # Identify closed positions
+    closed_positions = identify_closed_positions(trade_history)
+    logger.info(f"Identified {len(closed_positions)} closed positions")
+
+    if not closed_positions:
+        logger.info("No closed positions found")
+        return {"success": True, "closed_count": 0}
+
+    # Print summary
+    wins = sum(1 for p in closed_positions if p["outcome"] == "win")
+    losses = sum(1 for p in closed_positions if p["outcome"] == "loss")
+    total_pnl = sum(p["realized_pnl"] for p in closed_positions)
+
+    logger.info("")
+    logger.info("=== CLOSED POSITIONS ===")
+    for pos in closed_positions:
+        outcome_emoji = (
+            "✅" if pos["outcome"] == "win" else "❌" if pos["outcome"] == "loss" else "➖"
+        )
+        logger.info(
+            f"  {outcome_emoji} {pos['symbol']}: ${pos['realized_pnl']:+.2f} ({pos['outcome']})"
+        )
+
+    logger.info("")
+    logger.info("=== SUMMARY ===")
+    logger.info(f"  Closed positions: {len(closed_positions)}")
+    logger.info(f"  Wins: {wins}, Losses: {losses}")
+    logger.info(f"  Total P/L: ${total_pnl:.2f}")
+    if closed_positions:
+        logger.info(f"  Win Rate: {wins / len(closed_positions) * 100:.1f}%")
+
+    if dry_run:
+        logger.info("")
+        logger.info("DRY RUN - No changes saved")
+        return {
+            "success": True,
+            "dry_run": True,
+            "closed_count": len(closed_positions),
+            "wins": wins,
+            "losses": losses,
+            "total_pnl": total_pnl,
+        }
+
+    # Load existing trades ledger
+    ledger = load_trades_ledger()
+    existing_ids = {t.get("id") for t in ledger.get("trades", [])}
+
+    # Add closed positions (avoid duplicates)
+    new_count = 0
+    for pos in closed_positions:
+        if pos["id"] not in existing_ids:
+            ledger.setdefault("trades", []).append(pos)
+            new_count += 1
+
+    # Calculate stats
+    paper_phase_start = ledger.get("meta", {}).get("paper_phase_start") or ledger.get(
+        "stats", {}
+    ).get("paper_phase_start", "2026-01-15")
+    stats = calculate_stats(ledger.get("trades", []), paper_phase_start)
+    ledger["stats"] = stats
+
+    # Update metadata
+    ledger.setdefault("meta", {})
+    ledger["meta"]["last_sync"] = datetime.now(timezone.utc).isoformat()
+    ledger["meta"]["sync_source"] = "sync_closed_positions.py"
+
+    # Save
+    with open(TRADES_FILE, "w") as f:
+        json.dump(ledger, f, indent=2)
+
+    logger.info("")
+    logger.info(f"✅ Saved {new_count} new closed positions to {TRADES_FILE}")
+    logger.info(f"   Total trades in ledger: {len(ledger.get('trades', []))}")
+    logger.info(f"   Win Rate: {stats.get('win_rate_pct', 'N/A')}%")
+
+    return {
+        "success": True,
+        "new_count": new_count,
+        "total_trades": len(ledger.get("trades", [])),
+        "stats": stats,
+    }
+
+
+def main() -> int:
+    """Main entry point."""
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Sync closed positions for win rate tracking")
+    parser.add_argument("--dry-run", action="store_true", help="Preview without saving")
+    args = parser.parse_args()
+
+    result = sync_closed_positions(dry_run=args.dry_run)
+
+    if result.get("success"):
+        return 0
+    else:
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
Fixed win rate showing 0% by creating a self-healing system that:
1. Auto-detects closed positions from Alpaca trade history
2. Calculates P/L for each closed position  
3. Updates trades.json with accurate win rate stats

## Root Cause Analysis
- 38 trades existed in Alpaca history but only 3 in trades.json
- No automatic detection of closed positions (matching BUY + SELL pairs)
- trades.json was never updated when positions closed

## Solution
- Created `sync_closed_positions.py` script to auto-detect and record closed trades
- Added to daily-trading.yml and update-progress-dashboard.yml workflows
- System is now self-healing - win rate updates automatically

## Current Stats (From Actual Trades)
| Metric | Value |
|--------|-------|
| Closed positions | 6 |
| Wins | 1 |
| Losses | 5 |
| Win Rate | 16.7% |
| Total P/L | -$10.65 |

## Test plan
- [x] Script correctly identifies closed positions
- [x] Win rate calculated accurately (16.7%)
- [x] Dashboard shows real win rate instead of 0%
- [x] Workflow files updated to run sync automatically

CEO Directive: "I want our system to be self-healing"

🤖 Generated with [Claude Code](https://claude.com/claude-code)