### PR TITLE
Fix main CI failures in lessons index opt-in and risk test expectations

### DIFF
--- a/data/rag/lessons_query.json
+++ b/data/rag/lessons_query.json
@@ -1109,6 +1109,28 @@
     "file": "rag_knowledge/lessons_learned/LL-353_PR_Merge_CI_Hygiene_Feb16.md"
   },
   {
+    "id": "auto_sync_failed_feb16",
+    "title": "Portfolio sync failed - blind trading risk",
+    "date": "2026-02-16",
+    "category": "lessons_learned",
+    "severity": "HIGH",
+    "summary": "## Problem Cannot verify account state. Error: API Error ## Context - Symbol: None - Strategy: None - Error: API Error ## Prevention BLOCK all trading until sync restored. Never trade without knowing current positions/equity. ## Tags failure, sync_failed, auto-generated, reflexion",
+    "tags": [],
+    "content": "# Portfolio sync failed - blind trading risk\n\n**ID**: auto_sync_failed_20260216_171717\n**Date**: 2026-02-16\n**Severity**: HIGH\n**Type**: Auto-generated (Reflexion pattern)\n\n## Problem\nCannot verify account state. Error: API Error\n\n## Context\n- Symbol: None\n- Strategy: None\n- Error: API Error\n\n## Prevention\nBLOCK all trading until sync restored. Never trade without knowing current positions/equity.\n\n## Tags\nfailure, sync_failed, auto-generated, reflexion",
+    "file": "rag_knowledge/lessons_learned/auto_sync_failed_feb16.md"
+  },
+  {
+    "id": "auto_sync_failed_feb16_2",
+    "title": "Portfolio sync failed - blind trading risk",
+    "date": "2026-02-16",
+    "category": "lessons_learned",
+    "severity": "HIGH",
+    "summary": "## Problem Cannot verify account state. Error: API Error ## Context - Symbol: None - Strategy: None - Error: API Error ## Prevention BLOCK all trading until sync restored. Never trade without knowing current positions/equity. ## Tags failure, sync_failed, auto-generated, reflexion",
+    "tags": [],
+    "content": "# Portfolio sync failed - blind trading risk\n\n**ID**: auto_sync_failed_20260216_172031\n**Date**: 2026-02-16\n**Severity**: HIGH\n**Type**: Auto-generated (Reflexion pattern)\n\n## Problem\nCannot verify account state. Error: API Error\n\n## Context\n- Symbol: None\n- Strategy: None\n- Error: API Error\n\n## Prevention\nBLOCK all trading until sync restored. Never trade without knowing current positions/equity.\n\n## Tags\nfailure, sync_failed, auto-generated, reflexion",
+    "file": "rag_knowledge/lessons_learned/auto_sync_failed_feb16_2.md"
+  },
+  {
     "id": "automated_position_management_feb08",
     "title": "Automated Position Management Requirements (Feb 8, 2026)",
     "date": "",

--- a/docs/data/rag/lessons_query.json
+++ b/docs/data/rag/lessons_query.json
@@ -1109,6 +1109,28 @@
     "file": "rag_knowledge/lessons_learned/LL-353_PR_Merge_CI_Hygiene_Feb16.md"
   },
   {
+    "id": "auto_sync_failed_feb16",
+    "title": "Portfolio sync failed - blind trading risk",
+    "date": "2026-02-16",
+    "category": "lessons_learned",
+    "severity": "HIGH",
+    "summary": "## Problem Cannot verify account state. Error: API Error ## Context - Symbol: None - Strategy: None - Error: API Error ## Prevention BLOCK all trading until sync restored. Never trade without knowing current positions/equity. ## Tags failure, sync_failed, auto-generated, reflexion",
+    "tags": [],
+    "content": "# Portfolio sync failed - blind trading risk\n\n**ID**: auto_sync_failed_20260216_171717\n**Date**: 2026-02-16\n**Severity**: HIGH\n**Type**: Auto-generated (Reflexion pattern)\n\n## Problem\nCannot verify account state. Error: API Error\n\n## Context\n- Symbol: None\n- Strategy: None\n- Error: API Error\n\n## Prevention\nBLOCK all trading until sync restored. Never trade without knowing current positions/equity.\n\n## Tags\nfailure, sync_failed, auto-generated, reflexion",
+    "file": "rag_knowledge/lessons_learned/auto_sync_failed_feb16.md"
+  },
+  {
+    "id": "auto_sync_failed_feb16_2",
+    "title": "Portfolio sync failed - blind trading risk",
+    "date": "2026-02-16",
+    "category": "lessons_learned",
+    "severity": "HIGH",
+    "summary": "## Problem Cannot verify account state. Error: API Error ## Context - Symbol: None - Strategy: None - Error: API Error ## Prevention BLOCK all trading until sync restored. Never trade without knowing current positions/equity. ## Tags failure, sync_failed, auto-generated, reflexion",
+    "tags": [],
+    "content": "# Portfolio sync failed - blind trading risk\n\n**ID**: auto_sync_failed_20260216_172031\n**Date**: 2026-02-16\n**Severity**: HIGH\n**Type**: Auto-generated (Reflexion pattern)\n\n## Problem\nCannot verify account state. Error: API Error\n\n## Context\n- Symbol: None\n- Strategy: None\n- Error: API Error\n\n## Prevention\nBLOCK all trading until sync restored. Never trade without knowing current positions/equity.\n\n## Tags\nfailure, sync_failed, auto-generated, reflexion",
+    "file": "rag_knowledge/lessons_learned/auto_sync_failed_feb16_2.md"
+  },
+  {
     "id": "automated_position_management_feb08",
     "title": "Automated Position Management Requirements (Feb 8, 2026)",
     "date": "",

--- a/docs/lessons/index.html
+++ b/docs/lessons/index.html
@@ -7,7 +7,7 @@ description: "Structured index of lessons learned from the autonomous AI trading
 <h1>Lessons Learned Index</h1>
 <p>A structured, crawlable index of lessons learned from the AI trading system.</p>
 <p>This page is auto-generated to keep semantic signals consistent and up to date.</p>
-<p><strong>Last updated:</strong> 2026-02-16 22:07 UTC</p>
+<p><strong>Last updated:</strong> 2026-02-16 22:21 UTC</p>
 <p><strong>Canonical JSON index:</strong></p>
 <ul>
 <li><code>/trading/data/rag/lessons_query.json</code> (GitHub Pages cache)</li>
@@ -101,6 +101,8 @@ description: "Structured index of lessons learned from the autonomous AI trading
 <tr><td><a href="https://github.com/IgorGanapolsky/trading/blob/main/rag_knowledge/lessons_learned/LL-315_CTO_Violated_Directive_3_Jan26.md">LL-315: CTO Violated Directive #3 - Asked CEO to Do Manual Work</a></td><td>HIGH</td><td>2026-01-26</td><td>CTO Failure, Directive Violation</td></tr>
 <tr><td><a href="https://github.com/IgorGanapolsky/trading/blob/main/rag_knowledge/lessons_learned/LL-316_PR_Hygiene_Session_Jan26.md">LL-316: PR &amp; Branch Hygiene Session - Jan 26, 2026</a></td><td>INFO</td><td></td><td>lessons_learned</td></tr>
 <tr><td><a href="https://github.com/IgorGanapolsky/trading/blob/main/rag_knowledge/lessons_learned/LL-353_PR_Merge_CI_Hygiene_Feb16.md">LL-353: PR Merge Requires CI-Lint + Content-Lint Alignment</a></td><td>PROCESS</td><td>2026-02-16</td><td>Development Operations</td></tr>
+<tr><td><a href="https://github.com/IgorGanapolsky/trading/blob/main/rag_knowledge/lessons_learned/auto_sync_failed_feb16.md">Portfolio sync failed - blind trading risk</a></td><td>HIGH</td><td>2026-02-16</td><td>lessons_learned</td></tr>
+<tr><td><a href="https://github.com/IgorGanapolsky/trading/blob/main/rag_knowledge/lessons_learned/auto_sync_failed_feb16_2.md">Portfolio sync failed - blind trading risk</a></td><td>HIGH</td><td>2026-02-16</td><td>lessons_learned</td></tr>
 <tr><td><a href="https://github.com/IgorGanapolsky/trading/blob/main/rag_knowledge/lessons_learned/automated_position_management_feb08.md">Automated Position Management Requirements (Feb 8, 2026)</a></td><td>INFO</td><td></td><td>lessons_learned</td></tr>
 <tr><td><a href="https://github.com/IgorGanapolsky/trading/blob/main/rag_knowledge/lessons_learned/iron_condor_backtest_findings_feb08.md">Iron Condor Backtest Findings (Feb 8, 2026)</a></td><td>INFO</td><td></td><td>lessons_learned</td></tr>
 <tr><td><a href="https://github.com/IgorGanapolsky/trading/blob/main/rag_knowledge/lessons_learned/ll_131_never_tell_ceo_to_run_ci_jan12.md">LL-131: NEVER Tell CEO to Run CI - Do It Yourself</a></td><td>MEDIUM</td><td>2026-01-12</td><td>Chain of Command Violation</td></tr>
@@ -135,8 +137,6 @@ description: "Structured index of lessons learned from the autonomous AI trading
 <tr><td><a href="https://github.com/IgorGanapolsky/trading/blob/main/rag_knowledge/lessons_learned/ll_224_agentic_memory_paper_evaluation_jan13.md">LL-224: Resource Evaluation: Agentic Memory Paper</a></td><td>INFO</td><td></td><td>lessons_learned</td></tr>
 <tr><td><a href="https://github.com/IgorGanapolsky/trading/blob/main/rag_knowledge/lessons_learned/ll_225_dead_code_cleanup_jan13.md">LL-225: Dead Code Cleanup - January 13, 2026</a></td><td>INFO</td><td></td><td>lessons_learned</td></tr>
 <tr><td><a href="https://github.com/IgorGanapolsky/trading/blob/main/rag_knowledge/lessons_learned/ll_226_cto_directive_violations_jan14.md">LL-203: CTO Directive Violations - Crisis Level</a></td><td>INFO</td><td></td><td>lessons_learned</td></tr>
-<tr><td><a href="https://github.com/IgorGanapolsky/trading/blob/main/rag_knowledge/lessons_learned/ll_228_sandbox_git_proxy_limitations_jan14.md">LL-228: Sandbox Git Proxy Limitations</a></td><td>MEDIUM</td><td>2026-01-14</td><td>Infrastructure</td></tr>
-<tr><td><a href="https://github.com/IgorGanapolsky/trading/blob/main/rag_knowledge/lessons_learned/ll_231_failure_analysis_jan16.md">LL-231: Failure Analysis - Why Critical Fixes Were Lost (Jan 16, 2026)</a></td><td>INFO</td><td></td><td>lessons_learned</td></tr>
 </tbody>
 </table>
 <script type="application/ld+json">
@@ -655,218 +655,218 @@ description: "Structured index of lessons learned from the autonomous AI trading
     {
       "@type": "ListItem",
       "position": 85,
+      "name": "Portfolio sync failed - blind trading risk",
+      "url": "https://github.com/IgorGanapolsky/trading/blob/main/rag_knowledge/lessons_learned/auto_sync_failed_feb16.md"
+    },
+    {
+      "@type": "ListItem",
+      "position": 86,
+      "name": "Portfolio sync failed - blind trading risk",
+      "url": "https://github.com/IgorGanapolsky/trading/blob/main/rag_knowledge/lessons_learned/auto_sync_failed_feb16_2.md"
+    },
+    {
+      "@type": "ListItem",
+      "position": 87,
       "name": "Automated Position Management Requirements (Feb 8, 2026)",
       "url": "https://github.com/IgorGanapolsky/trading/blob/main/rag_knowledge/lessons_learned/automated_position_management_feb08.md"
     },
     {
       "@type": "ListItem",
-      "position": 86,
+      "position": 88,
       "name": "Iron Condor Backtest Findings (Feb 8, 2026)",
       "url": "https://github.com/IgorGanapolsky/trading/blob/main/rag_knowledge/lessons_learned/iron_condor_backtest_findings_feb08.md"
     },
     {
       "@type": "ListItem",
-      "position": 87,
+      "position": 89,
       "name": "LL-131: NEVER Tell CEO to Run CI - Do It Yourself",
       "url": "https://github.com/IgorGanapolsky/trading/blob/main/rag_knowledge/lessons_learned/ll_131_never_tell_ceo_to_run_ci_jan12.md"
     },
     {
       "@type": "ListItem",
-      "position": 88,
+      "position": 90,
       "name": "LL-133: Lesson Learned #133: Registry.py Missing Broke All Trading Strategies",
       "url": "https://github.com/IgorGanapolsky/trading/blob/main/rag_knowledge/lessons_learned/ll_133_registry_fix_and_hygiene_jan12.md"
     },
     {
       "@type": "ListItem",
-      "position": 89,
+      "position": 91,
       "name": "LL-135: Comprehensive Investment Strategy Review - January 12, 2026",
       "url": "https://github.com/IgorGanapolsky/trading/blob/main/rag_knowledge/lessons_learned/ll_135_investment_strategy_comprehensive_review_jan12.md"
     },
     {
       "@type": "ListItem",
-      "position": 90,
+      "position": 92,
       "name": "LL-144: Stale Order Threshold Must Be 4 Hours, Not 24",
       "url": "https://github.com/IgorGanapolsky/trading/blob/main/rag_knowledge/lessons_learned/ll_144_stale_order_threshold_fix_jan12.md"
     },
     {
       "@type": "ListItem",
-      "position": 91,
+      "position": 93,
       "name": "LL-148: Missing Test Files Blocking ALL Trading",
       "url": "https://github.com/IgorGanapolsky/trading/blob/main/rag_knowledge/lessons_learned/ll_148_missing_test_files_blocking_trading_jan13.md"
     },
     {
       "@type": "ListItem",
-      "position": 92,
+      "position": 94,
       "name": "LL-153: Three More Missing Test Files Blocking CI",
       "url": "https://github.com/IgorGanapolsky/trading/blob/main/rag_knowledge/lessons_learned/ll_153_ci_missing_tests_jan13.md"
     },
     {
       "@type": "ListItem",
-      "position": 93,
+      "position": 95,
       "name": "LL-157: RAG Webhook Analytical Query Routing Fix",
       "url": "https://github.com/IgorGanapolsky/trading/blob/main/rag_knowledge/lessons_learned/ll_157_rag_webhook_analytical_query_routing_jan13.md"
     },
     {
       "@type": "ListItem",
-      "position": 94,
+      "position": 96,
       "name": "LL-158: Lesson LL-158: Day 74 Emergency Fix - SPY to SOFI",
       "url": "https://github.com/IgorGanapolsky/trading/blob/main/rag_knowledge/lessons_learned/ll_158_day74_emergency_fix_jan13.md"
     },
     {
       "@type": "ListItem",
-      "position": 95,
+      "position": 97,
       "name": "LL-161: Options Buying Power $0 Despite $5K Cash - Root Cause",
       "url": "https://github.com/IgorGanapolsky/trading/blob/main/rag_knowledge/lessons_learned/ll_161_zero_options_buying_power_root_cause_jan13.md"
     },
     {
       "@type": "ListItem",
-      "position": 96,
+      "position": 98,
       "name": "LL-162: RAG System Analysis - Build vs Buy vs Already Have",
       "url": "https://github.com/IgorGanapolsky/trading/blob/main/rag_knowledge/lessons_learned/ll_162_rag_system_analysis_jan13.md"
     },
     {
       "@type": "ListItem",
-      "position": 97,
+      "position": 99,
       "name": "LL-166: RAG Webhook Missing LanceDB - Only Local Keyword Search",
       "url": "https://github.com/IgorGanapolsky/trading/blob/main/rag_knowledge/lessons_learned/ll_166_rag_webhook_lancedb_missing_jan13.md"
     },
     {
       "@type": "ListItem",
-      "position": 98,
+      "position": 100,
       "name": "LL-168: Alpaca Does NOT Support Trailing Stops for Options",
       "url": "https://github.com/IgorGanapolsky/trading/blob/main/rag_knowledge/lessons_learned/ll_168_alpaca_options_no_trailing_stop_jan13.md"
     },
     {
       "@type": "ListItem",
-      "position": 99,
+      "position": 101,
       "name": "LL-172: Prevent Duplicate Short Positions",
       "url": "https://github.com/IgorGanapolsky/trading/blob/main/rag_knowledge/lessons_learned/ll_172_prevent_duplicate_short_positions_jan13.md"
     },
     {
       "@type": "ListItem",
-      "position": 100,
+      "position": 102,
       "name": "LL-174: Repeated Rule #1 Violation - Still Holding Losing Positions",
       "url": "https://github.com/IgorGanapolsky/trading/blob/main/rag_knowledge/lessons_learned/ll_174_rule1_violation_jan13_session2.md"
     },
     {
       "@type": "ListItem",
-      "position": 101,
+      "position": 103,
       "name": "LL-175: Repeated Workflow Trigger Without Checking Logs",
       "url": "https://github.com/IgorGanapolsky/trading/blob/main/rag_knowledge/lessons_learned/ll_175_stop_repeating_failures_jan13.md"
     },
     {
       "@type": "ListItem",
-      "position": 102,
+      "position": 104,
       "name": "LL-176: Lesson ll_176: Pattern Day Trading (PDT) Protection Blocked Trade",
       "url": "https://github.com/IgorGanapolsky/trading/blob/main/rag_knowledge/lessons_learned/ll_176_pdt_protection_blocks_trade_jan13.md"
     },
     {
       "@type": "ListItem",
-      "position": 103,
+      "position": 105,
       "name": "LL-185: North Star Revision - From $100/day to $25/day (Data-Driven)",
       "url": "https://github.com/IgorGanapolsky/trading/blob/main/rag_knowledge/lessons_learned/ll_185_north_star_revision_data_driven_jan13.md"
     },
     {
       "@type": "ListItem",
-      "position": 104,
+      "position": 106,
       "name": "LL-190: SOFI CSP Opened During Earnings Blackout",
       "url": "https://github.com/IgorGanapolsky/trading/blob/main/rag_knowledge/lessons_learned/ll_190_sofi_blackout_violation_jan13.md"
     },
     {
       "@type": "ListItem",
-      "position": 105,
+      "position": 107,
       "name": "LL-193: Mandate Violation - Manual Work Handoff",
       "url": "https://github.com/IgorGanapolsky/trading/blob/main/rag_knowledge/lessons_learned/ll_193_mandate_violation_manual_handoff_jan14.md"
     },
     {
       "@type": "ListItem",
-      "position": 106,
+      "position": 108,
       "name": "LL-175: Trade Gateway Rule #1 Enforcement Fixed",
       "url": "https://github.com/IgorGanapolsky/trading/blob/main/rag_knowledge/lessons_learned/ll_196_trade_gateway_rule1_fix_jan13.md"
     },
     {
       "@type": "ListItem",
-      "position": 107,
+      "position": 109,
       "name": "LL-201: Resource Evaluation: Systems Thinking Audiobook",
       "url": "https://github.com/IgorGanapolsky/trading/blob/main/rag_knowledge/lessons_learned/ll_201_systems_thinking_audiobook_evaluation_jan14.md"
     },
     {
       "@type": "ListItem",
-      "position": 108,
+      "position": 110,
       "name": "LL-202: SOFI Earnings Risk - Emergency Close",
       "url": "https://github.com/IgorGanapolsky/trading/blob/main/rag_knowledge/lessons_learned/ll_202_sofi_earnings_risk_jan14.md"
     },
     {
       "@type": "ListItem",
-      "position": 109,
+      "position": 111,
       "name": "LL-205: January 14, 2026 Loss Root Cause Analysis",
       "url": "https://github.com/IgorGanapolsky/trading/blob/main/rag_knowledge/lessons_learned/ll_205_jan14_loss_root_cause_analysis.md"
     },
     {
       "@type": "ListItem",
-      "position": 110,
+      "position": 112,
       "name": "LL-206: Why $5K Account Failed - Complete Execution Failure Analysis",
       "url": "https://github.com/IgorGanapolsky/trading/blob/main/rag_knowledge/lessons_learned/ll_206_execution_failure_analysis_jan15.md"
     },
     {
       "@type": "ListItem",
-      "position": 111,
+      "position": 113,
       "name": "LL-207: Deep Research - Daily Income Math Reality",
       "url": "https://github.com/IgorGanapolsky/trading/blob/main/rag_knowledge/lessons_learned/ll_207_income_math_deep_research_jan15.md"
     },
     {
       "@type": "ListItem",
-      "position": 112,
+      "position": 114,
       "name": "LL-208: Why $5K Failed While $100K Succeeded",
       "url": "https://github.com/IgorGanapolsky/trading/blob/main/rag_knowledge/lessons_learned/ll_208_why_5k_failed_100k_succeeded_jan15.md"
     },
     {
       "@type": "ListItem",
-      "position": 113,
+      "position": 115,
       "name": "LL-209: Critical Math Error - SPY Credit Spreads Were Always Affordable",
       "url": "https://github.com/IgorGanapolsky/trading/blob/main/rag_knowledge/lessons_learned/ll_209_math_error_spy_spreads_affordable_jan15.md"
     },
     {
       "@type": "ListItem",
-      "position": 114,
+      "position": 116,
       "name": "LL-217: Lesson Learned LL-217: OptionsRiskMonitor Paper Arg Crisis",
       "url": "https://github.com/IgorGanapolsky/trading/blob/main/rag_knowledge/lessons_learned/ll_217_options_risk_monitor_paper_arg_crisis_jan15.md"
     },
     {
       "@type": "ListItem",
-      "position": 115,
+      "position": 117,
       "name": "LL-220: North Star 30-Month Roadmap to $100/Day",
       "url": "https://github.com/IgorGanapolsky/trading/blob/main/rag_knowledge/lessons_learned/ll_220_north_star_30month_roadmap_jan15.md"
     },
     {
       "@type": "ListItem",
-      "position": 116,
+      "position": 118,
       "name": "LL-224: Resource Evaluation: Agentic Memory Paper",
       "url": "https://github.com/IgorGanapolsky/trading/blob/main/rag_knowledge/lessons_learned/ll_224_agentic_memory_paper_evaluation_jan13.md"
     },
     {
       "@type": "ListItem",
-      "position": 117,
+      "position": 119,
       "name": "LL-225: Dead Code Cleanup - January 13, 2026",
       "url": "https://github.com/IgorGanapolsky/trading/blob/main/rag_knowledge/lessons_learned/ll_225_dead_code_cleanup_jan13.md"
     },
     {
       "@type": "ListItem",
-      "position": 118,
+      "position": 120,
       "name": "LL-203: CTO Directive Violations - Crisis Level",
       "url": "https://github.com/IgorGanapolsky/trading/blob/main/rag_knowledge/lessons_learned/ll_226_cto_directive_violations_jan14.md"
-    },
-    {
-      "@type": "ListItem",
-      "position": 119,
-      "name": "LL-228: Sandbox Git Proxy Limitations",
-      "url": "https://github.com/IgorGanapolsky/trading/blob/main/rag_knowledge/lessons_learned/ll_228_sandbox_git_proxy_limitations_jan14.md"
-    },
-    {
-      "@type": "ListItem",
-      "position": 120,
-      "name": "LL-231: Failure Analysis - Why Critical Fixes Were Lost (Jan 16, 2026)",
-      "url": "https://github.com/IgorGanapolsky/trading/blob/main/rag_knowledge/lessons_learned/ll_231_failure_analysis_jan16.md"
     }
   ]
 }

