### PR TITLE
security: patch vulnerable aiohttp and pillow pins

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@
 # Python Version Requirement: >=3.9,<3.14
 # Note: Python 3.14+ has limited wheel availability; use 3.12 for best compatibility
 aiohappyeyeballs==2.6.1
-aiohttp==3.13.2
+aiohttp==3.13.3
 aiosignal==1.4.0
 alpaca-py==0.43.2
 alpha-vantage==2.3.1
@@ -115,7 +115,7 @@ ormsgpack==1.12.0
 packaging==25.0
 pandas==2.3.3
 peewee==3.18.3
-pillow==11.1.0
+pillow==12.1.1
 platformdirs==4.5.1
 praw==7.8.1
 prawcore==2.4.0


### PR DESCRIPTION
## Summary
- bump `aiohttp` from `3.13.2` to `3.13.3` in `requirements.txt`
- bump `pillow` from `11.1.0` to `12.1.1` in `requirements.txt`
- align with GitHub Dependabot advisory first patched versions for open alerts

## Verification
- `python3 scripts/check_pypi_pins.py`
- `ruff check . --output-format=github`
- `ruff format --check .`
- `python3 scripts/lint_blog_posts.py --changed --strict`
- `python3 scripts/check_anthropic_compliance.py`
