### PR TITLE
security: remediate open CodeQL findings

### DIFF
--- a/docs/rag-query.html
+++ b/docs/rag-query.html
@@ -871,19 +871,46 @@ layout: null
       ).toString();
       const LESSONS_FALLBACK_URL =
         "https://raw.githubusercontent.com/IgorGanapolsky/trading/main/data/rag/lessons_query.json";
+      const WORKER_URL = "https://trading-rag-chat.iganapolsky.workers.dev";
+      const ALLOWED_RAG_HOSTS = new Set([
+        new URL(WORKER_URL).hostname,
+        "localhost",
+        "127.0.0.1",
+      ]);
+
+      function sanitizeRagWebhookUrl(candidate) {
+        if (!candidate) return "";
+        try {
+          const parsed = new URL(candidate, window.location.origin);
+          const isLocalhost =
+            parsed.hostname === "localhost" || parsed.hostname === "127.0.0.1";
+          const protocolAllowed =
+            parsed.protocol === "https:" ||
+            (isLocalhost && parsed.protocol === "http:");
+          if (!protocolAllowed) return "";
+          if (!ALLOWED_RAG_HOSTS.has(parsed.hostname)) return "";
+          return parsed.toString();
+        } catch {
+          return "";
+        }
+      }
+
       const queryParams = new URLSearchParams(window.location.search);
-      const urlFromParam = queryParams.get("rag_url");
+      const urlFromParam = sanitizeRagWebhookUrl(queryParams.get("rag_url"));
       let storedUrl = "";
       try {
         if (urlFromParam) {
           localStorage.setItem("rag_webhook_url", urlFromParam);
         }
-        storedUrl = localStorage.getItem("rag_webhook_url") || "";
+        storedUrl = sanitizeRagWebhookUrl(
+          localStorage.getItem("rag_webhook_url") || "",
+        );
       } catch {
         storedUrl = "";
       }
