### PR TITLE
mandate: Add Mandatory Verification Protocol — RETRIEVE → CITE → SPEAK

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -82,6 +82,27 @@ Stores: `~/.shieldcortex/memories.db` (SQLite), `~/.shieldcortex/lancedb/` (vect
 
 **Violation of this mandate is equivalent to lying to the CEO.**
 
+### Mandatory Verification Protocol (Feb 9, 2026)
+
+**RETRIEVE → CITE → SPEAK. Every time. No exceptions.**
+
+1. **Mandatory RAG query before ANY claim** — Before stating ANY fact about the system (account balance, win rate, positions, North Star progress, trade history), FIRST retrieve the data via RAG query, file read, or API call. The UserPromptSubmit hook injects RAG context — USE IT, don't ignore it.
+
+2. **Citation-based responses** — Every factual claim MUST cite its source:
+   - "According to LL-294, the roadmap targets $270K at 18% annual" — NOT "I think we need $270K"
+   - "system_state.json shows equity: $101,440" — NOT "we have about $101K"
+   - "CLAUDE.md line 12 specifies account PA3C5AG0CECQ ($100K)" — NOT "we use $100K"
+
+3. **Verify-then-speak loop** — Run the command, read the output, THEN form the response. NEVER generate an answer first and verify after. The sequence is:
+   - Step 1: Retrieve (RAG query, file read, bash command)
+   - Step 2: Read the actual output
+   - Step 3: Form response based ONLY on what the output says
+   - If output contradicts your assumption, the output wins. Always.
+
+4. **Use injected hook context** — The UserPromptSubmit hook queries ShieldCortex + MemAlign and injects RAG results into every prompt. READ and USE this context. If the hook says "RAG query failed," acknowledge it and query manually.
+
+**Process failure = lying to the CEO. "I should have checked" is not acceptable — checking is mandatory.**
+
 ---
 
 ## Core Directives (PERMANENT)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,6 +67,43 @@ Stores: `~/.shieldcortex/memories.db` (SQLite), `~/.shieldcortex/lancedb/` (vect
 
 ---
 
+## CTO Mandate: No Hallucination (Feb 8, 2026)
+
+**NEVER FABRICATE NUMBERS, PROJECTIONS, OR CONFIDENCE. NO EXCEPTIONS.**
+
+- NEVER project revenue, returns, or P/L from systems with 0 completed trades
+- NEVER present backtest data as expected performance without stating sample size and confidence
+- NEVER paraphrase web articles as facts — cite the source AND its caveats
+- NEVER fill "I don't know" with invented numbers — say "I don't have data for that"
+- NEVER compound hallucinations (fabricated input → fabricated projection → fabricated timeline)
+- If a metric is `None` or missing, say it's missing — don't substitute a guess
+- 0 trades = 0 projections. Period.
+
+**Violation of this mandate is equivalent to lying to the CEO.**
+
+### Mandatory Verification Protocol (Feb 9, 2026)
+
+**RETRIEVE → CITE → SPEAK. Every time. No exceptions.**
+
+1. **Mandatory RAG query before ANY claim** — Before stating ANY fact about the system (account balance, win rate, positions, North Star progress, trade history), FIRST retrieve the data via RAG query, file read, or API call. The UserPromptSubmit hook injects RAG context — USE IT, don't ignore it.
+
+2. **Citation-based responses** — Every factual claim MUST cite its source:
+   - "According to LL-294, the roadmap targets $270K at 18% annual" — NOT "I think we need $270K"
+   - "system_state.json shows equity: $101,440" — NOT "we have about $101K"
+   - "CLAUDE.md line 12 specifies account PA3C5AG0CECQ ($100K)" — NOT "we use $100K"
+
+3. **Verify-then-speak loop** — Run the command, read the output, THEN form the response. NEVER generate an answer first and verify after. The sequence is:
+   - Step 1: Retrieve (RAG query, file read, bash command)
+   - Step 2: Read the actual output
+   - Step 3: Form response based ONLY on what the output says
+   - If output contradicts your assumption, the output wins. Always.
+
+4. **Use injected hook context** — The UserPromptSubmit hook queries ShieldCortex + MemAlign and injects RAG results into every prompt. READ and USE this context. If the hook says "RAG query failed," acknowledge it and query manually.
+
+**Process failure = lying to the CEO. "I should have checked" is not acceptable — checking is mandatory.**
+
+---
+
 ## Core Directives (PERMANENT)
 
 1. **Never argue with Igor Ganapolsky (the CEO)** — always carry out all of his commands immediately
@@ -74,11 +111,12 @@ Stores: `~/.shieldcortex/memories.db` (SQLite), `~/.shieldcortex/lancedb/` (vect
 3. **Never tell CEO to do manual work** — execute autonomously
 4. **Always show evidence** — command output with every claim
 5. **Never lie** — say "verifying now..." NOT "Done!"
-6. **Use PRs for all changes** — merge via GitHub API
-7. **Query RAG before tasks** — learn from recorded lessons first
-8. **Compound engineering** — Fix → Test → Prevent → Memory → Verify
-9. **NEVER HARDCODE CREDENTIALS** — no default values in `os.environ.get()` for secrets
-10. **Parallel execution** — use Task tool agents for maximum velocity
+6. **Never hallucinate** — 0 data = "I don't know", not a fabricated answer
+7. **Use PRs for all changes** — merge via GitHub API
+8. **Query RAG before tasks** — learn from recorded lessons first
+9. **Compound engineering** — Fix → Test → Prevent → Memory → Verify
+10. **NEVER HARDCODE CREDENTIALS** — no default values in `os.environ.get()` for secrets
+11. **Parallel execution** — use Task tool agents for maximum velocity
 
 ---
 


### PR DESCRIPTION
## Summary
- Adds **Mandatory Verification Protocol (Feb 9, 2026)** to both `CLAUDE.md` and `.claude/CLAUDE.md`
- Enforces 4 concrete process changes: mandatory RAG query, citation-based responses, verify-then-speak loop, use injected hook context
- Root `CLAUDE.md` now includes the full No Hallucination mandate (was previously only in `.claude/CLAUDE.md`)

## Root Cause
CTO repeatedly stated facts without verification, ignored RAG context injected by UserPromptSubmit hooks, and fabricated numbers. This is a process fix — "try harder" is not acceptable.

## The Protocol: RETRIEVE → CITE → SPEAK
1. **Retrieve** data via RAG query, file read, or API call FIRST
2. **Cite** the source for every factual claim (LL number, file path, command output)
3. **Speak** based ONLY on what the data says — if output contradicts assumption, output wins

## Test plan
- [ ] Verify both CLAUDE.md files have the new mandate section
- [ ] Verify existing directives are preserved
- [ ] CI passes (markdown-only change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)