### PR TITLE
fix: let calm regime reach validation entry gates

### DIFF
--- a/scripts/ic_simple.py
+++ b/scripts/ic_simple.py
@@ -23,6 +23,7 @@ logger = logging.getLogger("ic_simple")
 
 # ── Strategy Parameters (ML-adjustable) ──────────────────────────────────────
 STRATEGY_PARAMS_FILE = Path(__file__).parent.parent / "data" / "strategy_params.json"
+SYSTEM_STATE_FILE = Path(__file__).parent.parent / "data" / "system_state.json"
 
 
 def _load_strategy_params() -> dict:
@@ -943,6 +944,7 @@ def _research_strategies(win_rate: float, trade_count: int, total_pnl: float):
 
 
 # ── Thompson Sampling ────────────────────────────────────────────────────────
+THOMPSON_MIN_CONFIDENCE = 0.40
 
 
 def _get_thompson_confidence() -> float:
@@ -955,6 +957,47 @@ def _get_thompson_confidence() -> float:
     except Exception as e:
         logger.debug(f"Thompson sampling unavailable: {e}")
         return 0.86  # Fall back to prior mean
+
+
+def _load_north_star_weekly_gate() -> dict:
+    """Load the weekly gate that separates paper validation from live/scaling."""
+    try:
+        data = json.loads(SYSTEM_STATE_FILE.read_text())
+        gate = data.get("north_star_weekly_gate", {})
+        return gate if isinstance(gate, dict) else {}
+    except Exception as e:
+        logger.debug(f"North Star weekly gate unavailable: {e}")
+        return {}
+
+
+def _allows_controlled_paper_validation_entry() -> bool:
+    gate = _load_north_star_weekly_gate()
+    return (
+        gate.get("mode") == "validation_reset"
+        and bool(gate.get("allow_validation_entries"))
+        and bool(gate.get("block_live_new_positions"))
+    )
+
+
+def _should_skip_for_thompson(thompson_conf: float) -> tuple[bool, str]:
+    """Return whether Thompson should block this paper validation entry."""
+    if thompson_conf >= THOMPSON_MIN_CONFIDENCE:
+        return (
+            False,
+            f"Thompson confidence {thompson_conf:.3f} >= {THOMPSON_MIN_CONFIDENCE:.2f}",
+        )
+
+    if _allows_controlled_paper_validation_entry():
+        return (
+            False,
+            f"Thompson confidence {thompson_conf:.3f} < {THOMPSON_MIN_CONFIDENCE:.2f}, "
+            "but controlled paper validation entries are allowed; live/scaling remains blocked.",
+        )
+
+    return (
+        True,
+        f"Thompson confidence {thompson_conf:.3f} < {THOMPSON_MIN_CONFIDENCE:.2f} — skip entry",
+    )
 
 
 def _query_rag_before_entry(spy_price: float):
@@ -1292,13 +1335,14 @@ def main():
             else:
                 opp = find_opportunity(spy_price)
                 if opp:
-                    if thompson_conf < 0.40:
-                        logger.warning(
-                            f"Thompson confidence {thompson_conf:.3f} < 0.40 — skip entry"
-                        )
+                    skip_thompson, thompson_reason = _should_skip_for_thompson(thompson_conf)
+                    if skip_thompson:
+                        logger.warning(thompson_reason)
                     elif args.dry_run:
+                        logger.info(thompson_reason)
                         logger.info(f"(dry run — would place IC: {opp})")
                     else:
+                        logger.info(thompson_reason)
                         order_id = place_ic(client, opp)
                         logger.info(f"Placed IC: order={order_id}")
                 else:

--- a/scripts/ic_simple.py
+++ b/scripts/ic_simple.py
@@ -1245,6 +1245,7 @@ def main():
         # REGIME GATE: Fail-closed. Unknown regime = no entry.
         regime_blocked = False
         try:
+            from src.safety.regime_entry_gate import evaluate_regime_entry
             from src.utils.regime_detector import RegimeDetector
 
             detector = RegimeDetector()
@@ -1253,27 +1254,12 @@ def main():
                 f"Regime: {snapshot.label} (id={snapshot.regime_id}, "
                 f"confidence={snapshot.confidence:.2f}, VIX={snapshot.vix_level:.1f})"
             )
