### PR TITLE
Automate North Star blocker issue monitoring and upsert

### DIFF
--- a/.github/workflows/north-star-blocker-watch.yml
+++ b/.github/workflows/north-star-blocker-watch.yml
@@ -1,0 +1,144 @@
+name: North Star Blocker Watch
+
+on:
+  schedule:
+    - cron: "17 */6 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  monitor:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: "pip"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements-minimal.txt
+
+      - name: Refresh broker state (best effort)
+        env:
+          ALPACA_API_KEY: ${{ secrets.ALPACA_PAPER_TRADING_API_KEY }}
+          ALPACA_SECRET_KEY: ${{ secrets.ALPACA_PAPER_TRADING_API_SECRET }}
+          ALPACA_BROKERAGE_TRADING_API_KEY: ${{ secrets.ALPACA_BROKERAGE_TRADING_API_KEY }}
+          ALPACA_BROKERAGE_TRADING_API_SECRET: ${{ secrets.ALPACA_BROKERAGE_TRADING_API_SECRET }}
+        run: |
+          python3 scripts/sync_alpaca_state.py || echo "sync_alpaca_state skipped/failed (continuing)"
+          python3 scripts/auto_clear_stale_trading_halt.py --json || true
+          python3 scripts/update_north_star_operating_plan.py
+
+      - name: Build blocker report artifacts
+        run: |
+          python3 scripts/build_north_star_blocker_report.py \
+            --state data/system_state.json \
+            --history data/north_star_weekly_history.json \
+            --halt-file data/TRADING_HALTED \
+            --json-out artifacts/devloop/north_star_blocker_report.json \
+            --markdown-out artifacts/devloop/north_star_blocker_report.md
+
+      - name: Upsert blocker issue
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require("fs");
+            const title = "North Star Blockers (Automated)";
+            const label = "north-star-blocker";
+            const reportPath = "artifacts/devloop/north_star_blocker_report.json";
+            const markdownPath = "artifacts/devloop/north_star_blocker_report.md";
+            const report = JSON.parse(fs.readFileSync(reportPath, "utf8"));
+            const body = fs.readFileSync(markdownPath, "utf8");
+
+            async function ensureLabel(name, color, description) {
+              try {
+                await github.rest.issues.getLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  name,
+                });
+              } catch (err) {
+                if (err.status !== 404) throw err;
+                await github.rest.issues.createLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  name,
+                  color,
+                  description,
+                });
+              }
+            }
+
+            await ensureLabel(
+              label,
+              "B60205",
+              "Automated North Star blocker tracking"
+            );
+
+            const openIssues = await github.paginate(github.rest.issues.listForRepo, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: "open",
+              labels: label,
+              per_page: 100,
+            });
+
+            const existing = openIssues.find(
+              (item) => !item.pull_request && item.title === title
+            );
+
+            if (report.blocked) {
+              if (existing) {
+                await github.rest.issues.update({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: existing.number,
+                  body,
+                });
+                core.info(`Updated blocker issue #${existing.number}`);
+              } else {
+                const created = await github.rest.issues.create({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  title,
+                  body,
+                  labels: [label],
+                });
+                core.info(`Created blocker issue #${created.data.number}`);
+              }
+            } else if (existing) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: existing.number,
+                body:
+                  `Auto-close: blockers cleared at ${report.generated_at_utc} UTC.\n\n` +
+                  "The monitor will reopen this issue automatically if blockers return.",
+              });
+              await github.rest.issues.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: existing.number,
+                state: "closed",
+              });
+              core.info(`Closed blocker issue #${existing.number}`);
+            } else {
+              core.info("No active blockers and no open blocker issue.");
+            }
+
+      - name: Upload report artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: north-star-blocker-report
+          path: |
+            artifacts/devloop/north_star_blocker_report.json
+            artifacts/devloop/north_star_blocker_report.md

