### PR TITLE
Update CI checkout action for Node 24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,7 +74,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Trunk Check
         uses: trunk-io/trunk-action@v1
         with:


### PR DESCRIPTION
## Summary
- update the remaining required CI workflow checkout step from actions/checkout@v4 to actions/checkout@v6
- address the Node.js 20 deprecation annotation emitted by the post-merge main CI run

## Verification
- sh scripts/validate_yaml_before_commit.sh
- /Users/igorganapolsky/workspace/git/igor/trading/.venv/bin/python -m pytest tests/test_workflow_contracts.py tests/test_ci_runner_wiring.py -q
- trunk fmt .github/workflows/ci.yml
- git diff --check