### PR TITLE
fix(ci): harden Artifact Registry auth for webhook deploy

### DIFF
--- a/.github/workflows/deploy-rag-webhook.yml
+++ b/.github/workflows/deploy-rag-webhook.yml
@@ -41,7 +41,14 @@ jobs:
           project_id: ${{ env.PROJECT_ID }}
 
       - name: Configure Docker auth
-        run: gcloud auth configure-docker ${{ env.REGION }}-docker.pkg.dev --quiet
+        run: |
+          gcloud auth configure-docker ${{ env.REGION }}-docker.pkg.dev --quiet
+          # Extra defense-in-depth: ensure docker is logged in even if cred helpers
+          # are not honored in some runner edge cases.
+          gcloud auth print-access-token | docker login \
+            -u oauth2accesstoken \
+            --password-stdin \
+            https://${{ env.REGION }}-docker.pkg.dev
 
       - name: Prepare Dockerfile
         run: |


### PR DESCRIPTION
Problem: main workflow 'Deploy RAG Webhook' failed on 2026-02-18 with 'error from registry: failed authentication' during docker push.

Fix:
- After 'gcloud auth configure-docker', also perform an explicit docker login using a short-lived access token to ensure credentials are present for Artifact Registry.

Expected outcome:
- docker push succeeds reliably; Cloud Run deploy can proceed.
