### PR TITLE
fix(lint): resolve 37 lint errors + fix GRPO test

### DIFF
--- a/scripts/check_north_star_probability.py
+++ b/scripts/check_north_star_probability.py
@@ -1,7 +1,5 @@
-import json
-import logging
-from pathlib import Path
 from src.safety.milestone_controller import compute_milestone_snapshot
+
 
 def main():
     """
@@ -9,25 +7,25 @@ def main():
     Uses the system's own milestone and probability logic.
     """
     print("🔭 Formally assessing North Star trajectory...")
-    
+
     status = compute_milestone_snapshot()
     ns = status.get("north_star_probability", {})
-    
+
     print("\n" + "="*60)
     print("NORTH STAR PROBABILITY REPORT")
     print("="*60)
-    print(f"Goal: $6,000/month after-tax")
+    print("Goal: $6,000/month after-tax")
     print(f"Confidence Score: {ns.get('probability_score', 0):.1f}%")
     print(f"Label: {ns.get('probability_label', 'unknown').upper()}")
     print(f"Target Mode: {ns.get('target_mode', 'N/A')}")
     print(f"Estimated Monthly (Current Expectancy): ${ns.get('estimated_monthly_after_tax_from_expectancy', 0):.2f}")
     print(f"Monthly Target Progress: {ns.get('monthly_target_progress_pct', 0):.2f}%")
-    
+
     print("\n" + "="*60)
     print("CTO HONEST ASSESSMENT")
     print("="*60)
     score = ns.get('probability_score', 0)
-    
+
     if score > 80:
         print("✅ SYSTEM IS PROVEN. Trajectory is high-certainty.")
     elif score > 50:

--- a/scripts/generate_strategy_promotion_gate.py
+++ b/scripts/generate_strategy_promotion_gate.py
@@ -3,14 +3,14 @@ from __future__ import annotations
 
 import json
 import logging
-from pathlib import Path
 from datetime import datetime
+from pathlib import Path
 
 # Import constants from the single source of truth
 from src.core.trading_constants import (
-    NORTH_STAR_TARGET_WIN_RATE_PCT,
     NORTH_STAR_MONTHLY_AFTER_TAX,
-    NORTH_STAR_PAPER_VALIDATION_DAYS
+    NORTH_STAR_PAPER_VALIDATION_DAYS,
+    NORTH_STAR_TARGET_WIN_RATE_PCT,
 )
 
 logger = logging.getLogger(__name__)
@@ -32,7 +32,7 @@ def main():
     # Note: Using the paper account metrics for promotion decisions
     paper = state.get("paper_trading", {})
     win_rate = float(paper.get("win_rate", 0.0) or 0.0) * 100.0
-    
+
     # Calculate run rate from history if possible
     # (Simple version: use the milestone controller's estimate if available)
     milestones = state.get("strategy_milestones", {})
@@ -48,7 +48,7 @@ def main():
     # Check 1: Win Rate
     if win_rate < NORTH_STAR_TARGET_WIN_RATE_PCT:
         reasons.append(f"Win Rate {win_rate:.1f}% below target {NORTH_STAR_TARGET_WIN_RATE_PCT}%")
-    
+
     # Check 2: Validation Days
     start_date_str = paper.get("start_date")
     if start_date_str:

--- a/scripts/inject_synthetic_trades.py
+++ b/scripts/inject_synthetic_trades.py
@@ -27,7 +27,7 @@ def generate_regime_aware_trades(count=100):
         # Pick a random regime
         regime_name, vix_range, win_rate, avg_credit, avg_loss = random.choice(REGIMES)
         vix = random.uniform(vix_range[0], vix_range[1])
-        
+
         trade_date = base_date + timedelta(days=i)
         is_win = random.random() < win_rate
 
@@ -75,7 +75,7 @@ def inject():
 
     # Clean existing synthetic trades to avoid duplicates or pollution
     state["trade_history"] = [t for t in state.get("trade_history", []) if not str(t.get("id", "")).startswith("syn-")]
-    
+
     synthetic_trades = generate_regime_aware_trades(100)
     state["trade_history"].extend(synthetic_trades)
 

--- a/scripts/sync_dual_accounts.py
+++ b/scripts/sync_dual_accounts.py
@@ -1,7 +1,8 @@
-import os
 import logging
-from dotenv import load_dotenv
+import os
+
 from alpaca.trading.client import TradingClient
+from dotenv import load_dotenv
 from src.utils.alpaca_client import get_alpaca_credentials, get_brokerage_credentials
 
 # Load environment variables from .env
@@ -21,7 +22,7 @@ def main():
             return
         paper_client = TradingClient(p_key, p_secret, paper=True)
         paper_acc = paper_client.get_account()
-        
+
         # 2. Connect to Field ($200 Live)
         l_key, l_secret = get_brokerage_credentials()
         if not l_key:
@@ -29,13 +30,13 @@ def main():
             return
         live_client = TradingClient(l_key, l_secret, paper=False)
         live_acc = live_client.get_account()
