### PR TITLE
fix: Guardian PYTHONPATH + pre-existing CI mandate

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -25,6 +25,7 @@ If you violate any protocol in this file: stop, acknowledge, fix completely, rec
 
 - Every commit on main MUST have green CI. If CI is red, fixing it is #1 priority.
 - Changes are NOT done until committed, pushed, PR'd, CI-green, and merged to main.
+- **Pre-existing CI failures are NOT acceptable.** If you see ANY workflow failing — even if it pre-dates your changes — you MUST fix it in the same session. "Pre-existing" is not an excuse to ignore broken CI.
 
 ---
 

--- a/.github/workflows/iron-condor-guardian.yml
+++ b/.github/workflows/iron-condor-guardian.yml
@@ -31,6 +31,7 @@ jobs:
         env:
           ALPACA_API_KEY: ${{ secrets.ALPACA_PAPER_TRADING_API_KEY }}
           ALPACA_SECRET_KEY: ${{ secrets.ALPACA_PAPER_TRADING_API_SECRET }}
+          PYTHONPATH: ${{ github.workspace }}
         run: |
           python scripts/iron_condor_guardian.py
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,6 +24,7 @@ If you violate any protocol in this file: stop, acknowledge, fix completely, rec
 
 - Every commit on main MUST have green CI. If CI is red, fixing it is #1 priority.
 - Changes are NOT done until committed, pushed, PR'd, CI-green, and merged to main.
+- **Pre-existing CI failures are NOT acceptable.** If you see ANY workflow failing — even if it pre-dates your changes — you MUST fix it in the same session. "Pre-existing" is not an excuse to ignore broken CI.
 
 ---
 


### PR DESCRIPTION
## Summary
- Adds `PYTHONPATH: ${{ github.workspace }}` to Iron Condor Guardian workflow so `from src.safety...` resolves
- Adds mandate to CLAUDE.md: pre-existing CI failures must be fixed immediately, not ignored

## Test plan
- [ ] CI passes on PR
- [ ] Guardian workflow no longer fails with ModuleNotFoundError

🤖 Generated with [Claude Code](https://claude.com/claude-code)