### PR TITLE
fix: Align crisis detector with iron condor 200% stop-loss

### DIFF
--- a/src/core/trading_constants.py
+++ b/src/core/trading_constants.py
@@ -32,6 +32,8 @@ MAX_POSITIONS: int = 4  # 1 iron condor = 4 legs max (HARDCODED per CLAUDE.md)
 MAX_CONTRACTS_PER_TRADE: int = 1  # Max contracts per single trade
 CRISIS_LOSS_PCT: float = 0.25  # 25% unrealized loss triggers crisis mode
 CRISIS_POSITION_COUNT: int = 4  # More than 4 positions triggers crisis mode
+# Iron condor stop-loss: close if one side reaches 200% of credit received (per CLAUDE.md)
+IRON_CONDOR_STOP_LOSS_MULTIPLIER: float = 2.0
 
 # =============================================================================
 # OPTIONS PARAMETERS

--- a/tests/test_trade_lock.py
+++ b/tests/test_trade_lock.py
@@ -135,19 +135,19 @@ class TestCrisisMonitor:
         loss_conditions = [c for c in conditions if c.condition_type == "EXCESS_UNREALIZED_LOSS"]
         assert len(loss_conditions) > 0
 
-    def test_single_position_crisis(self):
-        """Test that single position losing 50%+ triggers crisis."""
+    def test_stop_loss_breach(self):
+        """Test that loss exceeding 200% of credit triggers stop-loss breach."""
         from src.safety.crisis_monitor import check_crisis_conditions
 
+        # Loss of $2500 on $1000 credit = 250% > 200% threshold
         positions = [
-            {"symbol": "SPY260220P00658000", "qty": 4, "unrealized_pl": -600, "cost_basis": 1000},
+            {"symbol": "SPY260220P00658000", "qty": 4, "unrealized_pl": -2500, "cost_basis": 1000},
         ]
 
         conditions = check_crisis_conditions(positions, account_equity=10000)
 
-        # Should detect single position crisis (60% loss > 50% threshold)
-        single_conditions = [c for c in conditions if c.condition_type == "SINGLE_POSITION_CRISIS"]
-        assert len(single_conditions) > 0
+        stop_loss_conditions = [c for c in conditions if c.condition_type == "STOP_LOSS_BREACH"]
+        assert len(stop_loss_conditions) > 0
 
     def test_no_crisis_when_normal(self):
         """Test that normal conditions don't trigger crisis."""


### PR DESCRIPTION
## Summary
- Replace false-positive `SINGLE_POSITION_CRISIS` (50% cost basis) with `STOP_LOSS_BREACH` (200% of credit) per CLAUDE.md
- Add auto-clear: stale `TRADING_HALTED` removed when no open positions remain
- Add `IRON_CONDOR_STOP_LOSS_MULTIPLIER` constant to `trading_constants.py`

## Root cause
Options regularly swing 50%+ intraday and still expire profitable. The old 50% threshold was designed for stocks, not iron condors. This caused repeated false halts that prevented trading entirely.

## Test plan
- [x] 25 safety/crisis tests pass (including updated `test_stop_loss_breach`)
- [x] 122 unit + 8 integration tests pass
- [x] `TRADING_HALTED` removed (0 open positions, portfolio at 99.88%)

🤖 Generated with [Claude Code](https://claude.com/claude-code)