### PR TITLE
docs: Correct tax strategy - SPY vs XSP Section 1256 treatment

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -6,7 +6,8 @@ CTO: Claude | CEO: Igor Ganapolsky
 - **North Star**: $6,000/month after-tax = FINANCIAL INDEPENDENCE
 - **Philosophy**: Grow $30K → $600K through disciplined compounding (Phil Town Rule #1)
 - **Current capital**: $30,000 | Fresh start - clean slate Jan 22, 2026
-- **Primary strategy**: IRON CONDORS on SPY ONLY - defined risk on BOTH sides
+- **Primary strategy**: IRON CONDORS on SPY (current) - evaluating XSP for tax optimization
+- **Tax note**: XSP (Mini-SPX) = same size as SPY but Section 1256 (60/40 tax treatment, no wash sales)
 - **Iron condor setup**:
   - Sell 15-20 delta put spread (bull put)
   - Sell 15-20 delta call spread (bear call)
@@ -39,12 +40,16 @@ CTO: Claude | CEO: Igor Ganapolsky
    - $30K → $76K (Year 1) → $192K (Year 2) → $600K (Year 3)
    - DO NOT WITHDRAW until $600K target reached
 
-3. **Tax Optimization** (Keep What You Earn)
-   - Iron condors held >60 days = 60% long-term / 40% short-term (Section 1256)
-   - Track cost basis meticulously for wash sale compliance
-   - Consider tax-loss harvesting on losing trades
-   - Estimated tax rate: ~25-30% blended (vs 37% short-term max)
-   - Set aside 30% of profits quarterly for estimated taxes
+3. **Tax Optimization** (Keep What You Earn) - UPDATED Jan 23, 2026
+   - **CRITICAL**: SPY options are EQUITY options - taxed as 100% short-term capital gains
+   - **XSP/SPX alternative**: Mini-SPX (XSP) options qualify for Section 1256 (60/40 treatment)
+   - Section 1256 benefits: 60% long-term / 40% short-term tax rates, NO wash sale rules
+   - **Recommendation**: Evaluate XSP iron condors for ~30% tax savings (see LL-296)
+   - Track cost basis for SPY positions (wash sale rules APPLY to SPY)
+   - Tax-loss harvest losing SPY trades (offset gains)
+   - Estimated tax rate: ~32% for SPY (short-term), ~22% for XSP (60/40 blended)
+   - Set aside 30% of profits quarterly for estimated taxes (due Apr 15, Jun 16, Sep 15, Jan 15)
+   - File Form 6781 for any Section 1256 contracts (XSP/SPX)
 
 4. **Reinvestment Strategy** (Scale Intelligently)
    - Phase 1 ($30K-$50K): 1 iron condor max, prove the system

--- a/rag_knowledge/lessons_learned/LL-297_Comprehensive_Tax_Strategy_Planning.md
+++ b/rag_knowledge/lessons_learned/LL-297_Comprehensive_Tax_Strategy_Planning.md
@@ -1,0 +1,189 @@
+# LL-297: Comprehensive Tax Strategy for Financial Independence
+
+**Date**: January 23, 2026
+**Category**: Tax Strategy / Financial Planning
+**Severity**: HIGH (Alpaca Inquiry Response)
+**Related**: LL-294, LL-295, LL-296
+
+## Executive Summary
+
+This document consolidates our tax strategy for achieving $6K/month after-tax financial independence. Key insight: **switching from SPY to XSP iron condors could save ~$15,000-20,000 in taxes over 7 years**.
+
+## Current Tax Situation
+
+### SPY Options (Current Strategy)
+| Aspect | Treatment |
+|--------|-----------|
+| Tax classification | Equity options |
+| Short-term gains (<1 year) | Taxed at ordinary income rates (up to 37%) |
+| Long-term gains (>1 year) | Taxed at 0-20% |
+| Wash sale rules | **APPLY** |
+| Typical effective rate | ~32% (all short-term for 30-45 DTE trades) |
+
+### XSP/SPX Options (Proposed Alternative)
+| Aspect | Treatment |
+|--------|-----------|
+| Tax classification | Section 1256 contracts |
+| Tax split | 60% long-term / 40% short-term (regardless of holding period) |
+| Wash sale rules | **DO NOT APPLY** |
+| Typical effective rate | ~22% blended |
+| IRS form required | Form 6781 |
+
+## Tax Savings Math
+
+### Per $10,000 in Gains
+| Strategy | Tax Calculation | Total Tax |
+|----------|-----------------|-----------|
+| SPY | $10,000 x 32% | $3,200 |
+| XSP | $6,000 x 15% + $4,000 x 32% | $2,180 |
+| **Savings** | | **$1,020 (31.9%)** |
+
+### 7-Year Projection (Compounded Savings)
+| Year | Pre-Tax Gains | SPY Tax | XSP Tax | Annual Savings | Cumulative |
+|------|---------------|---------|---------|----------------|------------|
+| 1 | $5,400 | $1,728 | $1,210 | $518 | $518 |
+| 2 | $7,900 | $2,528 | $1,770 | $758 | $1,276 |
+| 3 | $11,600 | $3,712 | $2,598 | $1,114 | $2,390 |
+| 4 | $17,000 | $5,440 | $3,808 | $1,632 | $4,022 |
+| 5 | $25,000 | $8,000 | $5,600 | $2,400 | $6,422 |
+| 6 | $36,500 | $11,680 | $8,176 | $3,504 | $9,926 |
+| 7 | $53,500 | $17,120 | $11,984 | $5,136 | **$15,062** |
+
+**Result**: ~$15,000-20,000 extra in your account through tax optimization alone.
+
+## Quarterly Estimated Tax Requirements
+
+### 2026 Due Dates
+| Quarter | Period | Due Date |
+|---------|--------|----------|
+| Q1 | Jan-Mar | April 15, 2026 |
+| Q2 | Apr-May | June 16, 2026 |
+| Q3 | Jun-Aug | September 15, 2026 |
+| Q4 | Sep-Dec | January 15, 2027 |
+
+### Safe Harbor Rules
+- Pay **100% of prior year's tax liability** (110% if AGI > $150K)
+- OR pay **90% of current year's tax liability**
+- Meeting either threshold avoids underpayment penalties
+
+### Recommended Approach
+1. Set aside 30% of trading profits each month
+2. Pay quarterly using IRS Direct Pay or EFTPS
+3. Adjust Q4 payment based on actual year performance
+4. Use annualized method (Form 2210 Schedule AI) if income varies significantly
+
+## What to Tell Alpaca (Braxton's Inquiry)
+
+### Key Questions for Alpaca
+1. **"Does Alpaca support XSP (Mini-SPX) options trading?"**
+   - XSP has same contract size as SPY but Section 1256 tax treatment
+   - This is critical for tax optimization
+
+2. **"Does Alpaca support SPX options trading?"**
+   - If account grows to $100K+, SPX becomes viable (10x contract size)
+
+3. **"What tax lot accounting methods do you support?"**
+   - FIFO (First In, First Out)
+   - LIFO (Last In, First Out)
+   - Specific Identification
+   - Specific ID is preferred for tax optimization
+
+4. **"Do you provide wash sale tracking across accounts?"**
+   - Important if trading in multiple accounts
+
+5. **"What tax documents do you provide?"**
+   - 1099-B for equity options (SPY)
+   - Need to understand if Form 6781 data is provided for Section 1256
+
+6. **"Do you support tax-loss harvesting features?"**
+   - Automated alerts for harvesting opportunities
+
+### Our Tax Strategy Summary for Alpaca
+> "We're trading iron condors for income and optimizing for taxes. Currently on SPY but evaluating XSP for Section 1256 treatment (60/40 tax split). Goal is $6K/month after-tax within 7 years. We need:
+> 1. XSP/SPX options access (confirm availability)
+> 2. Specific lot identification for tax optimization
+> 3. Robust cost basis and wash sale tracking
+> 4. Clean 1099-B and Form 6781 support"
+
+## Tax-Loss Harvesting Strategy
+
+### When to Harvest
+- If a position is down, close and realize loss
+- Immediately re-enter with different underlying (XSP vs SPY) or different expiration
+- Losses offset gains dollar-for-dollar
+
+### Wash Sale Avoidance (SPY Only)
+- Wait 31 days before re-entering substantially identical position
+- OR switch to XSP (not substantially identical to SPY)
+- Note: Wash sales do NOT apply to XSP/SPX (Section 1256 exemption)
+
+### Harvesting Rules
+| Strategy | Wash Sale Risk | Alternative Entry |
+|----------|---------------|-------------------|
+| Close losing SPY, reopen SPY | YES (31-day wait) | Use XSP instead |
+| Close losing SPY, open XSP | NO (different underlying) | Immediate |
+| Close losing XSP, reopen XSP | NO (Section 1256 exempt) | Immediate |
+
+## Migration Plan: SPY to XSP
+
+### Phase 1: Paper Testing (Current - 30 days)
+- [ ] Confirm XSP available on Alpaca
+- [ ] Paper trade XSP iron condors alongside SPY
+- [ ] Compare bid-ask spreads and fill quality
+- [ ] Document any execution differences
+
+### Phase 2: Small Live Allocation (After validation)
+- [ ] Allocate 50% of iron condor trades to XSP
+- [ ] Track actual tax lots and cost basis
+- [ ] Measure real-world slippage vs SPY
+
+### Phase 3: Full Migration (After 90 days success)
+- [ ] Move 100% of iron condor activity to XSP
+- [ ] Maintain SPY capability for hedging/emergencies
+- [ ] Realize ~30% tax savings going forward
+
+## Year-End Tax Planning Checklist
+
+### Q4 Actions (October-December)
+- [ ] Review YTD gains and estimate tax liability
+- [ ] Harvest any losses before Dec 31
+- [ ] Evaluate deferring gains to next year (careful with mark-to-market)
+- [ ] Make Q4 estimated payment by Jan 15
+
+### January Actions
+- [ ] Receive 1099-B from Alpaca
+- [ ] Reconcile with trading records
+- [ ] File Form 6781 for any Section 1256 contracts
+- [ ] Calculate actual effective tax rate
+
+## Impact on Financial Independence Goal
+
+### Original Projection (SPY, 32% tax rate)
+| Year | Pre-Tax | After-Tax | Account Growth |
+|------|---------|-----------|----------------|
+| 2026 | $5,400 | $3,672 | $33,672 |
+| 2029 | $50,000 | $34,000 | ~$200K |
+
+### Optimized Projection (XSP, 22% tax rate)
+| Year | Pre-Tax | After-Tax | Account Growth |
+|------|---------|-----------|----------------|
+| 2026 | $5,400 | $4,212 | $34,212 |
+| 2029 | $50,000 | $39,000 | ~$235K |
+
+**XSP tax optimization accelerates financial independence by ~6-12 months.**
+
+## Sources
+
+- [CBOE XSP Tax Benefit](https://www.cboe.com/tradable_products/sp_500/mini_spx_options/tax_benefit/)
+- [CBOE Index Options Tax Treatment](https://www.cboe.com/tradable_products/index-options-benefits-tax-treatment/)
+- [26 U.S. Code Section 1256](https://www.law.cornell.edu/uscode/text/26/1256)
+- [IRS Form 6781](https://www.irs.gov/pub/irs-access/f6781_accessible.pdf)
+- [Green Trader Tax - Section 1256](https://greentradertax.com/trading-futures-other-section-1256-contracts-has-tax-advantages/)
+- [NerdWallet - Estimated Taxes](https://www.nerdwallet.com/taxes/learn/estimated-quarterly-taxes)
+- [IRS Estimated Taxes](https://www.irs.gov/businesses/small-businesses-self-employed/estimated-taxes)
+- [Charles Schwab - Options Taxes](https://www.schwab.com/learn/story/how-are-options-taxed)
+- [TradeStation - SPX vs SPY](https://www.tradestation.com/insights/2025/05/28/spy-vs-spx-options-explained/)
+
+## Tags
+
+`tax-strategy`, `Section-1256`, `XSP`, `SPY`, `estimated-taxes`, `financial-independence`, `wash-sale`, `quarterly-taxes`


### PR DESCRIPTION
## Summary
- Fix incorrect claim that SPY options get Section 1256 treatment
- SPY options are EQUITY options (100% short-term, wash sales apply)
- XSP/SPX options ARE Section 1256 (60/40 treatment, no wash sales)
- Add LL-297: Comprehensive Tax Strategy Planning document
- Include quarterly estimated tax guidance for Alpaca inquiry
- Tax savings projection: ~$15-20K over 7 years with XSP migration

## Test Plan
- [x] CI passes
- [x] Documentation is accurate