### PR TITLE
fix(strategy): Disable conflicting traders and add compliance test (LL-242)

### DIFF
--- a/.github/workflows/daily-trading.yml
+++ b/.github/workflows/daily-trading.yml
@@ -909,14 +909,12 @@ jobs:
           echo "✅ Position management complete - stop-losses enforced"
           # ================================================================
 
-          # ========== GUARANTEED TRADER (Dec 18, 2025) ==========
-          # Problem: Complex gates blocked ALL trades for 50 days
-          # Solution: Run simple guaranteed trader FIRST
-          echo "🎯 Running guaranteed trader (bypass complex gates)..."
-          python3 -u scripts/guaranteed_trader.py 2>&1 | tee /tmp/guaranteed_output.log || {
-            echo "⚠️ Guaranteed trader had issues, continuing with main orchestrator..."
-          }
-          echo "✅ Guaranteed trader complete"
+          # ========== GUARANTEED TRADER - DISABLED Jan 19, 2026 ==========
+          # DISABLED: LL-242 audit found this buys SPY SHARES, not iron condors
+          # CLAUDE.md mandates: Iron condors only, SPY only, defined risk
+          # This was causing strategy mismatch - iron_condor_trader.py is the ONLY trader
+          # See: rag_knowledge/lessons_learned/ll_242_adversarial_audit_strategy_mismatch_jan19.md
+          echo "⏭️ Guaranteed trader DISABLED (strategy mismatch - iron condors only)"
           # ======================================================
 
           # ========== DIAGNOSTIC CHECKPOINT (Jan 5, 2026) ==========
@@ -1055,19 +1053,16 @@ jobs:
           # FIX Jan 15, 2026: When options_buying_power=$0, fall back to equity
           if (( $(echo "$OPTIONS_BP == 0" | bc -l) )); then
             echo ""
-            echo "🚨 OPTIONS BUYING POWER = \$0 - EQUITY FALLBACK MODE"
+            echo "🚨 OPTIONS BUYING POWER = \$0 - CANNOT TRADE TODAY"
             echo "   Root cause: Stale orders or margin calculation issue"
-            echo "   Action: Buy SPY shares instead of options"
+            echo "   Action: WAIT - do not buy equity (LL-242: iron condors only)"
             echo ""
-
-            # Buy $100 of SPY as fallback (builds towards credit spread collateral)
-            echo "   📈 Buying \$100 of SPY (equity fallback)..."
-            python3 scripts/guaranteed_trader.py || {
-              echo "   ⚠️  Equity fallback also failed - check account state"
-            }
-
+            # DISABLED Jan 19, 2026: guaranteed_trader buys SPY SHARES, not iron condors
+            # This violates CLAUDE.md strategy - iron condors ONLY for defined risk
+            # See: rag_knowledge/lessons_learned/ll_242_adversarial_audit_strategy_mismatch_jan19.md
+            echo "   ⏭️ Equity fallback DISABLED - resolve buying power issue instead"
             echo ""
-            echo "⚠️  Options blocked - used equity fallback. Check Alpaca for stale orders."
+            echo "⚠️  Options blocked - investigate Alpaca for stale orders."
 
           elif (( $(echo "$OPTIONS_BP < 1000" | bc -l) )); then
             echo ""
@@ -1205,48 +1200,15 @@ jobs:
           echo ""
           echo "✅ Iron condor strategy complete"
 
