### PR TITLE
feat: RLHF feedback system improvements

### DIFF
--- a/.claude/hooks/semantic_rag_context.sh
+++ b/.claude/hooks/semantic_rag_context.sh
@@ -10,21 +10,32 @@ set -euo pipefail
 
 SCRIPT_DIR="$(dirname "$0")"
 SEMANTIC_MEMORY="$SCRIPT_DIR/../scripts/feedback/semantic-memory-v2.py"
-VENV_PYTHON="$SCRIPT_DIR/../../.venv/bin/python3"
+VENV_PYTHON="$SCRIPT_DIR/../scripts/feedback/venv/bin/python3"
 
 # Read user message from stdin
 USER_MESSAGE=$(cat)
 
 # Only query if we have semantic memory and message is substantial
-if [[ -f "$SEMANTIC_MEMORY" ]] && [[ ${#USER_MESSAGE} -gt 10 ]]; then
+if [[ -f "$SEMANTIC_MEMORY" ]] && [[ -x "$VENV_PYTHON" ]] && [[ ${#USER_MESSAGE} -gt 10 ]]; then
     # Query LanceDB for relevant context (top 3 lessons)
-    CONTEXT=$($VENV_PYTHON "$SEMANTIC_MEMORY" --query "$USER_MESSAGE" -n 3 2>/dev/null || echo "")
+    CONTEXT=$("$VENV_PYTHON" "$SEMANTIC_MEMORY" --query "$USER_MESSAGE" -n 3 2>/dev/null || echo "")
 
     if [[ -n "$CONTEXT" && "$CONTEXT" != *"No results"* ]]; then
         echo "═══════════════════════════════════════════════════════════"
         echo "📚 RAG CONTEXT (Semantic Search)"
         echo "═══════════════════════════════════════════════════════════"
         echo "$CONTEXT" | head -30
+        echo "═══════════════════════════════════════════════════════════"
+    fi
+
+    # Query for relevant past negative feedback (warnings)
+    FEEDBACK_WARNINGS=$("$VENV_PYTHON" "$SEMANTIC_MEMORY" --feedback-only --query "$USER_MESSAGE" -n 2 2>/dev/null || echo "")
+
+    if [[ -n "$FEEDBACK_WARNINGS" && "$FEEDBACK_WARNINGS" != *"No results"* && "$FEEDBACK_WARNINGS" != *"Found 0"* ]]; then
+        echo "═══════════════════════════════════════════════════════════"
+        echo "⚠️  WARNING: Past negative feedback relevant to this task"
+        echo "═══════════════════════════════════════════════════════════"
+        echo "$FEEDBACK_WARNINGS" | head -20
         echo "═══════════════════════════════════════════════════════════"
     fi
 fi

--- a/models/ml/feedback_model.json
+++ b/models/ml/feedback_model.json
@@ -1,13 +1,58 @@
 {
-  "alpha": 20.0,
-  "beta": 1.0,
+  "alpha": 12.75,
+  "beta": 3.0,
   "feature_weights": {
-    "ci": 0.3,
+    "ci": 0.69,
+    "rag": 0.4,
+    "fix": 0.26,
+    "pr": 0.46,
+    "trade": 0.1,
     "entry": 0.1,
-    "test": 1.8,
-    "pr": 0.1,
     "refactor": 0.1,
-    "rag": 0.1
+    "system_health": 0.2,
+    "test": 0.2
   },
-  "last_updated": "2026-01-28T14:42:05.099326"
+  "per_category": {
+    "test": {
+      "alpha": 3.0,
+      "beta": 1.0,
+      "count": 2
+    },
+    "ci": {
+      "alpha": 7.75,
+      "beta": 1.0,
+      "count": 9
+    },
+    "trade": {
+      "alpha": 2.0,
+      "beta": 1.0,
+      "count": 1
+    },
+    "pr": {
+      "alpha": 5.5,
+      "beta": 1.0,
+      "count": 6
+    },
+    "refactor": {
+      "alpha": 2.0,
+      "beta": 1.0,
+      "count": 1
+    },
+    "analysis": {
+      "alpha": 1.0,
+      "beta": 1.0,
+      "count": 0
+    },
+    "log_parsing": {
+      "alpha": 1.0,
+      "beta": 1.0,
+      "count": 0
+    },
+    "system_health": {
+      "alpha": 4.0,
+      "beta": 2.0,
+      "count": 4
+    }
+  },
+  "last_updated": "2026-01-29T10:14:24.456139"
 }

--- a/scripts/train_from_feedback.py
+++ b/scripts/train_from_feedback.py
@@ -13,25 +13,45 @@ import argparse
 import json
 import logging
 import re
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 MODEL_PATH = Path(__file__).parent.parent / "models" / "ml" / "feedback_model.json"
+FEEDBACK_DIRS = [
+    Path(__file__).parent.parent / "data" / "feedback",
+    Path(__file__).parent.parent / ".claude" / "memory" / "feedback",
+]
+
+DEFAULT_CATEGORIES = {
+    "test": {"alpha": 1.0, "beta": 1.0, "count": 0},
+    "ci": {"alpha": 1.0, "beta": 1.0, "count": 0},
+    "trade": {"alpha": 1.0, "beta": 1.0, "count": 0},
+    "pr": {"alpha": 1.0, "beta": 1.0, "count": 0},
+    "refactor": {"alpha": 1.0, "beta": 1.0, "count": 0},
+    "analysis": {"alpha": 1.0, "beta": 1.0, "count": 0},
+    "log_parsing": {"alpha": 1.0, "beta": 1.0, "count": 0},
+    "system_health": {"alpha": 1.0, "beta": 1.0, "count": 0},
+}
 
 
 def load_model() -> dict:
     """Load the feedback model from disk."""
     if MODEL_PATH.exists():
         with open(MODEL_PATH) as f:
-            return json.load(f)
+            model = json.load(f)
+        # Backward compat: add per_category if missing
+        if "per_category" not in model:
+            model["per_category"] = json.loads(json.dumps(DEFAULT_CATEGORIES))
+        return model
     # Initialize with uniform prior (alpha=1, beta=1)
     return {
         "alpha": 1.0,
         "beta": 1.0,
         "feature_weights": {},
+        "per_category": json.loads(json.dumps(DEFAULT_CATEGORIES)),
         "last_updated": None,
     }
 
@@ -71,6 +91,12 @@ def extract_features(context: str) -> list[str]:
         features.append("pr")
     if re.search(r"refactor|clean|improve", context_lower):
         features.append("refactor")
+    if re.search(r"analys|research|backtest", context_lower):
+        features.append("analysis")
+    if re.search(r"log|parse|output", context_lower):
+        features.append("log_parsing")
+    if re.search(r"health|system|check|monitor", context_lower):
+        features.append("system_health")
 
     return features
 
@@ -101,6 +127,17 @@ def update_model(feedback_type: str, context: str) -> None:
         current_weight = model["feature_weights"].get(feature, 0.0)
         model["feature_weights"][feature] = round(current_weight + weight_delta, 2)
 
+    # Update per-category bandits
+    per_cat = model.get("per_category", {})
+    for feature in features:
+        if feature in per_cat:
+            if feedback_type == "positive":
+                per_cat[feature]["alpha"] += 1.0
+            else:
+                per_cat[feature]["beta"] += 1.0
+            per_cat[feature]["count"] += 1
+    model["per_category"] = per_cat
+
     save_model(model)
 
     # Log for observability
@@ -108,20 +145,135 @@ def update_model(feedback_type: str, context: str) -> None:
     logger.info(f"Feedback: {feedback_type} | Posterior: {posterior:.3f} | Features: {features}")
 
 
+def compute_time_weight(timestamp: str) -> float:
+    """Compute a decay weight based on age of feedback.
+
+    <7 days: 1.0, 7-30 days: 0.5, >30 days: 0.25
+    """
+    try:
+        if "T" in timestamp:
+            ts = datetime.fromisoformat(timestamp)
+        else:
+            ts = datetime.strptime(timestamp, "%Y-%m-%d %H:%M:%S")
+        # Make naive if needed
+        if ts.tzinfo is not None:
+            now = datetime.now(timezone.utc)
+        else:
+            now = datetime.now()
+        age_days = (now - ts).total_seconds() / 86400
+    except (ValueError, TypeError):
+        return 0.25  # Unknown timestamp = oldest weight
+
+    if age_days < 7:
+        return 1.0
+    elif age_days <= 30:
+        return 0.5
+    else:
+        return 0.25
+
+
+def recompute_from_history() -> None:
+    """Rebuild model from all historical feedback with time decay."""
+    logger.info("Recomputing model from feedback history with time decay...")
+
+    # Reset model
+    model = {
+        "alpha": 1.0,
+        "beta": 1.0,
+        "feature_weights": {},
+        "per_category": json.loads(json.dumps(DEFAULT_CATEGORIES)),
+        "last_updated": None,
+    }
+
+    entries = []
+    for fb_dir in FEEDBACK_DIRS:
+        if not fb_dir.exists():
+            continue
+        for f in fb_dir.glob("feedback_*.jsonl"):
+            with open(f) as fh:
+                for line in fh:
+                    line = line.strip()
+                    if line:
+                        try:
+                            entries.append(json.loads(line))
+                        except json.JSONDecodeError:
+                            continue
+        # Also check feedback-log.jsonl
+        log_file = fb_dir / "feedback-log.jsonl"
+        if log_file.exists():
+            with open(log_file) as fh:
+                for line in fh:
+                    line = line.strip()
+                    if line:
+                        try:
+                            entries.append(json.loads(line))
+                        except json.JSONDecodeError:
+                            continue
+
+    logger.info(f"Found {len(entries)} historical feedback entries")
+
+    for entry in entries:
+        fb_type = entry.get("type", entry.get("feedback", ""))
+        if fb_type not in ("positive", "negative"):
+            continue
+
+        ts = entry.get("timestamp", "")
+        weight = compute_time_weight(ts)
+
+        context = entry.get("summary", entry.get("context", entry.get("user_message", "")))
+        features = extract_features(context)
+
+        if fb_type == "positive":
+            model["alpha"] += weight
+            weight_delta = 0.1 * weight
+        else:
+            model["beta"] += weight
+            weight_delta = -0.1 * weight
+
+        for feature in features:
+            current = model["feature_weights"].get(feature, 0.0)
+            model["feature_weights"][feature] = round(current + weight_delta, 2)
+
+        per_cat = model["per_category"]
+        for feature in features:
+            if feature in per_cat:
+                if fb_type == "positive":
+                    per_cat[feature]["alpha"] += weight
+                else:
+                    per_cat[feature]["beta"] += weight
+                per_cat[feature]["count"] += 1
+
+    save_model(model)
+    posterior = model["alpha"] / (model["alpha"] + model["beta"])
+    logger.info(
+        f"Recompute done: alpha={model['alpha']:.1f}, beta={model['beta']:.1f}, "
+        f"posterior={posterior:.3f}, entries={len(entries)}"
+    )
+
+
 def main():
     parser = argparse.ArgumentParser(description="Train feedback model from signals")
     parser.add_argument(
         "--feedback",
-        required=True,
         choices=["positive", "negative"],
         help="Type of feedback received",
     )
     parser.add_argument(
         "--context", default="", help="Context around the feedback (for feature extraction)"
     )
+    parser.add_argument(
+        "--recompute",
+        action="store_true",
+        help="Rebuild model from all feedback history with time decay",
+    )
     args = parser.parse_args()
 
-    update_model(args.feedback, args.context)
+    if args.recompute:
+        recompute_from_history()
+    elif args.feedback:
+        update_model(args.feedback, args.context)
+    else:
+        parser.error("Either --feedback or --recompute is required")
 
 
 if __name__ == "__main__":

--- a/tests/test_train_from_feedback.py
+++ b/tests/test_train_from_feedback.py
@@ -4,6 +4,7 @@ import json
 import subprocess
 import sys
 import tempfile
+from datetime import datetime, timedelta
 from pathlib import Path
 from unittest.mock import patch
 
@@ -150,3 +151,153 @@ class TestTrainFromFeedback:
         )
         assert result.returncode != 0
         assert "required" in result.stderr.lower() or "error" in result.stderr.lower()
+
+    def test_per_category_update_positive(self):
+        """Positive feedback increments category alpha."""
+        sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
+        try:
+            import train_from_feedback
+
+            with tempfile.TemporaryDirectory() as tmpdir:
+                model_path = Path(tmpdir) / "feedback_model.json"
+                with patch.object(train_from_feedback, "MODEL_PATH", model_path):
+                    train_from_feedback.update_model("positive", "Running pytest suite")
+
+                    with open(model_path) as f:
+                        model = json.load(f)
+                    assert model["per_category"]["test"]["alpha"] == 2.0
+                    assert model["per_category"]["test"]["beta"] == 1.0
+                    assert model["per_category"]["test"]["count"] == 1
+        finally:
+            sys.path.pop(0)
+
+    def test_per_category_update_negative(self):
+        """Negative feedback increments category beta."""
+        sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
+        try:
+            import train_from_feedback
+
+            with tempfile.TemporaryDirectory() as tmpdir:
+                model_path = Path(tmpdir) / "feedback_model.json"
+                with patch.object(train_from_feedback, "MODEL_PATH", model_path):
+                    train_from_feedback.update_model("negative", "CI workflow broken")
+
+                    with open(model_path) as f:
+                        model = json.load(f)
+                    assert model["per_category"]["ci"]["alpha"] == 1.0
+                    assert model["per_category"]["ci"]["beta"] == 2.0
+                    assert model["per_category"]["ci"]["count"] == 1
+        finally:
+            sys.path.pop(0)
+
+    def test_per_category_backward_compat(self):
+        """Old model without per_category loads correctly."""
+        sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
+        try:
+            import train_from_feedback
+
+            with tempfile.TemporaryDirectory() as tmpdir:
+                model_path = Path(tmpdir) / "feedback_model.json"
+                # Write old-format model without per_category
+                old_model = {
+                    "alpha": 5.0,
+                    "beta": 2.0,
+                    "feature_weights": {"test": 0.5},
+                    "last_updated": "2026-01-01T00:00:00",
+                }
+                with open(model_path, "w") as f:
+                    json.dump(old_model, f)
+
+                with patch.object(train_from_feedback, "MODEL_PATH", model_path):
+                    model = train_from_feedback.load_model()
+                    assert "per_category" in model
+                    assert "test" in model["per_category"]
+                    assert model["per_category"]["test"]["alpha"] == 1.0
+        finally:
+            sys.path.pop(0)
+
+    def test_time_decay_recent(self):
+        """Feedback from 3 days ago gets weight 1.0."""
+        sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
+        try:
+            from train_from_feedback import compute_time_weight
+
+            ts = (datetime.now() - timedelta(days=3)).isoformat()
+            assert compute_time_weight(ts) == 1.0
+        finally:
+            sys.path.pop(0)
+
+    def test_time_decay_medium(self):
+        """Feedback from 14 days ago gets weight 0.5."""
+        sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
+        try:
+            from train_from_feedback import compute_time_weight
+
+            ts = (datetime.now() - timedelta(days=14)).isoformat()
+            assert compute_time_weight(ts) == 0.5
+        finally:
+            sys.path.pop(0)
+
+    def test_time_decay_old(self):
+        """Feedback from 60 days ago gets weight 0.25."""
+        sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
+        try:
+            from train_from_feedback import compute_time_weight
+
+            ts = (datetime.now() - timedelta(days=60)).isoformat()
+            assert compute_time_weight(ts) == 0.25
+        finally:
+            sys.path.pop(0)
+
+    def test_new_feature_extraction(self):
+        """New feature patterns: analysis, log_parsing, system_health."""
+        sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
+        try:
+            from train_from_feedback import extract_features
+
+            assert "analysis" in extract_features("Running backtest analysis")
+            assert "analysis" in extract_features("Research the market data")
+            assert "log_parsing" in extract_features("Parse the output log")
+            assert "system_health" in extract_features("Check system health monitor")
+        finally:
+            sys.path.pop(0)
+
+    def test_recompute_flag(self):
+        """--recompute rebuilds model from history."""
+        sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
+        try:
+            import train_from_feedback
+
+            with tempfile.TemporaryDirectory() as tmpdir:
+                model_path = Path(tmpdir) / "feedback_model.json"
+                fb_dir = Path(tmpdir) / "feedback"
+                fb_dir.mkdir()
+
+                # Write some feedback history
+                ts = datetime.now().isoformat()
+                with open(fb_dir / "feedback_2026-01-29.jsonl", "w") as f:
+                    f.write(
+                        json.dumps({"timestamp": ts, "type": "positive", "summary": "test passed"})
+                        + "\n"
+                    )
+                    f.write(
+                        json.dumps(
+                            {"timestamp": ts, "type": "negative", "summary": "CI workflow broke"}
+                        )
+                        + "\n"
+                    )
+
+                with patch.object(train_from_feedback, "MODEL_PATH", model_path):
+                    with patch.object(train_from_feedback, "FEEDBACK_DIRS", [fb_dir]):
+                        train_from_feedback.recompute_from_history()
+
+                with open(model_path) as f:
+                    model = json.load(f)
+
+                # Should have 1.0 (prior) + 1.0 (positive) = 2.0 alpha
+                assert model["alpha"] == 2.0
+                # Should have 1.0 (prior) + 1.0 (negative) = 2.0 beta
+                assert model["beta"] == 2.0
+                assert "per_category" in model
+        finally:
+            sys.path.pop(0)


### PR DESCRIPTION
## Summary
- Per-context Thompson Sampling with 8 category-specific bandits (test, ci, trade, pr, refactor, analysis, log_parsing, system_health)
- Time-decay weighting for feedback entries (<7d=1.0, 7-30d=0.5, >30d=0.25) with `--recompute` flag
- Preference pairs: captures bad_response on negative feedback, links follow-up corrections
- Query-driven retrieval: `--feedback-only` flag for negative feedback search, fixed venv path in RAG hook

## Test plan
- [x] `pytest tests/test_train_from_feedback.py -v` — 18/18 tests pass (8 new)
- [x] `python3 scripts/train_from_feedback.py --feedback positive --context "test CI workflow"` — per_category updated
- [x] `python3 scripts/train_from_feedback.py --recompute` — model rebuilt with time decay
- [x] `bash .claude/hooks/surface_feedback_patterns.sh` — per-category display works
- [x] Pre-push: 122 unit + 8 integration tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)