### PR TITLE
fix(compliance): Filter out SPY stock from option parsing

### DIFF
--- a/.github/workflows/auto-position-compliance.yml
+++ b/.github/workflows/auto-position-compliance.yml
@@ -62,11 +62,13 @@ jobs:
           positions = client.get_all_positions()
           print(f"Total Positions: {len(positions)}")
 
-          # Analyze SPY puts
+          # Analyze SPY puts (options only, not stock)
           puts = {}
           for pos in positions:
               symbol = pos.symbol
-              if "P" in symbol and symbol.startswith("SPY"):
+              # Option symbols are like SPY260220P00653000 (21+ chars)
+              # Stock "SPY" is only 3 chars - must filter it out
+              if len(symbol) > 10 and "P" in symbol and symbol.startswith("SPY"):
                   strike = int(symbol[-8:]) / 1000
                   puts[strike] = {
                       "symbol": symbol,


### PR DESCRIPTION
## Bug
ValueError: invalid literal for int() with base 10: "SPY"

## Cause
Condition `"P" in symbol and symbol.startswith("SPY")` matches both:
- Options: SPY260220P00653000 ✅
- Stock: SPY ❌

## Fix
Add length check `len(symbol) > 10` to filter out stock symbols.

## Test
- CI passes
- Auto Position Compliance workflow should work