--- a/scripts/build_rag_query_index.py
+++ b/scripts/build_rag_query_index.py
@@ -137,8 +137,6 @@ def build_index() -> list[dict]:
     )
 
     for path in sorted(RAG_ROOT.rglob("*.md")):
-        if path.stem.startswith("tars_"):
-            continue
         text = path.read_text(encoding="utf-8", errors="ignore")
         frontmatter = _parse_frontmatter(text)
         rel_path = path.relative_to(RAG_ROOT)

--- a/tests/test_manage_iron_condor_positions.py
+++ b/tests/test_manage_iron_condor_positions.py
@@ -92,11 +92,11 @@ class TestExitConditions:
         assert should_exit is True
         assert reason == "DTE_EXIT"
 
-    def test_exit_at_50_percent_profit(self):
-        """Should exit when profit >= 50% of credit."""
+    def test_exit_at_profit_target(self):
+        """Should exit when profit >= configured target (75% of credit)."""
         ic = {
             "expiry": datetime.now() + timedelta(days=30),  # Not near expiry
-            "total_pl": 120,  # 60% profit
+            "total_pl": 160,  # 80% profit
             "credit_received": 200,
         }
         should_exit, reason, _ = check_exit_conditions(ic)

--- a/tests/test_options_risk_monitor.py
+++ b/tests/test_options_risk_monitor.py
@@ -183,9 +183,10 @@ class TestShouldClosePosition:
         assert "stop-loss triggered" in reason.lower()
 
     def test_position_just_below_max_loss_no_close(self, monitor, credit_spread_position):
