### PR TITLE
fix: Use GetCalendarRequest for Alpaca calendar API

### DIFF
--- a/.github/workflows/execute-credit-spread.yml
+++ b/.github/workflows/execute-credit-spread.yml
@@ -57,16 +57,18 @@ jobs:
           import os
           from datetime import date
           from alpaca.trading.client import TradingClient
-          
+          from alpaca.trading.requests import GetCalendarRequest
+
           client = TradingClient(
               os.environ['ALPACA_API_KEY'],
               os.environ['ALPACA_API_SECRET'],
               paper=True
           )
-          
+
           today = date.today()
-          calendar = client.get_calendar(start=today, end=today)
-          
+          calendar_request = GetCalendarRequest(start=today, end=today)
+          calendar = client.get_calendar(calendar_request)
+
           if not calendar:
               print(f"::notice::{today} is NOT a trading day (holiday/weekend)")
               print("skip=true >> $GITHUB_OUTPUT")
@@ -91,33 +93,33 @@ jobs:
           python3 << 'COMPLIANCE_EOF'
           import os
           from alpaca.trading.client import TradingClient
-          
+
           client = TradingClient(
               os.environ['ALPACA_API_KEY'],
               os.environ['ALPACA_API_SECRET'],
               paper=True
           )
-          
+
           account = client.get_account()
           equity = float(account.equity)
           positions = client.get_all_positions()
-          
+
           # Calculate current exposure
           total_risk = 0
           option_positions = [p for p in positions if len(p.symbol) > 10]  # Options have longer symbols
-          
+
           print(f"Account Equity: ${equity:.2f}")
           print(f"5% Position Limit: ${equity * 0.05:.2f}")
           print(f"15% Total Limit: ${equity * 0.15:.2f}")
           print(f"Current option positions: {len(option_positions)}")
-          
+
           # Estimate risk (simplified: count spreads * $500 max)
           spread_count = len(option_positions) // 2
           estimated_risk = spread_count * 500
           risk_pct = (estimated_risk / equity) * 100
-          
+
           print(f"Estimated current risk: ${estimated_risk} ({risk_pct:.1f}%)")
-          
+
           # CLAUDE.md rule: max 15% total exposure
           MAX_EXPOSURE_PCT = 15
           if risk_pct > MAX_EXPOSURE_PCT:
@@ -146,34 +148,34 @@ jobs:
           from alpaca.trading.client import TradingClient
           from alpaca.trading.requests import LimitOrderRequest
           from alpaca.trading.enums import OrderSide, TimeInForce, OrderClass
-          
+
           # Get parameters
           symbol = os.environ.get('SYMBOL', 'SPY')
           spread_width = int(os.environ.get('SPREAD_WIDTH', '3'))
           quantity = int(os.environ.get('QUANTITY', '1'))
-          
+
           print(f"=== Executing {symbol} Bull Put Credit Spread ===")
           print(f"Spread width: ${spread_width}")
           print(f"Quantity: {quantity}")
-          
+
           client = TradingClient(
               os.environ['ALPACA_API_KEY'],
               os.environ['ALPACA_API_SECRET'],
               paper=True
           )
-          
+
           # Get account info
           account = client.get_account()
           print(f"Account equity: ${account.equity}")
           print(f"Buying power: ${account.buying_power}")
-          
+
           # TODO: Implement actual spread execution
           # This is a placeholder - need to:
           # 1. Get current price of underlying
           # 2. Calculate 30-delta strike
           # 3. Find appropriate expiration (30-45 DTE)
           # 4. Submit multi-leg order
