### PR TITLE
feat(llm): schema-first trade opinion output with robust parsing

### DIFF
--- a/src/llm/trade_opinion.py
+++ b/src/llm/trade_opinion.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 
 import json
 import logging
+import re
 from typing import Any
 
 from pydantic import BaseModel, Field
@@ -30,6 +31,7 @@ from src.utils.llm_gateway import (
 from src.utils.model_selector import get_model_selector
 
 logger = logging.getLogger(__name__)
+JSON_BLOCK_RE = re.compile(r"```(?:json)?\s*(\{.*?\})\s*```", re.IGNORECASE | re.DOTALL)
 
 
 # =============================================================================
@@ -65,6 +67,117 @@ class TradeOpinion(BaseModel):
 # =============================================================================
 # PRE-TRADE RESEARCH AGENT
 # =============================================================================
+
+
+def _trade_opinion_schema() -> dict[str, Any]:
+    """Return strict JSON schema for provider-native structured output."""
+    schema = TradeOpinion.model_json_schema()
+    if isinstance(schema, dict):
+        schema.setdefault("additionalProperties", False)
+    return schema
+
+
+def _response_format_candidates() -> list[dict[str, Any]]:
+    """
+    Ordered response format preferences.
+
+    1) Strict json_schema for providers that support schema-constrained output.
+    2) json_object fallback for providers that only support JSON mode.
+    """
+    return [
+        {
+            "type": "json_schema",
+            "json_schema": {
+                "name": "trade_opinion",
+                "strict": True,
+                "schema": _trade_opinion_schema(),
+            },
+        },
+        {"type": "json_object"},
+    ]
+
+
+def _extract_text_content(raw: Any) -> str:
+    """Normalize OpenAI-compatible message content into a single string."""
+    if isinstance(raw, str):
+        return raw
+    if isinstance(raw, list):
+        chunks: list[str] = []
+        for item in raw:
+            if isinstance(item, str):
+                chunks.append(item)
+            elif isinstance(item, dict):
+                text = item.get("text")
+                if isinstance(text, str):
+                    chunks.append(text)
+        return "\n".join(part.strip() for part in chunks if part.strip())
+    return ""
+
+
+def _parse_json_object(text: str) -> dict[str, Any]:
+    """Parse JSON object with defensive fallbacks for markdown-wrapped payloads."""
+    normalized = (text or "").strip()
+    if not normalized:
+        raise json.JSONDecodeError("Empty response", text, 0)
+
+    candidates: list[str] = [normalized]
+    match = JSON_BLOCK_RE.search(normalized)
+    if match:
+        candidates.append(match.group(1).strip())
+
+    first = normalized.find("{")
+    last = normalized.rfind("}")
+    if first >= 0 and last > first:
+        candidates.append(normalized[first : last + 1].strip())
+
+    seen: set[str] = set()
+    for candidate in candidates:
+        if candidate in seen:
+            continue
+        seen.add(candidate)
+        try:
+            parsed = json.loads(candidate)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(parsed, dict):
+            return parsed
+
+    raise json.JSONDecodeError("No JSON object found in response", normalized, 0)
+
+
+def _request_structured_completion(
+    client: Any,
+    *,
+    model: str,
+    messages: list[dict[str, str]],
+    max_tokens: int,
+) -> Any:
+    """
+    Call provider with structured output settings.
+
+    Tries strict schema mode first, then falls back to generic JSON mode.
+    """
+    last_exc: Exception | None = None
+    for fmt in _response_format_candidates():
+        try:
+            return client.chat.completions.create(
+                model=model,
+                messages=messages,
+                max_tokens=max_tokens,
+                response_format=fmt,
+            )
+        except Exception as exc:
+            last_exc = exc
+            logger.debug(
+                "Trade opinion: response_format=%s unsupported/failed (%s)",
+                fmt.get("type"),
+                exc,
+            )
+            continue
+
+    if last_exc is not None:
+        raise last_exc
+    raise RuntimeError("No response_format candidates configured")
 
 
 def get_trade_opinion(
@@ -117,15 +230,17 @@ def get_trade_opinion(
         )
         model_for_call = transport_model_id if using_gateway else model_id
 
+        messages = [
+            {"role": "system", "content": _system_prompt()},
+            {"role": "user", "content": prompt},
+        ]
+
         try:
-            response = client.chat.completions.create(
+            response = _request_structured_completion(
+                client,
                 model=model_for_call,
-                messages=[
-                    {"role": "system", "content": _system_prompt()},
-                    {"role": "user", "content": prompt},
-                ],
+                messages=messages,
                 max_tokens=2048,
-                response_format={"type": "json_object"},
             )
         except Exception as gateway_exc:
             # If we're routing through a gateway (TARS) and it fails, retry via
@@ -138,14 +253,11 @@ def get_trade_opinion(
                 fallback_client = OpenAI(
                     api_key=fallback_cfg.api_key, base_url=fallback_cfg.base_url
                 )
-                response = fallback_client.chat.completions.create(
+                response = _request_structured_completion(
+                    fallback_client,
                     model=model_id,
-                    messages=[
-                        {"role": "system", "content": _system_prompt()},
-                        {"role": "user", "content": prompt},
-                    ],
+                    messages=messages,
                     max_tokens=2048,
-                    response_format={"type": "json_object"},
                 )
             else:
                 raise
@@ -159,12 +271,12 @@ def get_trade_opinion(
             )
 
         # Parse response
-        text = response.choices[0].message.content if response.choices else ""
+        text = _extract_text_content(response.choices[0].message.content) if response.choices else ""
         if not text:
             logger.warning("Trade opinion: empty response from LLM")
             return None
 
-        data = json.loads(text)
+        data = _parse_json_object(text)
         opinion = TradeOpinion.model_validate(data)
 
         logger.info(

--- a/tests/test_trade_opinion.py
+++ b/tests/test_trade_opinion.py
@@ -19,6 +19,7 @@ import pytest
 from src.llm.trade_opinion import (
     TradeOpinion,
     _build_prompt,
+    _parse_json_object,
     _system_prompt,
     get_trade_opinion,
 )
@@ -224,6 +225,78 @@ class TestPromptConstruction:
         assert "5W/1L" in prompt
         assert "TRENDING_UP" in prompt
         assert "Avoid FOMC weeks" in prompt
+
+
+# =============================================================================
+# STRUCTURED OUTPUT RESILIENCE TESTS
+# =============================================================================
+
+
+class TestStructuredOutputResilience:
+    """Ensure schema-first calls degrade safely across provider capabilities."""
+
+    def test_parse_json_object_from_markdown_fence(self):
+        """Parser should handle JSON wrapped in markdown code fences."""
+        text = """```json
+{"should_trade": true, "confidence": 0.76, "regime": "calm", "reasoning": "ok"}
+```"""
+        parsed = _parse_json_object(text)
+        assert parsed["should_trade"] is True
+        assert parsed["confidence"] == 0.76
+        assert parsed["regime"] == "calm"
+
+    @patch.dict(os.environ, {"OPENROUTER_API_KEY": "test-key"})
+    def test_schema_mode_falls_back_to_json_object(self):
+        """If json_schema is unsupported, client falls back to json_object."""
+        _ensure_openai_mock()
+
+        valid_response = json.dumps(
+            {
+                "should_trade": True,
+                "confidence": 0.8,
+                "regime": "calm",
+                "suggested_short_delta": 0.15,
+                "suggested_dte": 35,
+                "reasoning": "Fallback path succeeded.",
+                "risk_flags": [],
+            }
+        )
+
+        with patch("src.llm.trade_opinion.get_model_selector") as mock_sel:
+            mock_selector = MagicMock()
+            mock_selector.select_model.return_value = "deepseek/deepseek-r1"
+            mock_selector.get_model_provider.return_value = "openrouter"
+            mock_selector.get_transport_model_id.return_value = "deepseek/deepseek-r1"
+            mock_sel.return_value = mock_selector
+
+            with patch("openai.OpenAI") as mock_client_cls:
+                mock_client = MagicMock()
+                mock_response = MagicMock()
+                mock_choice = MagicMock()
+                mock_choice.message.content = valid_response
+                mock_response.choices = [mock_choice]
+                mock_response.usage = None
+
+                mock_client.chat.completions.create.side_effect = [
+                    RuntimeError("json_schema not supported"),
+                    mock_response,
+                ]
+                mock_client_cls.return_value = mock_client
+
+                result = get_trade_opinion(vix_current=19.0)
+
+                assert result is not None
+                assert result.should_trade is True
+                assert mock_client.chat.completions.create.call_count == 2
+
+                first_fmt = mock_client.chat.completions.create.call_args_list[0].kwargs[
+                    "response_format"
+                ]
+                second_fmt = mock_client.chat.completions.create.call_args_list[1].kwargs[
+                    "response_format"
+                ]
+                assert first_fmt["type"] == "json_schema"
+                assert second_fmt["type"] == "json_object"
 
 
 # =============================================================================


### PR DESCRIPTION
## Summary
- enforce schema-first structured output for `get_trade_opinion()` using provider-native `json_schema` first
- add automatic fallback to `json_object` when schema mode is unsupported
- harden response parsing to recover JSON from markdown fences and wrapped output
- keep advisory behavior and risk-gate compatibility unchanged

## Testing
- `pytest -q tests/test_trade_opinion.py`
- `ruff check src/llm/trade_opinion.py tests/test_trade_opinion.py`

## Why
This reduces brittle prompt-format failures and makes autonomous trading decisions more deterministic with typed contracts.
