### PR TITLE
feat: autonomous OpenRouter price monitor for reasoning models

### DIFF
--- a/.github/workflows/openrouter-price-monitor.yml
+++ b/.github/workflows/openrouter-price-monitor.yml
@@ -1,0 +1,38 @@
+name: OpenRouter Price Monitor
+
+on:
+  schedule:
+    # Run daily at 6am ET (11:00 UTC) — check before market open
+    - cron: '0 11 * * *'
+  workflow_dispatch:  # Manual trigger
+
+permissions:
+  issues: write
+
+jobs:
+  check-prices:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Check OpenRouter pricing
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: python scripts/openrouter_price_monitor.py
+
+      - name: Commit updated baseline
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          if git diff --quiet data/openrouter_pricing_baseline.json 2>/dev/null; then
+            echo "No pricing changes to commit"
+          else
+            git add data/openrouter_pricing_baseline.json
+            git commit -m "chore: update OpenRouter pricing baseline [auto]"
+            git push
+          fi

--- a/data/openrouter_pricing_baseline.json
+++ b/data/openrouter_pricing_baseline.json
@@ -1,0 +1,32 @@
+{
+  "moonshotai/kimi-k2-0905": {
+    "name": "Kimi K2",
+    "input_cost_per_1m": 0.39,
+    "output_cost_per_1m": 1.9,
+    "fetched_at": "2026-02-13T15:51:47.616519"
+  },
+  "mistralai/mistral-medium-3": {
+    "name": "Mistral Medium 3",
+    "input_cost_per_1m": 0.4,
+    "output_cost_per_1m": 2.0,
+    "fetched_at": "2026-02-13T15:51:47.616554"
+  },
+  "qwen/qwen3-235b-a22b": {
+    "name": "Qwen3 235B",
+    "input_cost_per_1m": 0.3,
+    "output_cost_per_1m": 1.2,
+    "fetched_at": "2026-02-13T15:51:47.616572"
+  },
+  "deepseek/deepseek-r1": {
+    "name": "DeepSeek-R1 (reasoning)",
+    "input_cost_per_1m": 0.7,
+    "output_cost_per_1m": 2.5,
+    "fetched_at": "2026-02-13T15:51:47.616588"
+  },
+  "deepseek/deepseek-chat": {
+    "name": "DeepSeek V3 (chat)",
+    "input_cost_per_1m": 0.3,
+    "output_cost_per_1m": 1.2,
+    "fetched_at": "2026-02-13T15:51:47.616600"
+  }
+}

