### PR TITLE
Ignore generated regime market cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,7 @@ article_*.html
 data/cache/
 data/gpu_backtests/cache/
 data/gpu_backtests/price_cache/
+data/market_cache/
 **/*.jsonl
 
 # Historical data (can be regenerated, but some may be useful to track)


### PR DESCRIPTION
## Summary
- ignore generated regime market cache artifacts
- keep post-dry-run repo status focused on real source/runtime changes

## Verification
- git check-ignore -v data/market_cache/regime_latest.json
- git diff --check