### PR TITLE
ci: ignore automated data sync commits

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,11 @@ name: CI
 on:
   push:
     branches: [main]
+    # Avoid cancelling long CI runs due to frequent automated data-sync commits.
+    # CI will still run for any commit that changes code or other non-ignored paths.
+    paths-ignore:
+      - "data/**"
+      - "docs/index.md"
   pull_request:
     branches: [main]
   workflow_dispatch:


### PR DESCRIPTION
Prevent long CI runs on main from being cancelled by frequent automated data-only commits.\n\nChanges:\n- CI workflow ignores pushes that only touch data/** and docs/index.md (auto sync + dashboard updates).