### PR TITLE
fix: Load .env into CLAUDE_ENV_FILE for hook access

### DIFF
--- a/.claude/hooks/load_env_file.sh
+++ b/.claude/hooks/load_env_file.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+# SessionStart hook: Load .env into CLAUDE_ENV_FILE so all hooks and bash commands
+# have access to environment variables (Alpaca keys, API keys, etc.)
+#
+# Per Claude Code docs: CLAUDE_ENV_FILE is a file path where you can persist
+# environment variables for subsequent bash commands in the session.
+
+set -euo pipefail
+
+ENV_FILE="$CLAUDE_PROJECT_DIR/.env"
+
+if [ ! -f "$ENV_FILE" ]; then
+    exit 0
+fi
+
+if [ -z "${CLAUDE_ENV_FILE:-}" ]; then
+    exit 0
+fi
+
+# Parse .env and write export statements to CLAUDE_ENV_FILE
+# Skip comments, blank lines, and don't override existing env vars
+while IFS= read -r line || [ -n "$line" ]; do
+    # Skip empty lines and comments
+    [[ -z "$line" || "$line" =~ ^[[:space:]]*# ]] && continue
+
+    # Extract key=value
+    if [[ "$line" =~ ^[[:space:]]*([A-Za-z_][A-Za-z0-9_]*)=(.*)$ ]]; then
+        key="${BASH_REMATCH[1]}"
+        value="${BASH_REMATCH[2]}"
+        # Strip surrounding quotes
+        value="${value#\"}"
+        value="${value%\"}"
+        value="${value#\'}"
+        value="${value%\'}"
+        # Only set if not already in environment
+        if [ -z "${!key:-}" ]; then
+            echo "export ${key}='${value}'" >> "$CLAUDE_ENV_FILE"
+        fi
+    fi
+done < "$ENV_FILE"
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -125,6 +125,11 @@
         "hooks": [
           {
             "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/load_env_file.sh",
+            "timeout": 3
+          },
+          {
+            "type": "command",
             "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/github_account_switch.sh",
             "timeout": 3
           },


### PR DESCRIPTION
## Summary
- Adds `load_env_file.sh` SessionStart hook that loads `.env` into `CLAUDE_ENV_FILE`
- Uses the official Claude Code mechanism for persisting env vars across hooks and bash commands
- Runs as the first SessionStart hook so all subsequent hooks have access to Alpaca API keys

## Test plan
- [x] `settings.json` validates as valid JSON
- [x] All pre-push checks pass (122 unit + 8 integration tests)
- [x] Hook script is executable and handles missing `.env` gracefully

🤖 Generated with [Claude Code](https://claude.com/claude-code)