### PR TITLE
feat: automate Perplexity trading intelligence

### DIFF
--- a/.github/workflows/perplexity-trading-intel.yml
+++ b/.github/workflows/perplexity-trading-intel.yml
@@ -1,0 +1,123 @@
+name: Perplexity Trading Intel
+
+on:
+  schedule:
+    # Post-market autopsy, weekdays after the close.
+    - cron: 20 21 * * 1-5
+    # Weekend strategy research.
+    - cron: 0 14 * * 6
+    # Weekly utilization audit.
+    - cron: 30 12 * * 1
+  workflow_dispatch: {}
+
+permissions:
+  contents: write
+
+concurrency:
+  group: ${{ format('perplexity-intel-{0}', github.ref_name || 'main') }}
+  cancel-in-progress: false
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          token: ${{ secrets.GH_PAT || github.token }}
+          fetch-depth: 0
+
+      - name: Refresh to latest main
+        run: |
+          git fetch origin main
+          git checkout -B main origin/main
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+          cache: pip
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install httpx
+
+      - name: Determine mode
+        id: mode
+        run: |
+          MODE="all"
+          DRY_RUN="false"
+          SCHEDULE="${{ github.event.schedule }}"
+
+          if [ "${{ github.event_name }}" = "schedule" ]; then
+            case "$SCHEDULE" in
+              "20 21 * * 1-5") MODE="post_market" ;;
+              "0 14 * * 6") MODE="weekend" ;;
+              "30 12 * * 1") MODE="audit" ;;
+              *) MODE="all" ;;
+            esac
+            DRY_RUN="false"
+          fi
+
+          echo "mode=$MODE" >> "$GITHUB_OUTPUT"
+          echo "dry_run=$DRY_RUN" >> "$GITHUB_OUTPUT"
+          echo "Mode: $MODE"
+          echo "Dry run: $DRY_RUN"
+
+      - name: Run Perplexity trading intelligence
+        if: steps.mode.outputs.mode != 'audit'
+        env:
+          PERPLEXITY_API_KEY: ${{ secrets.PERPLEXITY_API_KEY }}
+          PYTHONPATH: ${{ github.workspace }}
+        run: |
+          FLAGS="--mode ${{ steps.mode.outputs.mode }}"
+          if [ "${{ steps.mode.outputs.dry_run }}" = "true" ]; then
+            FLAGS="$FLAGS --dry-run"
+          fi
+          python3 scripts/run_perplexity_trading_intel.py $FLAGS
+
+      - name: Run Perplexity utilization audit
+        env:
+          PERPLEXITY_API_KEY: ${{ secrets.PERPLEXITY_API_KEY }}
+          PYTHONPATH: ${{ github.workspace }}
+        run: |
+          python3 -m src.analytics.perplexity_utilization_audit --write
+
+      - name: Commit intelligence artifacts
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          git add -f data/analysis/perplexity/ 2>/dev/null || true
+          git add -f data/analysis/pre_market_*.json 2>/dev/null || true
+          git add -f data/analytics/perplexity_utilization_latest.* 2>/dev/null || true
+          git add -f data/feedback/perplexity_intel_events.jsonl 2>/dev/null || true
+          git add -f rag_knowledge/lessons_learned/ll_perplexity_*.md 2>/dev/null || true
+
+          if git diff --staged --quiet; then
+            echo "No Perplexity intelligence artifact changes"
+          else
+            git commit -m "chore: Perplexity trading intel [auto]"
+            git pull --ff-only origin main
+            git push origin HEAD:main
+          fi
+
+      - name: Summary
+        run: |
+          echo "## Perplexity Trading Intel" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Mode: \`${{ steps.mode.outputs.mode }}\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Dry run: \`${{ steps.mode.outputs.dry_run }}\`" >> "$GITHUB_STEP_SUMMARY"
+          if [ -f data/analysis/perplexity/${{ steps.mode.outputs.mode }}_latest.json ]; then
+            python3 - << 'PY' >> "$GITHUB_STEP_SUMMARY"
+          import json
+          from pathlib import Path
+
+          mode = "${{ steps.mode.outputs.mode }}"
+          payload = json.loads(Path(f"data/analysis/perplexity/{mode}_latest.json").read_text())
+          print(f"- Recommendation: `{payload.get('recommendation')}`")
+          print(f"- Risk score: `{payload.get('risk_score')}`")
+          print(f"- API status: `{payload.get('api_status')}`")
+          PY
+          fi

--- a/.github/workflows/perplexity-trading-intel.yml
+++ b/.github/workflows/perplexity-trading-intel.yml
@@ -81,7 +81,11 @@ jobs:
           PERPLEXITY_API_KEY: ${{ secrets.PERPLEXITY_API_KEY }}
           PYTHONPATH: ${{ github.workspace }}
         run: |
-          python3 -m src.analytics.perplexity_utilization_audit --write
+          CREDENTIAL_FLAG=""
+          if [ -n "$PERPLEXITY_API_KEY" ]; then
+            CREDENTIAL_FLAG="--credential-present"
+          fi
+          python3 -m src.analytics.perplexity_utilization_audit --write $CREDENTIAL_FLAG
 
       - name: Commit intelligence artifacts
         run: |

--- a/.github/workflows/pre-market-scan.yml
+++ b/.github/workflows/pre-market-scan.yml
@@ -56,115 +56,22 @@ jobs:
       - name: Run Pre-Market Scan
         if: steps.market_check.outputs.should_run == 'true'
         id: scan
+        env:
+          PYTHONPATH: ${{ github.workspace }}
         run: |
+          python3 scripts/run_perplexity_trading_intel.py --mode pre_market
+
           python3 << 'EOF'
-          import asyncio
           import json
           import os
-          from datetime import datetime
           from pathlib import Path
 
-          import httpx
+          report = json.loads(Path("data/analysis/perplexity/pre_market_latest.json").read_text())
+          print(f"Pre-Market Scan - {report['generated_at_utc']}")
+          print(f"Risk Score: {report['risk_score']}")
+          print(f"Recommendation: {report['recommendation']}")
+          print(f"Reason: {report['gate_contract']['reason']}")
 
-          PERPLEXITY_API_KEY = os.environ.get("PERPLEXITY_API_KEY", "")
-
-          async def search_perplexity(query: str) -> dict:
-              """Execute Perplexity search."""
-              if not PERPLEXITY_API_KEY:
-                  return {"answer": "API key not configured", "error": True}
-
-              headers = {
-                  "Authorization": f"Bearer {PERPLEXITY_API_KEY}",
-                  "Content-Type": "application/json",
-              }
-
-              payload = {
-                  "model": "sonar",
-                  "messages": [
-                      {"role": "system", "content": "You are a financial analyst. Provide concise answers about market events."},
-                      {"role": "user", "content": query},
-                  ],
-                  "search_recency_filter": "day",
-              }
-
-              async with httpx.AsyncClient() as client:
-                  response = await client.post(
-                      "https://api.perplexity.ai/chat/completions",
-                      headers=headers,
-                      json=payload,
-                      timeout=30.0,
-                  )
-                  response.raise_for_status()
-                  data = response.json()
-                  return {"answer": data["choices"][0]["message"]["content"]}
-
-          async def run_scan():
-              """Run pre-market intelligence scan."""
-              queries = {
-                  "fed_speakers": "Are there any Federal Reserve speakers or FOMC events today?",
-                  "economic_data": "What economic data releases are scheduled today?",
-                  "spy_earnings": "Major S&P 500 earnings reports today?",
-                  "options_flow": "Unusual options activity on SPY today?",
-              }
-
-              results = {}
-              risk_score = 0.0
-
-              for key, query in queries.items():
-                  try:
-                      result = await search_perplexity(query)
-                      results[key] = result.get("answer", "No data")
-
-                      # Assess risk
-                      answer = result.get("answer", "").lower()
-                      if any(w in answer for w in ["fed", "fomc", "powell", "rate"]):
-                          risk_score += 0.3
-                      if any(w in answer for w in ["cpi", "jobs", "gdp", "inflation"]):
-                          risk_score += 0.2
-                      if any(w in answer for w in ["earnings", "guidance"]):
-                          risk_score += 0.15
-                  except Exception as e:
-                      results[key] = f"Error: {e}"
-
-              # Determine recommendation
-              if risk_score >= 0.5:
-                  recommendation = "AVOID"
-                  reason = "High-impact events could cause volatility"
-              elif risk_score >= 0.3:
-                  recommendation = "CAUTION"
-                  reason = "Moderate event risk - consider wider strikes"
-              else:
-                  recommendation = "CLEAR"
-                  reason = "No major market-moving events"
-
-              report = {
-                  "date": datetime.now().strftime("%Y-%m-%d"),
-                  "time": datetime.now().strftime("%H:%M UTC"),
-                  "risk_score": round(min(risk_score, 1.0), 2),
-                  "recommendation": recommendation,
-                  "reason": reason,
-                  "intel": results,
-              }
-
-              # Save to file
-              Path("data/analysis").mkdir(parents=True, exist_ok=True)
-              output_file = f"data/analysis/pre_market_{report['date']}.json"
-              Path(output_file).write_text(json.dumps(report, indent=2))
-
-              # Print summary
-              print(f"📊 Pre-Market Scan - {report['date']}")
-              print(f"Risk Score: {report['risk_score']}")
-              print(f"Recommendation: {report['recommendation']}")
-              print(f"Reason: {report['reason']}")
-              print("\n--- Intel ---")
-              for k, v in results.items():
-                  print(f"{k}: {v[:200]}...")
-
-              return report
-
-          report = asyncio.run(run_scan())
-
-          # Set outputs for next steps
           with open(os.environ["GITHUB_OUTPUT"], "a") as f:
               f.write(f"recommendation={report['recommendation']}\n")
               f.write(f"risk_score={report['risk_score']}\n")
@@ -175,7 +82,7 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add data/analysis/
+          git add -f data/analysis/ data/feedback/perplexity_intel_events.jsonl rag_knowledge/lessons_learned/
           git diff --staged --quiet || git commit -m "chore: Pre-market scan $(date +%Y-%m-%d)"
           git push || echo "Nothing to push"
 

--- a/data/analytics/perplexity_utilization_latest.json
+++ b/data/analytics/perplexity_utilization_latest.json
@@ -1,6 +1,6 @@
 {
-  "active_perplexity_files": 22,
-  "api_key_present_in_runtime": false,
+  "active_perplexity_files": 25,
+  "credential_available_in_runtime": false,
   "expected_high_roi_files": [
     "src/analytics/perplexity_trading_intel.py",
     "src/analytics/perplexity_utilization_audit.py",
@@ -9,10 +9,10 @@
     ".github/workflows/perplexity-trading-intel.yml"
   ],
   "gaps": [
-    "local_runtime_missing_PERPLEXITY_API_KEY",
+    "local_runtime_missing_perplexity_credential",
     "agent_playground_not_versioned_in_repo"
   ],
-  "generated_at_utc": "2026-04-13T21:16:58.577102+00:00",
+  "generated_at_utc": "2026-04-13T21:24:45.233340+00:00",
   "max_utilization_score": 70,
   "missing_expected_files": [],
   "models_referenced": ["sonar", "sonar-pro"],
@@ -20,16 +20,23 @@
     {
       "mentions_agent_playground": false,
       "models": [],
+      "path": "scripts/ic_simple.py",
+      "uses_api_endpoint": false,
+      "uses_perplexity_credential": false
+    },
+    {
+      "mentions_agent_playground": false,
+      "models": [],
       "path": "scripts/perplexity_local_mcp_snapshot.py",
       "uses_api_endpoint": false,
-      "uses_api_key": false
+      "uses_perplexity_credential": false
     },
     {
       "mentions_agent_playground": false,
       "models": [],
       "path": "scripts/run_perplexity_trading_intel.py",
       "uses_api_endpoint": false,
-      "uses_api_key": false
+      "uses_perplexity_credential": false
     }
   ],
   "source_modules_with_perplexity": [
@@ -38,114 +45,128 @@
       "models": [],
       "path": "src/agents/__init__.py",
       "uses_api_endpoint": false,
-      "uses_api_key": false
+      "uses_perplexity_credential": false
     },
     {
       "mentions_agent_playground": false,
       "models": ["sonar-pro"],
       "path": "src/agents/billing_guardian_agent.py",
       "uses_api_endpoint": true,
-      "uses_api_key": true
+      "uses_perplexity_credential": true
     },
     {
       "mentions_agent_playground": false,
       "models": ["sonar-pro"],
       "path": "src/agents/research_agent.py",
       "uses_api_endpoint": true,
-      "uses_api_key": true
+      "uses_perplexity_credential": true
     },
     {
       "mentions_agent_playground": false,
       "models": [],
       "path": "src/analytics/__init__.py",
       "uses_api_endpoint": false,
-      "uses_api_key": false
+      "uses_perplexity_credential": false
     },
     {
       "mentions_agent_playground": false,
       "models": [],
       "path": "src/analytics/local_ops_snapshot.py",
       "uses_api_endpoint": false,
-      "uses_api_key": false
+      "uses_perplexity_credential": false
     },
     {
       "mentions_agent_playground": false,
       "models": ["sonar-pro"],
       "path": "src/analytics/perplexity_trading_intel.py",
       "uses_api_endpoint": true,
-      "uses_api_key": true
+      "uses_perplexity_credential": true
     },
     {
       "mentions_agent_playground": false,
       "models": ["sonar"],
       "path": "src/analytics/perplexity_utilization_audit.py",
       "uses_api_endpoint": true,
-      "uses_api_key": true
+      "uses_perplexity_credential": true
     },
     {
       "mentions_agent_playground": false,
       "models": [],
       "path": "src/orchestration/agentic_guardrails.py",
       "uses_api_endpoint": false,
-      "uses_api_key": false
+      "uses_perplexity_credential": false
     },
     {
       "mentions_agent_playground": false,
       "models": [],
       "path": "src/orchestration/daggr_workflow.py",
       "uses_api_endpoint": false,
-      "uses_api_key": false
+      "uses_perplexity_credential": false
     },
     {
       "mentions_agent_playground": false,
       "models": [],
       "path": "src/orchestration/teammate_swarm.py",
       "uses_api_endpoint": false,
-      "uses_api_key": false
+      "uses_perplexity_credential": false
     },
     {
       "mentions_agent_playground": false,
       "models": ["sonar-pro"],
       "path": "src/orchestrator/gates.py",
       "uses_api_endpoint": true,
-      "uses_api_key": true
+      "uses_perplexity_credential": true
     },
     {
       "mentions_agent_playground": false,
       "models": [],
       "path": "src/research/__init__.py",
       "uses_api_endpoint": false,
-      "uses_api_key": false
+      "uses_perplexity_credential": false
+    },
+    {
+      "mentions_agent_playground": false,
+      "models": ["sonar"],
+      "path": "src/research/pre_trade_research.py",
+      "uses_api_endpoint": true,
+      "uses_perplexity_credential": true
     },
     {
       "mentions_agent_playground": false,
       "models": [],
       "path": "src/safety/macro_risk_guard.py",
       "uses_api_endpoint": false,
-      "uses_api_key": false
+      "uses_perplexity_credential": false
     },
     {
       "mentions_agent_playground": false,
       "models": [],
       "path": "src/strategies/iron_condor/signal.py",
       "uses_api_endpoint": false,
-      "uses_api_key": false
+      "uses_perplexity_credential": false
     }
   ],
   "workflows_with_perplexity": [
     {
       "mentions_agent_playground": false,
       "models": [],
+      "path": ".github/workflows/ic-simple.yml",
+      "uses_api_endpoint": false,
+      "uses_perplexity_credential": true
+    },
+    {
+      "mentions_agent_playground": false,
+      "models": [],
       "path": ".github/workflows/perplexity-trading-intel.yml",
       "uses_api_endpoint": false,
-      "uses_api_key": true
+      "uses_perplexity_credential": true
     },
     {
       "mentions_agent_playground": false,
       "models": [],
       "path": ".github/workflows/pre-market-scan.yml",
       "uses_api_endpoint": false,
-      "uses_api_key": true
+      "uses_perplexity_credential": true
     }
   ]
 }

--- a/data/analytics/perplexity_utilization_latest.json
+++ b/data/analytics/perplexity_utilization_latest.json
@@ -1,106 +1,151 @@
 {
-  "gaps": [],
-  "generated_at_utc": "2026-02-21T22:49:59.582240Z",
-  "live_probe": {
-    "detail": null,
-    "enabled": true,
-    "http_status": 200,
-    "latency_ms": 1655.028,
-    "model": "sonar",
-    "status": "success",
-    "usage": {
-      "completion_tokens": 1,
-      "cost": {
-        "input_tokens_cost": 1e-05,
-        "output_tokens_cost": 0.0,
-        "request_cost": 0.005,
-        "total_cost": 0.00501
-      },
-      "prompt_tokens": 8,
-      "search_context_size": "low",
-      "total_tokens": 9
-    }
-  },
-  "local_env": {
-    "perplexity_api_key_present": true
-  },
-  "recent_workflow_runs": [
+  "active_perplexity_files": 22,
+  "api_key_present_in_runtime": false,
+  "expected_high_roi_files": [
+    "src/analytics/perplexity_trading_intel.py",
+    "src/analytics/perplexity_utilization_audit.py",
+    "scripts/run_perplexity_trading_intel.py",
+    ".github/workflows/pre-market-scan.yml",
+    ".github/workflows/perplexity-trading-intel.yml"
+  ],
+  "gaps": [
+    "local_runtime_missing_PERPLEXITY_API_KEY",
+    "agent_playground_not_versioned_in_repo"
+  ],
+  "generated_at_utc": "2026-04-13T21:16:58.577102+00:00",
+  "max_utilization_score": 70,
+  "missing_expected_files": [],
+  "models_referenced": ["sonar", "sonar-pro"],
+  "scripts_with_perplexity": [
     {
-      "conclusion": "success",
-      "created_at": "2026-02-20T14:20:24Z",
-      "name": "Pre-Market Scan",
-      "status": "completed",
-      "updated_at": "2026-02-20T14:20:58Z",
-      "url": "https://github.com/IgorGanapolsky/trading/actions/runs/22227653602",
-      "workflow": "pre-market-scan.yml"
+      "mentions_agent_playground": false,
+      "models": [],
+      "path": "scripts/perplexity_local_mcp_snapshot.py",
+      "uses_api_endpoint": false,
+      "uses_api_key": false
     },
     {
-      "conclusion": "success",
-      "created_at": "2026-02-19T14:26:17Z",
-      "name": "Pre-Market Scan",
-      "status": "completed",
-      "updated_at": "2026-02-19T14:26:55Z",
-      "url": "https://github.com/IgorGanapolsky/trading/actions/runs/22185776231",
-      "workflow": "pre-market-scan.yml"
-    },
-    {
-      "conclusion": "failure",
-      "created_at": "2026-02-21T06:10:50Z",
-      "name": "Weekend Research",
-      "status": "completed",
-      "updated_at": "2026-02-21T06:11:25Z",
-      "url": "https://github.com/IgorGanapolsky/trading/actions/runs/22251732347",
-      "workflow": "weekend-research.yml"
-    },
-    {
-      "conclusion": "failure",
-      "created_at": "2026-02-14T06:12:00Z",
-      "name": "Weekend Research",
-      "status": "completed",
-      "updated_at": "2026-02-14T06:12:56Z",
-      "url": "https://github.com/IgorGanapolsky/trading/actions/runs/22012503906",
-      "workflow": "weekend-research.yml"
+      "mentions_agent_playground": false,
+      "models": [],
+      "path": "scripts/run_perplexity_trading_intel.py",
+      "uses_api_endpoint": false,
+      "uses_api_key": false
     }
   ],
-  "references": {
-    "local_mcp_snapshot_script": "/Users/ganapolsky_i/workspace/git/igor/trading/scripts/perplexity_local_mcp_snapshot.py",
-    "pre_market_scan_workflow": "/Users/ganapolsky_i/workspace/git/igor/trading/.github/workflows/pre-market-scan.yml",
-    "research_agent": "/Users/ganapolsky_i/workspace/git/igor/trading/src/agents/research_agent.py",
-    "weekend_research_workflow": "/Users/ganapolsky_i/workspace/git/igor/trading/.github/workflows/weekend-research.yml"
-  },
-  "source_presence": {
-    "local_mcp_snapshot_script": true,
-    "pre_market_scan_workflow": true,
-    "research_agent": true,
-    "weekend_research_workflow": true
-  },
-  "workflow_scan": {
-    "count": 3,
-    "distinct_models": [
-      "sonar"
-    ],
-    "endpoint_ref_count": 1,
-    "workflows_with_perplexity": [
-      {
-        "endpoint_refs": 0,
-        "has_api_key_secret_ref": true,
-        "models": [],
-        "path": ".github/workflows/perplexity-utilization-audit.yml"
-      },
-      {
-        "endpoint_refs": 1,
-        "has_api_key_secret_ref": true,
-        "models": [
-          "sonar"
-        ],
-        "path": ".github/workflows/pre-market-scan.yml"
-      },
-      {
-        "endpoint_refs": 0,
-        "has_api_key_secret_ref": true,
-        "models": [],
-        "path": ".github/workflows/weekend-research.yml"
-      }
-    ]
-  }
+  "source_modules_with_perplexity": [
+    {
+      "mentions_agent_playground": false,
+      "models": [],
+      "path": "src/agents/__init__.py",
+      "uses_api_endpoint": false,
+      "uses_api_key": false
+    },
+    {
+      "mentions_agent_playground": false,
+      "models": ["sonar-pro"],
+      "path": "src/agents/billing_guardian_agent.py",
+      "uses_api_endpoint": true,
+      "uses_api_key": true
+    },
+    {
+      "mentions_agent_playground": false,
+      "models": ["sonar-pro"],
+      "path": "src/agents/research_agent.py",
+      "uses_api_endpoint": true,
+      "uses_api_key": true
+    },
+    {
+      "mentions_agent_playground": false,
+      "models": [],
+      "path": "src/analytics/__init__.py",
+      "uses_api_endpoint": false,
+      "uses_api_key": false
+    },
+    {
+      "mentions_agent_playground": false,
+      "models": [],
+      "path": "src/analytics/local_ops_snapshot.py",
+      "uses_api_endpoint": false,
+      "uses_api_key": false
+    },
+    {
+      "mentions_agent_playground": false,
+      "models": ["sonar-pro"],
+      "path": "src/analytics/perplexity_trading_intel.py",
+      "uses_api_endpoint": true,
+      "uses_api_key": true
+    },
+    {
+      "mentions_agent_playground": false,
+      "models": ["sonar"],
+      "path": "src/analytics/perplexity_utilization_audit.py",
+      "uses_api_endpoint": true,
+      "uses_api_key": true
+    },
+    {
+      "mentions_agent_playground": false,
+      "models": [],
+      "path": "src/orchestration/agentic_guardrails.py",
+      "uses_api_endpoint": false,
+      "uses_api_key": false
+    },
+    {
+      "mentions_agent_playground": false,
+      "models": [],
+      "path": "src/orchestration/daggr_workflow.py",
+      "uses_api_endpoint": false,
+      "uses_api_key": false
+    },
+    {
+      "mentions_agent_playground": false,
+      "models": [],
+      "path": "src/orchestration/teammate_swarm.py",
+      "uses_api_endpoint": false,
+      "uses_api_key": false
+    },
+    {
+      "mentions_agent_playground": false,
+      "models": ["sonar-pro"],
+      "path": "src/orchestrator/gates.py",
+      "uses_api_endpoint": true,
+      "uses_api_key": true
+    },
+    {
+      "mentions_agent_playground": false,
+      "models": [],
+      "path": "src/research/__init__.py",
+      "uses_api_endpoint": false,
+      "uses_api_key": false
+    },
+    {
+      "mentions_agent_playground": false,
+      "models": [],
+      "path": "src/safety/macro_risk_guard.py",
+      "uses_api_endpoint": false,
+      "uses_api_key": false
+    },
+    {
+      "mentions_agent_playground": false,
+      "models": [],
+      "path": "src/strategies/iron_condor/signal.py",
+      "uses_api_endpoint": false,
+      "uses_api_key": false
+    }
+  ],
+  "workflows_with_perplexity": [
+    {
+      "mentions_agent_playground": false,
+      "models": [],
+      "path": ".github/workflows/perplexity-trading-intel.yml",
+      "uses_api_endpoint": false,
+      "uses_api_key": true
+    },
+    {
+      "mentions_agent_playground": false,
+      "models": [],
+      "path": ".github/workflows/pre-market-scan.yml",
+      "uses_api_endpoint": false,
+      "uses_api_key": true
+    }
+  ]
 }

--- a/data/analytics/perplexity_utilization_latest.md.txt
+++ b/data/analytics/perplexity_utilization_latest.md.txt
@@ -1,40 +1,15 @@
 # Perplexity Utilization Audit
 
-- Generated (UTC): `2026-02-21T22:49:59.582240Z`
-- Workflows wired: `3`
-- Models referenced: `sonar`
+- Generated UTC: `2026-04-13T21:16:58.577102+00:00`
+- Runtime API key present: `False`
+- Active Perplexity files: `22`
+- Max utilization score: `70/100`
+- Models referenced: `sonar, sonar-pro`
 
-## Workflow Wiring
-- `.github/workflows/perplexity-utilization-audit.yml`
-  - secret ref: `True`
-  - endpoint refs: `0`
-  - models: `none`
-- `.github/workflows/pre-market-scan.yml`
-  - secret ref: `True`
-  - endpoint refs: `1`
-  - models: `sonar`
-- `.github/workflows/weekend-research.yml`
-  - secret ref: `True`
-  - endpoint refs: `0`
-  - models: `none`
-
-## Source Presence
-- `local_mcp_snapshot_script`: `True`
-- `pre_market_scan_workflow`: `True`
-- `research_agent`: `True`
-- `weekend_research_workflow`: `True`
-
-## Recent Workflow Runs
-- `pre-market-scan.yml`: status=`completed` conclusion=`success` updated=`2026-02-20T14:20:58Z`
-- `pre-market-scan.yml`: status=`completed` conclusion=`success` updated=`2026-02-19T14:26:55Z`
-- `weekend-research.yml`: status=`completed` conclusion=`failure` updated=`2026-02-21T06:11:25Z`
-- `weekend-research.yml`: status=`completed` conclusion=`failure` updated=`2026-02-14T06:12:56Z`
-
-## Live Probe
-- enabled: `True`
-- status: `success`
-- latency_ms: `1655.028`
-- model: `sonar`
+## Workflows
+- `.github/workflows/perplexity-trading-intel.yml` models=`n/a`
+- `.github/workflows/pre-market-scan.yml` models=`n/a`
 
 ## Gaps
-- none
+- `local_runtime_missing_PERPLEXITY_API_KEY`
+- `agent_playground_not_versioned_in_repo`

--- a/data/analytics/perplexity_utilization_latest.md.txt
+++ b/data/analytics/perplexity_utilization_latest.md.txt
@@ -1,15 +1,16 @@
 # Perplexity Utilization Audit
 
-- Generated UTC: `2026-04-13T21:16:58.577102+00:00`
-- Runtime API key present: `False`
-- Active Perplexity files: `22`
+- Generated UTC: `2026-04-13T21:24:45.233340+00:00`
+- Runtime credential available: `False`
+- Active Perplexity files: `25`
 - Max utilization score: `70/100`
 - Models referenced: `sonar, sonar-pro`
 
 ## Workflows
+- `.github/workflows/ic-simple.yml` models=`n/a`
 - `.github/workflows/perplexity-trading-intel.yml` models=`n/a`
 - `.github/workflows/pre-market-scan.yml` models=`n/a`
 
 ## Gaps
-- `local_runtime_missing_PERPLEXITY_API_KEY`
+- `local_runtime_missing_perplexity_credential`
 - `agent_playground_not_versioned_in_repo`

--- a/scripts/run_perplexity_trading_intel.py
+++ b/scripts/run_perplexity_trading_intel.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python3
+"""Run the Perplexity trading intelligence loop."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _run() -> None:
+    if str(ROOT) not in sys.path:
+        sys.path.insert(0, str(ROOT))
+
+    from src.analytics.perplexity_trading_intel import main
+
+    main()
+
+
+if __name__ == "__main__":
+    _run()

--- a/src/analytics/perplexity_trading_intel.py
+++ b/src/analytics/perplexity_trading_intel.py
@@ -1,0 +1,597 @@
+"""Perplexity-backed trading intelligence loop.
+
+The goal is not to let web research place trades. The goal is to keep current
+market/event context flowing into artifacts that the trading gates, RAG, and ML
+feedback loop can inspect before the next entry decision.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+import re
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+DEFAULT_MODEL = "sonar-pro"
+PERPLEXITY_URL = "https://api.perplexity.ai/chat/completions"
+
+MODE_FRESHNESS_MINUTES = {
+    "pre_market": 240,
+    "post_market": 1440,
+    "weekend": 10080,
+}
+
+
+@dataclass(frozen=True)
+class QuerySpec:
+    """A single Perplexity query with scoring metadata."""
+
+    key: str
+    prompt: str
+    recency: str
+    risk_terms: tuple[str, ...]
+    priority: int = 1
+
+
+@dataclass(frozen=True)
+class IntelPaths:
+    """Output paths produced by the intelligence loop."""
+
+    latest_json: Path
+    stamped_json: Path
+    rag_lesson: Path
+    ml_jsonl: Path
+    legacy_pre_market_json: Path | None = None
+
+
+PRE_MARKET_QUERIES = (
+    QuerySpec(
+        key="macro_calendar",
+        prompt=(
+            "For today, list US economic releases, FOMC/Fed speaker events, Treasury "
+            "events, and market-moving policy headlines that could affect SPY/SPX "
+            "options premium selling. Identify exact times when available."
+        ),
+        recency="day",
+        risk_terms=("fomc", "powell", "cpi", "jobs", "nonfarm", "gdp", "auction", "fed"),
+    ),
+    QuerySpec(
+        key="volatility_regime",
+        prompt=(
+            "Summarize the current SPY/SPX volatility regime, including VIX drivers, "
+            "overnight futures context, and whether short premium entries face event "
+            "gap risk today."
+        ),
+        recency="day",
+        risk_terms=("vix", "volatility", "gap", "selloff", "risk-off", "tariff", "war"),
+    ),
+    QuerySpec(
+        key="index_event_risk",
+        prompt=(
+            "Are there broad index-level events today that should block or caution a "
+            "new SPY iron condor entry? Focus on scheduled catalysts, unscheduled "
+            "policy shocks, liquidity, and expected intraday volatility."
+        ),
+        recency="day",
+        risk_terms=("block", "avoid", "caution", "shock", "crisis", "halt", "uncertain"),
+    ),
+)
+
+POST_MARKET_QUERIES = (
+    QuerySpec(
+        key="market_move_autopsy",
+        prompt=(
+            "Explain today's SPY/SPX move and volatility shift. Identify the top "
+            "drivers, whether the move was event-driven or trend/regime-driven, and "
+            "what an iron condor system should learn for tomorrow."
+        ),
+        recency="day",
+        risk_terms=("trend", "breakout", "gap", "selloff", "volatility", "event"),
+    ),
+    QuerySpec(
+        key="options_premium_context",
+        prompt=(
+            "Summarize today's SPY/SPX options premium environment. Did implied "
+            "volatility, skew, or realized volatility favor selling defined-risk "
+            "premium, or should the system have waited?"
+        ),
+        recency="day",
+        risk_terms=("realized volatility", "skew", "waited", "unfavorable", "tail"),
+    ),
+)
+
+WEEKEND_QUERIES = (
+    QuerySpec(
+        key="iron_condor_research",
+        prompt=(
+            "Research recent evidence on SPY/SPX iron condor rules: 10-20 delta, "
+            "30-45 DTE, 50 percent profit exits, 2x credit stop, event avoidance, "
+            "and VIX regime filters. Return actionable rules with citations and "
+            "state which rules need backtesting before live use."
+        ),
+        recency="month",
+        risk_terms=("needs backtesting", "avoid", "underperforms", "drawdown", "tail risk"),
+    ),
+    QuerySpec(
+        key="strategy_failure_patterns",
+        prompt=(
+            "Find failure patterns for short premium index option strategies during "
+            "high-volatility regime shifts. Focus on what a 100k paper account should "
+            "block before entering new SPY/SPX iron condors."
+        ),
+        recency="month",
+        risk_terms=("regime shift", "tail risk", "loss", "drawdown", "block"),
+    ),
+)
+
+QUERY_BUNDLES = {
+    "pre_market": PRE_MARKET_QUERIES,
+    "post_market": POST_MARKET_QUERIES,
+    "weekend": WEEKEND_QUERIES,
+}
+
+HIGH_RISK_WEIGHTS = {
+    "fomc": 0.22,
+    "powell": 0.18,
+    "cpi": 0.18,
+    "nonfarm": 0.18,
+    "jobs report": 0.16,
+    "tariff": 0.16,
+    "war": 0.20,
+    "geopolitical": 0.16,
+    "selloff": 0.18,
+    "gap": 0.14,
+    "risk-off": 0.18,
+    "volatility spike": 0.22,
+    "vix spike": 0.22,
+    "avoid": 0.20,
+    "block": 0.24,
+    "halt": 0.24,
+    "crisis": 0.24,
+    "uncertain": 0.10,
+}
+
+LOW_RISK_WEIGHTS = {
+    "no major": -0.14,
+    "low volatility": -0.12,
+    "calm": -0.12,
+    "stable": -0.10,
+    "range-bound": -0.08,
+    "no scheduled": -0.10,
+}
+
+
+def utc_now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _read_json(path: Path) -> Any:
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        return None
+    except json.JSONDecodeError:
+        return None
+
+
+def _safe_float(value: Any, default: float = 0.0) -> float:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _clamp(value: float, low: float = 0.0, high: float = 1.0) -> float:
+    return max(low, min(high, value))
+
+
+def compact_trading_context(repo_root: Path) -> dict[str, Any]:
+    """Load the minimum account/ledger context needed for market research prompts."""
+
+    public_status = _read_json(repo_root / "docs" / "data" / "public_status.json") or {}
+    system_state = _read_json(repo_root / "data" / "system_state.json") or {}
+    trades = _read_json(repo_root / "data" / "trades.json") or {}
+
+    paper = public_status.get("paper", {}) if isinstance(public_status, dict) else {}
+    ledger = public_status.get("ledger", {}) if isinstance(public_status, dict) else {}
+    gate = public_status.get("gate", {}) if isinstance(public_status, dict) else {}
+
+    if not paper and isinstance(system_state, dict):
+        paper = system_state.get("paper_account", {})
+    if not ledger and isinstance(trades, dict):
+        ledger = trades.get("stats", {})
+
+    return {
+        "equity": paper.get("equity"),
+        "total_pnl_today": paper.get("total_pnl_today") or paper.get("daily_change"),
+        "positions_count": paper.get("positions_count")
+        or len(system_state.get("positions", []) if isinstance(system_state, dict) else []),
+        "closed_trades_total": ledger.get("closed_trades")
+        or ledger.get("closed_trades_total")
+        or ledger.get("total_trades"),
+        "win_rate_pct": ledger.get("win_rate_pct"),
+        "profit_factor": ledger.get("profit_factor"),
+        "expectancy_per_trade": ledger.get("expectancy_per_trade"),
+        "gate_mode": gate.get("mode") if isinstance(gate, dict) else None,
+        "scale_allowed": gate.get("scale_allowed") if isinstance(gate, dict) else None,
+        "verified_edge_available": gate.get("verified_edge_available")
+        if isinstance(gate, dict)
+        else None,
+    }
+
+
+def score_text(text: str, spec: QuerySpec | None = None) -> float:
+    """Score market/event risk from a Perplexity answer using transparent weights."""
+
+    normalized = re.sub(r"\s+", " ", text.lower())
+    score = 0.0
+
+    for term, weight in HIGH_RISK_WEIGHTS.items():
+        if term in normalized:
+            score += weight
+
+    for term, weight in LOW_RISK_WEIGHTS.items():
+        if term in normalized:
+            score += weight
+
+    if spec:
+        for term in spec.risk_terms:
+            if term.lower() in normalized:
+                score += 0.05
+
+    return round(_clamp(score), 3)
+
+
+def recommendation_for(risk_score: float, api_status: str) -> str:
+    """Translate risk into a gate-readable recommendation."""
+
+    if risk_score >= 0.70:
+        return "BLOCK_NEW_IC"
+    if risk_score >= 0.40:
+        return "CAUTION"
+    if api_status != "ok":
+        return "CAUTION_API_UNAVAILABLE"
+    return "CLEAR"
+
+
+def confidence_for(results: list[dict[str, Any]], api_status: str) -> float:
+    """Confidence rises with successful answers and citations, falls offline."""
+
+    if not results:
+        return 0.0
+
+    answered = sum(1 for item in results if item.get("answer"))
+    cited = sum(1 for item in results if item.get("citations"))
+    base = 0.35 if api_status == "ok" else 0.15
+    return round(_clamp(base + answered * 0.12 + cited * 0.08), 3)
+
+
+def _iso_slug(value: datetime) -> str:
+    return value.strftime("%Y%m%d_%H%M%S")
+
+
+def _date_slug(value: datetime) -> str:
+    return value.strftime("%Y-%m-%d")
+
+
+def build_paths(repo_root: Path, mode: str, now: datetime) -> IntelPaths:
+    base = repo_root / "data" / "analysis" / "perplexity"
+    date_slug = _date_slug(now)
+    stamp = _iso_slug(now)
+    legacy = repo_root / "data" / "analysis" / f"pre_market_{date_slug}.json"
+    return IntelPaths(
+        latest_json=base / f"{mode}_latest.json",
+        stamped_json=base / f"{mode}_{stamp}.json",
+        rag_lesson=repo_root
+        / "rag_knowledge"
+        / "lessons_learned"
+        / f"ll_perplexity_{mode}_{date_slug}.md",
+        ml_jsonl=repo_root / "data" / "feedback" / "perplexity_intel_events.jsonl",
+        legacy_pre_market_json=legacy if mode == "pre_market" else None,
+    )
+
+
+class PerplexityTradingIntelRunner:
+    """Run Perplexity trading research and persist gate/RAG/ML artifacts."""
+
+    def __init__(
+        self,
+        repo_root: Path,
+        *,
+        api_key: str | None = None,
+        model: str | None = None,
+        dry_run: bool = False,
+        now: datetime | None = None,
+    ) -> None:
+        self.repo_root = repo_root
+        self.api_key = api_key if api_key is not None else os.getenv("PERPLEXITY_API_KEY", "")
+        self.model = model or os.getenv("PERPLEXITY_TRADING_MODEL", DEFAULT_MODEL)
+        self.dry_run = dry_run
+        self.now = now or utc_now()
+
+    async def run(self, mode: str, *, write: bool = True) -> dict[str, Any]:
+        if mode == "all":
+            combined: dict[str, Any] = {
+                "generated_at_utc": self.now.isoformat(),
+                "mode": "all",
+                "runs": {},
+            }
+            for child_mode in ("pre_market", "post_market", "weekend"):
+                combined["runs"][child_mode] = await self.run(child_mode, write=write)
+            return combined
+
+        if mode not in QUERY_BUNDLES:
+            raise ValueError(f"Unsupported Perplexity intel mode: {mode}")
+
+        context = compact_trading_context(self.repo_root)
+        results: list[dict[str, Any]] = []
+        api_status = "dry_run" if self.dry_run else ("ok" if self.api_key else "missing_api_key")
+
+        for spec in QUERY_BUNDLES[mode]:
+            results.append(await self._ask(spec, mode, context))
+
+        if any(item.get("api_status") == "error" for item in results):
+            api_status = "partial_error"
+        elif all(item.get("api_status") == "missing_api_key" for item in results):
+            api_status = "missing_api_key"
+        elif all(item.get("api_status") == "dry_run" for item in results):
+            api_status = "dry_run"
+
+        risk_score = round(
+            _clamp(sum(_safe_float(item.get("risk_score")) for item in results) / max(len(results), 1)),
+            3,
+        )
+        recommendation = recommendation_for(risk_score, api_status)
+        confidence = confidence_for(results, api_status)
+
+        payload = {
+            "generated_at_utc": self.now.isoformat(),
+            "mode": mode,
+            "model": self.model,
+            "api_status": api_status,
+            "fresh_for_minutes": MODE_FRESHNESS_MINUTES[mode],
+            "risk_score": risk_score,
+            "recommendation": recommendation,
+            "confidence": confidence,
+            "trading_context": context,
+            "queries": results,
+            "gate_contract": {
+                "blocks_new_iron_condors": recommendation == "BLOCK_NEW_IC",
+                "reason": self._decision_reason(recommendation, risk_score, api_status),
+                "source": "perplexity_trading_intel",
+            },
+        }
+
+        if write:
+            self.write_artifacts(mode, payload)
+
+        return payload
+
+    async def _ask(
+        self, spec: QuerySpec, mode: str, context: dict[str, Any]
+    ) -> dict[str, Any]:
+        if self.dry_run:
+            answer = (
+                "Dry run: Perplexity API was not called. Local context was packaged for "
+                "research and scoring; live citations require PERPLEXITY_API_KEY."
+            )
+            return self._format_result(spec, answer, [], "dry_run")
+
+        if not self.api_key:
+            answer = (
+                "Perplexity API key is not configured in this runtime. The trading loop "
+                "should treat web intelligence as degraded until GitHub Actions or the "
+                "local agent provides PERPLEXITY_API_KEY."
+            )
+            return self._format_result(spec, answer, [], "missing_api_key")
+
+        system_prompt = (
+            "You are a trading risk analyst for a paper SPY/SPX iron condor system. "
+            "Be concise, cite current sources, and distinguish hard blockers from "
+            "context. Do not recommend trades. Output factual event/regime intelligence."
+        )
+        user_prompt = (
+            f"Mode: {mode}\n"
+            f"Current trading context JSON: {json.dumps(context, sort_keys=True)}\n\n"
+            f"Research task: {spec.prompt}"
+        )
+        payload = {
+            "model": self.model,
+            "messages": [
+                {"role": "system", "content": system_prompt},
+                {"role": "user", "content": user_prompt},
+            ],
+            "search_recency_filter": spec.recency,
+            "return_citations": True,
+        }
+        headers = {
+            "Authorization": f"Bearer {self.api_key}",
+            "Content-Type": "application/json",
+        }
+
+        try:
+            import httpx
+
+            async with httpx.AsyncClient(timeout=45.0) as client:
+                response = await client.post(PERPLEXITY_URL, headers=headers, json=payload)
+                response.raise_for_status()
+                data = response.json()
+        except Exception as exc:
+            return self._format_result(spec, f"Perplexity API error: {exc}", [], "error")
+
+        answer = (
+            data.get("choices", [{}])[0]
+            .get("message", {})
+            .get("content", "")
+            .strip()
+        )
+        citations = data.get("citations", [])
+        return self._format_result(spec, answer, citations, "ok")
+
+    def _format_result(
+        self,
+        spec: QuerySpec,
+        answer: str,
+        citations: list[str],
+        api_status: str,
+    ) -> dict[str, Any]:
+        return {
+            "key": spec.key,
+            "priority": spec.priority,
+            "prompt": spec.prompt,
+            "api_status": api_status,
+            "risk_score": score_text(answer, spec),
+            "answer": answer,
+            "citations": citations[:8],
+        }
+
+    def _decision_reason(self, recommendation: str, risk_score: float, api_status: str) -> str:
+        if recommendation == "BLOCK_NEW_IC":
+            return f"Fresh Perplexity event/regime risk score {risk_score:.2f} blocks new IC entries."
+        if recommendation == "CAUTION":
+            return f"Perplexity event/regime risk score {risk_score:.2f} requires caution."
+        if recommendation == "CAUTION_API_UNAVAILABLE":
+            return f"Perplexity intelligence degraded ({api_status}); do not increase risk based on stale context."
+        return "Fresh Perplexity intelligence found no major event/regime blocker."
+
+    def write_artifacts(self, mode: str, payload: dict[str, Any]) -> IntelPaths:
+        paths = build_paths(self.repo_root, mode, self.now)
+        for path in (
+            paths.latest_json,
+            paths.stamped_json,
+            paths.rag_lesson,
+            paths.ml_jsonl,
+            paths.legacy_pre_market_json,
+        ):
+            if path is not None:
+                path.parent.mkdir(parents=True, exist_ok=True)
+
+        json_text = json.dumps(payload, indent=2, sort_keys=True) + "\n"
+        paths.latest_json.write_text(json_text, encoding="utf-8")
+        paths.stamped_json.write_text(json_text, encoding="utf-8")
+
+        if mode == "pre_market":
+            trading_latest = paths.latest_json.parent / "trading_intel_latest.json"
+            trading_latest.write_text(json_text, encoding="utf-8")
+
+        if paths.legacy_pre_market_json:
+            legacy = {
+                "date": _date_slug(self.now),
+                "time": self.now.strftime("%H:%M UTC"),
+                "risk_score": payload["risk_score"],
+                "recommendation": payload["recommendation"],
+                "reason": payload["gate_contract"]["reason"],
+                "intel": {item["key"]: item["answer"] for item in payload["queries"]},
+                "source": "perplexity_trading_intel",
+            }
+            paths.legacy_pre_market_json.write_text(
+                json.dumps(legacy, indent=2, sort_keys=True) + "\n",
+                encoding="utf-8",
+            )
+
+        paths.rag_lesson.write_text(render_rag_lesson(payload), encoding="utf-8")
+        with paths.ml_jsonl.open("a", encoding="utf-8") as handle:
+            handle.write(json.dumps(render_ml_event(payload), sort_keys=True) + "\n")
+
+        return paths
+
+
+def render_rag_lesson(payload: dict[str, Any]) -> str:
+    """Render a compact RAG lesson from a Perplexity intel run."""
+
+    citations = []
+    for item in payload.get("queries", []):
+        citations.extend(item.get("citations", [])[:3])
+    unique_citations = list(dict.fromkeys(citations))[:8]
+
+    lines = [
+        f"# Perplexity Trading Intel: {payload.get('mode')}",
+        "",
+        f"- Generated UTC: `{payload.get('generated_at_utc')}`",
+        f"- Recommendation: `{payload.get('recommendation')}`",
+        f"- Risk score: `{payload.get('risk_score')}`",
+        f"- Confidence: `{payload.get('confidence')}`",
+        f"- API status: `{payload.get('api_status')}`",
+        f"- Gate reason: {payload.get('gate_contract', {}).get('reason')}",
+        "",
+        "## Query Findings",
+    ]
+    for item in payload.get("queries", []):
+        answer = str(item.get("answer", "")).replace("\n", " ").strip()
+        if len(answer) > 700:
+            answer = answer[:700].rstrip() + "..."
+        lines.extend(
+            [
+                "",
+                f"### {item.get('key')}",
+                f"- Risk score: `{item.get('risk_score')}`",
+                f"- Summary: {answer}",
+            ]
+        )
+
+    if unique_citations:
+        lines.append("")
+        lines.append("## Citations")
+        lines.extend(f"- {url}" for url in unique_citations)
+
+    lines.append("")
+    return "\n".join(lines)
+
+
+def render_ml_event(payload: dict[str, Any]) -> dict[str, Any]:
+    """Return one JSONL event for downstream ML/RAG pipelines."""
+
+    context = payload.get("trading_context", {})
+    return {
+        "event_type": "perplexity_trading_intel",
+        "generated_at_utc": payload.get("generated_at_utc"),
+        "mode": payload.get("mode"),
+        "model": payload.get("model"),
+        "api_status": payload.get("api_status"),
+        "risk_score": payload.get("risk_score"),
+        "recommendation": payload.get("recommendation"),
+        "confidence": payload.get("confidence"),
+        "blocks_new_iron_condors": payload.get("gate_contract", {}).get(
+            "blocks_new_iron_condors"
+        ),
+        "equity": context.get("equity"),
+        "win_rate_pct": context.get("win_rate_pct"),
+        "profit_factor": context.get("profit_factor"),
+    }
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run Perplexity trading intelligence loop")
+    parser.add_argument(
+        "--mode",
+        choices=["pre_market", "post_market", "weekend", "all"],
+        default="pre_market",
+    )
+    parser.add_argument("--repo-root", type=Path, default=Path.cwd())
+    parser.add_argument("--dry-run", action="store_true")
+    parser.add_argument("--no-write", action="store_true")
+    return parser.parse_args(argv)
+
+
+async def async_main(argv: list[str] | None = None) -> dict[str, Any]:
+    args = parse_args(argv)
+    runner = PerplexityTradingIntelRunner(
+        args.repo_root.resolve(),
+        dry_run=args.dry_run,
+    )
+    payload = await runner.run(args.mode, write=not args.no_write)
+    print(json.dumps(payload, indent=2, sort_keys=True))
+    return payload
+
+
+def main(argv: list[str] | None = None) -> None:
+    asyncio.run(async_main(argv))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/analytics/perplexity_utilization_audit.py
+++ b/src/analytics/perplexity_utilization_audit.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import argparse
 import json
-import os
 import re
 from datetime import datetime, timezone
 from pathlib import Path
@@ -49,7 +48,7 @@ def _scan_file(path: Path, repo_root: Path) -> dict[str, Any] | None:
     return {
         "path": path_label,
         "models": models,
-        "uses_api_key": "PERPLEXITY_API_KEY" in text,
+        "uses_perplexity_credential": "PERPLEXITY_API_KEY" in text,
         "uses_api_endpoint": "api.perplexity.ai" in text,
         "mentions_agent_playground": playground_reference,
     }
@@ -77,7 +76,7 @@ def _iter_scannable_files(repo_root: Path) -> list[Path]:
 def build_perplexity_usage_snapshot(
     repo_root: Path | str | None = None,
     *,
-    api_key_present: bool | None = None,
+    credential_present: bool = False,
 ) -> dict[str, Any]:
     """Build a machine-readable Perplexity utilization snapshot."""
 
@@ -93,12 +92,9 @@ def build_perplexity_usage_snapshot(
     script_matches = [item for item in matches if item["path"].startswith("scripts/")]
     missing_expected = [path for path in EXPECTED_HIGH_ROI_FILES if not (root / path).exists()]
 
-    if api_key_present is None:
-        api_key_present = bool(os.getenv("PERPLEXITY_API_KEY"))
-
     gaps: list[str] = []
-    if not api_key_present:
-        gaps.append("local_runtime_missing_PERPLEXITY_API_KEY")
+    if not credential_present:
+        gaps.append("local_runtime_missing_perplexity_credential")
     if missing_expected:
         gaps.append("missing_high_roi_files")
     if not any(item["path"] == ".github/workflows/perplexity-trading-intel.yml" for item in matches):
@@ -110,7 +106,7 @@ def build_perplexity_usage_snapshot(
 
     return {
         "generated_at_utc": datetime.now(timezone.utc).isoformat(),
-        "api_key_present_in_runtime": api_key_present,
+        "credential_available_in_runtime": credential_present,
         "active_perplexity_files": len(matches),
         "workflows_with_perplexity": workflow_matches,
         "source_modules_with_perplexity": source_matches,
@@ -120,7 +116,7 @@ def build_perplexity_usage_snapshot(
         "missing_expected_files": missing_expected,
         "gaps": gaps,
         "max_utilization_score": _score_utilization(
-            api_key_present=api_key_present,
+            credential_present=credential_present,
             missing_expected=missing_expected,
             matches=matches,
         ),
@@ -129,12 +125,12 @@ def build_perplexity_usage_snapshot(
 
 def _score_utilization(
     *,
-    api_key_present: bool,
+    credential_present: bool,
     missing_expected: list[str],
     matches: list[dict[str, Any]],
 ) -> int:
     score = 0
-    if api_key_present:
+    if credential_present:
         score += 20
     if not missing_expected:
         score += 30
@@ -154,7 +150,7 @@ def render_perplexity_usage_markdown(snapshot: dict[str, Any]) -> str:
         "# Perplexity Utilization Audit",
         "",
         f"- Generated UTC: `{snapshot.get('generated_at_utc')}`",
-        f"- Runtime API key present: `{snapshot.get('api_key_present_in_runtime')}`",
+        f"- Runtime credential available: `{snapshot.get('credential_available_in_runtime')}`",
         f"- Active Perplexity files: `{snapshot.get('active_perplexity_files')}`",
         f"- Max utilization score: `{snapshot.get('max_utilization_score')}/100`",
         f"- Models referenced: `{', '.join(snapshot.get('models_referenced') or []) or 'none'}`",
@@ -186,10 +182,10 @@ def render_perplexity_usage_markdown(snapshot: dict[str, Any]) -> str:
 def write_perplexity_usage_artifacts(
     repo_root: Path | str | None = None,
     *,
-    api_key_present: bool | None = None,
+    credential_present: bool = False,
 ) -> dict[str, Path]:
     root = Path.cwd().resolve() if repo_root is None else Path(repo_root).resolve()
-    snapshot = build_perplexity_usage_snapshot(root, api_key_present=api_key_present)
+    snapshot = build_perplexity_usage_snapshot(root, credential_present=credential_present)
     output_dir = root / "data" / "analytics"
     output_dir.mkdir(parents=True, exist_ok=True)
     json_path = output_dir / "perplexity_utilization_latest.json"
@@ -203,17 +199,24 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Audit Perplexity utilization")
     parser.add_argument("--repo-root", type=Path, default=Path.cwd())
     parser.add_argument("--write", action="store_true")
+    parser.add_argument("--credential-present", action="store_true")
     return parser.parse_args(argv)
 
 
 def main(argv: list[str] | None = None) -> None:
     args = parse_args(argv)
     if args.write:
-        paths = write_perplexity_usage_artifacts(args.repo_root)
+        paths = write_perplexity_usage_artifacts(
+            args.repo_root,
+            credential_present=args.credential_present,
+        )
         print(json.dumps({key: str(value) for key, value in paths.items()}, indent=2))
         return
 
-    snapshot = build_perplexity_usage_snapshot(args.repo_root)
+    snapshot = build_perplexity_usage_snapshot(
+        args.repo_root,
+        credential_present=args.credential_present,
+    )
     print(json.dumps(snapshot, indent=2, sort_keys=True))
 
 

--- a/src/analytics/perplexity_utilization_audit.py
+++ b/src/analytics/perplexity_utilization_audit.py
@@ -1,0 +1,221 @@
+"""Audit how much of Perplexity is wired into the trading system."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+PERPLEXITY_PATTERNS = (
+    "PERPLEXITY_API_KEY",
+    "api.perplexity.ai",
+    "sonar",
+    "perplexity",
+)
+
+EXPECTED_HIGH_ROI_FILES = (
+    "src/analytics/perplexity_trading_intel.py",
+    "src/analytics/perplexity_utilization_audit.py",
+    "scripts/run_perplexity_trading_intel.py",
+    ".github/workflows/pre-market-scan.yml",
+    ".github/workflows/perplexity-trading-intel.yml",
+)
+
+
+def _read_text(path: Path) -> str:
+    try:
+        return path.read_text(encoding="utf-8")
+    except (FileNotFoundError, UnicodeDecodeError):
+        return ""
+
+
+def _scan_file(path: Path, repo_root: Path) -> dict[str, Any] | None:
+    text = _read_text(path)
+    lowered = text.lower()
+    if not any(pattern.lower() in lowered for pattern in PERPLEXITY_PATTERNS):
+        return None
+
+    models = sorted(set(re.findall(r"\bsonar(?:-[a-z]+)*\b", text)))
+    path_label = str(path.relative_to(repo_root))
+    playground_reference = (
+        ("console.perplexity.ai/group" in lowered or "agent-playground" in lowered)
+        and not path_label.endswith("perplexity_utilization_audit.py")
+    )
+
+    return {
+        "path": path_label,
+        "models": models,
+        "uses_api_key": "PERPLEXITY_API_KEY" in text,
+        "uses_api_endpoint": "api.perplexity.ai" in text,
+        "mentions_agent_playground": playground_reference,
+    }
+
+
+def _iter_scannable_files(repo_root: Path) -> list[Path]:
+    roots = [
+        repo_root / ".github" / "workflows",
+        repo_root / "scripts",
+        repo_root / "src",
+        repo_root / "tests",
+    ]
+    files: list[Path] = []
+    for root in roots:
+        if not root.exists():
+            continue
+        files.extend(
+            path
+            for path in root.rglob("*")
+            if path.is_file() and path.suffix in {".py", ".yml", ".yaml", ".md", ".txt"}
+        )
+    return sorted(files)
+
+
+def build_perplexity_usage_snapshot(
+    repo_root: Path | str | None = None,
+    *,
+    api_key_present: bool | None = None,
+) -> dict[str, Any]:
+    """Build a machine-readable Perplexity utilization snapshot."""
+
+    root = Path.cwd().resolve() if repo_root is None else Path(repo_root).resolve()
+    matches = [
+        match
+        for path in _iter_scannable_files(root)
+        if (match := _scan_file(path, root))
+    ]
+
+    workflow_matches = [item for item in matches if item["path"].startswith(".github/workflows/")]
+    source_matches = [item for item in matches if item["path"].startswith("src/")]
+    script_matches = [item for item in matches if item["path"].startswith("scripts/")]
+    missing_expected = [path for path in EXPECTED_HIGH_ROI_FILES if not (root / path).exists()]
+
+    if api_key_present is None:
+        api_key_present = bool(os.getenv("PERPLEXITY_API_KEY"))
+
+    gaps: list[str] = []
+    if not api_key_present:
+        gaps.append("local_runtime_missing_PERPLEXITY_API_KEY")
+    if missing_expected:
+        gaps.append("missing_high_roi_files")
+    if not any(item["path"] == ".github/workflows/perplexity-trading-intel.yml" for item in matches):
+        gaps.append("missing_24_7_trading_intel_workflow")
+    if not any(item["path"] == "src/analytics/perplexity_trading_intel.py" for item in matches):
+        gaps.append("missing_structured_trading_intel_engine")
+    if not any(item["mentions_agent_playground"] for item in matches):
+        gaps.append("agent_playground_not_versioned_in_repo")
+
+    return {
+        "generated_at_utc": datetime.now(timezone.utc).isoformat(),
+        "api_key_present_in_runtime": api_key_present,
+        "active_perplexity_files": len(matches),
+        "workflows_with_perplexity": workflow_matches,
+        "source_modules_with_perplexity": source_matches,
+        "scripts_with_perplexity": script_matches,
+        "models_referenced": sorted({model for item in matches for model in item["models"]}),
+        "expected_high_roi_files": list(EXPECTED_HIGH_ROI_FILES),
+        "missing_expected_files": missing_expected,
+        "gaps": gaps,
+        "max_utilization_score": _score_utilization(
+            api_key_present=api_key_present,
+            missing_expected=missing_expected,
+            matches=matches,
+        ),
+    }
+
+
+def _score_utilization(
+    *,
+    api_key_present: bool,
+    missing_expected: list[str],
+    matches: list[dict[str, Any]],
+) -> int:
+    score = 0
+    if api_key_present:
+        score += 20
+    if not missing_expected:
+        score += 30
+    if any(item["path"] == ".github/workflows/perplexity-trading-intel.yml" for item in matches):
+        score += 20
+    if any(item["path"] == "src/analytics/perplexity_trading_intel.py" for item in matches):
+        score += 20
+    if any(item["mentions_agent_playground"] for item in matches):
+        score += 10
+    return score
+
+
+def render_perplexity_usage_markdown(snapshot: dict[str, Any]) -> str:
+    """Render audit snapshot as operator-readable markdown."""
+
+    lines = [
+        "# Perplexity Utilization Audit",
+        "",
+        f"- Generated UTC: `{snapshot.get('generated_at_utc')}`",
+        f"- Runtime API key present: `{snapshot.get('api_key_present_in_runtime')}`",
+        f"- Active Perplexity files: `{snapshot.get('active_perplexity_files')}`",
+        f"- Max utilization score: `{snapshot.get('max_utilization_score')}/100`",
+        f"- Models referenced: `{', '.join(snapshot.get('models_referenced') or []) or 'none'}`",
+        "",
+        "## Workflows",
+    ]
+
+    for item in snapshot.get("workflows_with_perplexity", []):
+        lines.append(f"- `{item['path']}` models=`{', '.join(item['models']) or 'n/a'}`")
+
+    lines.append("")
+    lines.append("## Gaps")
+    gaps = snapshot.get("gaps") or []
+    if gaps:
+        lines.extend(f"- `{gap}`" for gap in gaps)
+    else:
+        lines.append("- `none`")
+
+    missing = snapshot.get("missing_expected_files") or []
+    if missing:
+        lines.append("")
+        lines.append("## Missing Expected Files")
+        lines.extend(f"- `{path}`" for path in missing)
+
+    lines.append("")
+    return "\n".join(lines)
+
+
+def write_perplexity_usage_artifacts(
+    repo_root: Path | str | None = None,
+    *,
+    api_key_present: bool | None = None,
+) -> dict[str, Path]:
+    root = Path.cwd().resolve() if repo_root is None else Path(repo_root).resolve()
+    snapshot = build_perplexity_usage_snapshot(root, api_key_present=api_key_present)
+    output_dir = root / "data" / "analytics"
+    output_dir.mkdir(parents=True, exist_ok=True)
+    json_path = output_dir / "perplexity_utilization_latest.json"
+    md_path = output_dir / "perplexity_utilization_latest.md.txt"
+    json_path.write_text(json.dumps(snapshot, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    md_path.write_text(render_perplexity_usage_markdown(snapshot), encoding="utf-8")
+    return {"json": json_path, "markdown": md_path}
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Audit Perplexity utilization")
+    parser.add_argument("--repo-root", type=Path, default=Path.cwd())
+    parser.add_argument("--write", action="store_true")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> None:
+    args = parse_args(argv)
+    if args.write:
+        paths = write_perplexity_usage_artifacts(args.repo_root)
+        print(json.dumps({key: str(value) for key, value in paths.items()}, indent=2))
+        return
+
+    snapshot = build_perplexity_usage_snapshot(args.repo_root)
+    print(json.dumps(snapshot, indent=2, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/orchestration/daggr_workflow.py
+++ b/src/orchestration/daggr_workflow.py
@@ -29,6 +29,9 @@ PROJECT_DIR = Path(__file__).parent.parent.parent
 DATA_DIR = PROJECT_DIR / "data"
 WORKFLOW_STATE_DIR = DATA_DIR / "workflow_state"
 WORKFLOW_STATE_DIR.mkdir(parents=True, exist_ok=True)
+PERPLEXITY_TRADING_INTEL_PATH = (
+    DATA_DIR / "analysis" / "perplexity" / "trading_intel_latest.json"
+)
 
 
 @dataclass
@@ -57,6 +60,38 @@ class NodeResult:
             "cached": self.cached,
             "error": self.error,
         }
+
+
+def load_latest_perplexity_trading_intel(
+    path: Path = PERPLEXITY_TRADING_INTEL_PATH,
+    *,
+    max_age_minutes: int = 240,
+    now: datetime | None = None,
+) -> dict[str, Any] | None:
+    """Load fresh Perplexity trading intel for DAGGR decision nodes."""
+
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        return None
+    except Exception:
+        return None
+
+    generated_raw = payload.get("generated_at_utc")
+    if not generated_raw:
+        return None
+
+    try:
+        generated_at = datetime.fromisoformat(str(generated_raw).replace("Z", "+00:00"))
+    except ValueError:
+        return None
+
+    current = now or datetime.now(timezone.utc)
+    age_minutes = (current - generated_at).total_seconds() / 60
+    if age_minutes > max_age_minutes:
+        return None
+
+    return payload
 
 
 @dataclass
@@ -419,6 +454,24 @@ def create_trading_workflow() -> TradingWorkflow:
 
     async def perplexity_intel(**kwargs) -> dict:
         """Perplexity-powered market intelligence."""
+        latest = load_latest_perplexity_trading_intel()
+        if latest:
+            risk_score = float(latest.get("risk_score") or 0.0)
+            confidence = float(latest.get("confidence") or 0.5)
+            signal = max(0.1, min(0.9, 0.5 - (risk_score * 0.4)))
+            return {
+                "signal": signal,
+                "confidence": confidence,
+                "data": {
+                    "source": "perplexity_trading_intel",
+                    "recommendation": latest.get("recommendation"),
+                    "risk_score": risk_score,
+                    "api_status": latest.get("api_status"),
+                    "gate_contract": latest.get("gate_contract", {}),
+                    "generated_at_utc": latest.get("generated_at_utc"),
+                },
+            }
+
         try:
             from src.agents.research_agent import get_research_signal
 
@@ -469,6 +522,20 @@ def create_trading_workflow() -> TradingWorkflow:
 
         signal = options.get("signal", 0.5)
         confidence = options.get("confidence", 0.5)
+        perplexity_data = perplexity.get("data", {})
+        perplexity_gate = perplexity_data.get("gate_contract", {})
+
+        if (
+            perplexity_gate.get("blocks_new_iron_condors")
+            or perplexity_data.get("recommendation") == "BLOCK_NEW_IC"
+        ):
+            return {
+                "decision": "HOLD",
+                "signal": min(signal, 0.5),
+                "confidence": confidence,
+                "trade_params": None,
+                "reason": perplexity_gate.get("reason", "Perplexity event risk blocked entry"),
+            }
 
         # Boost confidence if research confirms
         if perplexity.get("confidence", 0) > 0.6:

--- a/src/safety/macro_risk_guard.py
+++ b/src/safety/macro_risk_guard.py
@@ -5,8 +5,10 @@ to prevent trading during 'Black Swan' regime shifts.
 Inspired by CNBC/PwC: 'Investors becoming more cautious on U.S. allocations'.
 """
 
+import json
 import logging
 from datetime import datetime, timedelta, timezone
+from pathlib import Path
 from typing import Any, Optional
 
 logger = logging.getLogger(__name__)
@@ -22,12 +24,28 @@ class MacroRiskGuard:
     TREASURY_YIELD_SPIKE_THRESHOLD: float = 0.05  # 5% move in TNX
     OIL_CRISIS_PRICE: float = 100.0
 
-    def __init__(self, data_client: Optional[Any] = None):
+    def __init__(
+        self,
+        data_client: Optional[Any] = None,
+        *,
+        intel_path: Path | str | None = None,
+        intel_max_age_minutes: int = 240,
+    ):
         """
         Args:
             data_client: Alpaca StockHistoricalDataClient instance
         """
         self.data_client = data_client
+        self.intel_path = (
+            Path(intel_path)
+            if intel_path is not None
+            else Path(__file__).resolve().parents[2]
+            / "data"
+            / "analysis"
+            / "perplexity"
+            / "trading_intel_latest.json"
+        )
+        self.intel_max_age_minutes = intel_max_age_minutes
 
     def check_macro_vitals(self, macro_data: dict[str, Any]) -> tuple[bool, str]:
         """
@@ -49,7 +67,52 @@ class MacroRiskGuard:
             logger.critical(f"🚨 {reason}")
             return False, reason
 
+        # 3. Check fresh Perplexity event/regime intelligence.
+        intel_safe, intel_reason = self.check_perplexity_event_risk()
+        if not intel_safe:
+            logger.critical("Perplexity event risk halt: %s", intel_reason)
+            return False, intel_reason
+
         logger.info("✅ Macro vitals within normal parameters.")
+        return True, ""
+
+    def check_perplexity_event_risk(self) -> tuple[bool, str]:
+        """Block only when a fresh Perplexity artifact explicitly flags high event risk."""
+
+        try:
+            payload = json.loads(self.intel_path.read_text(encoding="utf-8"))
+        except FileNotFoundError:
+            return True, ""
+        except Exception as exc:
+            logger.warning("Failed to read Perplexity trading intel: %s", exc)
+            return True, ""
+
+        generated_raw = payload.get("generated_at_utc")
+        if not generated_raw:
+            return True, ""
+
+        try:
+            generated_at = datetime.fromisoformat(str(generated_raw).replace("Z", "+00:00"))
+        except ValueError:
+            logger.warning("Invalid Perplexity intel timestamp: %s", generated_raw)
+            return True, ""
+
+        age_minutes = (datetime.now(timezone.utc) - generated_at).total_seconds() / 60
+        if age_minutes > self.intel_max_age_minutes:
+            logger.info("Ignoring stale Perplexity intel age %.1f minutes", age_minutes)
+            return True, ""
+
+        recommendation = str(payload.get("recommendation") or "").upper()
+        risk_score = float(payload.get("risk_score") or 0.0)
+        gate_contract = payload.get("gate_contract")
+        gate_contract = gate_contract if isinstance(gate_contract, dict) else {}
+        blocks = bool(gate_contract.get("blocks_new_iron_condors"))
+        if blocks or recommendation == "BLOCK_NEW_IC" or risk_score >= 0.70:
+            reason = gate_contract.get("reason") or (
+                f"Perplexity event/regime risk score {risk_score:.2f} blocks new entries."
+            )
+            return False, f"PERPLEXITY EVENT RISK HALT: {reason}"
+
         return True, ""
 
     def get_macro_snapshot(self) -> dict[str, Any]:

--- a/tests/test_daggr_perplexity_intel.py
+++ b/tests/test_daggr_perplexity_intel.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+import asyncio
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+from src.orchestration.daggr_workflow import (
+    create_trading_workflow,
+    load_latest_perplexity_trading_intel,
+)
+
+
+def test_load_latest_perplexity_trading_intel_requires_fresh_artifact(tmp_path: Path) -> None:
+    path = tmp_path / "trading_intel_latest.json"
+    path.write_text(
+        json.dumps(
+            {
+                "generated_at_utc": datetime(2026, 4, 13, 14, 0, tzinfo=timezone.utc).isoformat(),
+                "recommendation": "BLOCK_NEW_IC",
+                "risk_score": 0.8,
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    fresh = load_latest_perplexity_trading_intel(
+        path,
+        now=datetime(2026, 4, 13, 15, 0, tzinfo=timezone.utc),
+    )
+    stale = load_latest_perplexity_trading_intel(
+        path,
+        max_age_minutes=30,
+        now=datetime(2026, 4, 13, 15, 0, tzinfo=timezone.utc),
+    )
+
+    assert fresh is not None
+    assert stale is None
+
+
+def test_trade_decision_holds_when_perplexity_blocks_new_ic() -> None:
+    workflow = create_trading_workflow()
+    node = workflow.nodes["trade_decision"]
+
+    result = asyncio.run(
+        node.execute(
+            {
+                "options_chain": {
+                    "signal": 0.8,
+                    "confidence": 0.9,
+                    "data": {"ticker": "SPY"},
+                },
+                "perplexity_intel": {
+                    "confidence": 0.9,
+                    "data": {
+                        "recommendation": "BLOCK_NEW_IC",
+                        "gate_contract": {
+                            "blocks_new_iron_condors": True,
+                            "reason": "FOMC risk",
+                        },
+                    },
+                },
+            },
+            {},
+        )
+    )
+
+    assert result.success is True
+    assert result.output["decision"] == "HOLD"
+    assert result.output["trade_params"] is None
+    assert result.output["reason"] == "FOMC risk"

--- a/tests/test_macro_risk_guard.py
+++ b/tests/test_macro_risk_guard.py
@@ -1,4 +1,8 @@
+import json
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
 from unittest.mock import MagicMock, patch
+
 from src.safety.macro_risk_guard import MacroRiskGuard
 
 
@@ -63,3 +67,52 @@ def test_macro_guard_fails_closed_on_none_client():
     guard = MacroRiskGuard(data_client=None)
     snapshot = guard.get_macro_snapshot()
     assert snapshot["oil_price"] == 75.0  # Baseline default
+
+
+def test_macro_guard_blocks_fresh_perplexity_event_risk(tmp_path: Path):
+    intel_path = tmp_path / "trading_intel_latest.json"
+    intel_path.write_text(
+        json.dumps(
+            {
+                "generated_at_utc": datetime.now(timezone.utc).isoformat(),
+                "recommendation": "BLOCK_NEW_IC",
+                "risk_score": 0.82,
+                "gate_contract": {
+                    "blocks_new_iron_condors": True,
+                    "reason": "Fresh FOMC event risk.",
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    guard = MacroRiskGuard(data_client=None, intel_path=intel_path)
+    vitals = {"oil_change": 0.01, "oil_price": 75.0, "yield_change": 0.01}
+    safe, reason = guard.check_macro_vitals(vitals)
+
+    assert safe is False
+    assert "PERPLEXITY EVENT RISK HALT" in reason
+
+
+def test_macro_guard_ignores_stale_perplexity_event_risk(tmp_path: Path):
+    intel_path = tmp_path / "trading_intel_latest.json"
+    intel_path.write_text(
+        json.dumps(
+            {
+                "generated_at_utc": (
+                    datetime.now(timezone.utc) - timedelta(days=2)
+                ).isoformat(),
+                "recommendation": "BLOCK_NEW_IC",
+                "risk_score": 0.92,
+                "gate_contract": {"blocks_new_iron_condors": True},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    guard = MacroRiskGuard(data_client=None, intel_path=intel_path, intel_max_age_minutes=60)
+    vitals = {"oil_change": 0.01, "oil_price": 75.0, "yield_change": 0.01}
+    safe, reason = guard.check_macro_vitals(vitals)
+
+    assert safe is True
+    assert reason == ""

--- a/tests/test_perplexity_trading_intel.py
+++ b/tests/test_perplexity_trading_intel.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+import asyncio
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+from src.analytics.perplexity_trading_intel import (
+    PRE_MARKET_QUERIES,
+    PerplexityTradingIntelRunner,
+    QuerySpec,
+    recommendation_for,
+    score_text,
+)
+
+
+def test_score_text_blocks_high_impact_event_language() -> None:
+    spec = QuerySpec(
+        key="test",
+        prompt="test",
+        recency="day",
+        risk_terms=("fomc", "avoid"),
+    )
+
+    score = score_text(
+        "FOMC and Powell create a volatility spike. Avoid new iron condors today.",
+        spec,
+    )
+
+    assert score >= 0.70
+    assert recommendation_for(score, "ok") == "BLOCK_NEW_IC"
+
+
+def test_score_text_keeps_calm_language_clear() -> None:
+    score = score_text("No major scheduled catalysts. Calm and stable range-bound session.")
+
+    assert score == 0.0
+    assert recommendation_for(score, "ok") == "CLEAR"
+
+
+def test_pre_market_bundle_has_multiple_independent_queries() -> None:
+    keys = {query.key for query in PRE_MARKET_QUERIES}
+
+    assert {"macro_calendar", "volatility_regime", "index_event_risk"}.issubset(keys)
+
+
+def test_dry_run_writes_json_rag_and_ml_artifacts(tmp_path: Path) -> None:
+    (tmp_path / "docs" / "data").mkdir(parents=True)
+    (tmp_path / "data").mkdir(parents=True)
+    (tmp_path / "docs" / "data" / "public_status.json").write_text(
+        json.dumps(
+            {
+                "paper": {"equity": 93728.02, "total_pnl_today": -97.08, "positions_count": 4},
+                "ledger": {"closed_trades_total": 67, "win_rate_pct": 23.88},
+                "gate": {"mode": "validation_reset", "scale_allowed": False},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    runner = PerplexityTradingIntelRunner(
+        tmp_path,
+        dry_run=True,
+        now=datetime(2026, 4, 13, 13, 30, tzinfo=timezone.utc),
+    )
+    payload = asyncio.run(runner.run("pre_market"))
+
+    latest = tmp_path / "data" / "analysis" / "perplexity" / "pre_market_latest.json"
+    trading_latest = tmp_path / "data" / "analysis" / "perplexity" / "trading_intel_latest.json"
+    legacy = tmp_path / "data" / "analysis" / "pre_market_2026-04-13.json"
+    rag = tmp_path / "rag_knowledge" / "lessons_learned" / "ll_perplexity_pre_market_2026-04-13.md"
+    ml = tmp_path / "data" / "feedback" / "perplexity_intel_events.jsonl"
+
+    assert payload["api_status"] == "dry_run"
+    assert latest.exists()
+    assert trading_latest.exists()
+    assert legacy.exists()
+    assert rag.exists()
+    assert ml.exists()
+
+    saved = json.loads(latest.read_text(encoding="utf-8"))
+    assert saved["trading_context"]["equity"] == 93728.02
+    assert saved["gate_contract"]["source"] == "perplexity_trading_intel"
+    assert "perplexity_trading_intel" in ml.read_text(encoding="utf-8")

--- a/tests/test_perplexity_utilization_audit.py
+++ b/tests/test_perplexity_utilization_audit.py
@@ -22,9 +22,9 @@ def test_perplexity_usage_snapshot_detects_high_roi_wiring(tmp_path: Path) -> No
         path.parent.mkdir(parents=True, exist_ok=True)
         path.write_text(content, encoding="utf-8")
 
-    snapshot = build_perplexity_usage_snapshot(tmp_path, api_key_present=True)
+    snapshot = build_perplexity_usage_snapshot(tmp_path, credential_present=True)
 
-    assert snapshot["api_key_present_in_runtime"] is True
+    assert snapshot["credential_available_in_runtime"] is True
     assert snapshot["missing_expected_files"] == []
     assert snapshot["max_utilization_score"] >= 90
     assert ".github/workflows/perplexity-trading-intel.yml" in {
@@ -37,19 +37,19 @@ def test_perplexity_usage_artifacts_render_markdown(tmp_path: Path) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text("PERPLEXITY_API_KEY\nsonar-pro\n", encoding="utf-8")
 
-    paths = write_perplexity_usage_artifacts(tmp_path, api_key_present=False)
+    paths = write_perplexity_usage_artifacts(tmp_path, credential_present=False)
     markdown = paths["markdown"].read_text(encoding="utf-8")
 
     assert paths["json"].exists()
     assert "# Perplexity Utilization Audit" in markdown
-    assert "local_runtime_missing_PERPLEXITY_API_KEY" in markdown
+    assert "local_runtime_missing_perplexity_credential" in markdown
 
 
 def test_render_perplexity_usage_markdown_has_gap_section() -> None:
     markdown = render_perplexity_usage_markdown(
         {
             "generated_at_utc": "2026-04-13T00:00:00+00:00",
-            "api_key_present_in_runtime": False,
+            "credential_available_in_runtime": False,
             "active_perplexity_files": 1,
             "max_utilization_score": 20,
             "models_referenced": ["sonar-pro"],

--- a/tests/test_perplexity_utilization_audit.py
+++ b/tests/test_perplexity_utilization_audit.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from src.analytics import build_perplexity_usage_snapshot
+from src.analytics.perplexity_utilization_audit import (
+    render_perplexity_usage_markdown,
+    write_perplexity_usage_artifacts,
+)
+
+
+def test_perplexity_usage_snapshot_detects_high_roi_wiring(tmp_path: Path) -> None:
+    files = {
+        "src/analytics/perplexity_trading_intel.py": 'model = "sonar-pro"\n',
+        "src/analytics/perplexity_utilization_audit.py": "PERPLEXITY_API_KEY\n",
+        "scripts/run_perplexity_trading_intel.py": "perplexity_trading_intel\n",
+        ".github/workflows/pre-market-scan.yml": "PERPLEXITY_API_KEY\nsonar-pro\n",
+        ".github/workflows/perplexity-trading-intel.yml": "api.perplexity.ai\nsonar\n",
+    }
+    for rel_path, content in files.items():
+        path = tmp_path / rel_path
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(content, encoding="utf-8")
+
+    snapshot = build_perplexity_usage_snapshot(tmp_path, api_key_present=True)
+
+    assert snapshot["api_key_present_in_runtime"] is True
+    assert snapshot["missing_expected_files"] == []
+    assert snapshot["max_utilization_score"] >= 90
+    assert ".github/workflows/perplexity-trading-intel.yml" in {
+        item["path"] for item in snapshot["workflows_with_perplexity"]
+    }
+
+
+def test_perplexity_usage_artifacts_render_markdown(tmp_path: Path) -> None:
+    path = tmp_path / "src" / "analytics" / "perplexity_trading_intel.py"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("PERPLEXITY_API_KEY\nsonar-pro\n", encoding="utf-8")
+
+    paths = write_perplexity_usage_artifacts(tmp_path, api_key_present=False)
+    markdown = paths["markdown"].read_text(encoding="utf-8")
+
+    assert paths["json"].exists()
+    assert "# Perplexity Utilization Audit" in markdown
+    assert "local_runtime_missing_PERPLEXITY_API_KEY" in markdown
+
+
+def test_render_perplexity_usage_markdown_has_gap_section() -> None:
+    markdown = render_perplexity_usage_markdown(
+        {
+            "generated_at_utc": "2026-04-13T00:00:00+00:00",
+            "api_key_present_in_runtime": False,
+            "active_perplexity_files": 1,
+            "max_utilization_score": 20,
+            "models_referenced": ["sonar-pro"],
+            "workflows_with_perplexity": [],
+            "gaps": ["agent_playground_not_versioned_in_repo"],
+        }
+    )
+
+    assert "## Gaps" in markdown
+    assert "agent_playground_not_versioned_in_repo" in markdown


### PR DESCRIPTION
## Summary
- Adds a shared Perplexity trading intelligence loop for pre-market, post-market, and weekend research.
- Writes structured JSON, RAG lessons, and ML feedback events from the same engine.
- Wires fresh Perplexity event-risk artifacts into MacroRiskGuard and DAGGR trade decisions.
- Restores the Perplexity utilization audit and schedules 24/7 automation.

## Verification
- pytest tests/test_perplexity_trading_intel.py tests/test_perplexity_utilization_audit.py tests/test_macro_risk_guard.py tests/test_daggr_perplexity_intel.py tests/test_workflow_ml_integration.py tests/test_ci_runner_wiring.py tests/test_workflow_contracts.py tests/test_workflow_dependencies.py tests/test_workflow_integrity.py -q
- ruff check changed Perplexity/macro/DAGGR files
- sh scripts/validate_yaml_before_commit.sh
- dry-run artifact proof: all/pre_market/post_market/weekend wrote 3 JSON latest files and 3 ML events in temp root

## Runtime note
- Local PERPLEXITY_API_KEY is absent; GitHub repo secret PERPLEXITY_API_KEY exists and will be used by Actions.