### PR TITLE
Fast-path workflow-only CI changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,13 +2,72 @@ name: CI
 on: [push, pull_request]
 
 concurrency:
-  group: ${{ format('ci-{0}-{1}', github.ref, github.sha) }}
+  group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 permissions:
   contents: read
 
 jobs:
+  changes:
+    name: Detect Changed Paths
+    if: github.event_name == 'pull_request' || github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    outputs:
+      run_full_tests: ${{ steps.filter.outputs.run_full_tests }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Decide test scope
+        id: filter
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            base="${{ github.event.pull_request.base.sha }}"
+            head="${{ github.event.pull_request.head.sha }}"
+          else
+            base="${{ github.event.before }}"
+            head="${{ github.sha }}"
+          fi
+
+          if [[ -z "${base}" || "${base}" == "0000000000000000000000000000000000000000" ]]; then
+            echo "Could not determine a safe diff base; running full test suite."
+            echo "run_full_tests=true" >> "${GITHUB_OUTPUT}"
+            exit 0
+          fi
+
+          git diff --name-only "${base}" "${head}" | tee changed-files.txt
+
+          if [[ ! -s changed-files.txt ]]; then
+            echo "No changed files detected; running full test suite."
+            echo "run_full_tests=true" >> "${GITHUB_OUTPUT}"
+            exit 0
+          fi
+
+          safe_only=true
+          while IFS= read -r path; do
+            case "${path}" in
+              .github/workflows/* | .github/dependabot.yml | .gitignore | docs/* | *.md)
+                ;;
+              *)
+                safe_only=false
+                ;;
+            esac
+          done < changed-files.txt
+
+          if [[ "${safe_only}" == "true" ]]; then
+            echo "Only workflow/docs/config files changed; skipping full Python test suite."
+            echo "run_full_tests=false" >> "${GITHUB_OUTPUT}"
+          else
+            echo "Runtime-relevant files changed; running full Python test suite."
+            echo "run_full_tests=true" >> "${GITHUB_OUTPUT}"
+          fi
+
   trunk-check:
     name: Trunk Check
     if: github.event_name == 'pull_request' || github.ref == 'refs/heads/main'
@@ -24,13 +83,25 @@ jobs:
   test-suite:
     name: Run All Tests
     if: github.event_name == 'pull_request' || github.ref == 'refs/heads/main'
+    needs: changes
     runs-on: ubuntu-latest
     timeout-minutes: 50
     steps:
+      - name: Explain test scope
+        run: |
+          echo "run_full_tests=${{ needs.changes.outputs.run_full_tests }}"
+
+      - name: Skip full test suite
+        if: needs.changes.outputs.run_full_tests != 'true'
+        run: |
+          echo "Skipping full Python test suite for workflow/docs/config-only changes."
+
       - name: Checkout
+        if: needs.changes.outputs.run_full_tests == 'true'
         uses: actions/checkout@v6
 
       - name: Set up Python
+        if: needs.changes.outputs.run_full_tests == 'true'
         uses: actions/setup-python@v6
         with:
           python-version: "3.11"
@@ -38,11 +109,13 @@ jobs:
           cache-dependency-path: requirements-ci.txt
 
       - name: Install CI dependencies
+        if: needs.changes.outputs.run_full_tests == 'true'
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements-ci.txt
 
       - name: Run test runner
+        if: needs.changes.outputs.run_full_tests == 'true'
         env:
           PYTHON_BIN: python
           REPORT_DIR: artifacts/test-reports
@@ -51,7 +124,7 @@ jobs:
           bash scripts/ci/run_all_tests.sh
 
       - name: Upload test artifacts
-        if: always()
+        if: always() && needs.changes.outputs.run_full_tests == 'true'
         uses: actions/upload-artifact@v7
         with:
           name: ci-test-artifacts

--- a/tests/test_workflow_contracts.py
+++ b/tests/test_workflow_contracts.py
@@ -141,12 +141,23 @@ def test_browser_automation_pilot_respects_pr_only_rule():
         assert re.search(pattern, workflow_text) is None, pattern
 
 
-def test_main_ci_concurrency_uses_per_sha_key():
-    """Main CI must not serialize newer main SHAs behind stale runs."""
+def test_main_ci_concurrency_cancels_stale_branch_runs():
+    """CI should cancel superseded branch/PR runs without canceling main verification."""
     workflow_text = Path(".github/workflows/ci.yml").read_text()
 
-    assert "format('ci-{0}-{1}', github.ref, github.sha)" in workflow_text
+    assert "github.event.pull_request.number || github.ref" in workflow_text
     assert "cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}" in workflow_text
+
+
+def test_main_ci_fast_paths_workflow_docs_config_changes():
+    """Workflow/docs/config-only changes should keep the required test check fast."""
+    workflow_text = Path(".github/workflows/ci.yml").read_text()
+
+    assert "Detect Changed Paths" in workflow_text
+    assert "run_full_tests" in workflow_text
+    assert "Only workflow/docs/config files changed" in workflow_text
+    assert "Skipping full Python test suite" in workflow_text
+    assert ".github/workflows/*" in workflow_text
 
 
 def test_sync_alpaca_status_updates_public_surfaces():


### PR DESCRIPTION
## Summary
- keeps the required Run All Tests job, but fast-passes it for workflow/docs/config-only changes
- runs full Python tests only when runtime-relevant files change
- changes CI concurrency to cancel superseded branch/PR runs instead of keying by SHA
- adds workflow-contract tests for the new behavior

## Verification
- sh scripts/validate_yaml_before_commit.sh
- pytest tests/test_ci_runner_wiring.py tests/test_workflow_contracts.py tests/test_workflow_dependencies.py tests/test_workflow_integrity.py -q
- trunk fmt .github/workflows/ci.yml tests/test_workflow_contracts.py
- git diff --check