-      - name: Simple Daily Trader (CSP fallback)
-        if: steps.execute_trading.conclusion == 'success'
-        # FIXED Dec 30, 2025: Removed continue-on-error - trading failures must be visible
-        env:
-          ALPACA_API_KEY: ${{ github.event.inputs.trading_mode == 'live' && secrets.ALPACA_BROKERAGE_TRADING_API_KEY || secrets.ALPACA_PAPER_TRADING_5K_API_KEY }}
-          ALPACA_SECRET_KEY: ${{ github.event.inputs.trading_mode == 'live' && secrets.ALPACA_BROKERAGE_TRADING_API_SECRET || secrets.ALPACA_PAPER_TRADING_5K_API_SECRET }}
-        run: |
-          echo ""
-          echo "💰 ========================================"
-          echo "💰 SIMPLE DAILY TRADER - GUARANTEED EXECUTION"
-          echo "💰 ========================================"
-          echo "Strategy: Cash-secured puts on SPY (20 delta, 30 DTE)"
-          echo "Target: $20-40/day additional income"
-          echo ""
-          python3 scripts/simple_daily_trader.py || {
-            echo "⚠️  Simple daily trader returned non-zero"
-            echo "   Check logs for details"
-          }
-          echo ""
-          echo "✅ Simple daily trader complete"
-
-      - name: Rule #1 Options (Phil Town Strategy)
-        if: steps.execute_trading.conclusion == 'success'
-        # FIXED Dec 30, 2025: Removed continue-on-error - trading failures must be visible
-        env:
-          ALPACA_API_KEY: ${{ github.event.inputs.trading_mode == 'live' && secrets.ALPACA_BROKERAGE_TRADING_API_KEY || secrets.ALPACA_PAPER_TRADING_5K_API_KEY }}
-          ALPACA_SECRET_KEY: ${{ github.event.inputs.trading_mode == 'live' && secrets.ALPACA_BROKERAGE_TRADING_API_SECRET || secrets.ALPACA_PAPER_TRADING_5K_API_SECRET }}
-        run: |
-          echo ""
-          echo "📚 ========================================"
-          echo "📚 RULE #1 OPTIONS - PHIL TOWN STRATEGY"
-          echo "📚 ========================================"
-          echo "Strategy: Sell puts at 50% MOS, calls at Sticker Price"
-          echo "Based on: Rule #1 and Payback Time books"
-          echo "Target: $20-50/day on quality stocks with moats"
-          echo ""
-          python3 scripts/rule_one_trader.py || {
-            echo "⚠️  Rule #1 trader returned non-zero"
-            echo "   This is informational - strategy may need configuration"
-          }
-          echo ""
-          echo "✅ Rule #1 strategy complete"
+      # ========================================================================
+      # DISABLED Jan 19, 2026 - LL-242: Strategy Mismatch Crisis
+      # These traders VIOLATE CLAUDE.md strategy (iron condors only, SPY only)
+      # simple_daily_trader: Sells NAKED puts (undefined risk)
+      # rule_one_trader: Trades individual stocks (F, SOFI, etc.)
+      # See: rag_knowledge/lessons_learned/ll_242_adversarial_audit_strategy_mismatch_jan19.md
+      # ========================================================================
+      # - name: Simple Daily Trader (CSP fallback) - DISABLED
+      # - name: Rule #1 Options (Phil Town Strategy) - DISABLED
 
       - name: Update performance log
         if: steps.execute_trading.conclusion == 'success'

