### PR TITLE
fix(judge-demo): remove ambiguous UNKNOWN/ERROR status signals

### DIFF
--- a/docs/lessons/judge-demo.html
+++ b/docs/lessons/judge-demo.html
@@ -183,12 +183,13 @@
           <tr><td>Service Tier</td><td>default</td></tr>
           <tr><td>Request ID</td><td><span class="mono">chatcmpl-D9wEQoleLlGC22K3sGc2RSdKhIuGr</span></td></tr>
           <tr><td>Runs</td><td>1</td></tr>
+          <tr><td>Latest Smoke Probe</td><td>PASS <span class="chip pass">PASS</span></td></tr>
           <tr><td>Success Rate</td><td>0.0%</td></tr>
           <tr><td>Actionable Rate</td><td>0.0%</td></tr>
           <tr><td>P95 Latency</td><td>1626.0 ms</td></tr>
           <tr><td>Token Envelope</td><td>30 prompt / 20 completion / 50 total</td></tr>
           <tr><td>Token Economics</td><td>$0.00004500 (0.000900 / 1K tokens)</td></tr>
-          <tr><td>Schema Gate (router_check)</td><td>UNKNOWN <span class="chip unknown">UNKNOWN</span></td></tr>
+          <tr><td>Schema Gate (router_check)</td><td>PASS <span class="chip pass">PASS</span></td></tr>
           <tr><td>Fallback Probe OK</td><td>0</td></tr>
           <tr><td>Estimated Cost / Smoke Run</td><td>$0.00004500</td></tr>
           <tr><td>Generated</td><td>2026-02-16T20:08:36Z</td></tr>

--- a/docs/lessons/ops-status.html
+++ b/docs/lessons/ops-status.html
@@ -59,8 +59,8 @@
       <article class="card span3"><div class="k">Gateway Latency</div><div class="v">1626 ms</div></article>
       <article class="card span3"><div class="k">Gateway Cost</div><div class="v">$0.00004500</div></article>
       <article class="card span3"><div class="k">Paper P/L</div><div class="v">$1,498.24 (1.50%)</div></article>
-      <article class="card span6"><div class="k">Resilience Check</div><div class="v"><span class="chip warn">ERROR</span></div><div class="k">type=invalid_request_error</div><div class="k">message=The specified model is not enabled for this mode or does not exist</div></article>
-      <article class="card span6"><div class="k">Win Rate Context</div><div class="v">100.00%</div><div class="k">sample_size=1 (must reach 30 for projection quality)</div><div class="k">Generated: 2026-02-17T18:03:47Z</div></article>
+      <article class="card span6"><div class="k">Resilience Check</div><div class="v"><span class="chip pass">EXPECTED_PATH</span></div><div class="k">test=invalid_model_error_path</div><div class="k">type=invalid_request_error</div><div class="k">message=The specified model is not enabled for this mode or does not exist</div></article>
+      <article class="card span6"><div class="k">Win Rate Context</div><div class="v">100.00%</div><div class="k">sample_size=1 (must reach 30 for projection quality)</div><div class="k">Generated: 2026-02-17T18:09:38Z</div></article>
 
       <article class="card span8">
         <div class="k">Readiness Metrics</div>
@@ -97,7 +97,31 @@
 
       <article class="card span6">
         <div class="k">Active Runtime Report</div>
-        <p>No runtime report available yet.</p>
+        <pre class='runtime'># Live Task Runtime Report
+
+- Generated (UTC): `2026-02-17T18:09:38Z`
+- Open Layer-1 tasks: `2`
+
+## Active Tasks (with elapsed time)
+- `ACTIVE` Add expectancy metrics (profit factor, avg winner, avg loser) to `scripts/generate_profit_readiness_scorecard.py`. (elapsed: 47s)
+- `ACTIVE` Add a promotion gate artifact that blocks strategy promotion when win rate/run-rate thresholds are below target. (elapsed: 47s)
+
+## Current Task In Progress
+- Task: Add expectancy metrics (profit factor, avg winner, avg loser) to `scripts/generate_profit_readiness_scorecard.py`.
+- Started (UTC): `2026-02-17T18:08:51Z`
+- Elapsed: `47s`
+
+## Runtime Phases
+- No phase timing detected yet.
+
+## Newly Added Tasks This Run
+- None
+
+## Sources
+- `manual_layer1_tasks.md`
+- `artifacts/devloop/continuous.log`
+
+</pre>
       </article>
     </section>
   </div>

--- a/scripts/generate_judge_demo_page.py
+++ b/scripts/generate_judge_demo_page.py
@@ -50,18 +50,34 @@ def parse_smoke_response(smoke_response: dict) -> dict[str, object]:
     completion_tokens = int(usage.get("completion_tokens", 0) or 0)
     total_tokens = int(usage.get("total_tokens", 0) or 0)
 
-    choices_payload = smoke_response.get("choices", "") if isinstance(smoke_response, dict) else ""
-    if not isinstance(choices_payload, str):
-        choices_payload = str(choices_payload)
+    candidates: list[str] = []
+    choices_payload = smoke_response.get("choices") if isinstance(smoke_response, dict) else None
+    if isinstance(choices_payload, list):
+        for choice in choices_payload:
+            if not isinstance(choice, dict):
+                continue
+            message = choice.get("message", {})
+            if isinstance(message, dict) and isinstance(message.get("content"), str):
+                candidates.append(message["content"])
+    elif isinstance(choices_payload, str):
+        candidates.append(choices_payload)
 
     router_check = False
