### PR TITLE
fix(ci): handle gitignored file in Alpaca sync workflow

### DIFF
--- a/.github/workflows/sync-alpaca-status.yml
+++ b/.github/workflows/sync-alpaca-status.yml
@@ -66,7 +66,8 @@ jobs:
           git config user.name "GitHub Actions Bot"
           git config user.email "actions@github.com"
 
-          git add data/system_state.json data/north_star_weekly_history.json
+          git add data/system_state.json
+          git add -f data/north_star_weekly_history.json 2>/dev/null || true
           if git diff --staged --quiet; then
             echo "No state changes to commit"
             exit 0


### PR DESCRIPTION
## Summary
- `sync-alpaca-status.yml` has been failing since Feb 13 because `data/north_star_weekly_history.json` is gitignored but `git add` tries to stage it without `-f`
- This causes the commit step to abort with exit code 1, even though the Alpaca data sync succeeds
- Fix: use `git add -f` with fallback for the gitignored file

## Impact
- Sync workflow has failed 2x today, causing stale system_state.json (3 days old)
- After merge, the next scheduled sync run will succeed and update data

## Test plan
- [ ] Merge and verify next scheduled sync run passes
- [ ] Confirm system_state.json gets updated on main

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>