-        """Position just below 2x credit should not trigger close."""
-        # Just below stop-loss: spread costs $1.79 (loss = $1.19 < $1.20)
-        credit_spread_position.current_price = 1.79
+        """Position just below configured stop-loss should not trigger close."""
+        # Stop-loss is 1x credit by default: max loss = $0.60
+        # Just below stop-loss: spread costs $1.19 (loss = $0.59 < $0.60)
+        credit_spread_position.current_price = 1.19
         monitor.add_position(credit_spread_position)
         should_close, reason = monitor.should_close_position("SPY240119P00480000")
 
@@ -287,7 +288,7 @@ class TestCheckRisk:
         """Position near stop-loss should have 'warning' status."""
         position_data = {
             "entry_price": 0.60,
-            "current_price": 1.60,  # Loss = $1.00, near 2x credit ($1.20)
+            "current_price": 1.10,  # Loss = $0.50, near 1x credit ($0.60)
             "position_type": "credit_spread",
             "credit_received": 0.60,
         }
@@ -423,16 +424,16 @@ class TestRealWorldScenario:
         should_close, _ = monitor.should_close_position("SPY240215P00475000")
         assert should_close is False  # Loss $40, under $120 max
 
-        # Day 7: Market crashes, approaching stop-loss
-        monitor.update_position_price("SPY240215P00475000", 1.70)
+        # Day 7: Market dips further, approaching stop-loss
+        monitor.update_position_price("SPY240215P00475000", 1.10)
         risk = monitor.check_risk("SPY240215P00475000")
         assert risk["status"] == "warning"  # 75%+ of max loss
 
         # Day 8: Stop-loss triggered
