### PR TITLE
Avoid Trunk internal Node 20 cache action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,10 +75,19 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+      - name: Cache Trunk artifacts
+        uses: actions/cache@v5
+        with:
+          path: ~/.cache/trunk
+          key: ${{ runner.os }}-trunk-${{ github.ref_name }}-${{ hashFiles('.trunk/trunk.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-trunk-${{ github.ref_name }}-
+            ${{ runner.os }}-trunk-
       - name: Trunk Check
         uses: trunk-io/trunk-action@v1
         with:
           trunk-token: ${{ secrets.TRUNK_API_TOKEN }}
+          cache: "false"
 
   test-suite:
     name: Run All Tests


### PR DESCRIPTION
## Summary
- add an explicit actions/cache@v5 step for Trunk artifacts
- disable trunk-io/trunk-action's internal cache path so it does not execute actions/cache@v4
- keep the official Trunk action and existing Trunk Check behavior

## Verification
- sh scripts/validate_yaml_before_commit.sh
- trunk fmt .github/workflows/ci.yml
- git diff --check