### PR TITLE
fix: Use correct Alpaca secret names in IC workflow

### DIFF
--- a/.github/workflows/manage-iron-condor-positions.yml
+++ b/.github/workflows/manage-iron-condor-positions.yml
@@ -59,10 +59,11 @@ jobs:
       - name: Manage Iron Condor Positions
         if: steps.market.outputs.open == 'true'
         env:
-          ALPACA_API_KEY: ${{ secrets.ALPACA_PAPER_TRADING_30K_API_KEY }}
-          ALPACA_SECRET_KEY: ${{ secrets.ALPACA_PAPER_TRADING_30K_API_SECRET }}
-          ALPACA_PAPER_TRADING_30K_API_KEY: ${{ secrets.ALPACA_PAPER_TRADING_30K_API_KEY }}
-          ALPACA_PAPER_TRADING_30K_API_SECRET: ${{ secrets.ALPACA_PAPER_TRADING_30K_API_SECRET }}
+          # Use 5K secret names - they actually point to $30K account (historical naming)
+          ALPACA_PAPER_TRADING_5K_API_KEY: ${{ secrets.ALPACA_PAPER_TRADING_5K_API_KEY }}
+          ALPACA_PAPER_TRADING_5K_API_SECRET: ${{ secrets.ALPACA_PAPER_TRADING_5K_API_SECRET }}
+          ALPACA_API_KEY: ${{ secrets.ALPACA_PAPER_TRADING_5K_API_KEY }}
+          ALPACA_SECRET_KEY: ${{ secrets.ALPACA_PAPER_TRADING_5K_API_SECRET }}
         run: |
           echo "═══════════════════════════════════════════════════════════"
           echo "IRON CONDOR POSITION MANAGEMENT"


### PR DESCRIPTION
## Summary
Auto-generated PR from branch: `claude/fix-ic-workflow-secrets-Fc73z`

## Changes
8b5b0ddb fix: Use correct Alpaca secret names in IC workflow

## Test Plan
- [ ] CI passes
- [ ] Manual verification if needed