### PR TITLE
fix(safety): Add PDT check to credit spread workflow (LL-271)

### DIFF
--- a/.github/workflows/execute-credit-spread.yml
+++ b/.github/workflows/execute-credit-spread.yml
@@ -122,6 +122,27 @@ jobs:
           print(f"=== COMPLIANCE CHECK (CLAUDE.md Rules) ===")
           print(f"Account Equity: ${equity:.2f}")
           print(f"")
+
+          # NEW: PDT (Pattern Day Trading) Check - LL-271 Prevention
+          print(f"--- PDT (Pattern Day Trading) Check ---")
+          daytrade_count = int(getattr(account, 'daytrade_count', 0))
+          is_pdt = getattr(account, 'pattern_day_trader', False)
+          print(f"Day trades in last 5 days: {daytrade_count}")
+          print(f"PDT status: {'FLAGGED' if is_pdt else 'OK'}")
+
+          if is_pdt and equity < 25000:
+              print(f"::error::PDT BLOCKED: Account is PDT-flagged with equity under $25K")
+              print(f"::error::Cannot execute any day trades until restriction clears")
+              with open(os.environ['GITHUB_OUTPUT'], 'a') as f:
+                  f.write("compliant=false\n")
+              exit(1)
+
+          if daytrade_count >= 3 and equity < 25000:
+              print(f"::warning::PDT WARNING: {daytrade_count}/4 day trades used. One more day trade will trigger PDT.")
+              # Allow trade but warn - the position won't be a day trade if held overnight
+
+          print(f"✅ PDT check PASSED")
+          print(f"")
           print(f"--- Per-Position Limit (5% Rule) ---")
           max_per_position = equity * 0.05
           print(f"5% Position Limit: ${max_per_position:.2f}")

--- a/rag_knowledge/lessons_learned/ll_271_pdt_blocks_sofi_close_jan20.md
+++ b/rag_knowledge/lessons_learned/ll_271_pdt_blocks_sofi_close_jan20.md
@@ -1,0 +1,50 @@
+# LL-271: PDT Protection Blocks SOFI Position Close
+
+**Date**: 2026-01-20
+**Category**: Trading Compliance, Risk Management
+**Severity**: HIGH
+
+## The Problem
+
+SOFI260213P00032000 (short put) cannot be closed due to PDT (Pattern Day Trading) protection.
+
+**Error**: `{"code":40310100,"message":"trade denied due to pattern day trading protection"}`
+
+## Root Cause
+
+1. Account is under $25K (~$5,069)
+2. Account has accumulated 4+ day trades in the past 5 business days
+3. PDT rules prevent ANY additional day trades until one falls off
+
+## Impact
+
+- SOFI position remains open, violating "SPY ONLY" mandate
+- Position has -$80 unrealized loss
+- System compliance checks will fail until position is closed
+- Cannot execute new credit spreads until SOFI is closed
+
+## Resolution
+
+**Option 1**: Wait for a day trade to fall off (5 business days from oldest day trade)
+**Option 2**: Deposit funds to reach $25K (removes PDT restriction)
+**Option 3**: Accept the loss and let the option expire worthless (Feb 13, 2026)
+
+## Prevention
+
+1. **Check day trade count BEFORE opening positions** - query Alpaca API for day trade status
+2. **Never open non-SPY positions** - this was the original violation
+3. **Close positions on different days from opening** - avoid same-day round trips
+4. **Track day trade count in system_state.json** - monitor approaching limits
+
+## Alpaca PDT Rules
+
+- Applies to accounts < $25K
+- Day trade = open and close same security same day
+- 4+ day trades in 5 business days = PDT flagged
+- Flagged accounts cannot day trade until:
+  - A day trade falls off (5 business days)
+  - Account reaches $25K equity
+
+## Tags
+
+`pdt`, `compliance`, `sofi`, `options`, `risk-management`


### PR DESCRIPTION
Adds PDT check to prevent trades when account is PDT-restricted. Records LL-271 lesson. Tests pass (846/846).