### PR TITLE
URGENT: Fix Alpaca secrets in force-iron-condor workflow

### DIFF
--- a/.github/workflows/force-iron-condor.yml
+++ b/.github/workflows/force-iron-condor.yml
@@ -32,8 +32,8 @@ jobs:
 
       - name: Execute Iron Condor NOW
         env:
-          ALPACA_API_KEY: ${{ secrets.ALPACA_PAPER_TRADING_30K_API_KEY }}
-          ALPACA_SECRET_KEY: ${{ secrets.ALPACA_PAPER_TRADING_30K_API_SECRET }}
+          ALPACA_API_KEY: ${{ secrets.ALPACA_PAPER_TRADING_5K_API_KEY }}
+          ALPACA_API_SECRET: ${{ secrets.ALPACA_PAPER_TRADING_5K_API_SECRET }}
           PYTHONPATH: ${{ github.workspace }}
         run: |
           echo "🚀 FORCE IRON CONDOR EXECUTION"
@@ -53,8 +53,8 @@ jobs:
 
       - name: Verify positions
         env:
-          ALPACA_API_KEY: ${{ secrets.ALPACA_PAPER_TRADING_30K_API_KEY }}
-          ALPACA_SECRET_KEY: ${{ secrets.ALPACA_PAPER_TRADING_30K_API_SECRET }}
+          ALPACA_API_KEY: ${{ secrets.ALPACA_PAPER_TRADING_5K_API_KEY }}
+          ALPACA_API_SECRET: ${{ secrets.ALPACA_PAPER_TRADING_5K_API_SECRET }}
         run: |
           echo "📊 Verifying positions..."
           python3 -c "


### PR DESCRIPTION
## BUG
Workflow used non-existent `ALPACA_PAPER_TRADING_30K` secrets

## FIX
Use `ALPACA_PAPER_TRADING_5K` secrets (which point to $30K account)

## ROOT CAUSE
This is why iron condor was SIMULATED not LIVE - credentials failed!

Market closes at 4 PM ET - MERGE NOW!