### PR TITLE
fix(ci): auto-link GCP billing before webhook deploy

### DIFF
--- a/.github/workflows/deploy-rag-webhook.yml
+++ b/.github/workflows/deploy-rag-webhook.yml
@@ -16,6 +16,7 @@ env:
   PROJECT_ID: igor-trading-2025-v2
   REGION: us-central1
   SERVICE_NAME: trading-rag-webhook
+  BILLING_ACCOUNT: 013920-9AC710-4EFE94
 
   SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
   SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
@@ -39,6 +40,11 @@ jobs:
         uses: google-github-actions/setup-gcloud@v3
         with:
           project_id: ${{ env.PROJECT_ID }}
+
+      - name: Ensure project billing is linked
+        run: |
+          gcloud billing projects link ${{ env.PROJECT_ID }} \
+            --billing-account=${{ env.BILLING_ACCOUNT }}
 
       - name: Prepare Dockerfile
         run: |


### PR DESCRIPTION
Deploy runs keep failing in Cloud Run with CONSUMER_INVALID / permission denied on project. Root cause is project billing detached.

This change makes deploy self-heal by linking billing at workflow runtime before deploy:
- adds BILLING_ACCOUNT env
- adds  step

This uses the same authenticated service account already used for deployment.