### PR TITLE
fix: Correct sync workflow to use $30K initial equity

### DIFF
--- a/.github/workflows/sync-alpaca-status.yml
+++ b/.github/workflows/sync-alpaca-status.yml
@@ -96,13 +96,13 @@ jobs:
                   "type": "option" if len(pos.symbol) > 10 else "stock"
               })
 
-          # Calculate total P/L from initial $5000
-          initial_equity = 5000.0
+          # Calculate total P/L from initial $30K (Jan 22, 2026 - CLAUDE.md)
+          initial_equity = 30000.0
           total_pl = equity - initial_equity
           total_pl_pct = (total_pl / initial_equity) * 100
 
           print(f"\nTotal Unrealized P/L: ${total_unrealized:,.2f}")
-          print(f"Total P/L (from $5K): ${total_pl:,.2f} ({total_pl_pct:.2f}%)")
+          print(f"Total P/L (from $30K): ${total_pl:,.2f} ({total_pl_pct:.2f}%)")
 
           # LL-237 FIX: Sync trade_history to prevent knowledge loss
           # Fetch ALL closed orders, not just today's
@@ -217,7 +217,17 @@ jobs:
                   "last_updated": datetime.now(timezone.utc).isoformat(),
                   "trade_sync": "alpaca_api",
                   "sync_frequency_minutes": 5
-              }
+              },
+              # LL-312 Gap 1: Preserve paper_trading tracking across syncs
+              "paper_trading": (lambda pt: {
+                  **pt,
+                  "current_day": (datetime.now(timezone.utc).date() - datetime.fromisoformat(pt.get("start_date", "2026-01-22")).date()).days + 1
+              })(existing_state.get("paper_trading", {
+                  "start_date": "2026-01-22",
+                  "target_duration_days": 90,
+                  "target_win_rate": 0.80,
+                  "notes": "Paper phase per CLAUDE.md - validate 80%+ win rate before scaling"
+              }))
           }
 
           state_file.write_text(json.dumps(state, indent=2))


### PR DESCRIPTION
## Summary
- Fixed initial_equity from $5000 to $30000 per CLAUDE.md
- Added paper_trading section preservation (LL-312 Gap 1)
- Dynamic calculation of paper trading current_day

## Root Cause
Sync Alpaca Status workflow was failing because P/L calculations used wrong starting balance.

## Test Plan
- [ ] Verify Sync Alpaca Status workflow passes
- [ ] Confirm paper_trading.current_day updates correctly