### PR TITLE
Fix validation reset through ML halt

### DIFF
--- a/scripts/ic_simple.py
+++ b/scripts/ic_simple.py
@@ -64,6 +64,8 @@ EXIT_DTE = _SP["exit_dte"]
 WING_WIDTH = _SP["wing_width"]
 TARGET_DELTA = _SP["target_delta"]
 ENTRIES_FILE = Path(__file__).parent.parent / "data" / "ic_entries.json"
+SYSTEM_STATE_FILE = Path(__file__).parent.parent / "data" / "system_state.json"
+THOMPSON_MIN_CONFIDENCE = 0.40
 
 
 # ── Alpaca Client ────────────────────────────────────────────────────────────
@@ -200,6 +202,7 @@ def place_ic(client, opp: dict) -> str | None:
 
     if not filled:
         logger.warning(f"Price walk exhausted (${MAX_WALK:.2f} concession). No fill.")
+        return None
 
     # Save entry data
     entries = _load_entries()
@@ -940,6 +943,40 @@ def _get_thompson_confidence() -> float:
         return 0.0  # Fail-closed: block entry when model unavailable
 
 
+def _load_north_star_weekly_gate() -> dict:
+    try:
+        data = json.loads(SYSTEM_STATE_FILE.read_text(encoding="utf-8"))
+        gate = data.get("north_star_weekly_gate", {})
+        return gate if isinstance(gate, dict) else {}
+    except Exception as exc:
+        logger.debug(f"North Star weekly gate load failed: {exc}")
+        return {}
+
+
+def _allows_controlled_paper_validation_entry() -> bool:
+    gate = _load_north_star_weekly_gate()
+    return (
+        gate.get("mode") == "validation_reset"
+        and bool(gate.get("allow_validation_entries"))
+        and bool(gate.get("block_live_new_positions"))
+    )
+
+
+def _should_skip_for_thompson(confidence: float) -> tuple[bool, str]:
+    if confidence >= THOMPSON_MIN_CONFIDENCE:
+        return False, (
+            f"Thompson confidence {confidence:.3f} >= {THOMPSON_MIN_CONFIDENCE:.2f}"
+        )
+    if _allows_controlled_paper_validation_entry():
+        return False, (
+            f"Thompson confidence {confidence:.3f} < {THOMPSON_MIN_CONFIDENCE:.2f}, "
+            "but controlled paper validation entries are allowed; live/scaling remains blocked."
+        )
+    return True, (
+        f"Thompson confidence {confidence:.3f} < {THOMPSON_MIN_CONFIDENCE:.2f} — skip entry"
+    )
+
+
 def _query_rag_before_entry(spy_price: float):
     """Query RAG for relevant lessons before entering a trade."""
     try:
@@ -1289,15 +1326,17 @@ def main():
             else:
                 opp = find_opportunity(spy_price)
                 if opp:
-                    if thompson_conf < 0.40:
-                        logger.warning(
-                            f"Thompson confidence {thompson_conf:.3f} < 0.40 — skip entry"
-                        )
-                    elif args.dry_run:
-                        logger.info(f"(dry run — would place IC: {opp})")
+                    should_skip, thompson_reason = _should_skip_for_thompson(thompson_conf)
+                    if should_skip:
+                        logger.warning(thompson_reason)
                     else:
-                        order_id = place_ic(client, opp)
-                        logger.info(f"Placed IC: order={order_id}")
+                        if thompson_conf < THOMPSON_MIN_CONFIDENCE:
+                            logger.info(thompson_reason)
+                        if args.dry_run:
+                            logger.info(f"(dry run — would place IC: {opp})")
+                        else:
+                            order_id = place_ic(client, opp)
+                            logger.info(f"Placed IC: order={order_id}")
                 else:
                     logger.info("No opportunity found.")
 

--- a/src/safety/mandatory_trade_gate.py
+++ b/src/safety/mandatory_trade_gate.py
@@ -119,6 +119,99 @@ _POLICY_METADATA_PATH = (
 )
 _DEFAULT_POLICY_MAX_AGE_DAYS = 7
 _DEFAULT_POLICY_MIN_TRADE_COUNT = 30
