### PR TITLE
fix: Use get_alpaca_credentials() across all scripts

### DIFF
--- a/scripts/cancel_stale_orders.py
+++ b/scripts/cancel_stale_orders.py
@@ -34,13 +34,19 @@ def main() -> int:
         logger.error("alpaca-py not installed")
         return 1
 
-    # Get credentials directly from environment (CI workflow sets these)
-    api_key = os.getenv("ALPACA_API_KEY")
-    secret_key = os.getenv("ALPACA_SECRET_KEY")
+    # Use unified credentials (prioritizes $5K paper account per CLAUDE.md)
+    try:
+        from src.utils.alpaca_client import get_alpaca_credentials
+
+        api_key, secret_key = get_alpaca_credentials()
+    except ImportError:
+        # Fallback: use $5K account credentials directly
+        api_key = os.getenv("ALPACA_PAPER_TRADING_5K_API_KEY")
+        secret_key = os.getenv("ALPACA_PAPER_TRADING_5K_API_SECRET")
     paper = os.getenv("PAPER_TRADING", "true").lower() == "true"
 
     if not api_key or not secret_key:
-        logger.error("ALPACA_API_KEY and ALPACA_SECRET_KEY required")
+        logger.error("Alpaca credentials not configured")
         return 1
 
     client = TradingClient(api_key, secret_key, paper=paper)

--- a/scripts/fetch_100k_trade_history.py
+++ b/scripts/fetch_100k_trade_history.py
@@ -25,8 +25,15 @@ def main():
         print("ERROR: alpaca-py not installed")
         return
 
-    api_key = os.environ.get("ALPACA_API_KEY")
-    secret_key = os.environ.get("ALPACA_SECRET_KEY")
+    # Use unified credentials (prioritizes $5K paper account per CLAUDE.md)
+    try:
+        from src.utils.alpaca_client import get_alpaca_credentials
+
+        api_key, secret_key = get_alpaca_credentials()
+    except ImportError:
+        # Fallback: use $5K account credentials directly
+        api_key = os.environ.get("ALPACA_PAPER_TRADING_5K_API_KEY")
+        secret_key = os.environ.get("ALPACA_PAPER_TRADING_5K_API_SECRET")
 
     if not api_key or not secret_key:
         print("ERROR: Missing Alpaca credentials")

--- a/scripts/fix_653_spread.py
+++ b/scripts/fix_653_spread.py
@@ -8,13 +8,18 @@ from alpaca.trading.client import TradingClient
 from alpaca.trading.enums import OrderSide, TimeInForce
 from alpaca.trading.requests import MarketOrderRequest
 
-api_key = os.environ.get("ALPACA_API_KEY") or os.environ.get("ALPACA_PAPER_TRADING_5K_API_KEY")
-secret_key = os.environ.get("ALPACA_SECRET_KEY") or os.environ.get(
-    "ALPACA_PAPER_TRADING_5K_API_SECRET"
-)
+# Use unified credentials (prioritizes $5K paper account per CLAUDE.md)
+try:
+    from src.utils.alpaca_client import get_alpaca_credentials
+
+    api_key, secret_key = get_alpaca_credentials()
+except ImportError:
+    # Fallback: use $5K account credentials directly
+    api_key = os.environ.get("ALPACA_PAPER_TRADING_5K_API_KEY")
+    secret_key = os.environ.get("ALPACA_PAPER_TRADING_5K_API_SECRET")
 
 if not api_key or not secret_key:
-    print("ERROR: Missing API credentials")
+    print("ERROR: Missing Alpaca credentials")
     sys.exit(1)
 
 client = TradingClient(api_key, secret_key, paper=True)

--- a/scripts/verify_stops_in_place.py
+++ b/scripts/verify_stops_in_place.py
@@ -42,11 +42,15 @@ def get_alpaca_client():
         logger.error("alpaca-py not installed. Cannot verify stops.")
         return None
 