-    json_block_match = re.search(r"\{[\s\S]*\}", choices_payload)
-    if json_block_match:
+    for content in candidates:
+        fenced_match = re.search(r"```(?:json)?\s*(\{[\s\S]*?\})\s*```", content, re.IGNORECASE)
+        json_candidate = fenced_match.group(1) if fenced_match else None
+        if not json_candidate:
+            block_match = re.search(r"\{[\s\S]*\}", content)
+            json_candidate = block_match.group(0) if block_match else None
+        if not json_candidate:
+            continue
         try:
-            payload = json.loads(json_block_match.group(0))
-            router_check = bool(payload.get("router_check"))
+            payload = json.loads(json_candidate)
+            if isinstance(payload, dict) and "router_check" in payload:
+                router_check = bool(payload.get("router_check"))
+                break
         except Exception:
-            router_check = False
+            continue
 
     return {
         "model": model,
@@ -206,6 +222,9 @@ def main() -> int:
     fallback_probe_ok_count = exec_daily.get("fallback_probe_ok_count", 0) if has_exec_daily else 0
     est_cost_value = as_float(est_cost, 0.0)
     cost_per_1k = (est_cost_value / total_tokens) * 1000.0 if total_tokens > 0 else 0.0
+    smoke_probe_ok = bool(smoke_response.get("id")) and not bool(smoke_response.get("error"))
+    smoke_probe_text = "PASS" if smoke_probe_ok else "WARN"
+    smoke_probe_chip = status_chip("PASS" if smoke_probe_ok else "WARN")
 
     paper = system_state.get("paper_account", {}) if isinstance(system_state, dict) else {}
     north_star = system_state.get("north_star", {}) if isinstance(system_state, dict) else {}
@@ -415,6 +434,7 @@ def main() -> int:
           <tr><td>Service Tier</td><td>{smoke_service_tier}</td></tr>
           <tr><td>Request ID</td><td><span class="mono">{smoke_request_id}</span></td></tr>
           <tr><td>Runs</td><td>{exec_runs}</td></tr>
+          <tr><td>Latest Smoke Probe</td><td>{smoke_probe_text} {smoke_probe_chip}</td></tr>
           <tr><td>Success Rate</td><td>{exec_success}%</td></tr>
           <tr><td>Actionable Rate</td><td>{exec_actionable}%</td></tr>
           <tr><td>P95 Latency</td><td>{exec_p95} ms</td></tr>

--- a/scripts/generate_ops_status_page.py
+++ b/scripts/generate_ops_status_page.py
@@ -122,13 +122,20 @@ def main() -> int:
     generated_at = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
 
     has_error = resilience.get("has_error_field", "false").lower() == "true"
+    resilience_test = resilience.get("test", "unknown")
     err_type = resilience.get("error_type", "none")
     err_msg = resilience.get("error_message", "none")
-    resilience_status = (
-        '<span class="chip warn">ERROR</span>'
-        if has_error
-        else '<span class="chip pass">PASS</span>'
+    expected_invalid_model_path = (
+        resilience_test == "invalid_model_error_path"
+        and has_error
+        and err_type == "invalid_request_error"
     )
+    if expected_invalid_model_path:
+        resilience_status = '<span class="chip pass">EXPECTED_PATH</span>'
+    elif has_error:
+        resilience_status = '<span class="chip warn">ERROR</span>'
+    else:
+        resilience_status = '<span class="chip pass">PASS</span>'
     repo_blob = "https://github.com/IgorGanapolsky/trading/blob/main"
 
     runtime_block = (
@@ -200,7 +207,7 @@ def main() -> int:
       <article class="card span3"><div class="k">Gateway Latency</div><div class="v">{latency} ms</div></article>
       <article class="card span3"><div class="k">Gateway Cost</div><div class="v">${cost}</div></article>
       <article class="card span3"><div class="k">Paper P/L</div><div class="v">${total_pl:,.2f} ({total_pl_pct:.2f}%)</div></article>
-      <article class="card span6"><div class="k">Resilience Check</div><div class="v">{resilience_status}</div><div class="k">type={err_type}</div><div class="k">message={err_msg}</div></article>
+      <article class="card span6"><div class="k">Resilience Check</div><div class="v">{resilience_status}</div><div class="k">test={resilience_test}</div><div class="k">type={err_type}</div><div class="k">message={err_msg}</div></article>
       <article class="card span6"><div class="k">Win Rate Context</div><div class="v">{paper_win_rate:.2f}%</div><div class="k">sample_size={paper_samples} (must reach 30 for projection quality)</div><div class="k">Generated: {generated_at}</div></article>
 
       <article class="card span8">


### PR DESCRIPTION
## Summary
- fix `router_check` extraction from `smoke_response.json` by parsing `choices[].message.content` fenced JSON correctly
- add explicit `Latest Smoke Probe` status row so smoke health is unambiguous
- classify resilience `invalid_model_error_path` as `EXPECTED_PATH` (instead of generic ERROR) in ops status
- regenerate `docs/lessons/judge-demo.html` and `docs/lessons/ops-status.html`

## Validation
- ruff check scripts/generate_judge_demo_page.py scripts/generate_ops_status_page.py
- pytest -q tests/test_generate_judge_demo_page.py tests/test_generate_ops_status_page.py
