### PR TITLE
feat(autonomy): refresh credit stress + weekly gate before trading

### DIFF
--- a/scripts/autonomous_trader.py
+++ b/scripts/autonomous_trader.py
@@ -37,6 +37,7 @@ except Exception as e:
 
 SYSTEM_STATE_PATH = Path(os.getenv("SYSTEM_STATE_PATH", "data/system_state.json"))
 
+
 def _refresh_risk_overlays(logger) -> None:
     """Best-effort refresh of regime/risk overlays used by mandatory trade gate.
 

--- a/tests/test_autonomous_trader_risk_overlays.py
+++ b/tests/test_autonomous_trader_risk_overlays.py
@@ -22,4 +22,3 @@ def test_refresh_risk_overlays_invokes_updater_scripts():
 
         assert any("update_ai_credit_stress_signal.py" in str(part) for part in first_cmd)
         assert any("update_north_star_operating_plan.py" in str(part) for part in second_cmd)
-


### PR DESCRIPTION
Ensures runtime autonomy for risk overlays by refreshing:
- `ai_credit_stress` (FRED public series, synced into `data/system_state.json`)
- `north_star_weekly_gate` (derived weekly sizing/block gate)

Changes:
- Run overlay refresh in `scripts/autonomous_trader.py` before trading starts
- Add unit test to verify updater scripts are invoked

Tests:
- `pytest -q tests/test_autonomous_trader_risk_overlays.py`