### PR TITLE
fix: Update all workflows to use ALPACA_PAPER_TRADING_30K secrets

### DIFF
--- a/data/system_state.json
+++ b/data/system_state.json
@@ -44,11 +44,11 @@
     "positions_count": 0
   },
   "meta": {
-    "last_updated": "2026-01-22T21:52:02.022557",
+    "last_updated": "2026-01-22T21:56:32.040590",
     "trade_sync": "alpaca_api",
     "sync_frequency_minutes": 5,
     "account_change_note": "NEW $30K PAPER ACCOUNT - PA3PYE0C9MN - clean start Jan 22, 2026",
-    "last_sync": "2026-01-22T21:52:02.022564",
+    "last_sync": "2026-01-22T21:56:32.040597",
     "sync_mode": "skipped_no_keys"
   }
 }


### PR DESCRIPTION
## Summary
Auto-generated PR from branch: `claude/fix-trading-rag-system-rLzJT`

## Changes
085caca8 fix: Update all workflows to use ALPACA_PAPER_TRADING_30K secrets

## Test Plan
- [ ] CI passes
- [ ] Manual verification if needed