### PR TITLE
ci: auto-handle Dependabot PRs via Trunk merge command

### DIFF
--- a/.github/workflows/dependabot-trunk-automerge.yml
+++ b/.github/workflows/dependabot-trunk-automerge.yml
@@ -1,0 +1,174 @@
+name: Dependabot Trunk Automerge
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
+jobs:
+  queue-safe-update:
+    if: ${{ github.actor == 'dependabot[bot]' && github.event.pull_request.draft == false }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Classify update risk
+        id: classify
+        run: |
+          set -euo pipefail
+          update_type="${{ steps.metadata.outputs.update-type }}"
+
+          case "$update_type" in
+            version-update:semver-patch|version-update:semver-minor|security-update)
+              echo "safe=true" >> "$GITHUB_OUTPUT"
+              ;;
+            *)
+              echo "safe=false" >> "$GITHUB_OUTPUT"
+              ;;
+          esac
+
+          echo "update_type=$update_type" >> "$GITHUB_OUTPUT"
+
+      - name: Queue safe update via Trunk
+        if: ${{ steps.classify.outputs.safe == 'true' }}
+        uses: actions/github-script@v7
+        env:
+          UPDATE_TYPE: ${{ steps.classify.outputs.update_type }}
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const marker = "<!-- dependabot-trunk-automerge -->";
+            const pr = context.payload.pull_request;
+            const sha = pr.head.sha;
+
+            const comments = await github.paginate(
+              github.rest.issues.listComments,
+              {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: pr.number,
+                per_page: 100,
+              }
+            );
+
+            const existing = comments.find(
+              (comment) =>
+                comment.user?.login === "github-actions[bot]" &&
+                comment.body?.includes(marker) &&
+                comment.body?.includes(sha)
+            );
+
+            if (existing) {
+              core.info("Trunk automerge command already posted for current head SHA.");
+              return;
+            }
+
+            const body = [
+              marker,
+              "/trunk merge",
+              "",
+              `Queued automatically for ${process.env.UPDATE_TYPE} (${sha.slice(0, 7)}).`,
+            ].join("\n");
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: pr.number,
+              body,
+            });
+
+      - name: Auto-approve safe update
+        if: ${{ steps.classify.outputs.safe == 'true' }}
+        continue-on-error: true
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const pr = context.payload.pull_request;
+
+            const reviews = await github.paginate(github.rest.pulls.listReviews, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: pr.number,
+              per_page: 100,
+            });
+
+            const alreadyApproved = reviews.some(
+              (review) =>
+                review.user?.login === "github-actions[bot]" &&
+                review.state === "APPROVED"
+            );
+
+            if (alreadyApproved) {
+              core.info("Safe update already approved by github-actions[bot].");
+              return;
+            }
+
+            await github.rest.pulls.createReview({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: pr.number,
+              event: "APPROVE",
+              body: "Auto-approved safe Dependabot update.",
+            });
+
+      - name: Mark major update for manual review
+        if: ${{ steps.classify.outputs.safe != 'true' }}
+        uses: actions/github-script@v7
+        env:
+          UPDATE_TYPE: ${{ steps.classify.outputs.update_type }}
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const marker = "<!-- dependabot-manual-review -->";
+            const pr = context.payload.pull_request;
+            const sha = pr.head.sha;
+
+            const comments = await github.paginate(
+              github.rest.issues.listComments,
+              {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: pr.number,
+                per_page: 100,
+              }
+            );
+
+            const existing = comments.find(
+              (comment) =>
+                comment.user?.login === "github-actions[bot]" &&
+                comment.body?.includes(marker) &&
+                comment.body?.includes(sha)
+            );
+
+            if (existing) {
+              core.info("Manual-review marker already posted for current head SHA.");
+              return;
+            }
+
+            const body = [
+              marker,
+              `Not auto-queued: ${process.env.UPDATE_TYPE}.`,
+              "This update type requires manual review before merge.",
+            ].join("\n");
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: pr.number,
+              body,
+            });


### PR DESCRIPTION
## Why
Dependabot PRs currently stay open because this repo uses Trunk-managed merging and requires `/trunk merge` to queue a PR.

## What this changes
- Adds `.github/workflows/dependabot-trunk-automerge.yml`
- On Dependabot PR events, fetches metadata and classifies update type
- For safe updates (`patch`, `minor`, `security`):
  - posts `/trunk merge` automatically
  - auto-approves PR (best-effort)
- For non-safe updates (e.g., major):
  - posts a clear manual-review marker comment

## Result
Safe dependency updates become zero-touch and no longer require manual queueing in Trunk.