### PR TITLE
feat(risk): autonomous USD macro sentiment signal with soft sizing

### DIFF
--- a/.github/workflows/update-progress-dashboard.yml
+++ b/.github/workflows/update-progress-dashboard.yml
@@ -77,6 +77,16 @@ jobs:
             --max-stale-days 7
           echo "✅ AI credit stress signal updated"
 
+      - name: Update USD macro sentiment signal
+        run: |
+          echo "💵 Refreshing USD macro sentiment signal..."
+          python3 scripts/update_usd_macro_sentiment_signal.py \
+            --out data/market_signals/usd_macro_sentiment_signal.json \
+            --state data/system_state.json \
+            --sync-state \
+            --max-stale-days 7
+          echo "✅ USD macro sentiment signal updated"
+
       - name: Update North Star operating plan
         run: |
           echo "🎯 Updating weekly gate + contribution plan..."
@@ -212,7 +222,7 @@ jobs:
         run: |
           git config user.name "GitHub Actions Bot"
           git config user.email "actions@github.com"
-          git add data/system_state.json data/north_star_weekly_history.json data/trades.json data/market_signals/ai_credit_stress_signal.json artifacts/devloop/box_workspace_manifest.json artifacts/devloop/ai_discoverability_report.md artifacts/devloop/ai_discoverability_report.json artifacts/devloop/profit_readiness_scorecard.md artifacts/tars/ docs/ docs/_reports/*-dashboard-snapshot.md docs/_reports/hackathon-system-explainer.md docs/lessons/judge-demo.html wiki/ docs/index.md 2>/dev/null || true
+          git add data/system_state.json data/north_star_weekly_history.json data/trades.json data/market_signals/ai_credit_stress_signal.json data/market_signals/usd_macro_sentiment_signal.json artifacts/devloop/box_workspace_manifest.json artifacts/devloop/ai_discoverability_report.md artifacts/devloop/ai_discoverability_report.json artifacts/devloop/profit_readiness_scorecard.md artifacts/tars/ docs/ docs/_reports/*-dashboard-snapshot.md docs/_reports/hackathon-system-explainer.md docs/lessons/judge-demo.html wiki/ docs/index.md 2>/dev/null || true
           if ! git diff --staged --quiet; then
             git commit -m "chore: Sync dashboard data [auto]"
             if [ -n "${{ secrets.GH_PAT }}" ]; then

--- a/data/market_signals/usd_macro_sentiment_signal.json
+++ b/data/market_signals/usd_macro_sentiment_signal.json
@@ -1,0 +1,37 @@
+{
+  "signal": "usd_macro_sentiment",
+  "status": "unknown",
+  "bearish_score": 0.0,
+  "position_size_multiplier": 1.0,
+  "blocked": false,
+  "watch": false,
+  "reasons": [
+    "No USD macro data available."
+  ],
+  "latest_data_date": null,
+  "stale_days": null,
+  "metrics": {
+    "broad_usd_index": {
+      "series_id": "DTWEXBGS",
+      "latest_value": null,
+      "latest_date": null,
+      "ma_20": null,
+      "ma_50": null,
+      "pct_change_5d": null,
+      "pct_change_20d": null,
+      "point_count": 0
+    },
+    "usd_per_euro": {
+      "series_id": "DEXUSEU",
+      "latest_value": null,
+      "latest_date": null,
+      "ma_20": null,
+      "ma_50": null,
+      "pct_change_5d": null,
+      "pct_change_20d": null,
+      "point_count": 0
+    }
+  },
+  "source": "fred_public",
+  "updated_at": "2026-02-19T00:00:00+00:00"
+}

--- a/scripts/check_weekly_cadence_gate.py
+++ b/scripts/check_weekly_cadence_gate.py
@@ -65,9 +65,14 @@ def evaluate_weekly_cadence(state: dict[str, Any]) -> dict[str, Any]:
     ai_credit_stress = (
         gate_status.get("ai_credit_stress", {}) if isinstance(gate_status, dict) else {}
     )
+    usd_macro = gate_status.get("usd_macro", {}) if isinstance(gate_status, dict) else {}
     ai_credit_status = str(ai_credit_stress.get("status") or "unknown").lower()
     ai_credit_score = ai_credit_stress.get("severity_score")
     ai_credit_source = str(ai_credit_stress.get("source") or "none")
+    usd_macro_status = str(usd_macro.get("status") or "unknown").lower()
+    usd_macro_score = usd_macro.get("bearish_score")
+    usd_macro_multiplier = usd_macro.get("position_size_multiplier")
+    usd_macro_source = str(usd_macro.get("source") or "none")
 
     return {
         "passed": passed,
@@ -83,6 +88,10 @@ def evaluate_weekly_cadence(state: dict[str, Any]) -> dict[str, Any]:
         "ai_credit_stress_status": ai_credit_status,
         "ai_credit_stress_score": ai_credit_score,
         "ai_credit_stress_source": ai_credit_source,
+        "usd_macro_status": usd_macro_status,
+        "usd_macro_score": usd_macro_score,
+        "usd_macro_multiplier": usd_macro_multiplier,
+        "usd_macro_source": usd_macro_source,
     }
 
 
@@ -113,6 +122,13 @@ def markdown_report(result: dict[str, Any]) -> str:
         ai_line += f" (score={float(result['ai_credit_stress_score']):.1f})"
     ai_line += f" source={result.get('ai_credit_stress_source', 'none')}"
     lines.append(ai_line)
+    usd_line = f"- USD Macro: `{result.get('usd_macro_status', 'unknown')}`"
+    if isinstance(result.get("usd_macro_score"), (int, float)):
+        usd_line += f" (bearish_score={float(result['usd_macro_score']):.1f})"
+    if isinstance(result.get("usd_macro_multiplier"), (int, float)):
+        usd_line += f" size_multiplier={float(result['usd_macro_multiplier']):.2f}"
+    usd_line += f" source={result.get('usd_macro_source', 'none')}"
+    lines.append(usd_line)
     lines.append("")
     lines.append("## Top Rejection Reasons")
     if result["top_rejection_reasons"]:
@@ -250,6 +266,9 @@ def main() -> int:
             ],
             "ai_credit_stress_status": _sanitize(result.get("ai_credit_stress_status", "unknown")),
             "ai_credit_stress_score": result.get("ai_credit_stress_score"),
+            "usd_macro_status": _sanitize(result.get("usd_macro_status", "unknown")),
+            "usd_macro_score": result.get("usd_macro_score"),
+            "usd_macro_multiplier": result.get("usd_macro_multiplier"),
         }
         print(json.dumps(safe_result, indent=2))
     else:

--- a/scripts/train_from_feedback.py
+++ b/scripts/train_from_feedback.py
@@ -34,6 +34,7 @@ DEFAULT_CATEGORIES = {
     "pr": {"alpha": 1.0, "beta": 1.0, "count": 0},
     "refactor": {"alpha": 1.0, "beta": 1.0, "count": 0},
     "analysis": {"alpha": 1.0, "beta": 1.0, "count": 0},
+    "macro_usd": {"alpha": 1.0, "beta": 1.0, "count": 0},
     "log_parsing": {"alpha": 1.0, "beta": 1.0, "count": 0},
     "system_health": {"alpha": 1.0, "beta": 1.0, "count": 0},
 }
@@ -95,6 +96,8 @@ def extract_features(context: str) -> list[str]:
         features.append("refactor")
     if re.search(r"analys|research|backtest", context_lower):
         features.append("analysis")
+    if re.search(r"\busd\b|dxy|dollar|fx|macro", context_lower):
+        features.append("macro_usd")
     if re.search(r"log|parse|output", context_lower):
         features.append("log_parsing")
     if re.search(r"health|system|check|monitor", context_lower):

--- a/scripts/update_usd_macro_sentiment_signal.py
+++ b/scripts/update_usd_macro_sentiment_signal.py
@@ -1,0 +1,473 @@
+#!/usr/bin/env python3
+"""Update USD macro sentiment signal from public macro indicators.
+
+Signal source: FRED public CSV endpoints (no API key required)
+Series:
+- DTWEXBGS (Trade Weighted U.S. Dollar Index: Broad)
+- DEXUSEU (U.S. Dollars to One Euro)
+
+The resulting signal is consumed by the weekly North Star gate as a *soft*
+position-size multiplier (never a standalone hard trade block).
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+from dataclasses import dataclass
+from datetime import date, datetime, timezone
+from io import StringIO
+from pathlib import Path
+
+import requests
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+DEFAULT_OUTPUT_PATH = PROJECT_ROOT / "data" / "market_signals" / "usd_macro_sentiment_signal.json"
+DEFAULT_STATE_PATH = PROJECT_ROOT / "data" / "system_state.json"
+FRED_CSV_URL = "https://fred.stlouisfed.org/graph/fredgraph.csv?id={series_id}"
+
+SERIES_IDS = {
+    "broad_usd_index": "DTWEXBGS",
+    "usd_per_euro": "DEXUSEU",
+}
+
+WATCH_SCORE = 30.0
+BLOCK_SCORE = 60.0
+WATCH_MULTIPLIER = 0.95
+BLOCK_MULTIPLIER = 0.90
+
+
+@dataclass
+class SeriesSummary:
+    series_id: str
+    latest_value: float | None
+    latest_date: str | None
+    ma_20: float | None
+    ma_50: float | None
+    pct_change_5d: float | None
+    pct_change_20d: float | None
+    point_count: int
+
+
+def _safe_read_json(path: Path) -> dict:
+    if not path.exists():
+        return {}
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+        return payload if isinstance(payload, dict) else {}
+    except Exception:
+        return {}
+
+
+def _safe_write_json(path: Path, payload: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+
+
+def parse_fred_csv(csv_text: str) -> list[tuple[date, float]]:
+    """Parse FRED CSV into sorted (date, value) points."""
+    rows: list[tuple[date, float]] = []
+    reader = csv.DictReader(StringIO(csv_text))
+    for row in reader:
+        if not isinstance(row, dict):
+            continue
+        raw_date = str(row.get("DATE", "")).strip()
+        if not raw_date:
+            continue
+        try:
+            dt = datetime.strptime(raw_date, "%Y-%m-%d").date()
+        except ValueError:
+            continue
+
+        value: float | None = None
+        for key, raw_value in row.items():
+            if key == "DATE":
+                continue
+            text = str(raw_value).strip()
+            if not text or text == ".":
+                continue
+            try:
+                value = float(text)
+                break
+            except ValueError:
+                continue
+        if value is None:
+            continue
+        rows.append((dt, value))
+
+    rows.sort(key=lambda item: item[0])
+    return rows
+
+
+def _moving_average(values: list[float], window: int) -> float | None:
+    if not values:
+        return None
+    if len(values) < window:
+        return round(sum(values) / len(values), 6)
+    segment = values[-window:]
+    return round(sum(segment) / window, 6)
+
+
+def _percent_change(values: list[float], lookback: int) -> float | None:
+    if not values or len(values) <= lookback:
+        return None
+    latest = values[-1]
+    baseline = values[-1 - lookback]
+    if baseline == 0:
+        return None
+    return round((latest - baseline) / baseline, 6)
+
+
+def summarize_series(series_id: str, points: list[tuple[date, float]]) -> SeriesSummary:
+    if not points:
+        return SeriesSummary(
+            series_id=series_id,
+            latest_value=None,
+            latest_date=None,
+            ma_20=None,
+            ma_50=None,
+            pct_change_5d=None,
+            pct_change_20d=None,
+            point_count=0,
+        )
+
+    latest_date, latest_value = points[-1]
+    values = [value for _, value in points]
+    return SeriesSummary(
+        series_id=series_id,
+        latest_value=round(latest_value, 6),
+        latest_date=latest_date.isoformat(),
+        ma_20=_moving_average(values, 20),
+        ma_50=_moving_average(values, 50),
+        pct_change_5d=_percent_change(values, 5),
+        pct_change_20d=_percent_change(values, 20),
+        point_count=len(points),
+    )
+
+
+def _multiplier_for_status(status: str) -> float:
+    if status == "blocked":
+        return BLOCK_MULTIPLIER
+    if status == "watch":
+        return WATCH_MULTIPLIER
+    return 1.0
+
+
+def evaluate_usd_macro_sentiment_signal(
+    metrics: dict[str, SeriesSummary],
+) -> tuple[str, float, float, list[str]]:
+    """Return (status, bearish_score, position_size_multiplier, reasons)."""
+    score = 0.0
+    reasons: list[str] = []
+
+    broad = metrics.get("broad_usd_index")
+    eur = metrics.get("usd_per_euro")
+    has_data = any(
+        summary.latest_value is not None
+        for summary in metrics.values()
+        if isinstance(summary, SeriesSummary)
+    )
+    if not has_data:
+        return "unknown", 0.0, 1.0, ["No USD macro data available."]
+
+    if broad and broad.latest_value is not None:
+        if broad.ma_50 is not None and broad.ma_50 > 0:
+            ratio = broad.latest_value / broad.ma_50
+            if ratio <= 0.985:
+                score += 25
+                reasons.append(
+                    f"Broad USD index below 50D MA by {((1.0 - ratio) * 100):.2f}%"
+                )
+            elif ratio <= 0.995:
+                score += 12
+                reasons.append(
+                    f"Broad USD index slightly below 50D MA by {((1.0 - ratio) * 100):.2f}%"
+                )
+
+        if broad.pct_change_20d is not None:
+            if broad.pct_change_20d <= -0.02:
+                score += 30
+                reasons.append(f"Broad USD 20D drawdown {broad.pct_change_20d * 100:.2f}%")
+            elif broad.pct_change_20d <= -0.01:
+                score += 16
+                reasons.append(f"Broad USD 20D decline {broad.pct_change_20d * 100:.2f}%")
+
+        if broad.pct_change_5d is not None:
+            if broad.pct_change_5d <= -0.008:
+                score += 10
+                reasons.append(f"Broad USD 5D momentum weak {broad.pct_change_5d * 100:.2f}%")
+            elif broad.pct_change_5d <= -0.004:
+                score += 5
+                reasons.append(
+                    f"Broad USD 5D momentum mildly weak {broad.pct_change_5d * 100:.2f}%"
+                )
+
+    if eur and eur.latest_value is not None:
+        if eur.ma_50 is not None and eur.ma_50 > 0:
+            ratio = eur.latest_value / eur.ma_50
+            if ratio >= 1.008:
+                score += 15
+                reasons.append(
+                    f"USD per EUR above 50D MA by {((ratio - 1.0) * 100):.2f}% (USD softer)"
+                )
+            elif ratio >= 1.003:
+                score += 8
+                reasons.append(
+                    f"USD per EUR modestly above 50D MA by {((ratio - 1.0) * 100):.2f}%"
+                )
+
+        if eur.pct_change_20d is not None:
+            if eur.pct_change_20d >= 0.015:
+                score += 20
+                reasons.append(f"USD per EUR 20D rise {eur.pct_change_20d * 100:.2f}%")
+            elif eur.pct_change_20d >= 0.008:
+                score += 10
+                reasons.append(f"USD per EUR 20D uptick {eur.pct_change_20d * 100:.2f}%")
+
+    score = round(min(100.0, score), 2)
+    if score >= BLOCK_SCORE:
+        status = "blocked"
+    elif score >= WATCH_SCORE:
+        status = "watch"
+    else:
+        status = "pass"
+    multiplier = _multiplier_for_status(status)
+    return status, score, multiplier, reasons
+
+
+def _fetch_fred_series(
+    *,
+    series_id: str,
+    timeout_seconds: float,
+) -> list[tuple[date, float]]:
+    url = FRED_CSV_URL.format(series_id=series_id)
+    response = requests.get(url, timeout=timeout_seconds)
+    response.raise_for_status()
+    return parse_fred_csv(response.text)
+
+
+def _build_payload(
+    *,
+    metrics: dict[str, SeriesSummary],
+    status: str,
+    bearish_score: float,
+    position_size_multiplier: float,
+    reasons: list[str],
+    source: str,
+    max_stale_days: int,
+) -> dict:
+    latest_dates = [
+        datetime.strptime(summary.latest_date, "%Y-%m-%d").date()
+        for summary in metrics.values()
+        if summary.latest_date
+    ]
+    freshest = max(latest_dates) if latest_dates else None
+    stale_days = (date.today() - freshest).days if freshest else None
+    stale = stale_days is not None and stale_days > max_stale_days
+
+    effective_status = status
+    effective_multiplier = position_size_multiplier
+    effective_reasons = list(reasons)
+    if stale:
+        effective_status = "unknown"
+        effective_multiplier = 1.0
+        effective_reasons.append(
+            f"USD macro data stale: {stale_days} days old (max {max_stale_days})"
+        )
+
+    return {
+        "signal": "usd_macro_sentiment",
+        "status": effective_status,
+        "bearish_score": bearish_score,
+        "position_size_multiplier": round(min(1.0, max(0.1, effective_multiplier)), 4),
+        "blocked": effective_status == "blocked",
+        "watch": effective_status == "watch",
+        "reasons": effective_reasons,
+        "latest_data_date": freshest.isoformat() if freshest else None,
+        "stale_days": stale_days,
+        "metrics": {
+            name: {
+                "series_id": summary.series_id,
+                "latest_value": summary.latest_value,
+                "latest_date": summary.latest_date,
+                "ma_20": summary.ma_20,
+                "ma_50": summary.ma_50,
+                "pct_change_5d": summary.pct_change_5d,
+                "pct_change_20d": summary.pct_change_20d,
+                "point_count": summary.point_count,
+            }
+            for name, summary in metrics.items()
+        },
+        "source": source,
+        "updated_at": datetime.now(timezone.utc).isoformat(),
+    }
+
+
+def _apply_override(payload: dict, override_status: str, override_reason: str) -> dict:
+    status = override_status.strip().lower()
+    if status not in {"pass", "watch", "blocked", "unknown"}:
+        return payload
+    payload = dict(payload)
+    reasons = list(payload.get("reasons", []))
+    if override_reason.strip():
+        reasons.append(override_reason.strip())
+    else:
+        reasons.append(f"Manual override applied: {status}")
+    payload["status"] = status
+    payload["position_size_multiplier"] = _multiplier_for_status(status)
+    if status == "unknown":
+        payload["position_size_multiplier"] = 1.0
+    payload["blocked"] = status == "blocked"
+    payload["watch"] = status == "watch"
+    payload["reasons"] = reasons
+    payload["source"] = f"{payload.get('source', 'unknown')}+override"
+    payload["updated_at"] = datetime.now(timezone.utc).isoformat()
+    return payload
+
+
+def _sync_to_system_state(state_path: Path, payload: dict) -> None:
+    state = _safe_read_json(state_path)
+    if not isinstance(state, dict):
+        state = {}
+    market_signals = state.get("market_signals")
+    if not isinstance(market_signals, dict):
+        market_signals = {}
+    market_signals["usd_macro_sentiment"] = payload
+    state["market_signals"] = market_signals
+    _safe_write_json(state_path, state)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Update USD macro sentiment signal from FRED.")
+    parser.add_argument("--out", default=str(DEFAULT_OUTPUT_PATH), help="Signal output JSON path.")
+    parser.add_argument(
+        "--state",
+        default=str(DEFAULT_STATE_PATH),
+        help="system_state.json path for --sync-state updates.",
+    )
+    parser.add_argument(
+        "--sync-state",
+        action="store_true",
+        help="Write signal payload into system_state.market_signals.usd_macro_sentiment.",
+    )
+    parser.add_argument(
+        "--offline",
+        action="store_true",
+        help="Skip network fetch and reuse existing output payload if available.",
+    )
+    parser.add_argument(
+        "--timeout-seconds",
+        type=float,
+        default=15.0,
+        help="HTTP timeout in seconds for each FRED request.",
+    )
+    parser.add_argument(
+        "--max-stale-days",
+        type=int,
+        default=7,
+        help="Mark signal unknown when freshest data exceeds this age.",
+    )
+    parser.add_argument(
+        "--override-status",
+        default="",
+        help="Optional manual override status: pass/watch/blocked/unknown.",
+    )
+    parser.add_argument(
+        "--override-reason",
+        default="",
+        help="Optional text appended to reasons when override is used.",
+    )
+    parser.add_argument("--print-json", action="store_true", help="Print payload JSON to stdout.")
+    args = parser.parse_args()
+
+    out_path = Path(args.out).resolve()
+    state_path = Path(args.state).resolve()
+    existing_payload = _safe_read_json(out_path)
+
+    if args.offline:
+        payload = (
+            existing_payload
+            if existing_payload
+            else {
+                "signal": "usd_macro_sentiment",
+                "status": "unknown",
+                "bearish_score": 0.0,
+                "position_size_multiplier": 1.0,
+                "blocked": False,
+                "watch": False,
+                "reasons": ["Offline mode with no prior USD macro signal available."],
+                "latest_data_date": None,
+                "stale_days": None,
+                "metrics": {},
+                "source": "offline",
+                "updated_at": datetime.now(timezone.utc).isoformat(),
+            }
+        )
+    else:
+        summaries: dict[str, SeriesSummary] = {}
+        fetch_errors: list[str] = []
+        for name, series_id in SERIES_IDS.items():
+            try:
+                points = _fetch_fred_series(
+                    series_id=series_id,
+                    timeout_seconds=args.timeout_seconds,
+                )
+                summaries[name] = summarize_series(series_id=series_id, points=points)
+            except Exception as exc:  # noqa: BLE001 - network failures handled with fallback
+                fetch_errors.append(f"{series_id}: {exc}")
+                summaries[name] = SeriesSummary(
+                    series_id=series_id,
+                    latest_value=None,
+                    latest_date=None,
+                    ma_20=None,
+                    ma_50=None,
+                    pct_change_5d=None,
+                    pct_change_20d=None,
+                    point_count=0,
+                )
+
+        status, score, multiplier, reasons = evaluate_usd_macro_sentiment_signal(summaries)
+        payload = _build_payload(
+            metrics=summaries,
+            status=status,
+            bearish_score=score,
+            position_size_multiplier=multiplier,
+            reasons=reasons,
+            source="fred_public",
+            max_stale_days=max(1, args.max_stale_days),
+        )
+
+        if fetch_errors:
+            payload["reasons"] = list(payload.get("reasons", [])) + fetch_errors
+            if not reasons and existing_payload:
+                payload = dict(existing_payload)
+                payload["source"] = "cached_fallback"
+                payload["updated_at"] = datetime.now(timezone.utc).isoformat()
+                payload["reasons"] = list(payload.get("reasons", [])) + fetch_errors
+
+    if args.override_status:
+        payload = _apply_override(
+            payload,
+            override_status=args.override_status,
+            override_reason=args.override_reason,
+        )
+
+    _safe_write_json(out_path, payload)
+    if args.sync_state:
+        _sync_to_system_state(state_path, payload)
+
+    print(
+        "ok: usd macro sentiment signal updated",
+        f"status={payload.get('status')}",
+        f"score={payload.get('bearish_score')}",
+        f"size_multiplier={payload.get('position_size_multiplier')}",
+        f"out={out_path}",
+    )
+    if args.print_json:
+        print(json.dumps(payload, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/safety/north_star_operating_plan.py
+++ b/src/safety/north_star_operating_plan.py
@@ -31,6 +31,11 @@ DEFAULT_AI_CREDIT_STRESS_PATH = Path("market_signals/ai_credit_stress_signal.jso
 DEFAULT_AI_CREDIT_WATCH_SCORE = 30.0
 DEFAULT_AI_CREDIT_BLOCK_SCORE = 60.0
 DEFAULT_AI_CREDIT_HARD_BLOCK_SCORE = 80.0
+DEFAULT_USD_MACRO_SENTIMENT_PATH = Path("market_signals/usd_macro_sentiment_signal.json")
+DEFAULT_USD_MACRO_WATCH_SCORE = 30.0
+DEFAULT_USD_MACRO_BLOCK_SCORE = 60.0
+DEFAULT_USD_MACRO_WATCH_MULTIPLIER = 0.95
+DEFAULT_USD_MACRO_BLOCK_MULTIPLIER = 0.90
 
 _SPY_OPTION_RE = re.compile(r"^SPY(\d{6})[CP]\d{8}$")
 
@@ -198,6 +203,18 @@ def _categorize_reason(reason: str) -> set[str]:
         )
     ):
         categories.add("ai_credit_stress")
+    if any(
+        token in text
+        for token in (
+            "usd",
+            "dollar",
+            "dxy",
+            "dtwex",
+            "fx regime",
+            "macro sentiment",
+        )
+    ):
+        categories.add("usd_macro")
     return categories
 
 
@@ -225,11 +242,33 @@ def _normalize_ai_credit_stress_status(signal: dict[str, Any]) -> str:
     return "unknown"
 
 
+def _normalize_usd_macro_status(signal: dict[str, Any]) -> str:
+    raw_status = str(signal.get("status") or "").strip().lower()
+    score = _as_float(signal.get("bearish_score"), 0.0)
+    if raw_status in {"blocked", "high", "stress", "critical"} or score >= DEFAULT_USD_MACRO_BLOCK_SCORE:
+        return "blocked"
+    if raw_status in {"watch", "warning", "elevated"} or score >= DEFAULT_USD_MACRO_WATCH_SCORE:
+        return "watch"
+    if raw_status in {"pass", "ok", "normal", "low"}:
+        return "pass"
+    return "unknown"
+
+
 def _load_ai_credit_stress_signal(data_dir: Path, state: dict[str, Any]) -> dict[str, Any]:
     file_payload = _load_json_dict(data_dir / DEFAULT_AI_CREDIT_STRESS_PATH)
     if file_payload:
         return file_payload
     state_payload = _safe_nested_dict(state, "market_signals").get("ai_credit_stress")
+    if isinstance(state_payload, dict):
+        return state_payload
+    return {}
+
+
+def _load_usd_macro_sentiment_signal(data_dir: Path, state: dict[str, Any]) -> dict[str, Any]:
+    file_payload = _load_json_dict(data_dir / DEFAULT_USD_MACRO_SENTIMENT_PATH)
+    if file_payload:
+        return file_payload
+    state_payload = _safe_nested_dict(state, "market_signals").get("usd_macro_sentiment")
     if isinstance(state_payload, dict):
         return state_payload
     return {}
@@ -371,6 +410,33 @@ def _compute_no_trade_diagnostic(
         "signal_date": ai_credit_stress_signal.get("latest_data_date"),
         "source": ai_credit_stress_signal.get("source", "none"),
         "detail": ai_reason_text,
+    }
+
+    usd_macro_signal = _load_usd_macro_sentiment_signal(data_dir, state)
+    usd_status = _normalize_usd_macro_status(usd_macro_signal)
+    usd_score = usd_macro_signal.get("bearish_score")
+    usd_multiplier = _as_float(usd_macro_signal.get("position_size_multiplier"), 0.0)
+    if usd_multiplier <= 0:
+        if usd_status == "blocked":
+            usd_multiplier = DEFAULT_USD_MACRO_BLOCK_MULTIPLIER
+        elif usd_status == "watch":
+            usd_multiplier = DEFAULT_USD_MACRO_WATCH_MULTIPLIER
+        else:
+            usd_multiplier = 1.0
+    usd_reasons = usd_macro_signal.get("reasons", [])
+    usd_reason_text = ""
+    if isinstance(usd_reasons, list) and usd_reasons:
+        usd_reason_text = str(usd_reasons[0])
+    if not usd_reason_text:
+        usd_reason_text = str(usd_macro_signal.get("note") or "No USD macro sentiment evidence")
+    gate_status["usd_macro"] = {
+        "status": usd_status,
+        "signal_status": str(usd_macro_signal.get("status") or "unknown"),
+        "bearish_score": _as_float(usd_score, 0.0) if usd_score is not None else None,
+        "position_size_multiplier": round(min(1.0, max(0.1, usd_multiplier)), 4),
+        "signal_date": usd_macro_signal.get("latest_data_date"),
+        "source": usd_macro_signal.get("source", "none"),
+        "detail": usd_reason_text,
     }
 
     blocked_categories = [
@@ -711,6 +777,26 @@ def compute_weekly_gate(
         recommended_max = min(recommended_max, 0.015)
         reason = f"{reason} AI credit stress elevated; hold cautious sizing."
 
+    usd_macro_gate = _safe_nested_dict(no_trade_diagnostic, "gate_status", "usd_macro")
+    usd_macro_status = str(usd_macro_gate.get("status") or "unknown").lower()
+    usd_macro_multiplier = _as_float(usd_macro_gate.get("position_size_multiplier"), 1.0)
+    if usd_macro_multiplier <= 0:
+        usd_macro_multiplier = 1.0
+    usd_macro_multiplier = min(1.0, max(0.1, usd_macro_multiplier))
+    if usd_macro_status in {"watch", "blocked"} and usd_macro_multiplier < 1.0:
+        adjusted_limit = round(recommended_max * usd_macro_multiplier, 4)
+        recommended_max = min(recommended_max, adjusted_limit)
+        if mode == "expansion_candidate":
+            mode = "cautious"
+        score_text = usd_macro_gate.get("bearish_score")
+        score_suffix = (
+            f" score={_as_float(score_text, 0.0):.1f}" if isinstance(score_text, (int, float)) else ""
+        )
+        reason = (
+            f"{reason} USD macro sentiment {usd_macro_status}; "
+            f"applied size multiplier {usd_macro_multiplier:.2f}.{score_suffix}"
+        )
+
     weekly_history = _load_json_list(weekly_history_path)
     week_start = today - timedelta(days=today.weekday())
     week_start_iso = week_start.isoformat()
@@ -823,6 +909,8 @@ def compute_weekly_gate(
         "scale_blocked_by_cadence": not cadence_kpi["passed"],
         "ai_credit_stress": ai_credit_gate,
         "scale_blocked_by_ai_credit_stress": ai_credit_status == "blocked",
+        "usd_macro_sentiment": usd_macro_gate,
+        "scale_multiplier_from_usd_macro": round(usd_macro_multiplier, 4),
         "scaling_sample_gate": scaling_sample_gate,
         "no_trade_diagnostic": no_trade_diagnostic,
         "updated_at": datetime.now(timezone.utc).isoformat(),
@@ -965,4 +1053,13 @@ def apply_operating_plan_to_state(
     state["risk"]["weekly_ai_credit_stress_score"] = _safe_nested_dict(
         weekly_gate, "ai_credit_stress"
     ).get("severity_score")
+    state["risk"]["weekly_usd_macro_status"] = str(
+        _safe_nested_dict(weekly_gate, "usd_macro_sentiment").get("status") or "unknown"
+    )
+    state["risk"]["weekly_usd_macro_score"] = _safe_nested_dict(
+        weekly_gate, "usd_macro_sentiment"
+    ).get("bearish_score")
+    state["risk"]["weekly_usd_macro_multiplier"] = _safe_nested_dict(
+        weekly_gate, "usd_macro_sentiment"
+    ).get("position_size_multiplier")
     return state, weekly_history

--- a/tests/test_north_star_operating_plan.py
+++ b/tests/test_north_star_operating_plan.py
@@ -262,3 +262,84 @@ def test_ai_credit_stress_watch_caps_expansion_to_cautious(tmp_path):
     assert gate["recommended_max_position_pct"] <= 0.015
     assert gate["ai_credit_stress"]["status"] == "watch"
     assert gate["scale_blocked_by_ai_credit_stress"] is False
+
+
+def test_usd_macro_watch_applies_soft_size_multiplier(tmp_path):
+    trades_path = tmp_path / "trades.json"
+    history_path = tmp_path / "weekly_history.json"
+    today = date(2026, 2, 20)
+    trades = []
+    for idx in range(12):
+        exit_day = today - timedelta(days=idx)
+        trades.append(
+            {
+                "status": "closed",
+                "strategy": "iron_condor",
+                "realized_pnl": 40.0,
+                "outcome": "win",
+                "exit_date": exit_day.isoformat(),
+            }
+        )
+    _write_json(trades_path, {"stats": {"closed_trades": 40}, "trades": trades})
+
+    market_signals_dir = tmp_path / "market_signals"
+    market_signals_dir.mkdir(parents=True, exist_ok=True)
+    _write_json(
+        market_signals_dir / "usd_macro_sentiment_signal.json",
+        {
+            "signal": "usd_macro_sentiment",
+            "status": "watch",
+            "bearish_score": 45.0,
+            "position_size_multiplier": 0.95,
+            "latest_data_date": "2026-02-20",
+            "source": "fred_public",
+            "reasons": ["Broad USD index below 50D average"],
+        },
+    )
+
+    gate, _history = compute_weekly_gate(
+        {"paper_account": {"win_rate": 95.0, "win_rate_sample_size": 40, "total_pl": 480.0}},
+        trades_path=trades_path,
+        weekly_history_path=history_path,
+        today=today,
+    )
+
+    assert gate["usd_macro_sentiment"]["status"] == "watch"
+    assert gate["scale_multiplier_from_usd_macro"] == 0.95
+    assert gate["recommended_max_position_pct"] <= 0.019
+
+
+def test_apply_operating_plan_sets_usd_macro_risk_fields(tmp_path):
+    state = {
+        "paper_account": {"equity": 100000.0, "win_rate": 75.0, "win_rate_sample_size": 40},
+        "live_account": {"equity": 20.0, "positions_count": 0},
+        "risk": {},
+    }
+    trades_path = tmp_path / "trades.json"
+    history_path = tmp_path / "weekly_history.json"
+    market_signals_dir = tmp_path / "market_signals"
+    market_signals_dir.mkdir(parents=True, exist_ok=True)
+    _write_json(
+        market_signals_dir / "usd_macro_sentiment_signal.json",
+        {
+            "signal": "usd_macro_sentiment",
+            "status": "watch",
+            "bearish_score": 33.0,
+            "position_size_multiplier": 0.95,
+            "latest_data_date": "2026-02-20",
+            "source": "fred_public",
+            "reasons": ["USD softening"],
+        },
+    )
+    _write_json(trades_path, {"trades": []})
+
+    updated, _history = apply_operating_plan_to_state(
+        state,
+        trades_path=trades_path,
+        weekly_history_path=history_path,
+        today=date(2026, 2, 20),
+    )
+
+    assert updated["risk"]["weekly_usd_macro_status"] == "watch"
+    assert updated["risk"]["weekly_usd_macro_score"] == 33.0
+    assert updated["risk"]["weekly_usd_macro_multiplier"] == 0.95

--- a/tests/test_update_usd_macro_sentiment_signal.py
+++ b/tests/test_update_usd_macro_sentiment_signal.py
@@ -1,0 +1,80 @@
+"""Tests for USD macro sentiment signal updater."""
+
+from datetime import date, timedelta
+
+from scripts.update_usd_macro_sentiment_signal import (
+    SeriesSummary,
+    _build_payload,
+    evaluate_usd_macro_sentiment_signal,
+    parse_fred_csv,
+)
+
+
+def test_parse_fred_csv_skips_missing_values() -> None:
+    csv_text = """DATE,DTWEXBGS
+2026-02-16,110.12
+2026-02-17,.
+2026-02-18,109.77
+"""
+    points = parse_fred_csv(csv_text)
+    assert len(points) == 2
+    assert points[0][0].isoformat() == "2026-02-16"
+    assert points[1][1] == 109.77
+
+
+def test_evaluate_usd_macro_sentiment_returns_blocked_with_multiplier() -> None:
+    metrics = {
+        "broad_usd_index": SeriesSummary(
+            series_id="DTWEXBGS",
+            latest_value=100.0,
+            latest_date="2026-02-19",
+            ma_20=102.0,
+            ma_50=103.0,
+            pct_change_5d=-0.012,
+            pct_change_20d=-0.03,
+            point_count=120,
+        ),
+        "usd_per_euro": SeriesSummary(
+            series_id="DEXUSEU",
+            latest_value=1.12,
+            latest_date="2026-02-19",
+            ma_20=1.10,
+            ma_50=1.105,
+            pct_change_5d=0.01,
+            pct_change_20d=0.022,
+            point_count=120,
+        ),
+    }
+    status, score, multiplier, reasons = evaluate_usd_macro_sentiment_signal(metrics)
+    assert status == "blocked"
+    assert score >= 60.0
+    assert multiplier == 0.90
+    assert reasons
+
+
+def test_build_payload_marks_stale_as_unknown() -> None:
+    stale_date = (date.today() - timedelta(days=20)).isoformat()
+    metrics = {
+        "broad_usd_index": SeriesSummary(
+            series_id="DTWEXBGS",
+            latest_value=100.0,
+            latest_date=stale_date,
+            ma_20=101.0,
+            ma_50=102.0,
+            pct_change_5d=-0.01,
+            pct_change_20d=-0.02,
+            point_count=120,
+        )
+    }
+    payload = _build_payload(
+        metrics=metrics,
+        status="watch",
+        bearish_score=45.0,
+        position_size_multiplier=0.95,
+        reasons=["example"],
+        source="fred_public",
+        max_stale_days=7,
+    )
+    assert payload["status"] == "unknown"
+    assert payload["position_size_multiplier"] == 1.0
+    assert payload["stale_days"] >= 20

--- a/tests/test_weekly_cadence_gate.py
+++ b/tests/test_weekly_cadence_gate.py
@@ -27,6 +27,12 @@ def test_evaluate_weekly_cadence_extracts_kpi_and_diagnostic():
                         "status": "watch",
                         "severity_score": 42.0,
                         "source": "fred_public",
+                    },
+                    "usd_macro": {
+                        "status": "watch",
+                        "bearish_score": 37.0,
+                        "position_size_multiplier": 0.95,
+                        "source": "fred_public",
                     }
                 },
                 "top_rejection_reasons": [{"reason": "Vol=0.1x (low)", "count": 2}],
@@ -42,6 +48,9 @@ def test_evaluate_weekly_cadence_extracts_kpi_and_diagnostic():
     assert result["blocked_categories"] == ["liquidity"]
     assert result["ai_credit_stress_status"] == "watch"
     assert result["ai_credit_stress_score"] == 42.0
+    assert result["usd_macro_status"] == "watch"
+    assert result["usd_macro_score"] == 37.0
+    assert result["usd_macro_multiplier"] == 0.95
     assert result["top_rejection_reasons"][0]["count"] == 2
 
 


### PR DESCRIPTION
## Summary
- add `scripts/update_usd_macro_sentiment_signal.py` (FRED public data, no API key)
- persist `data/market_signals/usd_macro_sentiment_signal.json` and sync into `system_state.market_signals`
- wire `src/safety/north_star_operating_plan.py` to consume USD macro sentiment as a soft position-size multiplier
- expose USD macro status/score/multiplier in weekly cadence diagnostics
- wire hourly automation in `.github/workflows/update-progress-dashboard.yml`
- extend Thompson feedback feature extraction with `macro_usd`

## Validation
- `pytest -q tests/test_update_usd_macro_sentiment_signal.py tests/test_north_star_operating_plan.py tests/test_weekly_cadence_gate.py`
- `python3 tests/test_workflow_contracts.py`
- `pytest -q tests/test_workflow_dependencies.py -k "workflow or dashboard"`