-        
-        print(f"--- DUAL-TRACK SYNC COMPLETE ---")
+
+        print("--- DUAL-TRACK SYNC COMPLETE ---")
         print(f"LAB ($100K Paper):  ${float(paper_acc.equity):,.2f} [Account: {paper_acc.account_number}]")
         print(f"FIELD ($200 Live):  ${float(live_acc.equity):,.2f} [Account: {live_acc.account_number}]")
-        print(f"Strategy Status:    AI-Native Shadowing Active")
-        print(f"North Star Target:  $6,000/month after-tax")
-        
+        print("Strategy Status:    AI-Native Shadowing Active")
+        print("North Star Target:  $6,000/month after-tax")
+
     except Exception as e:
         print(f"❌ FAILED to sync: {e}")
 

--- a/src/agents/audit_agent.py
+++ b/src/agents/audit_agent.py
@@ -37,8 +37,8 @@ class AuditReport:
 class AuditAgent(BaseAgent):
     """
     Adversarial Audit Agent.
-    
-    Performs autonomous "Adversarial Audits" on trade execution logs using 
+
+    Performs autonomous "Adversarial Audits" on trade execution logs using
     deterministic checks and RLM Algorithm 1 for complex anomaly detection.
     """
 
@@ -50,7 +50,7 @@ class AuditAgent(BaseAgent):
 
     def analyze(self, data: dict[str, Any]) -> dict[str, Any]:
         """
-        Implementation of abstract base method. 
+        Implementation of abstract base method.
         Calls perform_audit() for the provided date or latest logs.
         """
         date_str = data.get("date", datetime.now().strftime("%Y-%m-%d"))
@@ -80,7 +80,7 @@ class AuditAgent(BaseAgent):
             )
 
         try:
-            with open(log_file, "r") as f:
+            with open(log_file) as f:
                 trades = json.load(f)
         except Exception as e:
             logger.error(f"Failed to load trade log {log_file}: {e}")
@@ -93,7 +93,7 @@ class AuditAgent(BaseAgent):
             )
 
         violations = []
-        
+
         # 1. Scan for Rule #1 Violations (Realized Loss)
         # 2. Scan for Position Sizing Violations
         # 3. Scan for Ticker Violations
@@ -108,7 +108,7 @@ class AuditAgent(BaseAgent):
             # Option symbols are longer, extract underlying
             underlying = symbol[:3] if len(symbol) > 5 else symbol
             allowed = ["SPY", "QQQ", "IWM", "SPX", "XSP", "VIX", "UVXY", "SVXY", "VOO"]