-    # Per CLAUDE.md: Use ALPACA_PAPER_TRADING_5K_API_KEY first
-    api_key = os.environ.get("ALPACA_PAPER_TRADING_5K_API_KEY") or os.environ.get("ALPACA_API_KEY")
-    api_secret = os.environ.get("ALPACA_PAPER_TRADING_5K_API_SECRET") or os.environ.get(
-        "ALPACA_SECRET_KEY"
-    )
+    # Use unified credentials (prioritizes $5K paper account per CLAUDE.md)
+    try:
+        from src.utils.alpaca_client import get_alpaca_credentials
+
+        api_key, api_secret = get_alpaca_credentials()
+    except ImportError:
+        # Fallback: use $5K account credentials directly
+        api_key = os.environ.get("ALPACA_PAPER_TRADING_5K_API_KEY")
+        api_secret = os.environ.get("ALPACA_PAPER_TRADING_5K_API_SECRET")
 
     if not api_key or not api_secret:
         logger.error("Alpaca credentials not found in environment")

--- a/scripts/verify_trade_execution.py
+++ b/scripts/verify_trade_execution.py
@@ -106,8 +106,9 @@ def check_alpaca_orders(date_str: str) -> dict:
 
         api_key, api_secret = get_alpaca_credentials()
     except ImportError:
-        api_key = os.getenv("ALPACA_API_KEY")
-        api_secret = os.getenv("ALPACA_SECRET_KEY")
+        # Fallback: use $5K account credentials directly
+        api_key = os.getenv("ALPACA_PAPER_TRADING_5K_API_KEY")
+        api_secret = os.getenv("ALPACA_PAPER_TRADING_5K_API_SECRET")
 
     if not api_key or not api_secret:
         result["error"] = "Alpaca credentials not set"

--- a/src/utils/calendar_validation.py
+++ b/src/utils/calendar_validation.py
@@ -10,16 +10,16 @@ from datetime import datetime, timedelta
 from typing import Optional
 
 from alpaca.trading.client import TradingClient
+from src.utils.alpaca_client import get_alpaca_credentials
 
 
 def get_alpaca_client() -> TradingClient:
-    """Get authenticated Alpaca client."""
-    api_key = os.environ.get("ALPACA_API_KEY")
-    secret_key = os.environ.get("ALPACA_SECRET_KEY")
+    """Get authenticated Alpaca client using unified credentials."""
+    api_key, secret_key = get_alpaca_credentials()
     paper = os.environ.get("PAPER_TRADING", "true").lower() == "true"
 
     if not api_key or not secret_key:
-        raise ValueError("ALPACA_API_KEY and ALPACA_SECRET_KEY must be set")
+        raise ValueError("Alpaca credentials not configured - use get_alpaca_credentials()")
 
     return TradingClient(api_key, secret_key, paper=paper)
 


### PR DESCRIPTION
## Summary
- Standardize Alpaca credential usage across 6 scripts
- Prevents API key mismatch bug (ll_134) where scripts used wrong account

## Files Updated
- `src/utils/calendar_validation.py` - Direct import of get_alpaca_credentials()
- `scripts/fetch_100k_trade_history.py` - Try/except with $5K fallback
- `scripts/verify_trade_execution.py` - Try/except with $5K fallback
- `scripts/fix_653_spread.py` - Try/except with $5K fallback
- `scripts/cancel_stale_orders.py` - Try/except with $5K fallback
- `scripts/verify_stops_in_place.py` - Try/except with $5K fallback

## Why This Matters
Per CLAUDE.md: "Use ALPACA_PAPER_TRADING_5K_API_KEY before ALPACA_API_KEY"

The $5K paper trading account is the primary account for R&D. Using the wrong
account can lead to trades executing on the wrong account (e.g., $100K instead
of $5K) which breaks tracking and win rate calculations.

## Test plan
- [x] `python3 scripts/validate_env_keys.py` passes
- [x] Unit tests pass for affected modules
- [x] Pre-push hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)