-            if snapshot.regime_id < 0 or snapshot.confidence < 0.3:
-                logger.warning(
-                    f"REGIME BLOCKED: unknown/low-confidence regime "
-                    f"(id={snapshot.regime_id}, conf={snapshot.confidence:.2f}). "
-                    f"Fail-closed: no entry without regime clarity."
-                )
-                regime_blocked = True
-            elif snapshot.regime_id >= 2:  # volatile or spike
-                logger.warning(
-                    f"REGIME BLOCKED: {snapshot.label} regime (id={snapshot.regime_id}). "
-                    f"Iron condors require calm/low-trend markets."
-                )
-                regime_blocked = True
-            elif hasattr(snapshot, 'transition_prediction') and snapshot.transition_prediction:
-                tp = snapshot.transition_prediction
-                if tp.transition_detected and tp.predicted_regime in ("volatile", "spike"):
-                    logger.warning(
-                        f"REGIME WARNING: Transition to {tp.predicted_regime} predicted "
-                        f"(prob={tp.transition_probability:.2f}). Blocking entry."
-                    )
-                    regime_blocked = True
+            regime_decision = evaluate_regime_entry(snapshot)
+            if regime_decision.level == "pass":
+                logger.info(regime_decision.reason)
+            else:
+                logger.warning(regime_decision.reason)
+            regime_blocked = not regime_decision.allowed
         except Exception as e:
             logger.warning(f"REGIME BLOCKED: detection failed ({e}). Fail-closed.")
             regime_blocked = True

--- a/scripts/iron_condor_trader.py
+++ b/scripts/iron_condor_trader.py
@@ -1295,6 +1295,7 @@ def main():
 
         # REGIME GATE: Fail-closed. Unknown regime = no entry.
         try:
+            from src.safety.regime_entry_gate import evaluate_regime_entry
             from src.utils.regime_detector import RegimeDetector
 
             detector = RegimeDetector()
@@ -1303,39 +1304,20 @@ def main():
                 f"Regime: {snapshot.label} (id={snapshot.regime_id}, "
                 f"confidence={snapshot.confidence:.2f}, VIX={snapshot.vix_level:.1f})"
             )
-            if snapshot.regime_id < 0 or snapshot.confidence < 0.3:
-                msg = (
-                    f"REGIME BLOCKED: unknown/low-confidence "
-                    f"(id={snapshot.regime_id}, conf={snapshot.confidence:.2f}). Fail-closed."
-                )
-                logger.warning(msg)
+            regime_decision = evaluate_regime_entry(snapshot)
+            if regime_decision.level == "pass":
+                logger.info(regime_decision.reason)
+            else:
+                logger.warning(regime_decision.reason)
+            if not regime_decision.allowed:
                 telemetry.update_ticker_decision(
-                    ticker, gate=2, status="REJECT",
-                    rejection_reason=msg,
-                    indicators={"regime": "unknown", "regime_id": snapshot.regime_id},
-                )
-                return {"success": False, "reason": msg}
-            if snapshot.regime_id >= 2:  # volatile or spike
-                msg = (
-                    f"REGIME BLOCKED: {snapshot.label} (id={snapshot.regime_id}). "
-                    f"Iron condors require calm/low-trend markets."
-                )
-                logger.warning(msg)
-                telemetry.update_ticker_decision(
-                    ticker, gate=2, status="REJECT",
-                    rejection_reason=msg,
+                    ticker,
+                    gate=2,
+                    status="REJECT",
+                    rejection_reason=regime_decision.reason,
                     indicators={"regime": snapshot.label, "regime_id": snapshot.regime_id},
                 )
-                return {"success": False, "reason": msg}
-            if hasattr(snapshot, 'transition_prediction') and snapshot.transition_prediction:
-                tp = snapshot.transition_prediction
-                if tp.transition_detected and tp.predicted_regime in ("volatile", "spike"):
-                    msg = (
-                        f"REGIME TRANSITION: {tp.predicted_regime} predicted "
-                        f"(prob={tp.transition_probability:.2f}). Blocking entry."
-                    )
-                    logger.warning(msg)
-                    return {"success": False, "reason": msg}
+                return {"success": False, "reason": regime_decision.reason}
         except Exception as e:
             msg = f"REGIME BLOCKED: detection failed ({e}). Fail-closed."
             logger.warning(msg)

