### PR TITLE
policy: enforce mandatory git worktrees

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,3 +19,10 @@ Always tell the user 100% truth. Never fabricate, hide, or misrepresent status, 
 - If security context is relevant, keep it minimal and technical.
 - Avoid phrasing like "your key is compromised" or "effectively compromised". State only concrete, verifiable facts (e.g., whether a secret appears in the repo) and the next required action.
 - Do not comment on a user-pasted key being "compromised" due to being pasted into chat. Only raise key-handling actions when a secret is present in the repo, logs, or other systems we control (or when the user explicitly asks).
+
+## Git Workflow Requirement
+
+- Always do implementation work in a dedicated `git worktree` on a task branch.
+- Do not implement feature/fix changes directly in the primary checkout.
+- Create one worktree per task to isolate branch state and avoid collisions.
+- Keep `main` clean: merge only after verification/tests pass on the task branch.


### PR DESCRIPTION
Adds a mandatory workflow rule in AGENTS.md: all implementation work must run in dedicated git worktrees, not primary checkout.