### PR TITLE
[codex] harden north star validation reporting

### DIFF
--- a/scripts/build_public_status.py
+++ b/scripts/build_public_status.py
@@ -41,11 +41,6 @@ def _fmt_pct(value: Any) -> str:
 
 
 def _short_status(block_new_positions: bool | None, mode: str | None) -> str:
-    # During validation_reset, show mode even if congruence flags a contradiction.
-    # The contradiction is expected — lifetime ledger is negative from old trades
-    # while validation is proving new edge.
-    if mode and "validation" in str(mode).lower():
-        return str(mode).lower()
     if block_new_positions:
         return "halted"
     if mode:

--- a/scripts/ic_simple.py
+++ b/scripts/ic_simple.py
@@ -430,6 +430,8 @@ def _close_ic(client, legs: list[dict], qty: int):
 # ── Learning: RAG + Trade Journal + Stats ────────────────────────────────────
 
 JOURNAL_FILE = Path(__file__).parent.parent / "data" / "trade_journal.jsonl"
+IC_STATS_FILE = Path(__file__).parent.parent / "data" / "ic_stats.json"
+TRADE_LEDGER_FILE = Path(__file__).parent.parent / "data" / "trades.json"
 LESSONS_DIR = Path(__file__).parent.parent / "rag_knowledge" / "lessons_learned"  # Primary corpus
 
 
