### PR TITLE
Use Node 24 cache action in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,8 +105,15 @@ jobs:
         uses: actions/setup-python@v6
         with:
           python-version: "3.11"
-          cache: pip
-          cache-dependency-path: requirements-ci.txt
+
+      - name: Cache pip dependencies
+        if: needs.changes.outputs.run_full_tests == 'true'
+        uses: actions/cache@v5
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-3.11-${{ hashFiles('requirements-ci.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-3.11-
 
       - name: Install CI dependencies
         if: needs.changes.outputs.run_full_tests == 'true'
@@ -147,8 +154,14 @@ jobs:
         uses: actions/setup-python@v6
         with:
           python-version: "3.11"
-          cache: pip
-          cache-dependency-path: requirements-ci.txt
+
+      - name: Cache pip dependencies
+        uses: actions/cache@v5
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-3.11-${{ hashFiles('requirements-ci.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-3.11-
 
       - name: Install CI dependencies
         run: |


### PR DESCRIPTION
## Summary
- replace setup-python's implicit pip cache in required CI with explicit actions/cache@v5
- keep pip dependency caching while removing the remaining Node.js 20 cache action annotation from the CI workflow

## Verification
- sh scripts/validate_yaml_before_commit.sh
- /Users/igorganapolsky/workspace/git/igor/trading/.venv/bin/python -m pytest tests/test_workflow_contracts.py tests/test_ci_runner_wiring.py -q
- trunk fmt .github/workflows/ci.yml
- git diff --check