### PR TITLE
fix(ci): align Rule One north-star target test

### DIFF
--- a/tests/test_rule_one_trader.py
+++ b/tests/test_rule_one_trader.py
@@ -54,11 +54,11 @@ class TestRuleOneTraderConfig:
         whitelisted_etfs = ["SPY", "SPX", "XSP"]
         assert all(s in whitelisted_etfs for s in CONFIG["watchlist"])
 
-    def test_north_star_target_is_100(self):
-        """North Star daily target should be $100."""
+    def test_north_star_target_is_200(self):
+        """North Star daily target should be $200."""
         from scripts.rule_one_trader import CONFIG
 
-        assert CONFIG["north_star_target"] == 100.0
+        assert CONFIG["north_star_target"] == 200.0
 
 
 class TestGetTradingClient:


### PR DESCRIPTION
CI on main is failing because the test expects  but CONFIG uses  (also used by the dashboard scripts). Update the test expectation to match.