### PR TITLE
fix: Feedback hook reads stdin JSON, calls Thompson Sampling model

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -113,7 +113,7 @@
           },
           {
             "type": "command",
-            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/capture_feedback.sh \"$CLAUDE_USER_PROMPT\"",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/capture_feedback.sh",
             "timeout": 10,
             "async": true
           }


### PR DESCRIPTION
## Summary
- Fix: Hook was using nonexistent `$CLAUDE_USER_PROMPT` env var — feedback was never captured
- Fix: Now reads `UserPromptSubmit` JSON from stdin per Claude Code docs
- Fix: Adds `train_from_feedback.py` call so Thompson Sampling model actually updates
- Fix: Removes dead `"$CLAUDE_USER_PROMPT"` arg from `settings.json`

## Evidence of bug
- `data/feedback/feedback_2026-01-29.jsonl` had 0 entries today
- `data/feedback/stats.json` last updated Jan 28 — nothing recorded since

## Test plan
- [x] `echo '{"prompt":"thumbs up"}' | bash capture_feedback.sh` — records positive, updates model
- [x] `echo '{"prompt":"thumbs down"}' | bash capture_feedback.sh` — records negative, writes pending_correction
- [x] All pre-push checks pass (122 unit + 8 integration tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)