@@ -513,11 +515,10 @@ def _record_lesson(expiry: str, credit: float, pnl: float, reason: str, dte: int
 
 def _update_stats(trade: dict):
     """Update running win rate and P/L stats."""
-    stats_file = Path(__file__).parent.parent / "data" / "ic_stats.json"
     try:
         stats = (
-            json.loads(stats_file.read_text())
-            if stats_file.exists()
+            json.loads(IC_STATS_FILE.read_text())
+            if IC_STATS_FILE.exists()
             else {
                 "total": 0,
                 "wins": 0,
@@ -560,7 +561,7 @@ def _update_stats(trade: dict):
         else 999.0
     )
 
-    stats_file.write_text(json.dumps(stats, indent=2))
+    IC_STATS_FILE.write_text(json.dumps(stats, indent=2))
     logger.info(
         f"Stats: {stats['total']} trades | {stats['win_rate']}% win rate | "
         f"PF={stats['profit_factor']} | Total P/L=${stats['total_pnl']:+.2f}"
@@ -570,14 +571,96 @@ def _update_stats(trade: dict):
 # ── Report + Weekend Learning ────────────────────────────────────────────────
 
 
-def _print_report():
-    """Print full performance report from trade journal."""
-    stats_file = Path(__file__).parent.parent / "data" / "ic_stats.json"
-    if not stats_file.exists():
-        logger.info("No stats yet. Complete trades to build data.")
+def _as_report_float(value, default: float = 0.0) -> float:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _as_report_int(value, default: int = 0) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _load_lifetime_ledger_summary() -> dict:
+    """Load paired-trade lifetime stats so validation reports cannot overstate edge."""
+    try:
+        payload = json.loads(TRADE_LEDGER_FILE.read_text(encoding="utf-8"))
+    except Exception as exc:
+        logger.debug(f"Lifetime ledger summary unavailable: {exc}")
+        return {}
+
+    stats = payload.get("stats", {}) if isinstance(payload, dict) else {}
+    if not isinstance(stats, dict):
+        return {}
+
+    closed = _as_report_int(stats.get("closed_trades") or stats.get("total_trades"))
+    wins = _as_report_int(stats.get("wins"))
+    losses = _as_report_int(stats.get("losses"))
+    win_rate = _as_report_float(stats.get("win_rate_pct"))
+    profit_factor = _as_report_float(stats.get("profit_factor"))
+    total_realized = _as_report_float(
+        stats.get("total_realized_pnl", stats.get("total_pnl"))
+    )
+    expectancy = round(total_realized / closed, 4) if closed else 0.0
+
+    return {
+        "closed_trades": closed,
+        "wins": wins,
+        "losses": losses,
+        "win_rate_pct": win_rate,
+        "profit_factor": profit_factor,
+        "total_realized_pnl": total_realized,
+        "expectancy_per_trade": expectancy,
+    }
+
+
+def _print_north_star_readiness_report(validation_total: int):
+    ledger = _load_lifetime_ledger_summary()
+    gate = _load_north_star_weekly_gate()
+    if not ledger and not gate:
         return
 
-    stats = json.loads(stats_file.read_text())
+    logger.info("")
+    logger.info("NORTH STAR READINESS")
+    logger.info(
+        "Validation slice is not promotion evidence until it reaches 30 clean closed trades."
+    )
+    logger.info(f"Validation slice: {validation_total}/30 closed trades")
+
+    if ledger:
+        logger.info(
+            "Lifetime ledger: "
+            f"{ledger['closed_trades']} closed | "
+            f"win_rate={ledger['win_rate_pct']:.2f}% | "
+            f"PF={ledger['profit_factor']:.2f} | "
+            f"expectancy=${ledger['expectancy_per_trade']:+.2f}/trade | "
+            f"realized=${ledger['total_realized_pnl']:+,.2f}"
+        )
+
+    if gate:
+        logger.info(
+            "Gate state: "
+            f"mode={gate.get('mode', 'unknown')} | "
+            f"scale_allowed={bool(gate.get('scale_allowed'))} | "
+            f"block_new_positions={bool(gate.get('block_new_positions'))}"
+        )
+        reason = str(gate.get("blocker_reason") or gate.get("reason") or "").strip()
+        if reason:
+            logger.info(f"Gate blocker: {reason}")
+
+
+def _print_report():
+    """Print full performance report from trade journal."""
+    if not IC_STATS_FILE.exists():
+        logger.info("No stats yet. Complete trades to build data.")
+        _print_north_star_readiness_report(0)
+        return
+
+    stats = json.loads(IC_STATS_FILE.read_text())
     logger.info("=" * 60)
     logger.info("PERFORMANCE REPORT")
     logger.info("=" * 60)
@@ -601,6 +684,8 @@ def _print_report():
             logger.info("\n70-80% win rate. Marginal — review delta selection.")
         else:
             logger.info(f"\n{wr}% win rate. Below target. Reassess strategy.")
+
+    _print_north_star_readiness_report(stats.get("total", 0))
 
     # Print recent trades from journal
     if JOURNAL_FILE.exists():
@@ -788,12 +873,11 @@ def _daily_learn():
         logger.debug(f"GRPO retrain skipped: {e}")
 
     # 2. Quick strategy research (one query per session, saves to RAG)
-    stats_file = Path(__file__).parent.parent / "data" / "ic_stats.json"
     trade_count = 0
     win_rate = 0
     total_pnl = 0
     try:
-        stats = json.loads(stats_file.read_text()) if stats_file.exists() else {}
+        stats = json.loads(IC_STATS_FILE.read_text()) if IC_STATS_FILE.exists() else {}
         win_rate = stats.get("win_rate", 0)
         trade_count = stats.get("total", 0)
         total_pnl = stats.get("total_pnl", 0)

--- a/src/safety/north_star_congruence.py
+++ b/src/safety/north_star_congruence.py
@@ -151,11 +151,19 @@ def assess_gate_congruence(
     cadence_passed = _as_bool(cadence.get("passed"))
     scaling_passed = _as_bool(scaling.get("passed"))
     weekly_mode = str(gate.get("mode") or "unknown").lower()
+    validation_reset_active = bool(
+        weekly_mode == "validation_reset"
+        and _as_bool(gate.get("allow_validation_entries"))
+        and _as_bool(gate.get("block_live_new_positions"))
+    )
 
     readiness_claimed = bool(
         weekly_verified
-        or scaling_passed
-        or (block_new_positions_present and not block_new_positions)
+        or (
+            block_new_positions_present
+            and not block_new_positions
+            and not validation_reset_active
+        )
         or weekly_mode == "expansion_candidate"
     )
 

--- a/tests/test_build_public_status.py
+++ b/tests/test_build_public_status.py
@@ -171,6 +171,38 @@ def test_build_public_status_fails_closed_when_weekly_gate_and_lifetime_ledger_c
     assert "lifetime paired-trade ledger" in status["gate"]["blocker_reason"].lower()
 
 
+def test_build_public_status_preserves_controlled_validation_reset(tmp_path: Path):
+    repo = _seed_repo(tmp_path)
+    state = json.loads((repo / "data/system_state.json").read_text(encoding="utf-8"))
+    state["north_star_weekly_gate"].update(
+        {
+            "mode": "validation_reset",
+            "block_new_positions": False,
+            "block_live_new_positions": True,
+            "allow_validation_entries": True,
+            "verified_edge_available": False,
+            "reason": (
+                "Legacy lifetime ledger remains negative; live/scaling stays blocked "
+                "while controlled paper validation continues at minimum size."
+            ),
+            "scaling_sample_gate": {
+                "closed_trades_observed": 134,
+                "min_closed_trades_for_scaling": 30,
+                "passed": False,
+            },
+        }
+    )
+    (repo / "data/system_state.json").write_text(json.dumps(state), encoding="utf-8")
+
+    status = build_public_status(repo)
+
+    assert status["system"]["public_status"] == "validation_reset"
+    assert status["gate"]["block_new_positions"] is False
+    assert status["gate"]["scale_allowed"] is False
+    assert status["gate"]["contradiction_detected"] is False
+    assert "controlled paper validation" in status["gate"]["blocker_reason"].lower()
+
+
 def test_build_public_status_cli_runs_from_repo_root(tmp_path: Path):
     repo = _seed_repo(tmp_path)
     script = Path(__file__).resolve().parents[1] / "scripts" / "build_public_status.py"

--- a/tests/unit/test_ic_simple.py
+++ b/tests/unit/test_ic_simple.py
@@ -5,6 +5,7 @@ price-walking, and full E2E pipeline with mocked Alpaca client.
 """
 
 import json
+import logging
 import sys
 from dataclasses import dataclass
 from enum import Enum
@@ -533,7 +534,82 @@ class TestThompsonValidationResetGate:
 
 
 # ══════════════════════════════════════════════════════════════════════════════
-# 6. E2E: Full pipeline mock
+# 6. Reporting: validation slice must not mask lifetime ledger
+# ══════════════════════════════════════════════════════════════════════════════
+
+
+class TestNorthStarReadinessReport:
+    def test_print_report_includes_lifetime_ledger_and_gate_state(
+        self, tmp_path, monkeypatch, caplog
+    ):
+        import scripts.ic_simple as ic
+
+        stats_file = tmp_path / "ic_stats.json"
+        stats_file.write_text(
+            json.dumps(
+                {
+                    "total": 1,
+                    "wins": 1,
+                    "losses": 0,
+                    "win_rate": 100.0,
+                    "profit_factor": 999.0,
+                    "total_pnl": 41.0,
+                    "avg_win": 41.0,
+                    "avg_loss": 0.0,
+                }
+            )
+        )
+        trades_file = tmp_path / "trades.json"
+        trades_file.write_text(
+            json.dumps(
+                {
+                    "stats": {
+                        "closed_trades": 66,
+                        "wins": 16,
+                        "losses": 49,
+                        "win_rate_pct": 24.24,
+                        "profit_factor": 0.25,
+                        "total_realized_pnl": -3402.0,
+                    }
+                }
+            )
+        )
+        state_file = tmp_path / "system_state.json"
+        state_file.write_text(
+            json.dumps(
+                {
+                    "north_star_weekly_gate": {
+                        "mode": "validation_reset",
+                        "scale_allowed": False,
+                        "block_new_positions": True,
+                        "blocker_reason": "lifetime ledger negative",
+                    }
+                }
+            )
+        )
+
+        monkeypatch.setattr(ic, "IC_STATS_FILE", stats_file)
+        monkeypatch.setattr(ic, "TRADE_LEDGER_FILE", trades_file)
+        monkeypatch.setattr(ic, "SYSTEM_STATE_FILE", state_file)
+        monkeypatch.setattr(ic, "JOURNAL_FILE", tmp_path / "missing.jsonl")
+
+        caplog.set_level(logging.INFO, logger="ic_simple")
+        ic._print_report()
+
+        assert "NORTH STAR READINESS" in caplog.text
+        assert "Validation slice: 1/30 closed trades" in caplog.text
+        assert "Lifetime ledger: 66 closed" in caplog.text
+        assert "win_rate=24.24%" in caplog.text
+        assert "PF=0.25" in caplog.text
+        assert "expectancy=$-51.55/trade" in caplog.text
+        assert "mode=validation_reset" in caplog.text
+        assert "scale_allowed=False" in caplog.text
+        assert "block_new_positions=True" in caplog.text
+        assert "lifetime ledger negative" in caplog.text
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# 7. E2E: Full pipeline mock
 # ══════════════════════════════════════════════════════════════════════════════
 
 

--- a/tests/unit/test_ml_pipeline.py
+++ b/tests/unit/test_ml_pipeline.py
@@ -1,5 +1,7 @@
 """Tests for ML/RAG pipeline — Thompson sampling, vector RAG, composite reward, strategy params."""
 
+import builtins
+import importlib.util
 import json
 import sys
 import types
@@ -21,9 +23,7 @@ def _ensure_module(name):
 
 
 # Only stub modules that aren't already installed
-try:
-    import numpy
-except ImportError:
+if importlib.util.find_spec("numpy") is None:
     _ensure_module("numpy")
     np_mod = sys.modules["numpy"]
     np_mod.array = lambda *a, **k: []
@@ -42,9 +42,7 @@ except ImportError:
     np_mod.object_ = object
     np_mod.str_ = str
 
-try:
-    import torch
-except ImportError:
+if importlib.util.find_spec("torch") is None:
     _ensure_module("torch")
     _ensure_module("torch.nn")
     _ensure_module("torch.optim")
@@ -143,6 +141,23 @@ class TestThompsonSampling:
 class TestRAGVectorStore:
     """Verify RAG indexes documents and returns relevant results."""
 
+    @staticmethod
+    def _disable_external_embedder(monkeypatch):
+        from src.rag import vector_store
+
+        monkeypatch.setattr(vector_store.TradeRAG, "_init_embedder", lambda self: None)
+
+    @staticmethod
+    def _block_sklearn(monkeypatch):
+        real_import = builtins.__import__
+
+        def guarded_import(name, *args, **kwargs):
+            if name.startswith("sklearn"):
+                raise ImportError("blocked to verify keyword fallback")
+            return real_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "__import__", guarded_import)
+
     def test_builds_index_without_error(self):
         rag = TradeRAG()
         # Manually add a doc instead of relying on filesystem
@@ -190,6 +205,114 @@ class TestRAGVectorStore:
         ]
         for doc in rag.documents:
             assert doc["source"] in ("lesson", "journal", "test")
+
+    def test_build_index_loads_lessons_and_journal_with_keyword_fallback(
+        self, tmp_path, monkeypatch
+    ):
+        from src.rag import vector_store
+
+        self._disable_external_embedder(monkeypatch)
+        self._block_sklearn(monkeypatch)
+
+        lessons_dir = tmp_path / "lessons"
+        lessons_dir.mkdir()
+        (lessons_dir / "vix_stop.md").write_text(
+            "VIX spike lesson: keep iron condor stops strict.", encoding="utf-8"
+        )
+
+        journal_file = tmp_path / "trade_journal.jsonl"
+        journal_file.write_text(
+            "\n".join(
+                [
+                    json.dumps(
+                        {
+                            "expiry": "260508",
+                            "outcome": "loss",
+                            "pnl": -120.0,
+                            "pnl_pct": -0.4,
+                            "exit_reason": "stop",
+                            "dte_at_exit": 25,
+                            "credit_per_share": 2.46,
+                        }
+                    ),
+                    "",
+                    "not valid json",
+                ]
+            ),
+            encoding="utf-8",
+        )
+
+        monkeypatch.setattr(vector_store, "LESSONS_DIR", lessons_dir)
+        monkeypatch.setattr(vector_store, "JOURNAL_FILE", journal_file)
+
+        rag = vector_store.TradeRAG()
+        rag.build_index()
+
+        assert len(rag.documents) == 2
+        assert {doc["source"] for doc in rag.documents} == {"lesson", "journal"}
+        assert rag.embeddings is None
+
+        results = rag.query("vix stop", top_k=2)
+
+        assert results[0]["source"] == "lesson"
+        assert results[0]["score"] > 0
+
+    def test_query_builds_index_and_returns_empty_when_no_documents(self, tmp_path, monkeypatch):
+        from src.rag import vector_store
+
+        self._disable_external_embedder(monkeypatch)
+
+        monkeypatch.setattr(vector_store, "LESSONS_DIR", tmp_path / "missing_lessons")
+        monkeypatch.setattr(vector_store, "JOURNAL_FILE", tmp_path / "missing_journal.jsonl")
+
+        rag = vector_store.TradeRAG()
+
+        assert rag.query("north star", top_k=3) == []
+
+    def test_numpy_cosine_backend_orders_by_similarity(self, monkeypatch):
+        import numpy as np
+
+        from src.rag import vector_store
+
+        self._disable_external_embedder(monkeypatch)
+
+        class FakeEmbedder:
+            def encode(self, texts, convert_to_numpy=True):
+                return np.array([[1.0, 0.0]], dtype=float)
+
+        rag = vector_store.TradeRAG()
+        rag.documents = [
+            {"id": "match", "content": "iron condor entry", "source": "lesson"},
+            {"id": "miss", "content": "unrelated macro note", "source": "lesson"},
+        ]
+        rag.embeddings = np.array([[1.0, 0.0], [0.0, 1.0]], dtype=float)
+        rag._embedder = FakeEmbedder()
+        rag._use_faiss = True
+
+        results = rag.query("iron condor", top_k=2)
+
+        assert [result["id"] for result in results] == ["match", "miss"]
+        assert results[0]["score"] > results[1]["score"]
+
+    def test_query_lessons_builds_and_queries_store(self, monkeypatch):
+        from src.rag import vector_store
+
+        calls = []
+
+        class FakeRAG:
+            def build_index(self):
+                calls.append("build_index")
+
+            def query(self, question, top_k):
+                calls.append(("query", question, top_k))
+                return [{"id": "lesson", "score": 1.0}]
+
+        monkeypatch.setattr(vector_store, "TradeRAG", FakeRAG)
+
+        results = vector_store.query_lessons("north star", top_k=2)
+
+        assert results == [{"id": "lesson", "score": 1.0}]
+        assert calls == ["build_index", ("query", "north star", 2)]
 
 
 # ══════════════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Summary

This hardens the North Star validation path so the system cannot confuse a small validation slice with real strategy readiness.

Changes include:
- adds a North Star readiness section to `scripts/ic_simple.py` that reports the validation slice separately from the lifetime paired-trade ledger
- treats `validation_reset` as a controlled paper-validation mode in public status congruence instead of a contradiction when validation entries are allowed but live/scaling remains blocked
- adds regression coverage for the public status gate, IC readiness report, and RAG vector-store query/index paths
- refreshes broker-derived public/runtime status artifacts after syncing Alpaca paper state

## Why

The prior reporting could make the system look healthier than the true lifetime ledger. The current lifetime paired-trade ledger still shows negative edge, so reporting must keep validation, live/scaling readiness, and legacy performance separated.

## Validation

- Full local CI: `PYTHON_BIN=python3 HEARTBEAT_SECONDS=30 scripts/ci/run_all_tests.sh`
- Result: core `2304 passed, 43 skipped, 1 xfailed, 4 xpassed`; integration `9 passed, 3 skipped`; total coverage `41%`; critical coverage `6/6 passed`
- Focused regression after hook formatting: `pytest tests/unit/test_ml_pipeline.py tests/unit/test_ic_simple.py tests/test_build_public_status.py -q`
- Result: `59 passed in 22.92s`
- Trunk commit hook: `Checked 14 modified files`; `No new issues`

## Current Broker Snapshot

Latest synced paper account state in this branch shows equity `$93,843.10`, daily P/L `+$18.00`, and `8` open positions. No new IC was opened by this change; the daily P/L is mark-to-market movement on open positions.