--- a/scripts/openrouter_price_monitor.py
+++ b/scripts/openrouter_price_monitor.py
@@ -1,0 +1,288 @@
+#!/usr/bin/env python3
+"""
+OpenRouter Reasoning Model Price Monitor
+
+Autonomous monitor that checks OpenRouter API pricing for reasoning models
+and alerts when costs drop significantly (signal that providers adopted
+optimizations like NVIDIA DMS, KV cache compression, etc.).
+
+Runs daily via GitHub Actions. When a drop ≥30% is detected:
+1. Creates a GitHub Issue with the pricing change details
+2. Updates data/openrouter_pricing_baseline.json with new prices
+
+This enables automatic detection of when to route more tasks through
+reasoning models in model_selector.py BATS framework.
+
+Feb 2026 — Built per CEO directive for autonomous price monitoring.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import sys
+import urllib.request
+from datetime import datetime
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
+logger = logging.getLogger(__name__)
+
+# Models we track for pricing changes
+TRACKED_MODELS = {
+    "deepseek/deepseek-r1": "DeepSeek-R1 (reasoning)",
+    "deepseek/deepseek-chat": "DeepSeek V3 (chat)",
+    "mistralai/mistral-medium-3": "Mistral Medium 3",
+    "moonshotai/kimi-k2-0905": "Kimi K2",
+    "qwen/qwen3-235b-a22b": "Qwen3 235B",
+    "qwen/qwen-r1-32b": "Qwen-R1 32B (reasoning)",
+}
+
+# Alert threshold: notify when price drops by this percentage
+PRICE_DROP_THRESHOLD = 0.30  # 30%
+
+BASELINE_FILE = Path("data/openrouter_pricing_baseline.json")
+OPENROUTER_API_URL = "https://openrouter.ai/api/v1/models"
+
+
+def fetch_openrouter_prices() -> dict[str, dict]:
+    """Fetch current pricing from OpenRouter API (no auth required)."""
+    logger.info("Fetching pricing from OpenRouter API...")
+
+    req = urllib.request.Request(
+        OPENROUTER_API_URL,
+        headers={"User-Agent": "trading-price-monitor/1.0"},
+    )
+
+    with urllib.request.urlopen(req, timeout=30) as resp:
+        data = json.loads(resp.read().decode())
+
+    models = data.get("data", [])
+    logger.info(f"Fetched {len(models)} models from OpenRouter")
+
+    prices = {}
+    for model in models:
+        model_id = model.get("id", "")
+        if model_id in TRACKED_MODELS:
+            pricing = model.get("pricing", {})
+            # OpenRouter returns cost as string per-token, convert to per-1M
+            prompt_cost = float(pricing.get("prompt", "0")) * 1_000_000
+            completion_cost = float(pricing.get("completion", "0")) * 1_000_000
+
+            prices[model_id] = {
+                "name": TRACKED_MODELS[model_id],
+                "input_cost_per_1m": round(prompt_cost, 4),
+                "output_cost_per_1m": round(completion_cost, 4),
+                "fetched_at": datetime.now().isoformat(),
+            }
+            logger.info(f"  {model_id}: ${prompt_cost:.4f}/${completion_cost:.4f} per 1M tokens")
+
+    return prices
+
+
+def load_baseline() -> dict[str, dict]:
+    """Load baseline pricing from file, or return empty if first run."""
+    if not BASELINE_FILE.exists():
+        logger.info("No baseline file found — this is the first run")
+        return {}
+
+    with open(BASELINE_FILE) as f:
+        return json.load(f)
+
+
+def save_baseline(prices: dict[str, dict]) -> None:
+    """Save current prices as the new baseline."""
+    BASELINE_FILE.parent.mkdir(parents=True, exist_ok=True)
+    with open(BASELINE_FILE, "w") as f:
+        json.dump(prices, f, indent=2)
+    logger.info(f"Baseline saved to {BASELINE_FILE}")
+
+
+def detect_price_drops(
+    current: dict[str, dict],
+    baseline: dict[str, dict],
+) -> list[dict]:
+    """Compare current prices against baseline, return significant drops."""
+    drops = []
+
+    for model_id, curr_data in current.items():
+        if model_id not in baseline:
+            continue
+
+        base_data = baseline[model_id]
+        base_input = base_data.get("input_cost_per_1m", 0)
+        base_output = base_data.get("output_cost_per_1m", 0)
+        curr_input = curr_data.get("input_cost_per_1m", 0)
+        curr_output = curr_data.get("output_cost_per_1m", 0)
+
+        # Check input cost drop
+        if base_input > 0:
+            input_drop_pct = (base_input - curr_input) / base_input
+        else:
+            input_drop_pct = 0
+
+        # Check output cost drop
+        if base_output > 0:
+            output_drop_pct = (base_output - curr_output) / base_output
+        else:
+            output_drop_pct = 0
+
+        if input_drop_pct >= PRICE_DROP_THRESHOLD or output_drop_pct >= PRICE_DROP_THRESHOLD:
+            drops.append(
+                {
+                    "model_id": model_id,
+                    "name": curr_data["name"],
+                    "input_before": base_input,
+                    "input_after": curr_input,
+                    "input_drop_pct": round(input_drop_pct * 100, 1),
+                    "output_before": base_output,
+                    "output_after": curr_output,
+                    "output_drop_pct": round(output_drop_pct * 100, 1),
+                }
+            )
+
+    return drops
+
+
+def create_github_issue(drops: list[dict]) -> None:
+    """Create a GitHub issue alerting about significant price drops."""
+    import subprocess
+
+    title = f"OpenRouter Price Drop Alert: {len(drops)} reasoning model(s) cheaper"
+
+    body_lines = [
+        "## OpenRouter Reasoning Model Price Drop Detected",
+        "",
+        "The autonomous price monitor detected significant pricing changes.",
+        "This may indicate providers adopted optimizations (NVIDIA DMS, KV cache compression, etc.).",
+        "",
+        "### Price Changes",
+        "",
+        "| Model | Input (before → after) | Output (before → after) | Drop |",
+        "|---|---|---|---|",
+    ]
+
+    for d in drops:
+        max_drop = max(d["input_drop_pct"], d["output_drop_pct"])
+        body_lines.append(
+            f"| {d['name']} | ${d['input_before']:.2f} → ${d['input_after']:.2f}/1M "
+            f"| ${d['output_before']:.2f} → ${d['output_after']:.2f}/1M "
+            f"| **{max_drop:.0f}%** |"
+        )
+
+    body_lines.extend(
+        [
+            "",
+            "### Action Required",
+            "",
+            "- [ ] Update `MODEL_REGISTRY` in `src/utils/model_selector.py` with new prices",
+            "- [ ] Consider routing more tasks through cheaper reasoning models",
+            "- [ ] Update BATS budget thresholds if significant savings available",
+            "",
+            f"*Auto-generated by `scripts/openrouter_price_monitor.py` on {datetime.now().strftime('%Y-%m-%d')}*",
+        ]
+    )
+
+    body = "\n".join(body_lines)
+
+    try:
+        result = subprocess.run(
+            [
+                "gh",
+                "issue",
+                "create",
+                "--title",
+                title,
+                "--body",
+                body,
+                "--label",
+                "cost-optimization",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        if result.returncode == 0:
+            logger.info(f"GitHub Issue created: {result.stdout.strip()}")
+        else:
+            logger.warning(f"Failed to create issue: {result.stderr}")
+    except Exception as e:
+        logger.warning(f"Could not create GitHub issue: {e}")
+
+
+def main() -> dict:
+    """Run the price monitor."""
+    logger.info("=" * 60)
+    logger.info("OPENROUTER PRICE MONITOR")
+    logger.info("=" * 60)
+
+    # Fetch current prices
+    try:
+        current_prices = fetch_openrouter_prices()
+    except Exception as e:
+        logger.error(f"Failed to fetch OpenRouter prices: {e}")
+        return {"success": False, "reason": str(e)}
+
+    if not current_prices:
+        logger.warning("No tracked models found in OpenRouter response")
+        return {"success": False, "reason": "no_tracked_models_found"}
+
+    # Load baseline
+    baseline = load_baseline()
+
+    # First run: save baseline and exit
+    if not baseline:
+        save_baseline(current_prices)
+        logger.info("First run — baseline established. Will detect drops on next run.")
+        return {"success": True, "action": "baseline_established", "models": len(current_prices)}
+
+    # Detect significant price drops
+    drops = detect_price_drops(current_prices, baseline)
+
+    if drops:
+        logger.info("=" * 60)
+        logger.info(f"PRICE DROP ALERT: {len(drops)} model(s) significantly cheaper!")
+        logger.info("=" * 60)
+        for d in drops:
+            logger.info(
+                f"  {d['name']}: input {d['input_drop_pct']}% drop, "
+                f"output {d['output_drop_pct']}% drop"
+            )
+
+        # Create GitHub Issue
+        if os.getenv("GITHUB_TOKEN") or os.getenv("GH_TOKEN"):
+            create_github_issue(drops)
+        else:
+            logger.info("No GITHUB_TOKEN — skipping issue creation (local run)")
+
+        # Update baseline with new prices
+        save_baseline(current_prices)
+    else:
+        logger.info("No significant price drops detected")
+        # Still update baseline to track gradual changes
+        save_baseline(current_prices)
+
+    # Log summary
+    logger.info("=" * 60)
+    logger.info("CURRENT REASONING MODEL PRICES")
+    logger.info("=" * 60)
+    for model_id, data in current_prices.items():
+        logger.info(
+            f"  {data['name']}: ${data['input_cost_per_1m']:.4f} in / "
+            f"${data['output_cost_per_1m']:.4f} out per 1M"
+        )
+
+    return {
+        "success": True,
+        "models_checked": len(current_prices),
+        "drops_detected": len(drops),
+        "drops": drops,
+    }
+
+
+if __name__ == "__main__":
+    result = main()
+    print(f"\nResult: {json.dumps(result, indent=2, default=str)}")

--- a/src/utils/model_selector.py
+++ b/src/utils/model_selector.py
@@ -88,8 +88,8 @@ MODEL_REGISTRY: dict[ModelTier, ModelConfig] = {
     ModelTier.DEEPSEEK: ModelConfig(
         model_id="deepseek/deepseek-chat",
         tier=ModelTier.DEEPSEEK,
-        input_cost_per_1m=0.14,
-        output_cost_per_1m=0.28,
+        input_cost_per_1m=0.30,  # OpenRouter live price Feb 2026
+        output_cost_per_1m=1.20,
         max_context=128000,
         provider="openrouter",
         trading_sortino=0.0210,  # StockBench: DeepSeek-V3.1
@@ -97,8 +97,8 @@ MODEL_REGISTRY: dict[ModelTier, ModelConfig] = {
     ModelTier.DEEPSEEK_R1: ModelConfig(
         model_id="deepseek/deepseek-r1",
         tier=ModelTier.DEEPSEEK_R1,
-        input_cost_per_1m=0.55,
-        output_cost_per_1m=2.19,
+        input_cost_per_1m=0.70,  # OpenRouter live price Feb 2026
+        output_cost_per_1m=2.50,
         max_context=128000,
         provider="openrouter",
         supports_extended_thinking=True,  # Chain-of-thought reasoning

--- a/tests/test_openrouter_price_monitor.py
+++ b/tests/test_openrouter_price_monitor.py
@@ -1,0 +1,231 @@
+"""
+Tests for OpenRouter Price Monitor.
+
+Verifies:
+- Price drop detection logic
+- Baseline save/load
+- Alert threshold behavior
+- Graceful failure on API errors
+"""
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from scripts.openrouter_price_monitor import (
+    PRICE_DROP_THRESHOLD,
+    TRACKED_MODELS,
+    detect_price_drops,
+    fetch_openrouter_prices,
+)
+
+
+class TestDetectPriceDrops:
+    """Test price drop detection logic."""
+
+    def test_no_drops_when_prices_same(self):
+        """No drops when current equals baseline."""
+        baseline = {
+            "deepseek/deepseek-r1": {
+                "input_cost_per_1m": 0.70,
+                "output_cost_per_1m": 2.50,
+            }
+        }
+        current = {
+            "deepseek/deepseek-r1": {
+                "name": "DeepSeek-R1",
+                "input_cost_per_1m": 0.70,
+                "output_cost_per_1m": 2.50,
+            }
+        }
+        drops = detect_price_drops(current, baseline)
+        assert len(drops) == 0
+
+    def test_detects_input_cost_drop(self):
+        """Detects significant input cost drop."""
+        baseline = {
+            "deepseek/deepseek-r1": {
+                "input_cost_per_1m": 0.70,
+                "output_cost_per_1m": 2.50,
+            }
+        }
+        current = {
+            "deepseek/deepseek-r1": {
+                "name": "DeepSeek-R1",
+                "input_cost_per_1m": 0.10,  # 85% drop
+                "output_cost_per_1m": 2.50,
+            }
+        }
+        drops = detect_price_drops(current, baseline)
+        assert len(drops) == 1
+        assert drops[0]["model_id"] == "deepseek/deepseek-r1"
+        assert drops[0]["input_drop_pct"] > 80
+
+    def test_detects_output_cost_drop(self):
+        """Detects significant output cost drop."""
+        baseline = {
+            "deepseek/deepseek-r1": {
+                "input_cost_per_1m": 0.70,
+                "output_cost_per_1m": 2.50,
+            }
+        }
+        current = {
+            "deepseek/deepseek-r1": {
+                "name": "DeepSeek-R1",
+                "input_cost_per_1m": 0.70,
+                "output_cost_per_1m": 0.30,  # 88% drop
+            }
+        }
+        drops = detect_price_drops(current, baseline)
+        assert len(drops) == 1
+        assert drops[0]["output_drop_pct"] > 80
+
+    def test_ignores_small_drops(self):
+        """Ignores drops below threshold."""
+        baseline = {
+            "deepseek/deepseek-r1": {
+                "input_cost_per_1m": 0.70,
+                "output_cost_per_1m": 2.50,
+            }
+        }
+        current = {
+            "deepseek/deepseek-r1": {
+                "name": "DeepSeek-R1",
+                "input_cost_per_1m": 0.60,  # 14% drop — below 30% threshold
+                "output_cost_per_1m": 2.30,  # 8% drop
+            }
+        }
+        drops = detect_price_drops(current, baseline)
+        assert len(drops) == 0
+
+    def test_ignores_price_increases(self):
+        """Price increases are not flagged."""
+        baseline = {
+            "deepseek/deepseek-r1": {
+                "input_cost_per_1m": 0.70,
+                "output_cost_per_1m": 2.50,
+            }
+        }
+        current = {
+            "deepseek/deepseek-r1": {
+                "name": "DeepSeek-R1",
+                "input_cost_per_1m": 1.00,  # Increase
+                "output_cost_per_1m": 3.00,
+            }
+        }
+        drops = detect_price_drops(current, baseline)
+        assert len(drops) == 0
+
+    def test_skips_models_not_in_baseline(self):
+        """New models not in baseline are skipped."""
+        baseline = {}
+        current = {
+            "deepseek/deepseek-r1": {
+                "name": "DeepSeek-R1",
+                "input_cost_per_1m": 0.10,
+                "output_cost_per_1m": 0.30,
+            }
+        }
+        drops = detect_price_drops(current, baseline)
+        assert len(drops) == 0
+
+    def test_multiple_drops_detected(self):
+        """Multiple model drops detected simultaneously."""
+        baseline = {
+            "deepseek/deepseek-r1": {
+                "input_cost_per_1m": 0.70,
+                "output_cost_per_1m": 2.50,
+            },
+            "deepseek/deepseek-chat": {
+                "input_cost_per_1m": 0.30,
+                "output_cost_per_1m": 1.20,
+            },
+        }
+        current = {
+            "deepseek/deepseek-r1": {
+                "name": "R1",
+                "input_cost_per_1m": 0.09,  # 87% drop
+                "output_cost_per_1m": 0.31,
+            },
+            "deepseek/deepseek-chat": {
+                "name": "V3",
+                "input_cost_per_1m": 0.04,  # 87% drop
+                "output_cost_per_1m": 0.15,
+            },
+        }
+        drops = detect_price_drops(current, baseline)
+        assert len(drops) == 2
+
+    def test_zero_baseline_no_division_error(self):
+        """Zero baseline price doesn't cause division by zero."""
+        baseline = {
+            "deepseek/deepseek-r1": {
+                "input_cost_per_1m": 0,
+                "output_cost_per_1m": 0,
+            }
+        }
+        current = {
+            "deepseek/deepseek-r1": {
+                "name": "R1",
+                "input_cost_per_1m": 0.70,
+                "output_cost_per_1m": 2.50,
+            }
+        }
+        drops = detect_price_drops(current, baseline)
+        assert len(drops) == 0  # No error, no drop flagged
+
+
+class TestThreshold:
+    """Test that the alert threshold is configured correctly."""
+
+    def test_threshold_is_30_percent(self):
+        """Alert threshold is 30% drop."""
+        assert PRICE_DROP_THRESHOLD == 0.30
+
+    def test_tracked_models_include_reasoning(self):
+        """Reasoning models are tracked."""
+        assert "deepseek/deepseek-r1" in TRACKED_MODELS
+        assert "deepseek/deepseek-chat" in TRACKED_MODELS
+
+
+class TestFetchPrices:
+    """Test OpenRouter API fetch."""
+
+    def test_fetch_handles_api_error(self):
+        """API errors raise exceptions (caller handles)."""
+        with patch("scripts.openrouter_price_monitor.urllib.request.urlopen") as mock_url:
+            mock_url.side_effect = Exception("Connection timeout")
+            with pytest.raises(Exception, match="Connection timeout"):
+                fetch_openrouter_prices()
+
+    def test_fetch_parses_response(self):
+        """Parses OpenRouter API response correctly."""
+        mock_data = {
+            "data": [
+                {
+                    "id": "deepseek/deepseek-r1",
+                    "pricing": {
+                        "prompt": "0.0000007",  # $0.70 per 1M
+                        "completion": "0.0000025",  # $2.50 per 1M
+                    },
+                },
+                {
+                    "id": "some/other-model",
+                    "pricing": {"prompt": "0.001", "completion": "0.002"},
+                },
+            ]
+        }
+        mock_response = MagicMock()
+        mock_response.read.return_value = json.dumps(mock_data).encode()
+        mock_response.__enter__ = lambda s: s
+        mock_response.__exit__ = MagicMock(return_value=False)
+
+        with patch("scripts.openrouter_price_monitor.urllib.request.urlopen") as mock_url:
+            mock_url.return_value = mock_response
+            prices = fetch_openrouter_prices()
+
+        assert "deepseek/deepseek-r1" in prices
+        assert "some/other-model" not in prices  # Not tracked
+        assert prices["deepseek/deepseek-r1"]["input_cost_per_1m"] == 0.7
+        assert prices["deepseek/deepseek-r1"]["output_cost_per_1m"] == 2.5


### PR DESCRIPTION
## Summary
- Autonomous daily monitor that checks OpenRouter API pricing for reasoning models
- Auto-creates GitHub Issue when prices drop ≥30% (signal of NVIDIA DMS or similar optimizations)
- Updates `model_selector.py` with actual live OpenRouter prices (were stale)
- Establishes pricing baseline from live API data

## How It Works
```
Daily 6am ET → fetch OpenRouter /api/v1/models → compare vs baseline
    → drop ≥30%? → create GitHub Issue with update checklist
    → save new baseline → commit
```

## Tracked Models
| Model | Current Price (in/out per 1M) |
|---|---|
| DeepSeek-R1 (reasoning) | $0.70 / $2.50 |
| DeepSeek V3 (chat) | $0.30 / $1.20 |
| Kimi K2 | $0.39 / $1.90 |
| Mistral Medium 3 | $0.40 / $2.00 |
| Qwen3 235B | $0.30 / $1.20 |

## Test plan
- [x] 12 new tests pass (drop detection, thresholds, API parsing, edge cases)
- [x] 47 model_selector tests pass (with updated prices)
- [x] Local run established baseline successfully
- [x] ruff lint + format clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)