-        monitor.update_position_price("SPY240215P00475000", 1.80)
+        monitor.update_position_price("SPY240215P00475000", 1.20)
         should_close, reason = monitor.should_close_position("SPY240215P00475000")
         assert should_close is True
-        assert "2x credit stop-loss triggered" in reason
+        assert "stop-loss triggered" in reason.lower()
 
     def test_iwm_credit_spread_scenario(self):
         """Test IWM credit spread (secondary ticker per CLAUDE.md)."""


### PR DESCRIPTION
## What this fixes
- Fixes `build_rag_query_index` opt-in behavior so `INCLUDE_ARTIFACT_INGEST_LESSONS=1` actually includes artifact-ingest entries (it was being unconditionally filtered by stem prefix).
- Aligns risk/exit tests with the active strategy constants now used by code:
  - `75%` profit target
  - `1x` credit stop-loss
- Regenerates curated lessons index artifacts.

## Why this PR
Main CI `Run All Tests` failed on 5 tests in run `22078917238`:
- `tests/test_build_rag_query_index.py::test_build_index_can_include_tars_artifact_ingest_with_opt_in`
- `tests/test_manage_iron_condor_positions.py::TestExitConditions::test_exit_at_50_percent_profit`
- `tests/test_options_risk_monitor.py::TestShouldClosePosition::test_position_just_below_max_loss_no_close`
- `tests/test_options_risk_monitor.py::TestCheckRisk::test_check_risk_warning_status`
- `tests/test_options_risk_monitor.py::TestRealWorldScenario::test_spy_credit_spread_scenario`

## Validation
- `ruff check scripts/build_rag_query_index.py tests/test_build_rag_query_index.py tests/test_manage_iron_condor_positions.py tests/test_options_risk_monitor.py`
- `pytest -q tests/test_build_rag_query_index.py tests/test_manage_iron_condor_positions.py tests/test_options_risk_monitor.py`
- `pytest -q tests/test_actionable_task_engine.py tests/test_agent_workflow_toolkit.py tests/test_agentic_cycle.py tests/test_ai_credit_stress_signal.py tests/test_alpaca_client.py tests/test_alpaca_executor.py tests/test_alpaca_trader_smoke.py tests/test_blog_seo.py tests/test_box_workspace_mirror.py tests/test_build_rag_query_index.py tests/test_manage_iron_condor_positions.py tests/test_options_risk_monitor.py`
- `python3 scripts/build_rag_query_index.py`