-      const DIRECT_RAG_URL = window.RAG_WEBHOOK_URL || storedUrl || "";
-      const WORKER_URL = "https://trading-rag-chat.iganapolsky.workers.dev";
+      const DIRECT_RAG_URL = sanitizeRagWebhookUrl(
+        window.RAG_WEBHOOK_URL || storedUrl || "",
+      );
 
       // Initialize
       document.addEventListener("DOMContentLoaded", () => {

--- a/plugins/automation-plugin/skills/dynamic-agent-spawner/scripts/rlhf-integration.ts
+++ b/plugins/automation-plugin/skills/dynamic-agent-spawner/scripts/rlhf-integration.ts
@@ -8,7 +8,13 @@
 
 import { MemAlign, type Feedback } from "./memalign.ts";
 import { CortexWriter, type CortexEntry } from "./cortex-writer.ts";
-import { readFileSync, existsSync, writeFileSync } from "fs";
+import {
+  closeSync,
+  existsSync,
+  ftruncateSync,
+  openSync,
+  readFileSync,
+} from "fs";
 import { join } from "path";
 
 interface RLHFEvent {
@@ -50,18 +56,26 @@ class RLHFIntegration {
    */
   async syncPendingFeedback(): Promise<void> {
     this.pendingFeedbackFile = this.resolvePendingFile();
-    if (!existsSync(this.pendingFeedbackFile)) {
-      console.log("ℹ️  No pending feedback to sync");
-      return;
+    let pendingFileFd: number;
+    try {
+      pendingFileFd = openSync(this.pendingFeedbackFile, "r+");
+    } catch (error) {
+      const err = error as NodeJS.ErrnoException;
+      if (err.code === "ENOENT") {
+        console.log("ℹ️  No pending feedback to sync");
+        return;
+      }
+      throw error;
     }
 
-    const content = readFileSync(this.pendingFeedbackFile, "utf-8");
+    const content = readFileSync(pendingFileFd, "utf-8");
     const lines = content
       .trim()
       .split("\n")
       .filter((l) => l.length > 0);
 
     if (lines.length === 0) {
+      closeSync(pendingFileFd);
       console.log("ℹ️  No pending feedback to sync");
       return;
     }
@@ -79,8 +93,9 @@ class RLHFIntegration {
       }
     }
 
-    // Clear pending file after successful sync
-    writeFileSync(this.pendingFeedbackFile, "");
+    // Clear pending file after successful sync using the same descriptor.
+    ftruncateSync(pendingFileFd, 0);
+    closeSync(pendingFileFd);
     console.log("✅ Hybrid memory sync complete");
     console.log(
       "   - MemAlign: Semantic principles + episodic memories updated",

--- a/scripts/ingest_phil_town_blog.py
+++ b/scripts/ingest_phil_town_blog.py
@@ -17,6 +17,8 @@ from pathlib import Path
 from typing import Optional
 from urllib.parse import urljoin
 
+from bs4 import BeautifulSoup
+
 logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
 logger = logging.getLogger(__name__)
 
@@ -139,9 +141,11 @@ def discover_all_articles() -> list[dict]:
 
 def parse_article_content(html: str) -> Optional[str]:
     """Extract main article content from HTML."""
-    # Remove scripts and styles
-    html = re.sub(r"<script[^>]*>.*?</script>", "", html, flags=re.DOTALL | re.IGNORECASE)
-    html = re.sub(r"<style[^>]*>.*?</style>", "", html, flags=re.DOTALL | re.IGNORECASE)
+    # Remove scripts/styles with a real HTML parser to avoid regex-based filtering bypasses.
+    soup = BeautifulSoup(html, "html.parser")
+    for tag in soup(["script", "style"]):
+        tag.decompose()
+    html = str(soup)
 
     # Try to find article content
     content_patterns = [

--- a/scripts/linkedin_oauth_auto.py
+++ b/scripts/linkedin_oauth_auto.py
@@ -270,7 +270,7 @@ def main():
         print("❌ Failed to get authorization code")
         return 1
 
-    print(f"✅ Got authorization code: {auth_code[:20]}...")
+    print("✅ Got authorization code")
 
     # Exchange for token
     token_data = exchange_code_for_token(auth_code)

--- a/scripts/pre_market_health_check.py
+++ b/scripts/pre_market_health_check.py
@@ -76,12 +76,8 @@ def check_alpaca_api() -> bool:
 
     print("🔍 Alpaca API Configuration:")
     print(f"   Mode: {'PAPER' if paper_mode else 'LIVE'}")
-    print(
-        f"   API Key: {api_key[:8] if len(api_key) >= 8 else 'MISSING'}...{api_key[-4:] if len(api_key) >= 4 else ''}"
-    )
-    print(
-        f"   Secret: {secret_key[:8] if len(secret_key) >= 8 else 'MISSING'}...{secret_key[-4:] if len(secret_key) >= 4 else ''}"
-    )
+    print(f"   API Key configured: {'yes' if api_key else 'no'}")
+    print(f"   Secret configured: {'yes' if secret_key else 'no'}")
     print()
 
     # Self-healing: Retry up to 3 times with exponential backoff

--- a/src/agents/rag_webhook.py
+++ b/src/agents/rag_webhook.py
@@ -542,7 +542,7 @@ def check_ci_status() -> dict:
 
     except Exception as e:
         logger.warning(f"CI status check failed: {e}")
-        result["error"] = str(e)
+        result["error"] = "CI status temporarily unavailable"
 
     return result
 
@@ -846,7 +846,8 @@ def assess_trading_readiness(
             checks.append("System state loaded (GitHub API)")
             score += 10
         except Exception as e:
-            warnings.append(f"System state not found (local or GitHub API): {str(e)[:30]}")
+            logger.debug(f"System state fallback read failed: {e}")
+            warnings.append("System state not found (local or GitHub API)")
 
     # Check state freshness
     if state:
@@ -967,7 +968,7 @@ def assess_trading_readiness(
     max_score += 20
     ci_status = check_ci_status()
     if ci_status["error"]:
-        warnings.append(f"Could not verify CI status: {ci_status['error'][:50]}")
+        warnings.append("Could not verify CI status")
         score += 10  # Partial credit - we tried
     elif ci_status["is_passing"]:
         if ci_status["running_workflows"]:
@@ -1369,6 +1370,13 @@ def create_webhook_response(text: str) -> dict:
     return {"fulfillmentResponse": {"messages": [{"text": {"text": [text]}}]}}
 
 
+def sanitize_public_response_text(text: str) -> str:
+    """Prevent exception stack traces from being returned to API clients."""
+    if "Traceback (most recent call last)" in text or 'File "' in text:
+        return "An internal error occurred processing your request. Please try again."
+    return text
+
+
 def verify_webhook_auth(authorization: Optional[str] = Header(None)) -> bool:
     """
     Verify webhook authentication token.
@@ -1716,7 +1724,7 @@ Or ask me about **lessons learned** instead (e.g., "What lessons did we learn ab
         logger.info(f"Returning response with {len(response_text)} chars")
 
         # Create RAG Webhook response
-        response = create_webhook_response(response_text)
+        response = create_webhook_response(sanitize_public_response_text(response_text))
 
         return JSONResponse(content=response)
 
@@ -1863,22 +1871,32 @@ async def test_readiness(
         is_paper = context["is_paper"]
         is_live = context["is_live"]
 
-    assessment = assess_trading_readiness(
-        is_future=is_future,
-        is_paper=is_paper,
-        is_live=is_live,
-    )
-    return {
-        "query_type": "readiness",
-        "query": query,
-        "context": {
-            "is_future": is_future,
-            "is_paper": is_paper,
-            "is_live": is_live,
-        },
-        "assessment": assessment,
-        "formatted_response": format_readiness_response(assessment),
-    }
+    try:
+        assessment = assess_trading_readiness(
+            is_future=is_future,
+            is_paper=is_paper,
+            is_live=is_live,
+        )
+        return {
+            "query_type": "readiness",
+            "query": query,
+            "context": {
+                "is_future": is_future,
+                "is_paper": is_paper,
+                "is_live": is_live,
+            },
+            "assessment": assessment,
+            "formatted_response": sanitize_public_response_text(
+                format_readiness_response(assessment)
+            ),
+        }
+    except Exception as e:
+        logger.error(f"test-readiness endpoint failed: {e}", exc_info=True)
+        return {
+            "query_type": "readiness",
+            "query": query,
+            "error": "Readiness assessment is temporarily unavailable.",
+        }
 
 
 if __name__ == "__main__":

--- a/tests/test_github_pages_links.py
+++ b/tests/test_github_pages_links.py
@@ -116,12 +116,19 @@ class TestRegressionPrevention:
 
     def test_url_configured_in_config(self):
         """Ensure _config.yml has correct URL."""
+        import re
+        from urllib.parse import urlparse
+
         docs_dir = Path(__file__).parent.parent / "docs"
         config_file = docs_dir / "_config.yml"
 
         content = config_file.read_text()
 
-        assert "igorganapolsky.github.io" in content, (
+        match = re.search(r'^\s*url:\s*"?([^"\n]+)"?\s*$', content, flags=re.MULTILINE)
+        assert match, "_config.yml should define a url entry"
+
+        host = urlparse(match.group(1).strip()).hostname
+        assert host == "igorganapolsky.github.io", (
             "_config.yml should have correct GitHub Pages URL"
         )
 

--- a/tests/test_rag_webhook.py
+++ b/tests/test_rag_webhook.py
@@ -625,9 +625,14 @@ class TestPortfolioStatusFunction:
                     if hasattr(request_obj, "full_url")
                     else request_obj.get_full_url()
                 )
-                assert "github.com" in url or "githubusercontent" in url, (
-                    f"Expected GitHub URL, got: {url}"
-                )
+                from urllib.parse import urlparse
+
+                hostname = (urlparse(url).hostname or "").lower()
+                assert (
+                    hostname == "github.com"
+                    or hostname.endswith(".github.com")
+                    or hostname == "raw.githubusercontent.com"
+                ), f"Expected GitHub URL, got: {url}"
 
     def test_get_current_portfolio_status_returns_empty_on_all_failures(self):
         """Test that empty dict is returned when both local and GitHub fail."""


### PR DESCRIPTION
## Summary
- prevent clear-text secret/token logging in automation scripts
- harden public webhook/readiness responses to avoid exception-detail leakage
- replace regex script/style stripping with BeautifulSoup parsing in blog ingest
- avoid file TOCTOU pattern by truncating pending feedback via file descriptor
- sanitize dynamic RAG endpoint URLs in docs to allowed hosts/protocols
- tighten URL assertions in tests to avoid substring-based sanitization anti-pattern

## Validation
- `ruff check src/agents/rag_webhook.py scripts/ingest_phil_town_blog.py scripts/linkedin_oauth_auto.py scripts/pre_market_health_check.py tests/test_github_pages_links.py tests/test_rag_webhook.py`
- `ruff format --check src/agents/rag_webhook.py scripts/ingest_phil_town_blog.py scripts/linkedin_oauth_auto.py scripts/pre_market_health_check.py tests/test_github_pages_links.py tests/test_rag_webhook.py`
- `pytest -q tests/test_github_pages_links.py`

## Notes
- `tests/test_rag_webhook.py` is currently skipped in this environment by existing test guards.