--- a/scripts/build_north_star_blocker_report.py
+++ b/scripts/build_north_star_blocker_report.py
@@ -1,0 +1,427 @@
+#!/usr/bin/env python3
+"""Build North Star blocker report with dated evidence.
+
+This script is intentionally deterministic and side-effect free:
+- Reads local state files.
+- Computes blocker status + root causes.
+- Emits markdown and JSON artifacts for automation.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+def _load_json(path: Path) -> Any:
+    if not path.exists():
+        return {}
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except Exception:
+        return {}
+
+
+def _to_float(value: Any) -> float | None:
+    try:
+        return float(value)
+    except Exception:
+        return None
+
+
+def _to_int(value: Any) -> int | None:
+    try:
+        return int(value)
+    except Exception:
+        return None
+
+
+def _parse_dt(raw: Any) -> datetime | None:
+    if raw is None:
+        return None
+    text = str(raw).strip()
+    if not text:
+        return None
+    candidates = [text, text.replace("Z", "+00:00"), f"{text}T00:00:00+00:00"]
+    for candidate in candidates:
+        try:
+            dt = datetime.fromisoformat(candidate)
+            if dt.tzinfo is None:
+                dt = dt.replace(tzinfo=timezone.utc)
+            return dt.astimezone(timezone.utc)
+        except Exception:
+            continue
+    return None
+
+
+def _fmt_utc(dt: datetime | None) -> str:
+    if dt is None:
+        return "n/a"
+    return dt.isoformat().replace("+00:00", "Z")
+
+
+@dataclass
+class Blocker:
+    id: str
+    severity: str
+    message: str
+    evidence: str
+
+
+def _normalize_history_rows(raw: Any) -> list[dict[str, Any]]:
+    if not isinstance(raw, list):
+        return []
+    rows: list[dict[str, Any]] = []
+    for row in raw:
+        if not isinstance(row, dict):
+            continue
+        rows.append(
+            {
+                "week_start": str(row.get("week_start", "")),
+                "updated_at": str(row.get("updated_at", "")),
+                "mode": str(row.get("mode", "")),
+                "sample_size": _to_int(row.get("sample_size")) or 0,
+                "expectancy_per_trade": _to_float(row.get("expectancy_per_trade")),
+                "cadence_passed": bool(row.get("cadence_passed"))
+                if row.get("cadence_passed") is not None
+                else None,
+            }
+        )
+    rows.sort(
+        key=lambda r: _parse_dt(r.get("updated_at"))
+        or _parse_dt(r.get("week_start"))
+        or datetime.min.replace(tzinfo=timezone.utc),
+    )
+    return rows
+
+
+def compute_report(
+    *,
+    state: dict[str, Any],
+    weekly_history: list[dict[str, Any]],
+    halt_exists: bool,
+    now_utc: datetime,
+) -> dict[str, Any]:
+    meta = state.get("meta", {}) if isinstance(state.get("meta"), dict) else {}
+    weekly_gate = (
+        state.get("north_star_weekly_gate", {})
+        if isinstance(state.get("north_star_weekly_gate"), dict)
+        else {}
+    )
+    cadence = (
+        weekly_gate.get("cadence_kpi", {})
+        if isinstance(weekly_gate.get("cadence_kpi"), dict)
+        else {}
+    )
+    north_star = (
+        state.get("north_star", {}) if isinstance(state.get("north_star"), dict) else {}
+    )
+
+    blockers: list[Blocker] = []
+    warnings: list[Blocker] = []
+    root_causes: list[str] = []
+
+    if halt_exists:
+        blockers.append(
+            Blocker(
+                id="trading_halted",
+                severity="critical",
+                message="TRADING_HALTED is active; new risk-on entries are blocked.",
+                evidence="data/TRADING_HALTED exists.",
+            )
+        )
+        root_causes.append("Crisis latch is active.")
+
+    if not weekly_gate:
+        blockers.append(
+            Blocker(
+                id="weekly_gate_missing",
+                severity="high",
+                message="Weekly North Star gate data is missing.",
+                evidence="north_star_weekly_gate not found in system state.",
+            )
+        )
+        root_causes.append("Weekly gate snapshot unavailable.")
+    else:
+        expectancy = _to_float(weekly_gate.get("expectancy_per_trade"))
+        sample_size = _to_int(weekly_gate.get("sample_size")) or 0
+        mode = str(weekly_gate.get("mode") or "unknown")
+
+        if weekly_gate.get("block_new_positions") is True:
+            blockers.append(
+                Blocker(
+                    id="block_new_positions",
+                    severity="high",
+                    message="Weekly gate blocks new positions.",
+                    evidence=str(weekly_gate.get("reason") or "No reason provided."),
+                )
+            )
+            root_causes.append("Weekly gate set `block_new_positions=true`.")
+
+        if weekly_gate.get("scale_blocked_by_cadence") is True:
+            blockers.append(
+                Blocker(
+                    id="cadence_scale_block",
+                    severity="high",
+                    message="Scale-up blocked by cadence KPI.",
+                    evidence=(
+                        f"setups {cadence.get('qualified_setups_observed')}/"
+                        f"{cadence.get('min_qualified_setups_per_week')}, "
+                        f"closed trades {cadence.get('closed_trades_observed')}/"
+                        f"{cadence.get('min_closed_trades_per_week')}"
+                    ),
+                )
+            )
+            root_causes.append("Setup cadence is below weekly minimum.")
+
+        if cadence.get("passed") is False:
+            blockers.append(
+                Blocker(
+                    id="cadence_failed",
+                    severity="high",
+                    message="Cadence KPI is failing.",
+                    evidence=str(cadence.get("summary") or "Cadence KPI miss."),
+                )
+            )
+            root_causes.append("Cadence KPI is failing.")
+
+        if expectancy is not None and sample_size >= 1 and expectancy <= 0:
+            blockers.append(
+                Blocker(
+                    id="negative_expectancy",
+                    severity="high",
+                    message="Per-trade expectancy is non-positive.",
+                    evidence=f"expectancy_per_trade={expectancy:.2f}, sample_size={sample_size}.",
+                )
+            )
+            root_causes.append("Trade quality/edge is below zero expectancy.")
+
+        if weekly_gate.get("scale_blocked_by_ai_credit_stress") is True:
+            blockers.append(
+                Blocker(
+                    id="ai_credit_stress_block",
+                    severity="high",
+                    message="Scale-up blocked by AI credit stress signal.",
+                    evidence=json.dumps(weekly_gate.get("ai_credit_stress", {}), sort_keys=True),
+                )
+            )
+            root_causes.append("Macro credit-stress block is active.")
+
+        if mode.lower() == "validation":
+            warnings.append(
+                Blocker(
+                    id="validation_mode",
+                    severity="warning",
+                    message="System is still in validation mode.",
+                    evidence="Mode=validation requires conservative sizing until evidence improves.",
+                )
+            )
+
+    # Staleness checks with concrete timestamps.
+    report_last = _parse_dt(meta.get("last_updated")) or _parse_dt(state.get("last_updated"))
+    weekly_updated = _parse_dt(weekly_gate.get("updated_at"))
+    stale_threshold_hours = 30.0
+    for stale_id, label, dt in (
+        ("stale_state", "system_state", report_last),
+        ("stale_weekly_gate", "north_star_weekly_gate", weekly_updated),
+    ):
+        if dt is None:
+            warnings.append(
+                Blocker(
+                    id=stale_id,
+                    severity="warning",
+                    message=f"{label} timestamp unavailable.",
+                    evidence="No parseable timestamp.",
+                )
+            )
+            continue
+        age_h = (now_utc - dt).total_seconds() / 3600.0
+        if age_h > stale_threshold_hours:
+            blockers.append(
+                Blocker(
+                    id=stale_id,
+                    severity="high",
+                    message=f"{label} is stale.",
+                    evidence=f"last_update={_fmt_utc(dt)} age_hours={age_h:.1f} (> {stale_threshold_hours:.0f}h)",
+                )
+            )
+            root_causes.append(f"{label} data is stale.")
+
+    if not root_causes:
+        root_causes.append("No active blocker-level root causes detected.")
+
+    probability = _to_float(north_star.get("probability_score"))
+    probability_label = str(north_star.get("probability_label") or "unknown")
+    recent_history = weekly_history[-8:]
+
+    return {
+        "generated_at_utc": _fmt_utc(now_utc),
+        "blocked": len(blockers) > 0,
+        "blockers": [asdict(item) for item in blockers],
+        "warnings": [asdict(item) for item in warnings],
+        "root_causes": root_causes,
+        "state_timestamps": {
+            "meta_last_updated": _fmt_utc(_parse_dt(meta.get("last_updated"))),
+            "state_last_updated": _fmt_utc(_parse_dt(state.get("last_updated"))),
+            "weekly_gate_updated_at": _fmt_utc(_parse_dt(weekly_gate.get("updated_at"))),
+        },
+        "current_gate": {
+            "mode": str(weekly_gate.get("mode") or "unknown"),
+            "expectancy_per_trade": _to_float(weekly_gate.get("expectancy_per_trade")),
+            "sample_size": _to_int(weekly_gate.get("sample_size")),
+            "block_new_positions": bool(weekly_gate.get("block_new_positions")),
+            "scale_blocked_by_cadence": bool(weekly_gate.get("scale_blocked_by_cadence")),
+            "cadence_summary": str(cadence.get("summary") or ""),
+            "qualified_setups_observed": _to_int(cadence.get("qualified_setups_observed")),
+            "min_qualified_setups_per_week": _to_int(cadence.get("min_qualified_setups_per_week")),
+            "closed_trades_observed": _to_int(cadence.get("closed_trades_observed")),
+            "min_closed_trades_per_week": _to_int(cadence.get("min_closed_trades_per_week")),
+        },
+        "north_star_probability": {
+            "score": probability,
+            "label": probability_label,
+        },
+        "last_trade_date": str(state.get("trades", {}).get("last_trade_date", "")),
+        "trading_halted_file_exists": halt_exists,
+        "recent_weekly_history": recent_history,
+    }
+
+
+def render_markdown(report: dict[str, Any]) -> str:
+    lines: list[str] = []
+    lines.append("# North Star Blockers (Automated)")
+    lines.append("")
+    lines.append(f"- Generated (UTC): `{report.get('generated_at_utc', 'n/a')}`")
+    lines.append(
+        f"- Trading Halt File: `{'present' if report.get('trading_halted_file_exists') else 'absent'}`"
+    )
+    lines.append(f"- Last Trade Date: `{report.get('last_trade_date') or 'n/a'}`")
+    ts = report.get("state_timestamps", {})
+    lines.append(f"- System State Updated (UTC): `{ts.get('meta_last_updated', 'n/a')}`")
+    lines.append(f"- Weekly Gate Updated (UTC): `{ts.get('weekly_gate_updated_at', 'n/a')}`")
+    lines.append("")
+
+    gate = report.get("current_gate", {})
+    prob = report.get("north_star_probability", {})
+    lines.append("## Current Gate Snapshot")
+    lines.append(f"- Mode: `{gate.get('mode', 'unknown')}`")
+    lines.append(f"- Expectancy / Trade: `{gate.get('expectancy_per_trade')}`")
+    lines.append(f"- Sample Size: `{gate.get('sample_size')}`")
+    lines.append(
+        "- Cadence: "
+        f"`{gate.get('qualified_setups_observed')}/{gate.get('min_qualified_setups_per_week')}` setups, "
+        f"`{gate.get('closed_trades_observed')}/{gate.get('min_closed_trades_per_week')}` closed trades"
+    )
+    lines.append(f"- Cadence Summary: {gate.get('cadence_summary') or 'n/a'}")
+    lines.append(
+        f"- North Star Probability: `{prob.get('score')}` (`{prob.get('label', 'unknown')}`)"
+    )
+    lines.append("")
+
+    blockers = report.get("blockers", [])
+    warnings = report.get("warnings", [])
+    if blockers:
+        lines.append("## Active Blockers")
+        for i, blocker in enumerate(blockers, start=1):
+            lines.append(
+                f"{i}. **[{blocker.get('severity', 'unknown').upper()}] {blocker.get('message')}**"
+            )
+            lines.append(f"   Evidence: `{blocker.get('evidence')}`")
+    else:
+        lines.append("## Active Blockers")
+        lines.append("1. None. North Star blockers are currently clear.")
+
+    if warnings:
+        lines.append("")
+        lines.append("## Warnings")
+        for i, warning in enumerate(warnings, start=1):
+            lines.append(f"{i}. {warning.get('message')}")
+            lines.append(f"   Evidence: `{warning.get('evidence')}`")
+
+    lines.append("")
+    lines.append("## Root Cause Snapshot")
+    for i, item in enumerate(report.get("root_causes", []), start=1):
+        lines.append(f"{i}. {item}")
+
+    history = report.get("recent_weekly_history", [])
+    lines.append("")
+    lines.append("## Recent Weekly Evidence")
+    lines.append("")
+    lines.append("| Week Start | Updated At (UTC) | Mode | Sample | Expectancy | Cadence Passed |")
+    lines.append("|---|---|---|---:|---:|---|")
+    if history:
+        for row in history:
+            lines.append(
+                "| "
+                + f"{row.get('week_start') or 'n/a'} | "
+                + f"{row.get('updated_at') or 'n/a'} | "
+                + f"{row.get('mode') or 'n/a'} | "
+                + f"{row.get('sample_size') if row.get('sample_size') is not None else 'n/a'} | "
+                + f"{row.get('expectancy_per_trade') if row.get('expectancy_per_trade') is not None else 'n/a'} | "
+                + f"{row.get('cadence_passed') if row.get('cadence_passed') is not None else 'n/a'} |"
+            )
+    else:
+        lines.append("| n/a | n/a | n/a | n/a | n/a | n/a |")
+
+    lines.append("")
+    lines.append("_Auto-generated. This issue is updated by workflow and auto-closed when blockers clear._")
+    return "\n".join(lines)
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Build North Star blocker report artifacts.")
+    parser.add_argument("--state", default="data/system_state.json")
+    parser.add_argument("--history", default="data/north_star_weekly_history.json")
+    parser.add_argument("--halt-file", default="data/TRADING_HALTED")
+    parser.add_argument("--json-out", default="")
+    parser.add_argument("--markdown-out", default="")
+    parser.add_argument("--print-markdown", action="store_true")
+    parser.add_argument("--fail-on-blockers", action="store_true")
+    return parser
+
+
+def main() -> int:
+    args = _build_parser().parse_args()
+
+    state_path = Path(args.state)
+    history_path = Path(args.history)
+    halt_file = Path(args.halt_file)
+
+    state = _load_json(state_path)
+    if not isinstance(state, dict):
+        state = {}
+    history = _normalize_history_rows(_load_json(history_path))
+    now_utc = datetime.now(timezone.utc)
+
+    report = compute_report(
+        state=state,
+        weekly_history=history,
+        halt_exists=halt_file.exists(),
+        now_utc=now_utc,
+    )
+    markdown = render_markdown(report)
+
+    if args.json_out:
+        out = Path(args.json_out)
+        out.parent.mkdir(parents=True, exist_ok=True)
+        out.write_text(json.dumps(report, indent=2), encoding="utf-8")
+    if args.markdown_out:
+        out = Path(args.markdown_out)
+        out.parent.mkdir(parents=True, exist_ok=True)
+        out.write_text(markdown, encoding="utf-8")
+
+    print(json.dumps(report))
+    if args.print_markdown:
+        print(markdown)
+
+    if args.fail_on_blockers and report.get("blocked"):
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_build_north_star_blocker_report.py
+++ b/tests/test_build_north_star_blocker_report.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from scripts.build_north_star_blocker_report import compute_report, render_markdown
+
+
+def test_compute_report_marks_blocked_for_negative_expectancy_and_cadence_fail() -> None:
+    now = datetime(2026, 2, 19, 18, 0, tzinfo=timezone.utc)
+    state = {
+        "meta": {"last_updated": "2026-02-19T17:30:00Z"},
+        "last_updated": "2026-02-19T17:30:00Z",
+        "north_star": {"probability_score": 70.4, "probability_label": "medium"},
+        "trades": {"last_trade_date": "2026-02-09"},
+        "north_star_weekly_gate": {
+            "updated_at": "2026-02-19T17:30:00Z",
+            "mode": "validation",
+            "sample_size": 2,
+            "expectancy_per_trade": -94.5,
+            "block_new_positions": False,
+            "scale_blocked_by_cadence": True,
+            "cadence_kpi": {
+                "passed": False,
+                "summary": "Cadence KPI miss",
+                "qualified_setups_observed": 0,
+                "min_qualified_setups_per_week": 3,
+                "closed_trades_observed": 2,
+                "min_closed_trades_per_week": 1,
+            },
+        },
+    }
+
+    report = compute_report(
+        state=state,
+        weekly_history=[],
+        halt_exists=False,
+        now_utc=now,
+    )
+
+    assert report["blocked"] is True
+    blocker_ids = {item["id"] for item in report["blockers"]}
+    assert "negative_expectancy" in blocker_ids
+    assert "cadence_failed" in blocker_ids
+    assert "cadence_scale_block" in blocker_ids
+
+
+def test_compute_report_not_blocked_when_gate_is_clean() -> None:
+    now = datetime(2026, 2, 19, 18, 0, tzinfo=timezone.utc)
+    state = {
+        "meta": {"last_updated": "2026-02-19T17:30:00Z"},
+        "last_updated": "2026-02-19T17:30:00Z",
+        "north_star": {"probability_score": 82.0, "probability_label": "high"},
+        "north_star_weekly_gate": {
+            "updated_at": "2026-02-19T17:30:00Z",
+            "mode": "normal",
+            "sample_size": 10,
+            "expectancy_per_trade": 22.0,
+            "block_new_positions": False,
+            "scale_blocked_by_cadence": False,
+            "cadence_kpi": {
+                "passed": True,
+                "summary": "Cadence KPI met.",
+                "qualified_setups_observed": 4,
+                "min_qualified_setups_per_week": 3,
+                "closed_trades_observed": 2,
+                "min_closed_trades_per_week": 1,
+            },
+        },
+    }
+
+    report = compute_report(
+        state=state,
+        weekly_history=[],
+        halt_exists=False,
+        now_utc=now,
+    )
+
+    assert report["blocked"] is False
+    assert report["blockers"] == []
+
+
+def test_render_markdown_contains_absolute_dates_and_history_table() -> None:
+    report = {
+        "generated_at_utc": "2026-02-19T18:00:00Z",
+        "trading_halted_file_exists": False,
+        "last_trade_date": "2026-02-09",
+        "state_timestamps": {
+            "meta_last_updated": "2026-02-19T17:30:00Z",
+            "weekly_gate_updated_at": "2026-02-19T17:35:00Z",
+        },
+        "current_gate": {
+            "mode": "validation",
+            "expectancy_per_trade": -94.5,
+            "sample_size": 2,
+            "qualified_setups_observed": 0,
+            "min_qualified_setups_per_week": 3,
+            "closed_trades_observed": 2,
+            "min_closed_trades_per_week": 1,
+            "cadence_summary": "Cadence KPI miss",
+        },
+        "north_star_probability": {"score": 70.4, "label": "medium"},
+        "blockers": [
+            {
+                "id": "negative_expectancy",
+                "severity": "high",
+                "message": "Per-trade expectancy is non-positive.",
+                "evidence": "expectancy_per_trade=-94.50, sample_size=2.",
+            }
+        ],
+        "warnings": [],
+        "root_causes": ["Trade quality/edge is below zero expectancy."],
+        "recent_weekly_history": [
+            {
+                "week_start": "2026-02-16",
+                "updated_at": "2026-02-19T17:35:00Z",
+                "mode": "validation",
+                "sample_size": 2,
+                "expectancy_per_trade": -94.5,
+                "cadence_passed": False,
+            }
+        ],
+    }
+
+    markdown = render_markdown(report)
+    assert "Generated (UTC): `2026-02-19T18:00:00Z`" in markdown
+    assert "System State Updated (UTC): `2026-02-19T17:30:00Z`" in markdown
+    assert "| Week Start | Updated At (UTC) | Mode | Sample | Expectancy | Cadence Passed |" in markdown
+    assert "2026-02-16" in markdown


### PR DESCRIPTION
## What this adds
- New scheduled workflow: `.github/workflows/north-star-blocker-watch.yml`
  - refreshes broker/system gate state
  - auto-clears stale trading halt when flat
  - builds a dated blocker report artifact
  - automatically creates/updates/closes a `north-star-blocker` GitHub issue
- New report generator: `scripts/build_north_star_blocker_report.py`
  - computes blockers, warnings, root causes
  - includes absolute UTC timestamps and recent weekly evidence table
  - emits JSON + Markdown artifacts
- New tests: `tests/test_build_north_star_blocker_report.py`

## Autonomous behavior
- If blockers exist: creates or updates issue `North Star Blockers (Automated)`
- If blockers clear: auto-comments and closes the issue
- No manual triage needed

## Validation run
- `pytest -q tests/test_build_north_star_blocker_report.py`
- `python3 tests/test_workflow_contracts.py`
- `pytest -q tests/test_workflow_dependencies.py -k "workflow or blocker"`
- `python3 scripts/build_north_star_blocker_report.py --state data/system_state.json --history data/north_star_weekly_history.json --halt-file data/TRADING_HALTED --json-out /tmp/ns_report.json --markdown-out /tmp/ns_report.md`