### PR TITLE
fix(pages): unblock pages-build-deployment

### DIFF
--- a/docs/_layouts/post.html
+++ b/docs/_layouts/post.html
@@ -50,7 +50,7 @@ layout: default
 
       {%- if page.tags and page.tags.size > 0 -%}
         {%- assign primary_tag = page.tags[0] -%}
-        {%- assign related = candidates | where_exp: "p", "p.tags and p.tags contains primary_tag" -%}
+        {%- assign related = candidates | where_exp: "p", "p.tags contains primary_tag" -%}
       {%- endif -%}
 
       {%- if related.size == 0 -%}


### PR DESCRIPTION
GitHub Pages (jekyll-build-pages) fails to build docs due to a Liquid where_exp condition in docs/_layouts/post.html. This simplifies the where_exp expression to a form compatible with GitHub Pages' Jekyll/Liquid parser.