### PR TITLE
Harden regime data fallback

### DIFF
--- a/src/utils/regime_detector.py
+++ b/src/utils/regime_detector.py
@@ -16,11 +16,13 @@ Layers:
 
 from __future__ import annotations
 
+import json
 import logging
 import math
 import os
 from dataclasses import dataclass, field
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
 from typing import Any
 
 import numpy as np
@@ -42,6 +44,11 @@ REGIME_ALLOCATIONS = {
     "spike": {"equities": 0.0, "treasuries": 0.6, "pause_trading": True},
 }
 
+REGIME_DATA_CACHE = Path(os.getenv("REGIME_DATA_CACHE", "data/market_cache/regime_latest.json"))
+REGIME_DATA_CACHE_MAX_AGE = timedelta(
+    minutes=int(os.getenv("REGIME_DATA_CACHE_MAX_AGE_MINUTES", "90"))
+)
+
 
 def _finite_positive_float(value: Any) -> float | None:
     try:
@@ -51,6 +58,75 @@ def _finite_positive_float(value: Any) -> float | None:
     if not math.isfinite(parsed) or parsed <= 0:
         return None
     return parsed
+
+
+def _latest_finite_positive(series: Any) -> float | None:
+    try:
+        return _finite_positive_float(series.iloc[-1])
+    except AttributeError:
+        values = list(series or [])
+    except IndexError:
+        return None
+    return _finite_positive_float(values[-1]) if values else None
+
+
+def _parse_cache_timestamp(value: Any) -> datetime | None:
+    if not value:
+        return None
+    try:
+        parsed = datetime.fromisoformat(str(value).replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def _load_regime_data_cache() -> dict[str, float] | None:
+    try:
+        payload = json.loads(REGIME_DATA_CACHE.read_text())
+    except (OSError, json.JSONDecodeError):
+        return None
+
+    cached_at = _parse_cache_timestamp(payload.get("timestamp"))
+    if cached_at is None or datetime.now(timezone.utc) - cached_at > REGIME_DATA_CACHE_MAX_AGE:
+        return None
+
+    vix = _finite_positive_float(payload.get("vix_level"))
+    vvix = _finite_positive_float(payload.get("vvix_level"))
+    if vix is None or vvix is None:
+        return None
+    return {"vix_level": vix, "vvix_level": vvix}
+
+
+def _save_regime_data_cache(vix: float, vvix: float) -> None:
+    try:
+        REGIME_DATA_CACHE.parent.mkdir(parents=True, exist_ok=True)
+        REGIME_DATA_CACHE.write_text(
+            json.dumps(
+                {
+                    "timestamp": datetime.now(timezone.utc).isoformat(),
+                    "vix_level": round(vix, 4),
+                    "vvix_level": round(vvix, 4),
+                },
+                sort_keys=True,
+            )
+        )
+    except OSError as exc:
+        logger.debug("Failed to write regime market data cache: %s", exc)
+
+
+def _fetch_single_latest_close(yf_module: Any, symbol: str) -> float | None:
+    try:
+        ticker = yf_module.get_ticker(symbol)
+        history = ticker.history(period="5d")
+    except Exception as exc:
+        logger.warning("Single-ticker regime fetch failed for %s: %s", symbol, exc)
+        return None
+
+    if getattr(history, "empty", True) or "Close" not in history:
+        return None
+    return _latest_finite_positive(history["Close"])
 
 
 @dataclass
@@ -197,11 +273,30 @@ class RegimeDetector:
             if "^VIX" not in closes or "^VVIX" not in closes:
                 logger.warning("VIX/VVIX close data missing; regime detection fails closed")
                 return self._fallback_snapshot()
-            vix = _finite_positive_float(closes["^VIX"].iloc[-1])
-            vvix = _finite_positive_float(closes["^VVIX"].iloc[-1])
+            live_vix = _latest_finite_positive(closes["^VIX"])
+            live_vvix = _latest_finite_positive(closes["^VVIX"])
+            if live_vix is None:
+                live_vix = _fetch_single_latest_close(yf, "^VIX")
+            if live_vvix is None:
+                live_vvix = _fetch_single_latest_close(yf, "^VVIX")
+            vix = live_vix
+            vvix = live_vvix
             if vix is None or vvix is None:
-                logger.warning("VIX/VVIX latest close is invalid; regime detection fails closed")
-                return self._fallback_snapshot()
+                cached = _load_regime_data_cache()
+                if cached is not None:
+                    if vix is None:
+                        vix = cached["vix_level"]
+                    if vvix is None:
+                        vvix = cached["vvix_level"]
+                    logger.warning(
+                        "Using fresh cached regime data for missing live VIX/VVIX field(s)"
+                    )
+                else:
+                    logger.warning("VIX/VVIX latest close is invalid; regime detection fails closed")
+                    return self._fallback_snapshot()
+
+            if live_vix is not None and live_vvix is not None:
+                _save_regime_data_cache(live_vix, live_vvix)
 
             # Calculate skew percentile (VVIX relative to VIX)
             skew_ratio = vvix / vix

--- a/tests/test_regime_detector.py
+++ b/tests/test_regime_detector.py
@@ -1,16 +1,52 @@
 from __future__ import annotations
 
+import json
 import math
+from datetime import datetime, timedelta, timezone
 
 import pandas as pd
+import pytest
 
-from src.utils import yfinance_wrapper
+from src.utils import regime_detector, yfinance_wrapper
 from src.utils.regime_detector import RegimeDetector
+
+
+@pytest.fixture(autouse=True)
+def _isolated_regime_cache(monkeypatch, tmp_path):
+    monkeypatch.setattr(regime_detector, "REGIME_DATA_CACHE", tmp_path / "regime_latest.json")
 
 
 def _mock_yfinance(monkeypatch, frame: pd.DataFrame) -> None:
     monkeypatch.setattr(yfinance_wrapper, "is_available", lambda: True)
     monkeypatch.setattr(yfinance_wrapper, "download", lambda *_, **__: frame)
+    monkeypatch.setattr(
+        yfinance_wrapper,
+        "get_ticker",
+        lambda _symbol: _MockTicker(pd.DataFrame(columns=["Close"])),
+    )
+
+
+class _MockTicker:
+    def __init__(self, frame: pd.DataFrame):
+        self._frame = frame
+
+    def history(self, *_, **__) -> pd.DataFrame:
+        return self._frame
+
+
+def _write_regime_cache(tmp_path, *, vix: float, vvix: float, age_minutes: int = 0) -> None:
+    cache_file = tmp_path / "regime_latest.json"
+    cache_file.write_text(
+        json.dumps(
+            {
+                "timestamp": (
+                    datetime.now(timezone.utc) - timedelta(minutes=age_minutes)
+                ).isoformat(),
+                "vix_level": vix,
+                "vvix_level": vvix,
+            }
+        )
+    )
 
 
 def test_live_regime_fails_closed_on_latest_vix_nan(monkeypatch):
@@ -55,3 +91,78 @@ def test_live_regime_still_detects_calm_with_valid_vix_vvix(monkeypatch):
     assert snapshot.regime_id == 0
     assert snapshot.label == "calm"
     assert snapshot.confidence >= 0.5
+
+
+def test_live_regime_writes_fresh_regime_cache(monkeypatch, tmp_path):
+    frame = pd.DataFrame(
+        {
+            "^VIX": [18.0] * 30,
+            "^VVIX": [95.0] * 30,
+            "TLT": [90.0] * 30,
+        }
+    )
+    _mock_yfinance(monkeypatch, frame)
+
+    RegimeDetector(hmm_enabled=False).detect_live_regime()
+
+    payload = json.loads((tmp_path / "regime_latest.json").read_text())
+    assert payload["vix_level"] == 18.0
+    assert payload["vvix_level"] == 95.0
+
+
+def test_live_regime_uses_fresh_cache_when_live_vvix_invalid(monkeypatch, tmp_path):
+    _write_regime_cache(tmp_path, vix=18.8, vvix=96.5)
+    frame = pd.DataFrame(
+        {
+            "^VIX": [18.5, 19.0],
+            "^VVIX": [math.nan, math.nan],
+            "TLT": [90.0, 90.5],
+        }
+    )
+    _mock_yfinance(monkeypatch, frame)
+
+    snapshot = RegimeDetector(hmm_enabled=False).detect_live_regime()
+
+    assert snapshot.regime_id == 0
+    assert snapshot.label == "calm"
+    assert snapshot.vix_level == 19.0
+    assert snapshot.vvix_level == 96.5
+
+
+def test_live_regime_uses_single_ticker_vvix_before_cache(monkeypatch, tmp_path):
+    _write_regime_cache(tmp_path, vix=18.8, vvix=120.0)
+    frame = pd.DataFrame(
+        {
+            "^VIX": [18.5, 19.0],
+            "^VVIX": [math.nan, math.nan],
+            "TLT": [90.0, 90.5],
+        }
+    )
+    _mock_yfinance(monkeypatch, frame)
+    monkeypatch.setattr(
+        yfinance_wrapper,
+        "get_ticker",
+        lambda symbol: _MockTicker(pd.DataFrame({"Close": [97.0] if symbol == "^VVIX" else []})),
+    )
+
+    snapshot = RegimeDetector(hmm_enabled=False).detect_live_regime()
+
+    assert snapshot.regime_id == 0
+    assert snapshot.vvix_level == 97.0
+
+
+def test_live_regime_fails_closed_when_vvix_invalid_and_cache_stale(monkeypatch, tmp_path):
+    _write_regime_cache(tmp_path, vix=18.8, vvix=96.5, age_minutes=120)
+    frame = pd.DataFrame(
+        {
+            "^VIX": [18.5, 19.0],
+            "^VVIX": [math.nan, math.nan],
+            "TLT": [90.0, 90.5],
+        }
+    )
+    _mock_yfinance(monkeypatch, frame)
+
+    snapshot = RegimeDetector(hmm_enabled=False).detect_live_regime()
+
+    assert snapshot.regime_id == -1
+    assert snapshot.label == "unknown"


### PR DESCRIPTION
## Summary
- add single-ticker VIX/VVIX fallback when bulk yfinance regime download returns invalid latest closes
- add fresh regime data cache fallback with 90-minute max age and no fake defaults
- keep fail-closed behavior when live data and fresh cache are unavailable

## Verification
- pytest tests/test_regime_detector.py -q
- pytest tests/test_regime_detector.py tests/unit/test_ic_simple.py::TestFindOpportunity -q
- ruff check src/utils/regime_detector.py tests/test_regime_detector.py
- git diff --check
- dry run: ic_simple recovered regime classification despite bulk Yahoo VIX/VVIX failures, then correctly blocked entry on stale broker sync