-          
+
           print("::warning::Trade execution not yet implemented - placeholder only")
           TRADE_EOF
 

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -127,15 +127,6 @@
     }
   ],
   "results": {
-    ".github/workflows/close-put-position.yml": [
-      {
-        "type": "Secret Keyword",
-        "filename": ".github/workflows/close-put-position.yml",
-        "hashed_secret": "f86962bc539cecb5aaa3a2b00c3a69ca3f0ce021",
-        "is_verified": false,
-        "line_number": 45
-      }
-    ],
     ".github/workflows/daily-trading.yml": [
       {
         "type": "Secret Keyword",
@@ -170,40 +161,13 @@
         "line_number": 45
       }
     ],
-    ".github/workflows/execute-credit-spread.yml": [
-      {
-        "type": "Secret Keyword",
-        "filename": ".github/workflows/execute-credit-spread.yml",
-        "hashed_secret": "248a3d2f04326fd36fdf74e6940d104b9aa88c27",
-        "is_verified": false,
-        "line_number": 54
-      }
-    ],
-    ".github/workflows/exit-sofi-emergency.yml": [
-      {
-        "type": "Secret Keyword",
-        "filename": ".github/workflows/exit-sofi-emergency.yml",
-        "hashed_secret": "f86962bc539cecb5aaa3a2b00c3a69ca3f0ce021",
-        "is_verified": false,
-        "line_number": 52
-      }
-    ],
-    ".github/workflows/scheduled-close-put.yml": [
-      {
-        "type": "Secret Keyword",
-        "filename": ".github/workflows/scheduled-close-put.yml",
-        "hashed_secret": "f86962bc539cecb5aaa3a2b00c3a69ca3f0ce021",
-        "is_verified": false,
-        "line_number": 39
-      }
-    ],
     ".github/workflows/sync-alpaca-status.yml": [
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/sync-alpaca-status.yml",
         "hashed_secret": "f86962bc539cecb5aaa3a2b00c3a69ca3f0ce021",
         "is_verified": false,
-        "line_number": 34
+        "line_number": 44
       }
     ],
     ".github/workflows/update-alpaca-secrets.yml": [
@@ -344,7 +308,7 @@
       {
         "type": "Hex High Entropy String",
         "filename": "data/vector_db/vectorized_files.json",
-        "hashed_secret": "03938dd032bfe2016ce1bf6252b0f307a99934ef",
+        "hashed_secret": "d559450446215910c522beafcf0a0e7b0ebe9eee",
         "is_verified": false,
         "line_number": 4
       },
@@ -358,21 +322,21 @@
       {
         "type": "Hex High Entropy String",
         "filename": "data/vector_db/vectorized_files.json",
-        "hashed_secret": "d46941691036ba2b04e2642d8a192ae9a4bca581",
+        "hashed_secret": "2ec9db3f79e3cd5e4eb51fc451f2149ef3ebbeae",
         "is_verified": false,
         "line_number": 22
       },
       {
         "type": "Hex High Entropy String",
         "filename": "data/vector_db/vectorized_files.json",
-        "hashed_secret": "0cbe83b542b370efc5e4a8fca0743c654b9a2fe5",
+        "hashed_secret": "5f2ba5201db3a0438820a241e9fe390c6dad9165",
         "is_verified": false,
         "line_number": 37
       },
       {
         "type": "Hex High Entropy String",
         "filename": "data/vector_db/vectorized_files.json",
-        "hashed_secret": "89707cbdf275134bdad0e403e7441f845b1ed5e9",
+        "hashed_secret": "e90d9a03995dd33a3f93310e0c880a1dfd568313",
         "is_verified": false,
         "line_number": 55
       },
@@ -386,7 +350,7 @@
       {
         "type": "Hex High Entropy String",
         "filename": "data/vector_db/vectorized_files.json",
-        "hashed_secret": "bd872d4c604d2988b9dc186f386e44be82b6d066",
+        "hashed_secret": "a49f4c57c422cdf462bd3c06fe6fa425e341852d",
         "is_verified": false,
         "line_number": 71
       },
@@ -400,7 +364,7 @@
       {
         "type": "Hex High Entropy String",
         "filename": "data/vector_db/vectorized_files.json",
-        "hashed_secret": "76ff4cb752a8643be0aa205179dd1553262b89de",
+        "hashed_secret": "e323c5e4b2226b28b0c884ada4d72095185e2f4c",
         "is_verified": false,
         "line_number": 87
       },
@@ -414,42 +378,42 @@
       {
         "type": "Hex High Entropy String",
         "filename": "data/vector_db/vectorized_files.json",
-        "hashed_secret": "a1d4ca4db542a870d87ce00763d458e75f8f019a",
+        "hashed_secret": "4e199a43bfacbbe2b03f354a0c3ae6c57282caf7",
         "is_verified": false,
         "line_number": 102
       },
       {
         "type": "Hex High Entropy String",
         "filename": "data/vector_db/vectorized_files.json",
-        "hashed_secret": "031b6ac2ccef3018c76654c030f89cc1e3ffbc20",
+        "hashed_secret": "c1d2e9c5d9836d1dca77a64091f7048b73fdb592",
         "is_verified": false,
         "line_number": 118
       },
       {
         "type": "Hex High Entropy String",
         "filename": "data/vector_db/vectorized_files.json",
-        "hashed_secret": "46da7561248ae66cbdb1933a52e5764f4c3b3386",
+        "hashed_secret": "63e5fb543814fcbb751d5ed70888effdfe1cce3c",
         "is_verified": false,
         "line_number": 132
       },
       {
         "type": "Hex High Entropy String",
         "filename": "data/vector_db/vectorized_files.json",
-        "hashed_secret": "4f06be932549006b8fa85c649100200efa225409",
+        "hashed_secret": "7791b2da7f8a2a643c775c75193cf2247eeec981",
         "is_verified": false,
         "line_number": 148
       },
       {
         "type": "Hex High Entropy String",
         "filename": "data/vector_db/vectorized_files.json",
-        "hashed_secret": "7ac1a931e518358c8fe568e2fc072d8a985d66ac",
+        "hashed_secret": "5a789b24129f5756477b51c419aef610971e3662",
         "is_verified": false,
         "line_number": 163
       },
       {
         "type": "Hex High Entropy String",
         "filename": "data/vector_db/vectorized_files.json",
-        "hashed_secret": "af07fcb809d9064643d31adf86104e165924baf0",
+        "hashed_secret": "bde541bf680d7f68c0d75a7b068b4a9217313e6e",
         "is_verified": false,
         "line_number": 182
       },
@@ -463,28 +427,28 @@
       {
         "type": "Hex High Entropy String",
         "filename": "data/vector_db/vectorized_files.json",
-        "hashed_secret": "6289fa693a191f97bc815091803d62b406620026",
+        "hashed_secret": "9e6286ffd3512db54f0c442a9e4bc4610390efed",
         "is_verified": false,
         "line_number": 200
       },
       {
         "type": "Hex High Entropy String",
         "filename": "data/vector_db/vectorized_files.json",
-        "hashed_secret": "deabc693bb456a1a3d3dc7920788868bcca12629",
+        "hashed_secret": "6bfc26a437eb52dacfc598854d3dd3d262377d57",
         "is_verified": false,
         "line_number": 224
       },
       {
         "type": "Hex High Entropy String",
         "filename": "data/vector_db/vectorized_files.json",
-        "hashed_secret": "74638c43f3a71baec8e13afc4681b5e4b9236af9",
+        "hashed_secret": "fdd777c05ec207fb02778f2a0fe20f5ac0429520",
         "is_verified": false,
         "line_number": 245
       },
       {
         "type": "Hex High Entropy String",
         "filename": "data/vector_db/vectorized_files.json",
-        "hashed_secret": "0c506735d40b8b1c1d76b0bd9569c64664c95faf",
+        "hashed_secret": "17abf7375646e723de69281db08e66573fa87da1",
         "is_verified": false,
         "line_number": 261
       },
@@ -498,28 +462,28 @@
       {
         "type": "Hex High Entropy String",
         "filename": "data/vector_db/vectorized_files.json",
-        "hashed_secret": "eaf0a69c1dc0481292fd071eea9e4af1de316fa1",
+        "hashed_secret": "3720a033ca1f68cf7997bafd21bc8fbc9952c8c5",
         "is_verified": false,
         "line_number": 277
       },
       {
         "type": "Hex High Entropy String",
         "filename": "data/vector_db/vectorized_files.json",
-        "hashed_secret": "7699c3b16bb94fe182036d6d168054cefc0a4478",
+        "hashed_secret": "9f3d0b8e27bd9ea89520c9550ac85ca1cbce125b",
         "is_verified": false,
         "line_number": 294
       },
       {
         "type": "Hex High Entropy String",
         "filename": "data/vector_db/vectorized_files.json",
-        "hashed_secret": "a2b71046d48b872299e66d4e5cec9c4965118eb4",
+        "hashed_secret": "b8de244a464797268de1e090f2e91ba9f646a3af",
         "is_verified": false,
         "line_number": 309
       },
       {
         "type": "Hex High Entropy String",
         "filename": "data/vector_db/vectorized_files.json",
-        "hashed_secret": "726a2b26d257805d5417d719613a740b5184f4b7",
+        "hashed_secret": "0cf645bc625e9ee830714de1820ede4f44efb61f",
         "is_verified": false,
         "line_number": 326
       },
@@ -533,140 +497,140 @@
       {
         "type": "Hex High Entropy String",
         "filename": "data/vector_db/vectorized_files.json",
-        "hashed_secret": "1d97f11eac00004512a77964d7196f8d81ed7766",
+        "hashed_secret": "37ff0aa9014be71b2f7a5906fdb4e739a01f0df1",
         "is_verified": false,
         "line_number": 349
       },
       {
         "type": "Hex High Entropy String",
         "filename": "data/vector_db/vectorized_files.json",
-        "hashed_secret": "7cfcd9ab3986b03ab994dd522737c981f40e818f",
+        "hashed_secret": "5e02d8b15a394eb47d4acb9a29522a862abee507",
         "is_verified": false,
         "line_number": 367
       },
       {
         "type": "Hex High Entropy String",
         "filename": "data/vector_db/vectorized_files.json",
-        "hashed_secret": "3627da2564cee865eacc4a22e4c53a12a7a0832b",
+        "hashed_secret": "a8d323a0b84c6e4d6c762692a9ed89fb961591be",
         "is_verified": false,
         "line_number": 381
       },
       {
         "type": "Hex High Entropy String",
         "filename": "data/vector_db/vectorized_files.json",
-        "hashed_secret": "6feeef24c729e8b1f294ba116e468ad6d5080000",
+        "hashed_secret": "664a8deac8979d931e1bbb7feaa6e615d96edb91",
         "is_verified": false,
         "line_number": 396
       },
       {
         "type": "Hex High Entropy String",
         "filename": "data/vector_db/vectorized_files.json",
-        "hashed_secret": "eb6f8a03230c6beb3214fa91b3f09b8d6185485a",
+        "hashed_secret": "803b071c292ddfd254e935a7399a46cdedc7f595",
         "is_verified": false,
         "line_number": 412
       },
       {
         "type": "Hex High Entropy String",
         "filename": "data/vector_db/vectorized_files.json",
-        "hashed_secret": "5989ead1ad3e311311f5ecdf57733536e1d1e8c1",
+        "hashed_secret": "630d93e6b08e45adf13a60bfafb5a6ed944295c2",
         "is_verified": false,
         "line_number": 427
       },
       {
         "type": "Hex High Entropy String",
         "filename": "data/vector_db/vectorized_files.json",
-        "hashed_secret": "86452f741077b5dfb50550f69a772067c00a1a9c",
+        "hashed_secret": "31a84efc48c13a6c891a33f1d0bb161ec1b06cc8",
         "is_verified": false,
         "line_number": 442
       },
       {
         "type": "Hex High Entropy String",
         "filename": "data/vector_db/vectorized_files.json",
-        "hashed_secret": "92de81f6149edc13014772eedbf66e73d3f0dec0",
+        "hashed_secret": "d4e68ad50487479de5c690427df02654c4bb10e5",
         "is_verified": false,
         "line_number": 458
       },
       {
         "type": "Hex High Entropy String",
         "filename": "data/vector_db/vectorized_files.json",
-        "hashed_secret": "3b3867de1869c9ed1c226e95e5185c14e0f38d2d",
+        "hashed_secret": "79ccf55184cd502eedff28f095f578894b88408c",
         "is_verified": false,
         "line_number": 473
       },
       {
         "type": "Hex High Entropy String",
         "filename": "data/vector_db/vectorized_files.json",
-        "hashed_secret": "5801067929c07fd5b8c4d2d219cb36fbca7abc1e",
+        "hashed_secret": "92bd00e18ba61af74eac59352fac91513730b82d",
         "is_verified": false,
         "line_number": 488
       },
       {
         "type": "Hex High Entropy String",
         "filename": "data/vector_db/vectorized_files.json",
-        "hashed_secret": "d78a8a1a9cad81d601218258fe4dfb295c711320",
+        "hashed_secret": "c292d6802b13861311656b35de7a016fecb15ca2",
         "is_verified": false,
         "line_number": 503
       },
       {
         "type": "Hex High Entropy String",
         "filename": "data/vector_db/vectorized_files.json",
-        "hashed_secret": "5c74da3b959cb40ee6b2fdc1cd1a405f3b21da78",
+        "hashed_secret": "af519c1172ba2eb7206a95ae9caa2e761779bca1",
         "is_verified": false,
         "line_number": 518
       },
       {
         "type": "Hex High Entropy String",
         "filename": "data/vector_db/vectorized_files.json",
-        "hashed_secret": "ea2e7edd1c6ddc04d882a74829b4817b201edfea",
+        "hashed_secret": "c7373ac05401761d3ffd7c54f4124ab567ea8961",
         "is_verified": false,
         "line_number": 536
       },
       {
         "type": "Hex High Entropy String",
         "filename": "data/vector_db/vectorized_files.json",
-        "hashed_secret": "3ab77ac0d12ec659ba5e92a19ca6d624d3a2f4e0",
+        "hashed_secret": "2947c0d8d3732b50973fa80610c52979b40f9a6b",
         "is_verified": false,
         "line_number": 552
       },
       {
         "type": "Hex High Entropy String",
         "filename": "data/vector_db/vectorized_files.json",
-        "hashed_secret": "f398eb37ba919407540d9fa5c1fe334e9e5f0ad5",
+        "hashed_secret": "b71d070855f658de741ac18f61aa16e1c8edc213",
         "is_verified": false,
         "line_number": 567
       },
       {
         "type": "Hex High Entropy String",
         "filename": "data/vector_db/vectorized_files.json",
-        "hashed_secret": "69af8dcf687de88bf5fc522b3623ef0cefa171ee",
+        "hashed_secret": "54984c77f53c1c0d16d8c5742658756ad287ca8b",
         "is_verified": false,
         "line_number": 583
       },
       {
         "type": "Hex High Entropy String",
         "filename": "data/vector_db/vectorized_files.json",
-        "hashed_secret": "9a4729944064db5a9fd9dfebb78769de8295408e",
+        "hashed_secret": "542a108d22c36b76cfe12a8aa1a43ba66cc6a771",
         "is_verified": false,
         "line_number": 599
       },
       {
         "type": "Hex High Entropy String",
         "filename": "data/vector_db/vectorized_files.json",
-        "hashed_secret": "6fe4f3ab254d461dc0c3e87e32f8148b581fb5a9",
+        "hashed_secret": "936aa9952ae4c107d14a0b0a4c89c8ed75bd3bdb",
         "is_verified": false,
         "line_number": 615
       },
       {
         "type": "Hex High Entropy String",
         "filename": "data/vector_db/vectorized_files.json",
-        "hashed_secret": "c5488010cdf2ebb5021d555d784032611dd282cb",
+        "hashed_secret": "45ae69e0e8700225c725410f27592e76dbf43f5b",
         "is_verified": false,
         "line_number": 630
       },
       {
         "type": "Hex High Entropy String",
         "filename": "data/vector_db/vectorized_files.json",
-        "hashed_secret": "9c6cbbbb5e74a7dde883d2a1f9a87528f7a5ae42",
+        "hashed_secret": "8f7a3596eba28c06095071993039965c29196db5",
         "is_verified": false,
         "line_number": 645
       },
@@ -1842,7 +1806,7 @@
       {
         "type": "Hex High Entropy String",
         "filename": "data/vector_db/vectorized_files.json",
-        "hashed_secret": "9b645668a362ed57815519dba360dfdb6de0e28f",
+        "hashed_secret": "684933125a64db29dae065b26e5ce5cbb5342270",
         "is_verified": false,
         "line_number": 1896
       },
@@ -1877,7 +1841,7 @@
       {
         "type": "Hex High Entropy String",
         "filename": "data/vector_db/vectorized_files.json",
-        "hashed_secret": "2e1b3758d4d023d25e99df1663ca53b3142624be",
+        "hashed_secret": "9ae6f1d43e5f0c74b94e54769ec25b3964af632e",
         "is_verified": false,
         "line_number": 1962
       },
@@ -1912,14 +1876,14 @@
       {
         "type": "Hex High Entropy String",
         "filename": "data/vector_db/vectorized_files.json",
-        "hashed_secret": "74f08e3984ff84a24a1563edddb4aa2e8a4aac0d",
+        "hashed_secret": "514039153812c05145c3720821450332949672e6",
         "is_verified": false,
         "line_number": 2027
       },
       {
         "type": "Hex High Entropy String",
         "filename": "data/vector_db/vectorized_files.json",
-        "hashed_secret": "9d81b48396f26d378736a901f667219a1ff69cc1",
+        "hashed_secret": "23b2f05498ef120abc9c6e87e4c1cd5bc7630802",
         "is_verified": false,
         "line_number": 2039
       },
@@ -1940,14 +1904,14 @@
       {
         "type": "Hex High Entropy String",
         "filename": "data/vector_db/vectorized_files.json",
-        "hashed_secret": "97b753dd58d3d2ff294d0e47ae5f381e660904b2",
+        "hashed_secret": "4497b28d76886e018723a3f2754af7efe6c5a744",
         "is_verified": false,
         "line_number": 2077
       },
       {
         "type": "Hex High Entropy String",
         "filename": "data/vector_db/vectorized_files.json",
-        "hashed_secret": "cc497d9c4063643e3c6839ffcf25e69a3ae10c9a",
+        "hashed_secret": "11c57afc5033aba31ca09020d335792376188682",
         "is_verified": false,
         "line_number": 2091
       },
@@ -1961,7 +1925,7 @@
       {
         "type": "Hex High Entropy String",
         "filename": "data/vector_db/vectorized_files.json",
-        "hashed_secret": "48d83c80aced49ceda139531c1be01abea0cd72b",
+        "hashed_secret": "ddcfde9922db6aa40faa6ee84dc1b387bd0e9db7",
         "is_verified": false,
         "line_number": 2117
       },
@@ -1982,21 +1946,21 @@
       {
         "type": "Hex High Entropy String",
         "filename": "data/vector_db/vectorized_files.json",
-        "hashed_secret": "05a1cd0224f7f2c866ee18b5cf6649a9d22338ad",
+        "hashed_secret": "5ad5e29ef3458195d069cf1faf0cd17983be6d3e",
         "is_verified": false,
         "line_number": 2153
       },
       {
         "type": "Hex High Entropy String",
         "filename": "data/vector_db/vectorized_files.json",
-        "hashed_secret": "35c1c7f9452ebbf8dd14c8f28834e434feb58041",
+        "hashed_secret": "b7e3b1ba62eab8ba88fe66947e7af1b6bb27947c",
         "is_verified": false,
         "line_number": 2165
       },
       {
         "type": "Hex High Entropy String",
         "filename": "data/vector_db/vectorized_files.json",
-        "hashed_secret": "6358229fadcd48af4fdb8e33de25301ef64079f2",
+        "hashed_secret": "ce17eaded9b4981ea7d0865ab945a90026069c5a",
         "is_verified": false,
         "line_number": 2177
       },
@@ -2024,14 +1988,14 @@
       {
         "type": "Hex High Entropy String",
         "filename": "data/vector_db/vectorized_files.json",
-        "hashed_secret": "b224d17a5ea2d76b8644ab04fba0994d21d5be5f",
+        "hashed_secret": "694a566f8cd9e8e6a09996030499b93d9d5fe9d5",
         "is_verified": false,
         "line_number": 2229
       },
       {
         "type": "Hex High Entropy String",
         "filename": "data/vector_db/vectorized_files.json",
-        "hashed_secret": "14358480c572c2c2fd36560edc251f0c2ae49800",
+        "hashed_secret": "3e4b541103fbab8ef6a05aea8667a250be89b3b7",
         "is_verified": false,
         "line_number": 2243
       },
@@ -2059,7 +2023,7 @@
       {
         "type": "Hex High Entropy String",
         "filename": "data/vector_db/vectorized_files.json",
-        "hashed_secret": "fe400e123917ca48bcef0ffaf002feaafa15e0ad",
+        "hashed_secret": "6b2b6bf07ba26737741913805f4eed3b4c3b66f5",
         "is_verified": false,
         "line_number": 2298
       },
@@ -2080,21 +2044,21 @@
       {
         "type": "Hex High Entropy String",
         "filename": "data/vector_db/vectorized_files.json",
-        "hashed_secret": "4b876c4069486313fa67ff67b559ae9775f3a845",
+        "hashed_secret": "e4a0ee616b1abfecd82e380e3c398db0df13e353",
         "is_verified": false,
         "line_number": 2336
       },
       {
         "type": "Hex High Entropy String",
         "filename": "data/vector_db/vectorized_files.json",
-        "hashed_secret": "2d1bacc8cee3a42099621d0feee14855e20de8e1",
+        "hashed_secret": "f1a0e9f3a8dd9294c1cc29b866018fad02faf27e",
         "is_verified": false,
         "line_number": 2352
       },
       {
         "type": "Hex High Entropy String",
         "filename": "data/vector_db/vectorized_files.json",
-        "hashed_secret": "183fc15ae8d2022938af940fab35edb3b32b1cca",
+        "hashed_secret": "7f5c4b3c04197cee946f5397a08af111b7d5fe85",
         "is_verified": false,
         "line_number": 2364
       },
@@ -2129,21 +2093,21 @@
       {
         "type": "Hex High Entropy String",
         "filename": "data/vector_db/vectorized_files.json",
-        "hashed_secret": "b974e0090de78c75989048d042b2033bc1a8f263",
+        "hashed_secret": "fcb4e3200e521ad0600528187f6e169499dc559f",
         "is_verified": false,
         "line_number": 2431
       },
       {
         "type": "Hex High Entropy String",
         "filename": "data/vector_db/vectorized_files.json",
-        "hashed_secret": "4d4de55c88009c4b5ad8d0b158fb01de1716741d",
+        "hashed_secret": "3a78c73703d00b2882b0a537a920b28f2cebd748",
         "is_verified": false,
         "line_number": 2443
       },
       {
         "type": "Hex High Entropy String",
         "filename": "data/vector_db/vectorized_files.json",
-        "hashed_secret": "63a03928b55d6816c3389f21b22a076e380210dc",
+        "hashed_secret": "e6cdef921f724e906b84f6f1ee0ea404708b7f53",
         "is_verified": false,
         "line_number": 2455
       },
@@ -2157,7 +2121,7 @@
       {
         "type": "Hex High Entropy String",
         "filename": "data/vector_db/vectorized_files.json",
-        "hashed_secret": "fddc0c42daf215bedd44f487212f5c24dfc86ded",
+        "hashed_secret": "ea469d147db0eca29b44e7dab70bbbd1e7b5c849",
         "is_verified": false,
         "line_number": 2479
       },
@@ -2185,7 +2149,14 @@
       {
         "type": "Hex High Entropy String",
         "filename": "data/vector_db/vectorized_files.json",
-        "hashed_secret": "7879b5cf3f810477ab4414f73f94483bb1757319",
+        "hashed_secret": "18c82d8622d572f4ad175335da70d5e9b74279b9",
+        "is_verified": false,
+        "line_number": 2531
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "data/vector_db/vectorized_files.json",
+        "hashed_secret": "ad201106a8364df2988e74ef44e5b888e3e1055d",
         "is_verified": false,
         "line_number": 2562
       },
@@ -2213,21 +2184,21 @@
       {
         "type": "Hex High Entropy String",
         "filename": "data/vector_db/vectorized_files.json",
-        "hashed_secret": "97d49b90391486bcbeb5a7c5672058146f8be2d6",
+        "hashed_secret": "05bab3ba4135ce42596991d753ea826cc802772f",
         "is_verified": false,
         "line_number": 2614
       },
       {
         "type": "Hex High Entropy String",
         "filename": "data/vector_db/vectorized_files.json",
-        "hashed_secret": "030a39c13a90568cc8ef160e4e736d932e2c03fa",
+        "hashed_secret": "dea13b6b0274d7d1d79d331d81bf58f0810f96b9",
         "is_verified": false,
         "line_number": 2626
       },
       {
         "type": "Hex High Entropy String",
         "filename": "data/vector_db/vectorized_files.json",
-        "hashed_secret": "d90de97777651c2086dedab88fd24569a202d001",
+        "hashed_secret": "341d3991baff09974dff2f4e03eaefa3314222f1",
         "is_verified": false,
         "line_number": 2638
       },
@@ -2241,14 +2212,14 @@
       {
         "type": "Hex High Entropy String",
         "filename": "data/vector_db/vectorized_files.json",
-        "hashed_secret": "02d38fcf207ac18f967de746233bbabf86ad666d",
+        "hashed_secret": "b451eca6807b1dbf538633a232a7d70d08faeddc",
         "is_verified": false,
         "line_number": 2665
       },
       {
         "type": "Hex High Entropy String",
         "filename": "data/vector_db/vectorized_files.json",
-        "hashed_secret": "4b5a6df7aeecef34ec30ca585e8c672445e809ba",
+        "hashed_secret": "21fb540cdaaa849c29f0635e05fe9a7d89b2dde1",
         "is_verified": false,
         "line_number": 2677
       },
@@ -2262,9 +2233,16 @@
       {
         "type": "Hex High Entropy String",
         "filename": "data/vector_db/vectorized_files.json",
-        "hashed_secret": "8937e613279c7b1bb3b3f53953f32fe7d76630ef",
+        "hashed_secret": "0a5b5e84a9cd12772ec70d104c9582e1a49bde5d",
         "is_verified": false,
         "line_number": 2703
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "data/vector_db/vectorized_files.json",
+        "hashed_secret": "feff436826f7eb21c61f1fa68ae3ef7946320662",
+        "is_verified": false,
+        "line_number": 2715
       },
       {
         "type": "Hex High Entropy String",
@@ -2290,7 +2268,7 @@
       {
         "type": "Hex High Entropy String",
         "filename": "data/vector_db/vectorized_files.json",
-        "hashed_secret": "2eeb17bd084c726e97879f718540e19cdfe0e7a4",
+        "hashed_secret": "e8dcbf9312971d0d2497433d52a5a36264c99c50",
         "is_verified": false,
         "line_number": 2765
       },
@@ -2304,14 +2282,21 @@
       {
         "type": "Hex High Entropy String",
         "filename": "data/vector_db/vectorized_files.json",
-        "hashed_secret": "a3c2376d7d26a0761f6f3388174f0ed1f7fd28bf",
+        "hashed_secret": "fa8c64678fb3c5f7389e1b607c36c37e61b53e0a",
         "is_verified": false,
         "line_number": 2789
       },
       {
         "type": "Hex High Entropy String",
         "filename": "data/vector_db/vectorized_files.json",
-        "hashed_secret": "b6a70d03f6fbde4429113bdae71d2b2fdf801c72",
+        "hashed_secret": "483d37d3b7d9f0b8279679013e74efc7efd7c4df",
+        "is_verified": false,
+        "line_number": 2801
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "data/vector_db/vectorized_files.json",
+        "hashed_secret": "23f032924f9553e601d6ef70e398b274cd717c2b",
         "is_verified": false,
         "line_number": 2813
       },
@@ -2325,21 +2310,28 @@
       {
         "type": "Hex High Entropy String",
         "filename": "data/vector_db/vectorized_files.json",
-        "hashed_secret": "69cfffb42b9cf98e25ce5ab087c1bb2f6c513d4f",
+        "hashed_secret": "82cada748174c93688c92c4343b6c47ca48a5518",
         "is_verified": false,
         "line_number": 2837
       },
       {
         "type": "Hex High Entropy String",
         "filename": "data/vector_db/vectorized_files.json",
-        "hashed_secret": "9bdbcdda5fd56081458694351b04db47616f8b9e",
+        "hashed_secret": "1cc66864722bbb97a6e3074f90109ae0a2ee41bf",
+        "is_verified": false,
+        "line_number": 2849
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "data/vector_db/vectorized_files.json",
+        "hashed_secret": "e20ae3b048668e3242383c7ef1aacd6f68288a23",
         "is_verified": false,
         "line_number": 2861
       },
       {
         "type": "Hex High Entropy String",
         "filename": "data/vector_db/vectorized_files.json",
-        "hashed_secret": "b3431d7513cd3eca98fbd9ec33a2b5711e6cd5eb",
+        "hashed_secret": "61432265b26a9909921bfd2d09f313ab1d0fb198",
         "is_verified": false,
         "line_number": 2873
       },
@@ -2353,7 +2345,7 @@
       {
         "type": "Hex High Entropy String",
         "filename": "data/vector_db/vectorized_files.json",
-        "hashed_secret": "710c3e5ac7a4566710886ae57ef654cb5266583c",
+        "hashed_secret": "f1dea6508408b07165e68260ec81954c2067375a",
         "is_verified": false,
         "line_number": 2901
       },
@@ -2367,37 +2359,51 @@
       {
         "type": "Hex High Entropy String",
         "filename": "data/vector_db/vectorized_files.json",
-        "hashed_secret": "4220f68f76147e449d34470cd5a6151feb1a76f6",
+        "hashed_secret": "7c9cb5284745fb36111a79a42aa73e23437c4a53",
         "is_verified": false,
         "line_number": 2929
       },
       {
         "type": "Hex High Entropy String",
         "filename": "data/vector_db/vectorized_files.json",
-        "hashed_secret": "472ee6fdc7157eb0ca8f4b27ef5697bdc77e56db",
+        "hashed_secret": "0337a582673844de680a5532ad51106ebf9122e1",
         "is_verified": false,
         "line_number": 2941
       },
       {
         "type": "Hex High Entropy String",
         "filename": "data/vector_db/vectorized_files.json",
-        "hashed_secret": "b4d751d10946c3c8f96263f84101e11820f61982",
+        "hashed_secret": "9ad5401b5663fdc338d66f2003dacf1b70472267",
+        "is_verified": false,
+        "line_number": 2953
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "data/vector_db/vectorized_files.json",
+        "hashed_secret": "ecd7767884ed77289c127a4face9193ea0f34f27",
         "is_verified": false,
         "line_number": 2965
       },
       {
         "type": "Hex High Entropy String",
         "filename": "data/vector_db/vectorized_files.json",
-        "hashed_secret": "46693f36a7cd50d9c3248d6afe2e14a771aef1c7",
+        "hashed_secret": "99bc5443b855034633e92d680e4b6a9d8a25ab4c",
         "is_verified": false,
         "line_number": 2977
       },
       {
         "type": "Hex High Entropy String",
         "filename": "data/vector_db/vectorized_files.json",
-        "hashed_secret": "fdde78b4ce6c043dd45199643477a6b0b6814fec",
+        "hashed_secret": "38329db02dba9c092b96234f37e853905697e0ea",
         "is_verified": false,
         "line_number": 2989
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "data/vector_db/vectorized_files.json",
+        "hashed_secret": "c161c0729b0ab8d43022e502e38a402e8b063803",
+        "is_verified": false,
+        "line_number": 3004
       },
       {
         "type": "Hex High Entropy String",
@@ -2416,9 +2422,121 @@
       {
         "type": "Hex High Entropy String",
         "filename": "data/vector_db/vectorized_files.json",
-        "hashed_secret": "0be120226ae0242f21f8cfa13c4f69aef552d91f",
+        "hashed_secret": "e7de923d52ec5a1cf009158af03f63a60217b4e7",
         "is_verified": false,
         "line_number": 3047
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "data/vector_db/vectorized_files.json",
+        "hashed_secret": "9a64e9ac8e76b7a5116fea4c65960d0c4cc7f70c",
+        "is_verified": false,
+        "line_number": 3059
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "data/vector_db/vectorized_files.json",
+        "hashed_secret": "d1b7895721efc5f1b3930609d9b0ab8f2fee9f71",
+        "is_verified": false,
+        "line_number": 3073
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "data/vector_db/vectorized_files.json",
+        "hashed_secret": "40fd47b63687fe4203f8f81797ecf3b5e5db39d2",
+        "is_verified": false,
+        "line_number": 3085
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "data/vector_db/vectorized_files.json",
+        "hashed_secret": "1a8513661dcc67859946ea615b5e524ce9e4d1bf",
+        "is_verified": false,
+        "line_number": 3099
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "data/vector_db/vectorized_files.json",
+        "hashed_secret": "54d188f04143fe3e033ba34958511070308c81a2",
+        "is_verified": false,
+        "line_number": 3113
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "data/vector_db/vectorized_files.json",
+        "hashed_secret": "7225e873194282b8cea6f7fc5d6bf90c7fd85984",
+        "is_verified": false,
+        "line_number": 3127
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "data/vector_db/vectorized_files.json",
+        "hashed_secret": "14079334218e783a16aa4cfa0da08a9a572ea264",
+        "is_verified": false,
+        "line_number": 3139
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "data/vector_db/vectorized_files.json",
+        "hashed_secret": "53ada2e9c9f724c1b7d74b63f558ebcfa70e7bbd",
+        "is_verified": false,
+        "line_number": 3151
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "data/vector_db/vectorized_files.json",
+        "hashed_secret": "9fdbaaa62e4a6edb73bcf0e7deceea480984e710",
+        "is_verified": false,
+        "line_number": 3163
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "data/vector_db/vectorized_files.json",
+        "hashed_secret": "33a738306ebbc972ab71f65ab1e764e54a3e4ff5",
+        "is_verified": false,
+        "line_number": 3175
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "data/vector_db/vectorized_files.json",
+        "hashed_secret": "3454c2be8a172c96179ecfd971dd8b477f2e0fe7",
+        "is_verified": false,
+        "line_number": 3189
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "data/vector_db/vectorized_files.json",
+        "hashed_secret": "6118b6597e8064b686f35aea61f00da4162e898d",
+        "is_verified": false,
+        "line_number": 3201
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "data/vector_db/vectorized_files.json",
+        "hashed_secret": "1eafbb26eaf759679679af978038ca3959e0d184",
+        "is_verified": false,
+        "line_number": 3213
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "data/vector_db/vectorized_files.json",
+        "hashed_secret": "a5a803b47fc6900a89fe4ead93fcf7bffc9dbf46",
+        "is_verified": false,
+        "line_number": 3227
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "data/vector_db/vectorized_files.json",
+        "hashed_secret": "684960909025e52ba7adc345d86127b3b9c4f856",
+        "is_verified": false,
+        "line_number": 3239
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "data/vector_db/vectorized_files.json",
+        "hashed_secret": "bae8d5606d09c33578954212c78842e622ca9d86",
+        "is_verified": false,
+        "line_number": 3251
       }
     ],
     "pytest.ini": [
@@ -2480,6 +2598,36 @@
         "line_number": 21
       }
     ],
+    "tests/test_mcp_governance.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/test_mcp_governance.py",
+        "hashed_secret": "4dd0eb345270efc47af3f55998ffc216437cc631",
+        "is_verified": false,
+        "line_number": 151
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/test_mcp_governance.py",
+        "hashed_secret": "f2b14f68eb995facb3a1c35287b778d5bd785511",
+        "is_verified": false,
+        "line_number": 152
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/test_mcp_governance.py",
+        "hashed_secret": "f3bbbd66a63d4bf1747940578ec3d0103530e21d",
+        "is_verified": false,
+        "line_number": 153
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/test_mcp_governance.py",
+        "hashed_secret": "e5e9fa1ba31ecd1ae84f75caaa474f3a663f05f4",
+        "is_verified": false,
+        "line_number": 193
+      }
+    ],
     "tests/test_model_selector.py": [
       {
         "type": "Secret Keyword",
@@ -2533,5 +2681,5 @@
       }
     ]
   },
-  "generated_at": "2026-01-16T17:37:07Z"
+  "generated_at": "2026-01-19T13:42:05Z"
 }


### PR DESCRIPTION
## Summary
- Fix Alpaca SDK API call in Execute Credit Spread workflow
- SDK requires `GetCalendarRequest` object instead of direct keyword args

## Problem
The `Execute Credit Spread` workflow was failing with:
```
TypeError: TradingClient.get_calendar() got an unexpected keyword argument 'start'
```

## Solution
Changed from:
```python
client.get_calendar(start=today, end=today)
```
To:
```python
from alpaca.trading.requests import GetCalendarRequest
calendar_request = GetCalendarRequest(start=today, end=today)
client.get_calendar(calendar_request)
```

## Test plan
- [x] Pre-push validation passed
- [ ] CI workflow passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)