### PR TITLE
fix: close CodeQL cadence clear-text storage alert

### DIFF
--- a/scripts/check_weekly_cadence_gate.py
+++ b/scripts/check_weekly_cadence_gate.py
@@ -220,15 +220,19 @@ def main() -> int:
     )
 
     report = _sanitize(markdown_report(result), multiline=True)
-    public_report = _sanitize(markdown_public_report(result), multiline=True)
     if args.out:
         out_path = Path(_sanitize(args.out))
         out_path.parent.mkdir(parents=True, exist_ok=True)
-        # Persist only public-safe, schema-limited summary.
-        # Avoid writing free-text diagnostic payloads from state data.
-        safe_report = public_report
+        # SECURITY: Do not persist state-derived cadence values to disk from this
+        # checker. Keep detailed metrics in stdout (ephemeral CI stream) and write
+        # only a static marker artifact.
+        safe_report = (
+            "# Weekly Cadence KPI Artifact\n\n"
+            "Detailed cadence metrics are emitted to stdout only.\n"
+            "This file is an execution marker for workflow evidence.\n"
+        )
         with open(str(out_path), "w", encoding="utf-8") as f:
-            f.write(safe_report + "\n")
+            f.write(safe_report)
         print(f"ok: cadence report -> {_sanitize(out_path)}")
 
     if args.json:


### PR DESCRIPTION
## Summary
- Address CodeQL alert `py/clear-text-storage-sensitive-data` in `scripts/check_weekly_cadence_gate.py`.
- Remove state-derived markdown persistence for `--out` artifacts.
- Keep detailed cadence metrics in stdout; write only a static execution-marker artifact to disk.

## Validation
- `python3 -m pytest -q tests/test_weekly_cadence_gate.py --tb=short`
- `ruff format --check scripts/check_weekly_cadence_gate.py`
