### PR TITLE
fix(ci): clear lint and safe-wrapper gate failures

### DIFF
--- a/src/agents/audit_agent.py
+++ b/src/agents/audit_agent.py
@@ -176,20 +176,6 @@ class AuditAgent(BaseAgent):
         Use RLM Algorithm 1 to perform a deep reasoning audit.
         Generates Python code to analyze logs for subtle patterns.
         """
-        prompt = f"""
-        You are the Adversarial Audit Agent. Your mission is to find hidden bugs, 
-        risk management failures, or logic errors in today's ({date_str}) trade logs.
-        
-        Log location: data/trades_{date_str}.json
-        
-        Task:
-        1. Write a pure Python script to analyze this JSON file.
-        2. Look for:
-           - Duplicate orders within seconds (Race conditions)
-           - Inconsistent pricing (fills far from expected)
-           - Strategy drift (trades not matching the iron_condor schema)
-        3. Output the results as a JSON object with 'anomalies' and 'score'.
-        """
         # Algorithm 1: Plan -> Generate -> Execute -> Finalize
         # Implementation of RLM logic would go here,
         # using reason_with_llm to get the Python code.

--- a/src/ml/grpo_trade_learner.py
+++ b/src/ml/grpo_trade_learner.py
@@ -408,10 +408,6 @@ class GRPOTradeLearner:
         # Default features
         filled_at = trade.get("filled_at", "")
 
-        # Check for embedded indicators (new regime-aware format)
-        indicators = trade.get("indicators", {})
-        vix_level = float(indicators.get("vix", 18.0))
-
         # Extract hour from timestamp
         hour = 0.5  # Default to mid-day
         if len(filled_at) > 11:

--- a/src/safety/position_enforcer.py
+++ b/src/safety/position_enforcer.py
@@ -1,6 +1,8 @@
 import logging
 from dataclasses import dataclass, field
 
+from src.safety.mandatory_trade_gate import safe_close_position
+
 logger = logging.getLogger(__name__)
 
 
@@ -59,7 +61,7 @@ def enforce_positions(trader) -> EnforcementResult:
 
                 # Close the position
                 try:
-                    trader.close_position(symbol)
+                    safe_close_position(trader, symbol)
                     result.positions_closed += 1
                     result.closed_symbols.append(symbol)
                     logger.info(f"✅ Closed violating position: {symbol}")

--- a/tests/test_position_enforcer.py
+++ b/tests/test_position_enforcer.py
@@ -1,0 +1,45 @@
+from types import SimpleNamespace
+
+from src.safety import position_enforcer
+
+
+class FakeTrader:
+    def __init__(self, symbols):
+        self._positions = [SimpleNamespace(symbol=s) for s in symbols]
+
+    def get_all_positions(self):
+        return self._positions
+
+
+def test_enforce_positions_uses_safe_close_wrapper(monkeypatch):
+    calls = []
+
+    def fake_safe_close_position(trader, symbol, **kwargs):
+        calls.append((symbol, kwargs))
+
+    monkeypatch.setattr(position_enforcer, "safe_close_position", fake_safe_close_position)
+
+    trader = FakeTrader(["AAPL260320C00150000"])
+    result = position_enforcer.enforce_positions(trader)
+
+    assert result.violations_found == 1
+    assert result.positions_closed == 1
+    assert result.closed_symbols == ["AAPL260320C00150000"]
+    assert calls == [("AAPL260320C00150000", {})]
+
+
+def test_enforce_positions_keeps_allowed_underlyings_open(monkeypatch):
+    calls = []
+
+    def fake_safe_close_position(trader, symbol, **kwargs):
+        calls.append((symbol, kwargs))
+
+    monkeypatch.setattr(position_enforcer, "safe_close_position", fake_safe_close_position)
+
+    trader = FakeTrader(["SPY260320C00500000"])
+    result = position_enforcer.enforce_positions(trader)
+
+    assert result.violations_found == 0
+    assert result.positions_closed == 0
+    assert result.closed_symbols == []
+    assert calls == []


### PR DESCRIPTION
Fixes CI failures on main by:

- removing unused/trailing-whitespace lint violations in audit + GRPO learner modules
- switching position enforcement to mandatory safe_close_position wrapper
- adding regression tests for safe-wrapper usage in position_enforcer

Validated locally with ruff + targeted pytest and existing pre-push validation suite.