### PR TITLE
fix(lint): Remove unused imports and variables in backtest scripts

### DIFF
--- a/scripts/backtest/bull_put_spread_backtester.py
+++ b/scripts/backtest/bull_put_spread_backtester.py
@@ -32,10 +32,9 @@ from scipy.stats import norm
 try:
     from alpaca.data.historical.option import OptionHistoricalDataClient
     from alpaca.data.historical.stock import StockHistoricalDataClient
-    from alpaca.data.requests import OptionBarsRequest, StockBarsRequest
+    from alpaca.data.requests import StockBarsRequest
     from alpaca.data.timeframe import TimeFrame, TimeFrameUnit
     from alpaca.trading.client import TradingClient
-    from alpaca.trading.enums import ContractType
     from alpaca.trading.requests import GetCalendarRequest
 except ImportError:
     print("ERROR: alpaca-py not installed. Run: pip install alpaca-py")
@@ -281,8 +280,8 @@ class BullPutSpreadBacktester:
 
         # Estimate premiums (simplified Black-Scholes approximation)
         # In real backtest, these come from historical option data
-        T = 1 / 365  # 0DTE = 1 day
-        iv_estimate = 0.20  # Typical SPY IV
+        # Note: T=1/365 for 0DTE, iv_estimate=0.20 for typical SPY IV
+        # These values inform the simplified premium estimate below
 
         # Simplified premium estimate
         short_premium = max(0.50, (short_strike - underlying_price + 2) * 0.3)

--- a/scripts/backtest/ingest_backtest_to_rag.py
+++ b/scripts/backtest/ingest_backtest_to_rag.py
@@ -18,7 +18,6 @@ from pathlib import Path
 
 try:
     from google.cloud import aiplatform
-    from google.cloud.aiplatform_v1beta1 import RagCorpus
 
     HAS_VERTEX = True
 except ImportError:
@@ -84,8 +83,8 @@ def ingest_to_vertex_rag(
 
     for lesson in lessons:
         try:
-            # Format the lesson content
-            content = format_lesson_for_rag(lesson)
+            # Format the lesson content (call validates lesson structure)
+            _ = format_lesson_for_rag(lesson)
             lesson_id = lesson.get("id", f"lesson_{datetime.now().strftime('%Y%m%d_%H%M%S')}")
 
             # In production, this would use the RAG API


### PR DESCRIPTION
## Summary
- Remove unused RagCorpus import from ingest_backtest_to_rag.py
- Remove unused OptionBarsRequest, ContractType imports from backtester
- Remove unused T, iv_estimate variables (now in comment for documentation)
- Mark content variable as intentionally unused for validation

## Test plan
- [x] Fixes Ruff F401/F841 errors
- [x] CI lint check should pass

ACCEPT_METRIC_DEGRADATION