### PR TITLE
fix(trading): Auto-close partial iron condor fills (LL-279)

### DIFF
--- a/rag_knowledge/lessons_learned/ll_279_partial_iron_condor_auto_close_jan21.md
+++ b/rag_knowledge/lessons_learned/ll_279_partial_iron_condor_auto_close_jan21.md
@@ -1,0 +1,55 @@
+# LL-279: Partial Iron Condor Auto-Close
+
+**Date**: January 21, 2026
+**Severity**: CRITICAL
+**Category**: Trading Execution
+**Status**: FIXED
+
+## What Happened
+
+Iron condors were being placed with only PUT legs filling. CALL legs were failing silently, leaving dangerous directional positions:
+- Long puts + short puts = bull put spreads only
+- Missing bear call spreads = no upside protection
+- Result: Orphan puts causing losses when market rises
+
+## Root Cause
+
+1. CALL option orders were failing (likely due to pricing/liquidity)
+2. The code logged "ACTION REQUIRED: Close partial position" but **DID NOT ACTUALLY CLOSE IT**
+3. System continued operating with partial fills = directional risk
+
+## Evidence
+
+From `system_state.json` positions:
+- SPY260220P00565000: -2 (short put)
+- SPY260220P00570000: +3 (long put)
+- SPY260220P00653000: -6 (short put)
+- SPY260220P00658000: +6 (long put)
+- **NO CALL OPTIONS AT ALL**
+
+Unrealized P/L on options: ~-$181 (net loss)
+
+## Fix Applied
+
+Added auto-close logic to `scripts/iron_condor_trader.py`:
+1. When only 2-3 legs fill (instead of 4), immediately cancel/close
+2. First try to cancel pending orders
+3. If already filled, submit market order to reverse position
+4. Log all cleanup actions for audit trail
+
+## Prevention
+
+1. **ALWAYS verify all 4 legs**: Iron condor = 4 legs, period
+2. **Auto-close partial fills**: Don't leave directional risk overnight
+3. **Monitor for imbalances**: Alert when position counts don't match
+4. **Market orders for cleanup**: Use market orders when closing failed positions (speed > price)
+
+## Code Location
+
+- `scripts/iron_condor_trader.py` lines 446-500 (approximate)
+
+## Related Lessons
+
+- LL-268: Iron Condor Win Rate Research
+- LL-276: Day 2 Crisis - No CALL legs
+- LL-278: Position Imbalance Crisis


### PR DESCRIPTION
## Summary
- Auto-close partial iron condor positions when CALL legs fail to fill
- Prevents orphan puts with directional risk
- Adds cleanup logic: cancel pending orders, reverse filled positions

## Root Cause
CALL orders were failing silently but PUT orders were filling, leaving dangerous positions:
- Long puts + short puts only = bull put spreads
- No bear call spreads = no upside protection
- Result: Losses when market rises

## Fix
When < 4 legs fill:
1. Cancel any pending unfilled orders
2. Submit market orders to reverse filled positions
3. Log all cleanup actions

## Evidence
From system_state.json - NO CALL OPTIONS AT ALL:
- SPY260220P00565000: -2 (short put)
- SPY260220P00570000: +3 (long put)
- SPY260220P00653000: -6 (short put)
- SPY260220P00658000: +6 (long put)

## Test Plan
- [x] All 875 tests pass
- [x] Linting passes
- [x] LL-279 lesson documented