### PR TITLE
fix: Enforce mandatory completion gate in compound engineering

### DIFF
--- a/.claude/rules/compound-engineering.md
+++ b/.claude/rules/compound-engineering.md
@@ -47,6 +47,23 @@ Evidence of success — not just "done":
 ruff check src/ && pytest tests/ -x --tb=short && python scripts/system_health_check.py
 ```
 
+## Mandatory Completion Gate
+
+Before claiming ANY task is done, verify ALL 5 steps are addressed:
+
+```
+[ ] 1. FIX — code change committed
+[ ] 2. TEST — pytest passes, new tests cover the fix
+[ ] 3. PREVENT — CI check, hook, or guard added that blocks recurrence
+[ ] 4. MEMORY — lesson recorded if severity >= 4
+[ ] 5. VERIFY — CI green, evidence shown, state confirmed
+```
+
+**If step 3 (Prevention) is missing, the task is NOT complete.**
+Prevention means: if someone writes new code that reintroduces this bug,
+something automated (CI, hook, or runtime guard) will catch it BEFORE
+it reaches production. A fix without prevention is a fix that will recur.
+
 ## Anti-Patterns
 
 - Claiming "fixed" without verification evidence
@@ -54,6 +71,7 @@ ruff check src/ && pytest tests/ -x --tb=short && python scripts/system_health_c
 - Fix without prevention (will recur)
 - Fix without memory (won't learn)
 - Over-engineering the prevention (simple > complex)
+- **Shipping the fix and adding prevention as an afterthought when the CEO asks** (Feb 6, 2026 lesson)
 
 ## Trading-Specific Applications
 

--- a/rag_knowledge/lessons_learned/ll_skipped_prevention_step_feb06.md
+++ b/rag_knowledge/lessons_learned/ll_skipped_prevention_step_feb06.md
@@ -1,0 +1,33 @@
+# LL: Skipped Prevention Step in Compound Engineering
+
+**Date**: 2026-02-06
+**Severity**: CRITICAL (5)
+**Category**: Process Violation
+
+## What Happened
+
+PR #3313 added `safe_submit_order()`/`safe_close_position()` wrappers to enforce ticker validation
+across 27 files. The fix was correct. The tests passed. But **no CI check was added to prevent
+future scripts from bypassing the wrappers**. The CEO had to ask "can't we prevent that?" before
+the CI enforcement (PR #3314) was created.
+
+## Root Cause
+
+Skipped step 3 (Prevention) of the compound engineering protocol. Treated the fix + test as
+sufficient, when the protocol explicitly requires an automated mechanism to block recurrence.
+
+## Lesson
+
+Prevention is not optional. It is not an afterthought. If someone can write new code that
+reintroduces the bug and nothing automated catches it, the fix is incomplete. Period.
+
+## Prevention Applied
+
+1. Updated `.claude/rules/compound-engineering.md` with a mandatory completion gate checklist
+2. Added explicit anti-pattern: "Shipping the fix and adding prevention as an afterthought"
+3. CI job `Enforce Safe Order Wrappers` now blocks any PR with unprotected order calls
+
+## Severity Justification
+
+Intensity 5 (CRITICAL) — CEO frustration, direct process violation of a rule I'm supposed to follow
+automatically. The compound engineering protocol says "No exceptions." I made an exception.


### PR DESCRIPTION
## Summary
- Adds mandatory 5-step completion checklist to compound engineering protocol
- Records lesson learned from Feb 6 incident (skipped Prevention step)
- Prevention is no longer optional — task is incomplete without it

## Test plan
- [x] Rule file updated with completion gate
- [x] Lesson recorded in rag_knowledge/
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)