### PR TITLE
Show as-of timestamps inside RAG chat panel

### DIFF
--- a/docs/rag-query.html
+++ b/docs/rag-query.html
@@ -517,6 +517,12 @@ layout: null
         padding: 20px;
       }
 
+      .chat-asof {
+        padding: 10px 20px 0;
+        color: var(--text-muted);
+        font-size: 0.82rem;
+      }
+
       .chat-messages {
         max-height: 400px;
         overflow-y: auto;
@@ -797,6 +803,10 @@ layout: null
 	          <span class="panel-icon">&#128172;</span>
 	          <span>Ask the Knowledge Base</span>
 	        </div>
+          <div class="chat-asof">
+            <div id="ragAsOfTextChat">Knowledge base as of: --</div>
+            <div id="systemAsOfTextChat">System sync as of: --</div>
+          </div>
 	        <div class="chat-container">
 	          <div class="chat-messages" id="chatMessages">
 	            <div class="chat-message assistant">
@@ -1379,6 +1389,7 @@ layout: null
         if (lessonDates.length === 0) {
           daysEl.textContent = "--";
           updateAsOfText("ragAsOfText", "Knowledge base as of", null);
+          updateAsOfText("ragAsOfTextChat", "Knowledge base as of", null);
           return;
         }
 
@@ -1391,6 +1402,7 @@ layout: null
           .filter((entry) => entry && Number.isFinite(entry.epochMs));
         asOfLessons.sort((a, b) => (b.epochMs || 0) - (a.epochMs || 0));
         updateAsOfText("ragAsOfText", "Knowledge base as of", asOfLessons[0] || null);
+        updateAsOfText("ragAsOfTextChat", "Knowledge base as of", asOfLessons[0] || null);
       }
 
       // Initialize
@@ -1830,11 +1842,17 @@ Tags: ${lesson.tags.join(", ")}`;
             "System sync as of",
             parseTimestampDetails(systemAsOfRaw),
           );
+          updateAsOfText(
+            "systemAsOfTextChat",
+            "System sync as of",
+            parseTimestampDetails(systemAsOfRaw),
+          );
 
           bar.classList.remove("loading");
         } catch {
           bar.classList.add("error");
           updateAsOfText("systemAsOfText", "System sync as of", null);
+          updateAsOfText("systemAsOfTextChat", "System sync as of", null);
         }
       }
 

--- a/tests/test_rag_query_north_star_status.py
+++ b/tests/test_rag_query_north_star_status.py
@@ -25,6 +25,8 @@ def test_rag_query_surface_has_explicit_as_of_timestamp_labels() -> None:
 
     assert 'id="ragAsOfText"' in html
     assert 'id="systemAsOfText"' in html
+    assert 'id="ragAsOfTextChat"' in html
+    assert 'id="systemAsOfTextChat"' in html
     assert "function parseTimestampDetails(raw)" in html
     assert "function updateAsOfText(id, prefix, details)" in html
     assert "function renderTimestampMetric(label, raw)" in html


### PR DESCRIPTION
## Summary
- mirror `Knowledge base as of` and `System sync as of` timestamps inside the chat panel
- keep existing header timestamps intact
- update UI tests to assert chat-panel timestamp nodes

## Validation
- `pytest -q tests/test_rag_query_north_star_status.py`