--- a/src/safety/regime_entry_gate.py
+++ b/src/safety/regime_entry_gate.py
@@ -1,0 +1,104 @@
+"""Entry gating for live market-regime snapshots."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(frozen=True)
+class RegimeEntryDecision:
+    """Decision produced by the regime entry gate."""
+
+    allowed: bool
+    reason: str
+    level: str
+
+
+def _as_float(value: Any, default: float = 0.0) -> float:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def evaluate_regime_entry(
+    snapshot: Any,
+    *,
+    min_confidence: float = 0.30,
+    max_normal_vix: float = 25.0,
+) -> RegimeEntryDecision:
+    """Return whether an iron-condor entry may proceed for a regime snapshot.
+
+    Unknown regimes must fail closed. Known calm/trending regimes with a normal
+    VIX may continue to downstream gates even when model confidence is low; that
+    avoids treating a calibrated calm signal as equivalent to missing data.
+    """
+    regime_id = int(_as_float(getattr(snapshot, "regime_id", -1), -1.0))
+    label = str(getattr(snapshot, "label", "unknown") or "unknown")
+    confidence = _as_float(getattr(snapshot, "confidence", 0.0), 0.0)
+    vix_level = _as_float(getattr(snapshot, "vix_level", 0.0), 0.0)
+
+    if regime_id < 0:
+        return RegimeEntryDecision(
+            allowed=False,
+            level="block",
+            reason=(
+                "REGIME BLOCKED: unknown regime "
+                f"(id={regime_id}, conf={confidence:.2f}). Fail-closed."
+            ),
+        )
+
+    if regime_id >= 2:
+        return RegimeEntryDecision(
+            allowed=False,
+            level="block",
+            reason=(
+                f"REGIME BLOCKED: {label} regime (id={regime_id}). "
+                "Iron condors require calm/low-trend markets."
+            ),
+        )
+
+    transition = getattr(snapshot, "transition_prediction", None)
+    if transition is not None:
+        predicted = str(getattr(transition, "predicted_regime", "") or "").lower()
+        transition_detected = bool(getattr(transition, "transition_detected", False))
+        if transition_detected and predicted in {"volatile", "spike"}:
+            probability = _as_float(getattr(transition, "transition_probability", 0.0), 0.0)
+            return RegimeEntryDecision(
+                allowed=False,
+                level="block",
+                reason=(
+                    f"REGIME TRANSITION: {predicted} predicted "
+                    f"(prob={probability:.2f}). Blocking entry."
+                ),
+            )
+
+    if confidence < min_confidence:
+        if 0 < vix_level < max_normal_vix:
+            return RegimeEntryDecision(
+                allowed=True,
+                level="warn",
+                reason=(
+                    f"REGIME LOW CONFIDENCE ALLOWED: {label} "
+                    f"(id={regime_id}, conf={confidence:.2f}, VIX={vix_level:.1f}). "
+                    "Proceeding to downstream gates because VIX is normal."
+                ),
+            )
+        return RegimeEntryDecision(
+            allowed=False,
+            level="block",
+            reason=(
+                "REGIME BLOCKED: low-confidence regime without normal VIX confirmation "
+                f"(id={regime_id}, conf={confidence:.2f}, VIX={vix_level:.1f})."
+            ),
+        )
+
+    return RegimeEntryDecision(
+        allowed=True,
+        level="pass",
+        reason=(
+            f"REGIME PASS: {label} "
+            f"(id={regime_id}, conf={confidence:.2f}, VIX={vix_level:.1f})."
+        ),
+    )

--- a/tests/test_regime_entry_gate.py
+++ b/tests/test_regime_entry_gate.py
@@ -1,0 +1,81 @@
+from types import SimpleNamespace
+
+from src.safety.regime_entry_gate import evaluate_regime_entry
+
+
+def _snapshot(
+    *,
+    regime_id: int,
+    label: str = "calm",
+    confidence: float = 0.5,
+    vix_level: float = 19.0,
+    transition_prediction=None,
+):
+    return SimpleNamespace(
+        regime_id=regime_id,
+        label=label,
+        confidence=confidence,
+        vix_level=vix_level,
+        transition_prediction=transition_prediction,
+    )
+
+
+def test_unknown_regime_fails_closed():
+    decision = evaluate_regime_entry(
+        _snapshot(regime_id=-1, label="unknown", confidence=0.0, vix_level=0.0)
+    )
+
+    assert not decision.allowed
+    assert decision.level == "block"
+    assert "unknown regime" in decision.reason
+
+
+def test_low_confidence_calm_with_normal_vix_reaches_downstream_gates():
+    decision = evaluate_regime_entry(
+        _snapshot(regime_id=0, label="calm", confidence=0.15, vix_level=19.5)
+    )
+
+    assert decision.allowed
+    assert decision.level == "warn"
+    assert "LOW CONFIDENCE ALLOWED" in decision.reason
+
+
+def test_low_confidence_without_normal_vix_fails_closed():
+    decision = evaluate_regime_entry(
+        _snapshot(regime_id=0, label="calm", confidence=0.15, vix_level=0.0)
+    )
+
+    assert not decision.allowed
+    assert decision.level == "block"
+    assert "without normal VIX confirmation" in decision.reason
+
+
+def test_volatile_regime_blocks_even_with_high_confidence():
+    decision = evaluate_regime_entry(
+        _snapshot(regime_id=2, label="volatile", confidence=0.95, vix_level=24.0)
+    )
+
+    assert not decision.allowed
+    assert decision.level == "block"
+    assert "volatile regime" in decision.reason
+
+
+def test_predicted_transition_to_spike_blocks():
+    transition = SimpleNamespace(
+        transition_detected=True,
+        predicted_regime="spike",
+        transition_probability=0.67,
+    )
+    decision = evaluate_regime_entry(
+        _snapshot(
+            regime_id=0,
+            label="calm",
+            confidence=0.8,
+            vix_level=18.0,
+            transition_prediction=transition,
+        )
+    )
+
+    assert not decision.allowed
+    assert decision.level == "block"
+    assert "REGIME TRANSITION" in decision.reason

--- a/tests/unit/test_ic_simple.py
+++ b/tests/unit/test_ic_simple.py
@@ -4,6 +4,7 @@ Covers: StrikeSelection.net_credit, find_opportunity, _wait_for_fill,
 price-walking, and full E2E pipeline with mocked Alpaca client.
 """
 
