### PR TITLE
fix: Remove corrupted data appended to system_state.json

### DIFF
--- a/data/system_state.json
+++ b/data/system_state.json
@@ -446,4 +446,4 @@
     "trade_sync": "alpaca_api",
     "sync_frequency_minutes": 5
   }
-}Trigger: 20260123_185901
+}


### PR DESCRIPTION
## Summary
- system_state.json had garbage appended (Trigger: 20260123_185901)
- This caused 5 test failures
- Fixed by truncating to valid JSON

## Test Plan
- [x] All 894 tests pass locally