### PR TITLE
fix(structure): Add missing __init__.py files and deprecation notice (LL-251)

### DIFF
--- a/src/analytics/__init__.py
+++ b/src/analytics/__init__.py
@@ -1,0 +1,1 @@
+"""Analytics module for trading system metrics and analysis."""

--- a/src/utils/__init__.py
+++ b/src/utils/__init__.py
@@ -1,0 +1,1 @@
+"""Utility modules for the trading system."""

--- a/src/utils/retry_decorator.py
+++ b/src/utils/retry_decorator.py
@@ -3,6 +3,18 @@ Retry Decorator with Exponential Backoff and Timeout Support
 
 Provides retry functionality for API calls and network operations.
 Updated: 2025-12-04 - Added timeout support to prevent indefinite hangs.
+
+DEPRECATION NOTICE (Jan 19, 2026):
+This module is superseded by src.resilience.retry which provides:
+- Circuit breaker integration
+- Better configuration via RetryConfig dataclass
+- Consistent with other resilience patterns
+
+For new code, use:
+    from src.resilience import retry_with_backoff
+
+This module is kept for backwards compatibility with existing code
+(e.g., src/core/alpaca_trader.py uses this version with timeout features).
 """
 
 import logging


### PR DESCRIPTION
## Summary

- Add missing __init__.py files to src/analytics, src/core, src/utils
- Add deprecation notice to retry_decorator.py pointing to resilience.retry
- src/core/__init__.py exports trading constants for easier imports

## Test Plan

- [x] Verified imports work: from src.core import ALLOWED_TICKERS