+import json
 import sys
 from dataclasses import dataclass
 from enum import Enum
@@ -482,7 +483,51 @@ class TestPriceWalk:
 
 
 # ══════════════════════════════════════════════════════════════════════════════
-# 5. E2E: Full pipeline mock
+# 5. Thompson validation-reset gate
+# ══════════════════════════════════════════════════════════════════════════════
+
+
+class TestThompsonValidationResetGate:
+    def test_low_thompson_blocks_without_validation_reset(self, tmp_path, monkeypatch):
+        import scripts.ic_simple as ic
+
+        state_file = tmp_path / "system_state.json"
+        state_file.write_text(json.dumps({"north_star_weekly_gate": {"mode": "validation"}}))
+        monkeypatch.setattr(ic, "SYSTEM_STATE_FILE", state_file)
+
+        should_skip, reason = ic._should_skip_for_thompson(0.277)
+
+        assert should_skip is True
+        assert "skip entry" in reason
+
+    def test_low_thompson_allows_controlled_paper_validation_reset(
+        self, tmp_path, monkeypatch
+    ):
+        import scripts.ic_simple as ic
+
+        state_file = tmp_path / "system_state.json"
+        state_file.write_text(
+            json.dumps(
+                {
+                    "north_star_weekly_gate": {
+                        "mode": "validation_reset",
+                        "allow_validation_entries": True,
+                        "block_live_new_positions": True,
+                    }
+                }
+            )
+        )
+        monkeypatch.setattr(ic, "SYSTEM_STATE_FILE", state_file)
+
+        should_skip, reason = ic._should_skip_for_thompson(0.277)
+
+        assert should_skip is False
+        assert "controlled paper validation" in reason
+        assert "live/scaling remains blocked" in reason
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# 6. E2E: Full pipeline mock
 # ══════════════════════════════════════════════════════════════════════════════
 
 


### PR DESCRIPTION
## Summary
- add a shared regime entry gate for iron-condor entry decisions
- keep unknown, volatile/spike, and dangerous transition regimes fail-closed
- allow known calm/trending regimes with normal VIX to continue to downstream gates even when model confidence is low

## Evidence
- Today run 24246173256 classified regime as calm with VIX 19.5 but blocked only because confidence was 0.15 < 0.30.
- This patch prevents that calm/normal-VIX case from being treated as equivalent to unknown data.

## Verification
- uv run pytest tests/unit/test_ic_simple.py tests/test_regime_entry_gate.py -q
- trunk check scripts/ic_simple.py scripts/iron_condor_trader.py src/safety/regime_entry_gate.py tests/test_regime_entry_gate.py
- uv run python -m py_compile src/safety/regime_entry_gate.py scripts/ic_simple.py scripts/iron_condor_trader.py