--- a/scripts/close_excess_spreads.py
+++ b/scripts/close_excess_spreads.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+"""
+Close Excess Spreads - Enforce CLAUDE.md 1-spread limit.
+
+Created: Jan 19, 2026 (LL-242: Strategy Mismatch Crisis)
+
+Per CLAUDE.md:
+- "Position limit: 1 iron condor at a time (5% max = $248 risk)"
+- Currently have 3 spreads - need to close 2
+
+Close order:
+1. Spread 3 (653/658) - QTY mismatch, not a proper spread
+2. Spread 1 (565/570) - lowest P/L contribution
+3. KEEP Spread 2 (595/600) - closest to current price
+"""
+
+import logging
+import os
+import sys
+from datetime import datetime
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from src.core.alpaca_trader import AlpacaTrader
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
+logger = logging.getLogger(__name__)
+
+# Positions to close (in order)
+POSITIONS_TO_CLOSE = [
+    # Spread 3: QTY mismatch (close first)
+    {"symbol": "SPY260220P00653000", "qty": 2, "side": "sell"},  # Long put
+    {"symbol": "SPY260220P00658000", "qty": 1, "side": "buy"},  # Short put (buy to close)
+    # Spread 1: Lower P/L (close second)
+    {"symbol": "SPY260220P00565000", "qty": 1, "side": "sell"},  # Long put
+    {"symbol": "SPY260220P00570000", "qty": 1, "side": "buy"},  # Short put (buy to close)
+]
+
+# Position to KEEP
+KEEP_SPREAD = "595/600 put spread"
+
+
+def main():
+    """Close excess spreads to comply with CLAUDE.md 1-spread limit."""
+    logger.info("=" * 60)
+    logger.info("CLOSE EXCESS SPREADS - CLAUDE.md Compliance")
+    logger.info("=" * 60)
+    logger.info(f"Date: {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}")
+    logger.info("")
+
+    # Check if market is open
+    trader = AlpacaTrader(paper=True)
+    clock = trader.trading_client.get_clock()
+
+    if not clock.is_open:
+        logger.warning("Market is CLOSED. Cannot close positions now.")
+        logger.info(f"Next open: {clock.next_open}")
+        logger.info("")
+        logger.info("Positions queued for closure when market opens:")
+        for pos in POSITIONS_TO_CLOSE:
+            logger.info(f"  - {pos['side'].upper()} {pos['qty']} {pos['symbol']}")
+        logger.info("")
+        logger.info(f"Position to KEEP: {KEEP_SPREAD}")
+        return 0
+
+    logger.info("Market is OPEN - proceeding with closures")
+    logger.info("")
+
+    closed_count = 0
+    errors = []
+
+    for pos in POSITIONS_TO_CLOSE:
+        symbol = pos["symbol"]
+        qty = pos["qty"]
+        side = pos["side"]
+
+        logger.info(f"Closing: {side.upper()} {qty} {symbol}")
+
+        try:
+            # Use AlpacaTrader to close position
+            if side == "sell":
+                # Selling long position
+                order = trader.sell_option(symbol, qty)
+            else:
+                # Buying to close short position
+                order = trader.buy_option(symbol, qty)
+
+            if order:
+                logger.info(f"  ✅ Order submitted: {order.id}")
+                closed_count += 1
+            else:
+                logger.error("  ❌ Order failed - no order returned")
+                errors.append(symbol)
+
+        except Exception as e:
+            logger.error(f"  ❌ Error closing {symbol}: {e}")
+            errors.append(symbol)
+
+    logger.info("")
+    logger.info("=" * 60)
+    logger.info("SUMMARY")
+    logger.info("=" * 60)
+    logger.info(f"Positions closed: {closed_count}/{len(POSITIONS_TO_CLOSE)}")
+    logger.info(f"Position kept: {KEEP_SPREAD}")
+
+    if errors:
+        logger.error(f"Errors: {errors}")
+        return 1
+
+    logger.info("✅ Now compliant with CLAUDE.md 1-spread limit")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_claudemd_compliance.py
+++ b/tests/test_claudemd_compliance.py
@@ -1,0 +1,190 @@
+#!/usr/bin/env python3
+"""
+CLAUDE.md Compliance Test - Validates code matches documented strategy.
+
+Created: Jan 19, 2026 (LL-242: Strategy Mismatch Crisis)
+
+This test prevents the $5K account failure mode where:
+- CLAUDE.md said "credit spreads on SPY only"
+- Code actually executed naked puts on individual stocks
+
+Run: pytest tests/test_claudemd_compliance.py -v
+"""
+
+import json
+import re
+from pathlib import Path
+
+import pytest
+
+
+class TestClaudeMdCompliance:
+    """Test that code matches CLAUDE.md strategy rules."""
+
+    @pytest.fixture
+    def claudemd_content(self) -> str:
+        """Load CLAUDE.md content."""
+        claudemd_path = Path(".claude/CLAUDE.md")
+        if not claudemd_path.exists():
+            pytest.skip("CLAUDE.md not found")
+        return claudemd_path.read_text()
+
+    @pytest.fixture
+    def daily_trading_workflow(self) -> str:
+        """Load daily-trading.yml content."""
+        workflow_path = Path(".github/workflows/daily-trading.yml")
+        if not workflow_path.exists():
+            pytest.skip("daily-trading.yml not found")
+        return workflow_path.read_text()
+
+    @pytest.fixture
+    def system_state(self) -> dict:
+        """Load current system state."""
+        state_path = Path("data/system_state.json")
+        if not state_path.exists():
+            pytest.skip("system_state.json not found")
+        return json.loads(state_path.read_text())
+
+    def test_only_spy_tickers_in_workflow(self, daily_trading_workflow: str):
+        """Verify workflow only trades SPY (per CLAUDE.md ticker whitelist)."""
+        # Find all ticker references
+        # Allowed: SPY, IWM (per CLAUDE.md)
+        # Forbidden: SOFI, F, T, INTC, BAC, VZ, etc.
+        forbidden_tickers = ["SOFI", "F", "T", "INTC", "BAC", "VZ", "AMD", "NVDA"]
+
+        for ticker in forbidden_tickers:
+            # Check for ticker being actively traded (not just mentioned)
+            pattern = rf'--symbol\s+["\']?{ticker}["\']?'
+            matches = re.findall(pattern, daily_trading_workflow, re.IGNORECASE)
+            assert len(matches) == 0, f"Forbidden ticker {ticker} found in workflow: {matches}"
+
+    def test_no_naked_puts_in_workflow(self, daily_trading_workflow: str):
+        """Verify workflow doesn't execute naked put scripts."""
+        # CLAUDE.md says: "NO NAKED PUTS" - only iron condors/credit spreads
+        # Check for actual CSP script execution (not comments/documentation)
+        csp_execution_patterns = [
+            r"python3\s+.*execute_cash_secured_put",
+            r"python3\s+.*sell_naked_put",
+            r"python3\s+.*execute_csp",
+        ]
+
+        for pattern in csp_execution_patterns:
+            # Find lines that execute CSP scripts
+            matches = re.findall(pattern, daily_trading_workflow, re.IGNORECASE)
+            assert len(matches) == 0, (
+                f"Naked put execution '{pattern}' found in workflow: {matches}"
+            )
+
+    def test_conflicting_traders_disabled(self, daily_trading_workflow: str):
+        """Verify conflicting traders are disabled."""
+        # These traders violate CLAUDE.md (per LL-242):
+        # - simple_daily_trader.py: Sells naked CSPs
+        # - rule_one_trader.py: Trades individual stocks
+        # - guaranteed_trader.py: Buys SPY shares (not iron condors)
+
+        conflicting_traders = [
+            "simple_daily_trader.py",
+            "rule_one_trader.py",
+        ]
+
+        for trader in conflicting_traders:
+            # Check if trader is actively called (not commented)
+            # Pattern: python3 scripts/trader.py (without # before)
+            active_pattern = rf"^\s*python3\s+scripts/{trader}"
+            matches = re.findall(active_pattern, daily_trading_workflow, re.MULTILINE)
+            assert len(matches) == 0, f"Conflicting trader {trader} is still active in workflow"
+
+    def test_iron_condor_trader_is_primary(self, daily_trading_workflow: str):
+        """Verify iron_condor_trader.py is the primary strategy."""
+        assert "iron_condor_trader.py" in daily_trading_workflow, (
+            "iron_condor_trader.py should be in workflow"
+        )
+
+    def test_position_limit_compliance(self, system_state: dict):
+        """Verify position count doesn't exceed CLAUDE.md limit."""
+        # CLAUDE.md: "Position limit: 1 iron condor at a time"
+        # Iron condor = 4 legs, credit spread = 2 legs
+        # Max positions: 4 (one iron condor)
+        MAX_POSITIONS = 4
+
+        positions = system_state.get("positions", [])
+        position_count = len(positions)
+
+        # This is a WARNING, not failure - gives time to close excess
+        if position_count > MAX_POSITIONS:
+            pytest.fail(
+                f"Position limit exceeded: {position_count} positions "
+                f"(max {MAX_POSITIONS} per CLAUDE.md). "
+                f"Run: python3 scripts/close_excess_spreads.py"
+            )
+
+    def test_positions_are_spy_only(self, system_state: dict):
+        """Verify all positions are SPY (per CLAUDE.md ticker whitelist)."""
+        positions = system_state.get("positions", [])
+
+        for pos in positions:
+            symbol = pos.get("symbol", "")
+            # Extract underlying from option symbol (e.g., SPY260220P00565000 -> SPY)
+            underlying = symbol[:3] if len(symbol) > 3 else symbol
+
+            assert underlying in [
+                "SPY",
+                "IWM",
+            ], f"Non-whitelisted ticker in positions: {symbol} (underlying: {underlying})"
+
+    def test_no_individual_stocks_in_positions(self, system_state: dict):
+        """Verify no individual stock positions exist."""
+        positions = system_state.get("positions", [])
+        forbidden = ["SOFI", "F", "T", "INTC", "BAC", "VZ", "AMD", "NVDA"]
+
+        for pos in positions:
+            symbol = pos.get("symbol", "")
+            for ticker in forbidden:
+                assert not symbol.startswith(ticker), (
+                    f"Forbidden ticker {ticker} in positions: {symbol}"
+                )
+
+    def test_5pct_position_limit(self, system_state: dict):
+        """Verify no single position exceeds 5% of portfolio."""
+        # CLAUDE.md: "Position limit: 5% max = $248 risk"
+        portfolio = system_state.get("portfolio", {})
+        equity = portfolio.get("equity", 5000)
+        max_risk = equity * 0.05
+
+        positions = system_state.get("positions", [])
+        for pos in positions:
+            value = abs(pos.get("value", 0))
+            if value > max_risk:
+                pytest.fail(
+                    f"Position {pos.get('symbol')} value ${value:.2f} "
+                    f"exceeds 5% limit (${max_risk:.2f})"
+                )
+
+
+class TestStrategyDocumentation:
+    """Test that strategy documentation exists and is consistent."""
+
+    def test_claudemd_exists(self):
+        """Verify CLAUDE.md exists."""
+        assert Path(".claude/CLAUDE.md").exists(), "CLAUDE.md not found"
+
+    def test_claudemd_has_strategy_section(self):
+        """Verify CLAUDE.md has Strategy section."""
+        content = Path(".claude/CLAUDE.md").read_text()
+        assert "## Strategy" in content, "CLAUDE.md missing Strategy section"
+
+    def test_claudemd_has_iron_condor_strategy(self):
+        """Verify CLAUDE.md documents iron condor strategy."""
+        content = Path(".claude/CLAUDE.md").read_text()
+        assert "iron condor" in content.lower(), "CLAUDE.md should document iron condor strategy"
+
+    def test_claudemd_has_position_limit(self):
+        """Verify CLAUDE.md has position limit rule."""
+        content = Path(".claude/CLAUDE.md").read_text()
+        assert (
+            "1 iron condor at a time" in content.lower() or "position limit" in content.lower()
+        ), "CLAUDE.md should document position limit"
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary
- Disables conflicting traders that violate CLAUDE.md iron condor strategy
- Adds CLAUDE.md compliance test suite (10/12 passing)
- Creates script to close excess positions (3 → 1 spread)

## Problem (LL-242 Adversarial Audit)
CLAUDE.md says "iron condors only, SPY only, 1 position at a time" but code executed:
- `simple_daily_trader.py`: Naked puts (undefined risk)
- `rule_one_trader.py`: Individual stocks (F, SOFI, etc.)
- `guaranteed_trader.py`: SPY shares (not iron condors)
- **3 spreads open** when limit is 1

## Changes
1. **Disabled conflicting traders** in daily-trading.yml
2. **Added `close_excess_spreads.py`** - runs when market opens tomorrow
3. **Added `test_claudemd_compliance.py`** - validates code matches strategy

## Test plan
- [x] 10/12 compliance tests pass
- [ ] 2 failures will be fixed when excess positions closed
- [ ] Run `python3 scripts/close_excess_spreads.py` when market opens

## Phil Town Rule #1 Alignment
Naked puts had unlimited downside. Iron condors have defined risk on BOTH sides.

🤖 Generated with [Claude Code](https://claude.com/claude-code)