+_VALIDATION_ENTRY_MAX_QTY = 1
+_VALIDATION_STRATEGIES = {"iron_condor", "ic_simple", "options_income"}
+
+
+def _load_north_star_weekly_gate() -> dict[str, Any]:
+    """Load the current North Star weekly gate from system state."""
+    try:
+        payload = json.loads(_SYSTEM_STATE_PATH.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        return {}
+    except Exception as exc:
+        logger.warning("Failed to read North Star weekly gate: %s", exc)
+        return {}
+
+    if not isinstance(payload, dict):
+        return {}
+    gate = payload.get("north_star_weekly_gate", {})
+    return gate if isinstance(gate, dict) else {}
+
+
+def _weekly_gate_allows_validation_entries(gate: dict[str, Any] | None = None) -> bool:
+    gate = gate if isinstance(gate, dict) else _load_north_star_weekly_gate()
+    return (
+        str(gate.get("mode") or "").strip().lower() == "validation_reset"
+        and _to_bool(gate.get("allow_validation_entries"), default=False)
+        and _to_bool(gate.get("block_live_new_positions"), default=False)
+    )
+
+
+def _is_ml_gate_halt_reason(reason: str) -> bool:
+    normalized = str(reason or "").upper()
+    return "ML GATE BLOCKED" in normalized and "WIN RATE" in normalized
+
+
+def _extract_order_qty(order_request: Any) -> int:
+    try:
+        return max(1, int(float(getattr(order_request, "qty", 1) or 1)))
+    except Exception as exc:
+        logger.debug("Failed to parse order qty %r: %s", getattr(order_request, "qty", None), exc)
+        return 1
+
+
+def _infer_paper_trading_client(client: Any) -> bool:
+    """Best-effort paper/live inference. Unknown defaults to live/fail-closed."""
+    for attr in ("paper", "_paper", "is_paper", "paper_trading"):
+        value = getattr(client, attr, None)
+        if isinstance(value, bool):
+            return value
+
+    try:
+        from src.utils.alpaca_client import get_alpaca_credentials
+
+        _api_key, _api_secret, is_paper = get_alpaca_credentials()
+        return bool(is_paper)
+    except Exception as exc:
+        logger.warning("Unable to infer paper trading mode; validation reset stays closed: %s", exc)
+        return False
+
+
+def _allows_controlled_validation_halt_override(
+    *,
+    halt_reason: str,
+    strategy: str,
+    context: dict[str, Any] | None,
+) -> bool:
+    """Allow only explicit one-lot paper validation entries through the ML halt.
+
+    This does not disable crisis/manual halts. It only prevents the legacy
+    ML win-rate sentinel from deadlocking the validation cohort that must
+    generate new evidence before live/scaling can resume.
+    """
+    if not _is_ml_gate_halt_reason(halt_reason):
+        return False
+    if not _weekly_gate_allows_validation_entries():
+        return False
+
+    context = context or {}
+    if not _to_bool(context.get("controlled_paper_validation_entry"), default=False):
+        return False
+    if not _to_bool(context.get("paper_trading"), default=False):
+        return False
+
+    strategy_name = str(strategy or "").strip().lower()
+    if strategy_name not in _VALIDATION_STRATEGIES:
+        return False
+
+    try:
+        qty = int(float(context.get("validation_entry_quantity", 999)))
+    except Exception as exc:
+        logger.debug("Failed to parse validation quantity: %s", exc)
+        return False
+
+    return 1 <= qty <= _VALIDATION_ENTRY_MAX_QTY
 
 
 def _today_et_str() -> str:
@@ -701,6 +794,8 @@ def validate_trade_mandatory(
     if side == "SELL" and symbol in current_symbols:
         is_opening = False
 
+    halt_state = None
+    halt_override_allowed = False
     if is_opening:
         try:
             from src.safety.trading_halt import get_trading_halt_state
@@ -710,11 +805,29 @@ def validate_trade_mandatory(
             halt_state = None
 
         if halt_state and halt_state.active:
-            return GateResult(
-                approved=False,
-                reason=f"Trading halted: {halt_state.reason}",
-                checks_performed=checks_performed + [f"trading_halt: BLOCKED ({halt_state.kind})"],
+            halt_override_allowed = _allows_controlled_validation_halt_override(
+                halt_reason=halt_state.reason,
+                strategy=strategy,
+                context=context,
             )
+            if halt_override_allowed:
+                warning = (
+                    "validation_reset: legacy ML halt bypassed for one-lot paper "
+                    "validation entry; live/scaling remains blocked"
+                )
+                warnings.append(warning)
+                checks_performed.append("trading_halt: ML_HALT_BYPASSED_VALIDATION_RESET")
+                logger.warning("⚠️ %s", warning)
+            else:
+                return GateResult(
+                    approved=False,
+                    reason=f"Trading halted: {halt_state.reason}",
+                    checks_performed=checks_performed
+                    + [f"trading_halt: BLOCKED ({halt_state.kind})"],
+                )
+
+    if not halt_override_allowed:
+        checks_performed.append("trading_halt: PASS" if is_opening else "trading_halt: SKIP")
 
     guard_ok, guard_reason = _enforce_intraday_guardrails(
         equity=float(equity or 0.0),
@@ -1396,9 +1509,20 @@ def safe_submit_order(client, order_request, strategy: str | None = None):
                 equity = _get_account_equity_from_client(client) or 0.0
                 max_loss, _dte, _underlying = _estimate_opening_max_loss(order_request)
                 est_amount = float(max_loss or 0.0)
+                order_qty = _extract_order_qty(order_request)
+                paper_trading = _infer_paper_trading_client(client)
                 # Best-effort account context so that direct script submissions
                 # still benefit from the same dynamic guardrails as AlpacaExecutor.
-                account_context: dict[str, Any] = {"equity": float(equity)}
+                account_context: dict[str, Any] = {
+                    "equity": float(equity),
+                    "paper_trading": paper_trading,
+                    "validation_entry_quantity": order_qty,
+                    "controlled_paper_validation_entry": (
+                        paper_trading
+                        and order_qty <= _VALIDATION_ENTRY_MAX_QTY
+                        and str(strategy or "").strip().lower() in _VALIDATION_STRATEGIES
+                    ),
+                }
 
                 # Include current positions for stacking + count checks (best-effort).
                 try:

--- a/tests/test_mandatory_trade_gate.py
+++ b/tests/test_mandatory_trade_gate.py
@@ -277,6 +277,164 @@ class TestValidateTradeMandatory:
         assert "rebuild in progress" in result.reason.lower()
         assert any("trading_halt: BLOCKED" in check for check in result.checks_performed)
 
+    def test_ml_halt_allows_controlled_paper_validation_reset(
+        self, monkeypatch, tmp_path
+    ):
+        """Validation reset can collect new one-lot paper evidence despite legacy ML halt."""
+        import json
+
+        import src.safety.mandatory_trade_gate as gate_mod
+        import src.safety.trading_halt as halt_mod
+
+        state_file = tmp_path / "system_state.json"
+        state_file.write_text(
+            json.dumps(
+                {
+                    "north_star_weekly_gate": {
+                        "mode": "validation_reset",
+                        "allow_validation_entries": True,
+                        "block_live_new_positions": True,
+                    }
+                }
+            ),
+            encoding="utf-8",
+        )
+        monkeypatch.setattr(gate_mod, "_SYSTEM_STATE_PATH", state_file)
+        monkeypatch.setattr(
+            halt_mod,
+            "get_trading_halt_state",
+            lambda: SimpleNamespace(
+                active=True,
+                kind="system_halt",
+                path="data/TRADING_HALTED",
+                reason="ML GATE BLOCKED: Win rate 24.2% < 50.0%",
+            ),
+        )
+        monkeypatch.setattr(gate_mod, "_query_rag_for_blocking_lessons", lambda *_: (False, []))
+        monkeypatch.setattr(gate_mod, "_check_market_regime", lambda *_: (1.0, []))
+
+        result = gate_mod.validate_trade_mandatory(
+            symbol="SPY260515P00639000",
+            amount=200.0,
+            side="SELL",
+            strategy="iron_condor",
+            context={
+                "equity": 100000.0,
+                "paper_trading": True,
+                "controlled_paper_validation_entry": True,
+                "validation_entry_quantity": 1,
+            },
+        )
+
+        assert result.approved is True
+        assert any(
+            "ML_HALT_BYPASSED_VALIDATION_RESET" in check
+            for check in result.checks_performed
+        )
+        assert any("legacy ML halt bypassed" in warning for warning in result.rag_warnings)
+
+    def test_ml_halt_still_blocks_live_or_scaling_entries(
+        self, monkeypatch, tmp_path
+    ):
+        """Validation reset must not become a live/scaling bypass."""
+        import json
+
+        import src.safety.mandatory_trade_gate as gate_mod
+        import src.safety.trading_halt as halt_mod
+
+        state_file = tmp_path / "system_state.json"
+        state_file.write_text(
+            json.dumps(
+                {
+                    "north_star_weekly_gate": {
+                        "mode": "validation_reset",
+                        "allow_validation_entries": True,
+                        "block_live_new_positions": True,
+                    }
+                }
+            ),
+            encoding="utf-8",
+        )
+        monkeypatch.setattr(gate_mod, "_SYSTEM_STATE_PATH", state_file)
+        monkeypatch.setattr(
+            halt_mod,
+            "get_trading_halt_state",
+            lambda: SimpleNamespace(
+                active=True,
+                kind="system_halt",
+                path="data/TRADING_HALTED",
+                reason="ML GATE BLOCKED: Win rate 24.2% < 50.0%",
+            ),
+        )
+
+        result = gate_mod.validate_trade_mandatory(
+            symbol="SPY260515P00639000",
+            amount=200.0,
+            side="SELL",
+            strategy="iron_condor",
+            context={
+                "equity": 100000.0,
+                "paper_trading": False,
+                "controlled_paper_validation_entry": True,
+                "validation_entry_quantity": 1,
+            },
+        )
+
+        assert result.approved is False
+        assert "ml gate blocked" in result.reason.lower()
+        assert any("trading_halt: BLOCKED" in check for check in result.checks_performed)
+
+    def test_validation_reset_does_not_bypass_manual_halt(
+        self, monkeypatch, tmp_path
+    ):
+        """Only the legacy ML win-rate sentinel is bypassable."""
+        import json
+
+        import src.safety.mandatory_trade_gate as gate_mod
+        import src.safety.trading_halt as halt_mod
+
+        state_file = tmp_path / "system_state.json"
+        state_file.write_text(
+            json.dumps(
+                {
+                    "north_star_weekly_gate": {
+                        "mode": "validation_reset",
+                        "allow_validation_entries": True,
+                        "block_live_new_positions": True,
+                    }
+                }
+            ),
+            encoding="utf-8",
+        )
+        monkeypatch.setattr(gate_mod, "_SYSTEM_STATE_PATH", state_file)
+        monkeypatch.setattr(
+            halt_mod,
+            "get_trading_halt_state",
+            lambda: SimpleNamespace(
+                active=True,
+                kind="legacy_manual_halt",
+                path="data/trading_halt.txt",
+                reason="Manual halt for operator review.",
+            ),
+        )
+
+        result = gate_mod.validate_trade_mandatory(
+            symbol="SPY260515P00639000",
+            amount=200.0,
+            side="SELL",
+            strategy="iron_condor",
+            context={
+                "equity": 100000.0,
+                "paper_trading": True,
+                "controlled_paper_validation_entry": True,
+                "validation_entry_quantity": 1,
+            },
+        )
+
+        assert result.approved is False
+        assert "manual halt" in result.reason.lower()
+        assert any("trading_halt: BLOCKED" in check for check in result.checks_performed)
+
     def test_milestone_controller_blocks_paused_strategy_family(self):
         """Test that milestone controller blocks BUY for paused strategy families."""
         from src.safety.mandatory_trade_gate import validate_trade_mandatory

--- a/tests/test_validator_coverage.py
+++ b/tests/test_validator_coverage.py
@@ -352,6 +352,46 @@ class TestSafeSubmitOrder:
         assert ctx["positions"]
         mock_client.submit_order.assert_called_once_with(mock_request)
 
+    @patch("src.safety.mandatory_trade_gate._infer_paper_trading_client", return_value=True)
+    @patch("src.safety.mandatory_trade_gate._get_positions_qty_map", return_value={})
+    @patch("src.safety.mandatory_trade_gate._estimate_opening_max_loss")
+    @patch("src.safety.mandatory_trade_gate.validate_trade_mandatory")
+    @patch("src.safety.mandatory_trade_gate._infer_is_closing_order", return_value=False)
+    def test_marks_one_lot_paper_ic_as_controlled_validation_entry(
+        self,
+        _mock_is_closing,
+        mock_gate,
+        mock_estimate_opening_max_loss,
+        _mock_qty_map,
+        _mock_paper,
+    ):
+        """The final order gate gets enough context to keep live/scaling blocked."""
+        mock_gate.return_value = MagicMock(approved=True, reason="")
+        mock_estimate_opening_max_loss.return_value = (500.0, 35, "SPY")
+
+        mock_client = MagicMock(spec=["get_account", "submit_order"])
+        mock_client.get_account.return_value = MagicMock(equity="100000")
+        mock_client.submit_order.return_value = MagicMock(id="ok")
+
+        mock_request = MagicMock()
+        mock_request.symbol = None
+        mock_request.limit_price = -2.05
+        mock_request.qty = 1
+        mock_request.legs = [
+            MagicMock(symbol="SPY260515P00634000", side="BUY", ratio_qty=1),
+            MagicMock(symbol="SPY260515P00639000", side="SELL", ratio_qty=1),
+            MagicMock(symbol="SPY260515C00712000", side="SELL", ratio_qty=1),
+            MagicMock(symbol="SPY260515C00717000", side="BUY", ratio_qty=1),
+        ]
+
+        safe_submit_order(mock_client, mock_request, strategy="iron_condor")
+
+        ctx = mock_gate.call_args.kwargs["context"]
+        assert ctx["paper_trading"] is True
+        assert ctx["validation_entry_quantity"] == 1
+        assert ctx["controlled_paper_validation_entry"] is True
+        mock_client.submit_order.assert_called_once_with(mock_request)
+
 
 # -------------------------------------------------------------------
 # safe_close_position wrapper

--- a/tests/unit/test_ic_simple.py
+++ b/tests/unit/test_ic_simple.py
@@ -406,10 +406,12 @@ class TestPriceWalk:
         mock_submit.return_value = mock_order
         mock_wait.return_value = True  # Fills immediately
 
-        place_ic(MagicMock(), self._make_opp(est_credit=2.50))
+        result = place_ic(MagicMock(), self._make_opp(est_credit=2.50))
 
         # Should only submit once (no retry needed)
         assert mock_submit.call_count == 1
+        assert result == "order-1"
+        mock_save.assert_called_once()
         # Verify limit price: -(est_credit - 0.05) = -2.45
         submitted_request = mock_submit.call_args[0][1]
         assert submitted_request.limit_price == pytest.approx(-2.45)
@@ -457,10 +459,12 @@ class TestPriceWalk:
         mock_submit.return_value = mock_order
 
         client = MagicMock()
-        place_ic(client, self._make_opp(est_credit=2.50))
+        result = place_ic(client, self._make_opp(est_credit=2.50))
 
         # MAX_WALK = 0.20, WALK_INCREMENT = 0.05 → 5 attempts (0, 0.05, 0.10, 0.15, 0.20)
         assert mock_submit.call_count == 5
+        assert result is None
+        mock_save.assert_not_called()
 
     @patch("scripts.ic_simple._save_entries")
     @patch("scripts.ic_simple._load_entries", return_value={})
@@ -476,10 +480,12 @@ class TestPriceWalk:
 
         client = MagicMock()
         # est_credit = 0.60, limit = 0.55. After walk $0.05 → 0.50 (MIN). After $0.10 → 0.45 < MIN → stop
-        place_ic(client, self._make_opp(est_credit=0.60))
+        result = place_ic(client, self._make_opp(est_credit=0.60))
 
         # Should submit only 2 times: at $0.55 and $0.50 (then $0.45 < MIN_CREDIT stops)
         assert mock_submit.call_count == 2
+        assert result is None
+        mock_save.assert_not_called()
 
 
 # ══════════════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Summary
- Allow the legacy ML win-rate halt to be bypassed only for one-lot paper validation-reset IC entries.
- Keep live/scaling and manual/crisis halts fail-closed.
- Stop saving IC entries when price-walked orders never fill.

## Verification
- uv run pytest tests/test_mandatory_trade_gate.py tests/test_validator_coverage.py tests/unit/test_ic_simple.py -q -> 74 passed, 3 skipped
- python3 -m py_compile src/safety/mandatory_trade_gate.py scripts/ic_simple.py
- trunk check src/safety/mandatory_trade_gate.py scripts/ic_simple.py tests/test_mandatory_trade_gate.py tests/test_validator_coverage.py tests/unit/test_ic_simple.py -> No new issues
- RAG_QUERY_INDEX_MAX_AGE_MINUTES=999999 CONTEXT_INDEX_MAX_AGE_MINUTES=999999 SKIP_POLICY_GATE=true uv run python direct gate simulation -> approved=True