-            
+
             if underlying not in allowed:
                 violations.append(AuditViolation(
                     rule="Ticker Whitelist",
@@ -131,15 +131,13 @@ class AuditAgent(BaseAgent):
 
         # Status Determination
         status = "PASS"
-        if any(v.severity == "CRITICAL" for v in violations):
-            status = "FAIL"
-        elif any(v.severity == "HIGH" for v in violations):
+        if any(v.severity == "CRITICAL" for v in violations) or any(v.severity == "HIGH" for v in violations):
             status = "FAIL"
         elif violations:
             status = "WARN"
 
         summary = f"Audit for {date_str} complete. Scanned {len(trades)} entries. Found {len(violations)} violations."
-        
+
         report = AuditReport(
             timestamp=datetime.now().isoformat(),
             trades_scanned=len(trades),
@@ -166,12 +164,12 @@ class AuditAgent(BaseAgent):
         Use RLM Algorithm 1 to perform a deep reasoning audit.
         Generates Python code to analyze logs for subtle patterns.
         """
-        prompt = f"""
-        You are the Adversarial Audit Agent. Your mission is to find hidden bugs, 
+        _prompt = f"""
+        You are the Adversarial Audit Agent. Your mission is to find hidden bugs,
         risk management failures, or logic errors in today's ({date_str}) trade logs.
-        
+
         Log location: data/trades_{date_str}.json
-        
+
         Task:
         1. Write a pure Python script to analyze this JSON file.
         2. Look for:
@@ -181,9 +179,9 @@ class AuditAgent(BaseAgent):
         3. Output the results as a JSON object with 'anomalies' and 'score'.
         """
         # Algorithm 1: Plan -> Generate -> Execute -> Finalize
-        # Implementation of RLM logic would go here, 
+        # Implementation of RLM logic would go here,
         # using reason_with_llm to get the Python code.
-        
+
         logger.info(f"Running LLM Adversarial Audit for {date_str}...")
         # (Simplified for now - will be expanded in future PRs)
         return {"anomalies": [], "score": 1.0}

--- a/src/ml/grpo_trade_learner.py
+++ b/src/ml/grpo_trade_learner.py
@@ -407,10 +407,6 @@ class GRPOTradeLearner:
         """Estimate market features at time of trade."""
         # Default features
         filled_at = trade.get("filled_at", "")
-        
-        # Check for embedded indicators (new regime-aware format)
-        indicators = trade.get("indicators", {})
-        vix_level = float(indicators.get("vix", 18.0))
 
         # Extract hour from timestamp
         hour = 0.5  # Default to mid-day

--- a/tests/test_audit_agent.py
+++ b/tests/test_audit_agent.py
@@ -9,7 +9,7 @@ def mock_trade_logs(tmp_path):
     # Temporarily point the agent to a mock log directory
     date_str = "2026-02-23"
     log_file = tmp_path / f"trades_{date_str}.json"
-    
+
     trades = [
         {
             "symbol": "SPY",
@@ -33,33 +33,33 @@ def mock_trade_logs(tmp_path):
             "order_id": "T3"
         }
     ]
-    
+
     with open(log_file, "w") as f:
         json.dump(trades, f)
-        
+
     return str(tmp_path), date_str
 
 def test_audit_agent_perform_audit(mock_trade_logs):
     """Test deterministic audit logic."""
     log_dir, date_str = mock_trade_logs
-    
+
     agent = AuditAgent()
     agent.log_dir = Path(log_dir) # Point to mock dir
-    
+
     report = agent.perform_audit(date_str)
-    
+
     assert report.trades_scanned == 3
     assert len(report.violations) == 2
     assert report.status == "FAIL" # HIGH severity violation exists
-    
+
     v_symbols = [v.rule for v in report.violations]
     assert "Ticker Whitelist" in v_symbols
     assert "Position Sizing" in v_symbols
-    
+
     # Check that report file was saved
     report_file = agent.report_dir / f"audit_{date_str}.json"
     assert report_file.exists()
-    with open(report_file, "r") as f:
+    with open(report_file) as f:
         saved_report = json.load(f)
         assert saved_report["status"] == "FAIL"
 
@@ -67,7 +67,7 @@ def test_audit_agent_no_logs():
     """Test audit with no logs."""
     agent = AuditAgent()
     agent.log_dir = Path("non_existent_dir")
-    
+
     report = agent.perform_audit("2020-01-01")
     assert report.trades_scanned == 0
     assert report.status == "PASS"

--- a/tests/test_grpo_trade_learner.py
+++ b/tests/test_grpo_trade_learner.py
@@ -32,6 +32,7 @@ def _make_features(**overrides) -> TradeFeatures:
         day_of_week=0.4,
         days_to_expiry=30.0,
         put_call_ratio=1.0,
+        vix_term_structure=0.9,
     )
     defaults.update(overrides)
     return TradeFeatures(**defaults)
@@ -69,20 +70,20 @@ class TestTradeFeatures:
     def test_to_array_shape_and_dtype(self):
         f = _make_features()
         arr = f.to_array()
-        assert arr.shape == (8,)
+        assert arr.shape == (9,)
         assert arr.dtype == np.float32
 
     def test_to_array_normalization(self):
         f = _make_features(vix_level=25.0, days_to_expiry=60.0)
         arr = f.to_array()
         assert arr[0] == pytest.approx(25.0 / 50.0)  # vix normalized
-        assert arr[6] == pytest.approx(60.0 / 60.0)  # dte normalized
+        assert arr[7] == pytest.approx(60.0 / 60.0)  # dte normalized
 
     def test_to_array_returns_scaling(self):
         f = _make_features(spy_20d_return=0.02, spy_5d_return=-0.01)
         arr = f.to_array()
-        assert arr[2] == pytest.approx(0.02 * 10)
-        assert arr[3] == pytest.approx(-0.01 * 10)
+        assert arr[3] == pytest.approx(0.02 * 10)
+        assert arr[4] == pytest.approx(-0.01 * 10)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_workflow_ml_integration.py
+++ b/tests/test_workflow_ml_integration.py
@@ -9,7 +9,7 @@ async def test_workflow_consumes_ml_params():
     calls and consumes parameters from the ML learner.
     """
     workflow = create_trading_workflow()
-    
+
     # Execute only up to options_chain to verify data injection
     # We mock inputs for dependencies
     initial_inputs = {
@@ -19,20 +19,20 @@ async def test_workflow_consumes_ml_params():
         "risk_gate": {"passed": True},
         "regime_gate": {"passed": True}
     }
-    
+
     # Manual execution of the node to inspect output
     node = workflow.nodes["options_chain"]
     result = await node.execute(initial_inputs, {})
-    
+
     assert result.success is True
     data = result.output.get("data", {})
-    
+
     # PROOF: The ML Optimizer just recommended Delta 0.225 / DTE 30
     # The default was Delta 0.15 / DTE 30.
     # If the value is 0.225, the integration is proven.
     assert data["recommended_delta"] > 0.15
     assert data["recommended_dte"] == 30
-    
+
     print(f"\n✅ PROVEN: Workflow is using ML Delta: {data['recommended_delta']}")
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Fix 37 ruff lint errors across 6 source files (whitespace, unused imports/vars, f-strings)
- Fix `test_grpo_trade_learner` — add `vix_term_structure` to `TradeFeatures` fixture, update array indices for 9-element feature vector
- Remove unused `vix_level`/`indicators` vars from `grpo_trade_learner.py`

## Test plan
- [x] `ruff check src/ scripts/ tests/` — 0 errors
- [x] `pytest tests/test_grpo_trade_learner.py` — 45 passed
- [x] `pytest` on all changed files — 83 passed
- [x] Pre-push hook: 122 unit + 9 integration passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)