### PR TITLE
Bump github-script to v9

### DIFF
--- a/.github/workflows/ci-stale-run-watchdog.yml
+++ b/.github/workflows/ci-stale-run-watchdog.yml
@@ -25,7 +25,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Cancel stale runs
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         with:
           script: |
             const owner = context.repo.owner;

--- a/.github/workflows/dependabot-trunk-automerge.yml
+++ b/.github/workflows/dependabot-trunk-automerge.yml
@@ -27,8 +27,8 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Auto-approve update
-        continue-on-error: true  # Non-critical: approval may fail due to permissions, merge step handles retry
-        uses: actions/github-script@v8
+        continue-on-error: true # Non-critical: approval may fail due to permissions, merge step handles retry
+        uses: actions/github-script@v9
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/emergency-position-cleanup.yml
+++ b/.github/workflows/emergency-position-cleanup.yml
@@ -94,7 +94,7 @@ jobs:
 
       - name: Trigger State Sync
         if: inputs.dry_run == 'false'
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/execute-credit-spread.yml
+++ b/.github/workflows/execute-credit-spread.yml
@@ -3,8 +3,8 @@ name: Execute Credit Spread
 on:
   # DISABLED: ic_simple.py is sole trader (2026-04-01)
   # schedule:
-    # Run at 9:35 AM ET on weekdays (covers EST/EDT)
-    #     - cron: "35 13,14 * * 1-5"
+  # Run at 9:35 AM ET on weekdays (covers EST/EDT)
+  #     - cron: "35 13,14 * * 1-5"
   workflow_dispatch:
     inputs:
       symbol:
@@ -224,8 +224,8 @@ jobs:
       # ===== FAILURE NOTIFICATION VIA GITHUB ISSUE =====
       - name: Create Alert on Failure
         if: failure()
-        continue-on-error: true  # Non-critical: notification failure shouldn't change workflow status
-        uses: actions/github-script@v8
+        continue-on-error: true # Non-critical: notification failure shouldn't change workflow status
+        uses: actions/github-script@v9
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/north-star-blocker-watch.yml
+++ b/.github/workflows/north-star-blocker-watch.yml
@@ -48,7 +48,7 @@ jobs:
             --markdown-out artifacts/devloop/north_star_blocker_report.md
 
       - name: Upsert blocker issue
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         with:
           script: |
             const fs = require("fs");

--- a/.github/workflows/notify-alert.yml
+++ b/.github/workflows/notify-alert.yml
@@ -45,7 +45,7 @@ jobs:
           esac
 
       - name: Create Alert Issue
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         with:
           github-token: ${{ secrets.GH_PAT }}
           script: |

--- a/.github/workflows/notify-failure.yml
+++ b/.github/workflows/notify-failure.yml
@@ -41,7 +41,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Create GitHub Issue
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         with:
           script: |
             const title = `${{ inputs.title }}`;

--- a/.github/workflows/phil-town-ingestion.yml
+++ b/.github/workflows/phil-town-ingestion.yml
@@ -5,7 +5,7 @@ name: Phil Town Knowledge Ingestion
 on:
   schedule:
     # Run Saturday and Sunday at 8:00 AM Eastern (weekend learning)
-    - cron: '0 13 * * 0,6'
+    - cron: "0 13 * * 0,6"
   workflow_dispatch:
     inputs:
       mode:
@@ -216,7 +216,7 @@ jobs:
 
       - name: Create issue on failure
         if: failure()
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         with:
           script: |
             const title = '❌ Phil Town Ingestion Failed';

--- a/.github/workflows/post-reset-setup.yml
+++ b/.github/workflows/post-reset-setup.yml
@@ -143,7 +143,7 @@ jobs:
 
       - name: Sync State
         if: success()
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/run-liquidation.yml
+++ b/.github/workflows/run-liquidation.yml
@@ -105,7 +105,7 @@ jobs:
 
       - name: Trigger State Sync
         if: inputs.dry_run == 'false'
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/self-healing-monitor.yml
+++ b/.github/workflows/self-healing-monitor.yml
@@ -76,7 +76,7 @@ jobs:
 
       - name: Create Issue if Unhealthy
         if: steps.health_check.outputs.status == 'unhealthy'
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         with:
           script: |
             const fs = require('fs');

--- a/.github/workflows/swarm-orchestration.yml
+++ b/.github/workflows/swarm-orchestration.yml
@@ -177,7 +177,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Create GitHub Issue for Trade Signal
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         with:
           script: |
             const consensus = '${{ needs.run-swarm.outputs.consensus }}';

--- a/.github/workflows/verify-trade-execution.yml
+++ b/.github/workflows/verify-trade-execution.yml
@@ -85,7 +85,7 @@ jobs:
 
       - name: Create issue on failure (weekdays only, with deduplication)
         if: steps.verify.outputs.verification_passed == 'false' && steps.check_weekday.outputs.is_weekday == 'true'
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         with:
           script: |
             const date = '${{ steps.get_date.outputs.date }}';


### PR DESCRIPTION
## Summary
- supersedes stale Dependabot PR #3819 and conflicted replacement #3854
- bumps actions/github-script references from v8 to v9 across workflows
- applies Trunk/Prettier formatting to affected workflow files

## Verification
- trunk fmt on all 13 changed workflow files
- git diff --check