### PR TITLE
fix(ci): stabilize Run All Tests marker handling

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -28,6 +28,7 @@ addopts =
 
 # Markers
 markers =
+    asyncio: marks tests that use asyncio event loop
     slow: marks tests as slow (deselect with '-m "not slow"')
     integration: marks tests as integration tests
     unit: marks tests as unit tests

--- a/tests/test_workflow_ml_integration.py
+++ b/tests/test_workflow_ml_integration.py
@@ -1,10 +1,8 @@
-import pytest
 import asyncio
 from src.orchestration.daggr_workflow import create_trading_workflow
 
 
-@pytest.mark.asyncio
-async def test_workflow_consumes_ml_params():
+def test_workflow_consumes_ml_params():
     """
     Integration Test: Proves that the Daggr Workflow correctly
     calls and consumes parameters from the ML learner.
@@ -23,7 +21,7 @@ async def test_workflow_consumes_ml_params():
 
     # Manual execution of the node to inspect output
     node = workflow.nodes["options_chain"]
-    result = await node.execute(initial_inputs, {})
+    result = asyncio.run(node.execute(initial_inputs, {}))
 
     assert result.success is True
     data = result.output.get("data", {})


### PR DESCRIPTION
Fixes Run All Tests collection failure in CI by:

- registering `asyncio` marker in pytest.ini (strict-markers compatibility)
- removing pytest-asyncio plugin dependency from `tests/test_workflow_ml_integration.py` by using `asyncio.run()` in a sync test

Validated locally with targeted pytest and existing pre-push suite.
