### PR TITLE
Quarantine negative-expectancy North Star strategy

### DIFF
--- a/docs/trading/strategy_validation_hypothesis.example.json
+++ b/docs/trading/strategy_validation_hypothesis.example.json
@@ -1,0 +1,14 @@
+{
+  "enabled": true,
+  "strategy_family": "ic_simple",
+  "hypothesis": "Example only: entries will restart only after a concrete changed-rule thesis explains why the next cohort should have positive expectancy.",
+  "changed_rules": [
+    "Example only: replace this with the exact entry, exit, DTE, delta, regime, or sizing rule change being tested."
+  ],
+  "kill_criteria": {
+    "min_closed_trades": 30,
+    "min_expectancy_per_trade": 0.01,
+    "min_profit_factor": 1.01,
+    "min_total_realized_pnl": 0.01
+  }
+}

--- a/mcp/governance/input_validation.py
+++ b/mcp/governance/input_validation.py
@@ -12,6 +12,11 @@ from typing import Any, Optional, TypeVar
 
 from pydantic import BaseModel, Field, field_validator
 
+try:
+    from src.core.trading_constants import MAX_POSITION_PCT
+except ImportError:
+    MAX_POSITION_PCT = 0.02
+
 # Allowlist of tradeable symbols - UPDATED Jan 19, 2026 (LL-244)
 # Per CLAUDE.md: SPY/SPX/XSP for index options
 # SPY = equity option, SPX/XSP = index options with Section 1256 tax treatment
@@ -19,8 +24,8 @@ ALLOWED_SYMBOLS = frozenset({"SPY"})  # SPY ONLY per CLAUDE.md — aligned with 
 
 # Maximum values to prevent resource exhaustion
 MAX_LOOKBACK_DAYS = 365
-MAX_ORDER_AMOUNT_USD = 5000.0  # 5% of $100K account
-MAX_POSITION_RISK = 5000.0
+MAX_ORDER_AMOUNT_USD = MAX_POSITION_PCT * 100_000.0
+MAX_POSITION_RISK = MAX_ORDER_AMOUNT_USD
 
 
 T = TypeVar("T", bound=BaseModel)

--- a/scripts/build_public_status.py
+++ b/scripts/build_public_status.py
@@ -50,6 +50,8 @@ def _short_status(block_new_positions: bool | None, mode: str | None) -> str:
     normalized_mode = str(mode).lower() if mode else None
     if normalized_mode == "validation_reset":
         return normalized_mode
+    if normalized_mode == "quarantine":
+        return normalized_mode
     if block_new_positions:
         return "halted"
     if normalized_mode:
@@ -101,6 +103,9 @@ def _public_fail_closed(weekly: dict[str, Any], congruence: dict[str, Any]) -> b
 
 
 def _blocker_reason(weekly: dict[str, Any], congruence: dict[str, Any]) -> Any:
+    quarantine = weekly.get("strategy_quarantine")
+    if isinstance(quarantine, dict) and _as_bool(quarantine.get("active")):
+        return quarantine.get("reason") or quarantine.get("required_action")
     if congruence["contradiction_reason"]:
         return congruence["contradiction_reason"]
     if (

--- a/src/risk/pre_trade_checklist.py
+++ b/src/risk/pre_trade_checklist.py
@@ -2,7 +2,7 @@
 
 This module enforces the MANDATORY Pre-Trade Checklist from CLAUDE.md:
 1. Is ticker SPY? (SPY only per CLAUDE.md - best liquidity, tightest spreads)
-2. Is position size <=5% of account ($248)?
+2. Is position size within the canonical account risk cap?
 3. Is it a SPREAD (not naked put)?
 4. Checked earnings calendar? (No blackout violations)
 5. 30-45 DTE expiration?
@@ -24,7 +24,7 @@ try:
     )
 except ImportError:
     _CENTRAL_ALLOWED_TICKERS = {"SPY", "SPX", "XSP", "QQQ", "IWM"}
-    _CENTRAL_MAX_POSITION_PCT = 0.05
+    _CENTRAL_MAX_POSITION_PCT = 0.02
 
     def _extract_underlying_shared(symbol: str) -> str:  # type: ignore[misc]
         """Fallback - see trading_constants.extract_underlying."""
@@ -39,7 +39,7 @@ class PreTradeChecklist:
 
     Attributes:
         ALLOWED_TICKERS: Set of approved underlying tickers (SPY only per CLAUDE.md).
-        MAX_POSITION_PCT: Maximum position size as percentage of account (5%).
+        MAX_POSITION_PCT: Maximum position size as percentage of account.
         MIN_DTE: Minimum days to expiration (30).
         MAX_DTE: Maximum days to expiration (45).
         EARNINGS_BLACKOUTS: Dictionary of ticker blackout periods around earnings.
@@ -82,7 +82,7 @@ class PreTradeChecklist:
 
         Validates a proposed trade against all CLAUDE.md checklist items:
         1. Ticker must be SPY
-        2. Max loss must be <= 5% of account
+        2. Max loss must be within the canonical account risk cap
         3. Must be a spread (not naked)
         4. Must not be in earnings blackout period
         5. DTE must be 30-45
@@ -109,7 +109,9 @@ class PreTradeChecklist:
 
         # 2. Position size check
         if max_loss > self.max_risk:
-            failures.append(f"Max loss ${max_loss:.2f} exceeds 5% limit (${self.max_risk:.2f})")
+            failures.append(
+                f"Max loss ${max_loss:.2f} exceeds {self.MAX_POSITION_PCT:.0%} limit (${self.max_risk:.2f})"
+            )
 
         # 3. Spread check
         if not is_spread:
@@ -182,7 +184,7 @@ class PreTradeChecklist:
             "position_size": {
                 "passed": max_loss <= self.max_risk,
                 "value": f"${max_loss:.2f}",
-                "requirement": f"<= ${self.max_risk:.2f} (5%)",
+                "requirement": f"<= ${self.max_risk:.2f} ({self.MAX_POSITION_PCT:.0%})",
             },
             "is_spread": {
                 "passed": is_spread,

--- a/src/risk/risk_manager.py
+++ b/src/risk/risk_manager.py
@@ -35,13 +35,13 @@ class RiskManager:
     Risk manager for Phil Town options trading.
 
     Enforces:
-    - Position size limits (max 5% of portfolio per position)
+    - Position size limits (canonical max of portfolio per position)
     - Daily loss limits (max 2% daily drawdown)
     - Concentration limits (no more than 20% in single sector)
     - Cash reserve requirements (keep 20% cash minimum)
     """
 
-    # Default risk parameters (CLAUDE.md mandates 5% max - Phil Town Rule #1)
+    # Default risk parameters (canonical max - Phil Town Rule #1)
     DEFAULT_MAX_POSITION_PCT = MAX_POSITION_PCT  # canonical max per position
     DEFAULT_MAX_DAILY_LOSS_PCT = MAX_DAILY_LOSS_PCT  # canonical max daily loss
     DEFAULT_MIN_CASH_RESERVE_PCT = 0.20  # Keep 20% cash

--- a/src/risk/trade_gateway.py
+++ b/src/risk/trade_gateway.py
@@ -36,9 +36,7 @@ try:
     from src.core.trading_constants import (
         MAX_CUMULATIVE_RISK_PCT as _MAX_CUMULATIVE_RISK_PCT,
     )
-    from src.core.trading_constants import (
-        MAX_POSITION_PCT as _MAX_POSITION_PCT,
-    )
+    from src.core.trading_constants import MAX_POSITION_PCT as _MAX_POSITION_PCT
     from src.core.trading_constants import (
         extract_underlying as _extract_underlying_shared,
     )
@@ -83,7 +81,7 @@ class RejectionReason(Enum):
     """Enumeration of trade rejection reasons."""
 
     INSUFFICIENT_FUNDS = "Insufficient funds in account"
-    MAX_ALLOCATION_EXCEEDED = "Maximum allocation per symbol exceeded (5%)"
+    MAX_ALLOCATION_EXCEEDED = "Maximum allocation per symbol exceeded"
     HIGH_CORRELATION = "High correlation with existing positions (>0.8)"
     FREQUENCY_LIMIT = "Frequency limit exceeded (>5 trades/hour)"
     CIRCUIT_BREAKER_DAILY_LOSS = "Daily loss limit exceeded"
@@ -101,12 +99,12 @@ class RejectionReason(Enum):
         "Phil Town Rule #1 validation failed - not a wonderful company at attractive price"
     )
     EARNINGS_BLACKOUT = "Ticker is in earnings blackout period - avoid new positions"
-    POSITION_SIZE_TOO_LARGE = "Position max loss exceeds 5% of portfolio"
+    POSITION_SIZE_TOO_LARGE = "Position max loss exceeds configured portfolio cap"
     TICKER_NOT_ALLOWED = "Ticker not in whitelist - liquid ETFs only per CLAUDE.md"
     FORBIDDEN_STRATEGY = "Strategy is forbidden - naked positions not allowed"
     PRE_TRADE_CHECKLIST_FAILED = "Pre-trade checklist failed - CLAUDE.md rules violated"
     DTE_OUT_OF_RANGE = "DTE must be 30-45 days per CLAUDE.md"
-    CUMULATIVE_RISK_TOO_HIGH = "Cumulative position risk exceeds 5% limit"
+    CUMULATIVE_RISK_TOO_HIGH = "Cumulative position risk exceeds configured limit"
     MAX_IRON_CONDORS_EXCEEDED = f"Max {MAX_CONCURRENT_ICS} iron condors at a time"
     EXPIRY_CONCENTRATION_TOO_HIGH = "Too many ICs in same expiry week (>40%)"
     BEHAVIORAL_GUARD_BLOCKED = "Behavioral guard blocked trade (FOMO/cooling/blacklist)"
@@ -175,9 +173,9 @@ class TradeGateway:
     """
 
     # Risk limits (HARD CODED - cannot be bypassed)
-    # UPDATED Jan 19, 2026: Enforced 5% per CLAUDE.md (Phil Town Rule #1)
+    # UPDATED Apr 14, 2026: Enforced canonical per-position cap (Phil Town Rule #1)
     # Previous: 10% per symbol (Jan 14) - Still too high, caused 35% exposure
-    MAX_SYMBOL_ALLOCATION_PCT = _MAX_POSITION_PCT  # 5% max per symbol per CLAUDE.md
+    MAX_SYMBOL_ALLOCATION_PCT = _MAX_POSITION_PCT
     MAX_CORRELATION_THRESHOLD = 0.80  # 80% correlation threshold
     MAX_TRADES_PER_HOUR = 5  # Frequency limit
     MIN_TRADE_BATCH = (
@@ -270,9 +268,8 @@ class TradeGateway:
 
     # Maximum position risk as percentage of portfolio
     # LL-190: SOFI CSP had 48% portfolio risk - unacceptable
-    # UPDATED Jan 15, 2026: Changed from 10% to 5% per CLAUDE.md mandate
-    # CLAUDE.md: "Position limit: 1 spread at a time (5% max = $248 risk)"
-    MAX_POSITION_RISK_PCT = _MAX_POSITION_PCT  # 5% max risk per position - MANDATORY per CLAUDE.md
+    # UPDATED Apr 14, 2026: Use canonical position cap from trading_constants.
+    MAX_POSITION_RISK_PCT = _MAX_POSITION_PCT
 
     def __init__(self, executor=None, paper: bool = True):
         """
@@ -1050,7 +1047,7 @@ class TradeGateway:
             logger.warning(f"❌ REJECTED: Insufficient funds for ${trade_value:.2f} trade")
 
         # ============================================================
-        # CHECK 2: Maximum Allocation per Symbol (5%)
+        # CHECK 2: Maximum allocation per symbol
         # ============================================================
         current_exposure = self._get_symbol_exposure(request.symbol, positions)
         new_exposure = (

--- a/src/safety/mandatory_trade_gate.py
+++ b/src/safety/mandatory_trade_gate.py
@@ -141,6 +141,14 @@ def _load_north_star_weekly_gate() -> dict[str, Any]:
 
 def _weekly_gate_allows_validation_entries(gate: dict[str, Any] | None = None) -> bool:
     gate = gate if isinstance(gate, dict) else _load_north_star_weekly_gate()
+    quarantine = gate.get("strategy_quarantine", {}) if isinstance(gate, dict) else {}
+    if isinstance(quarantine, dict):
+        if _to_bool(quarantine.get("block_new_positions"), default=False):
+            return False
+        if _to_bool(quarantine.get("active"), default=False) and not _to_bool(
+            quarantine.get("paper_validation_allowed"), default=False
+        ):
+            return False
     return (
         str(gate.get("mode") or "").strip().lower() == "validation_reset"
         and _to_bool(gate.get("allow_validation_entries"), default=False)

--- a/src/safety/north_star_guard.py
+++ b/src/safety/north_star_guard.py
@@ -139,8 +139,32 @@ def get_guard_context(state_path: Path = DEFAULT_STATE_PATH) -> dict[str, Any]:
         and _to_bool(weekly_gate.get("allow_validation_entries"), default=False)
         and _to_bool(weekly_gate.get("block_live_new_positions"), default=False)
     )
+    quarantine = (
+        weekly_gate.get("strategy_quarantine", {})
+        if isinstance(weekly_gate.get("strategy_quarantine"), dict)
+        else {}
+    )
+    quarantine_blocks_new = bool(
+        _to_bool(quarantine.get("block_new_positions"), default=False)
+        or (
+            _to_bool(quarantine.get("active"), default=False)
+            and not _to_bool(quarantine.get("paper_validation_allowed"), default=False)
+        )
+    )
+    if quarantine_blocks_new:
+        validation_reset_active = False
 
-    if validation_reset_active:
+    if quarantine_blocks_new:
+        mode = "quarantine"
+        max_position_pct = 0.0
+        block_new_positions = True
+        reasons.append(
+            str(
+                quarantine.get("reason")
+                or "Mathematical quarantine active; negative expectancy blocks new entries."
+            )
+        )
+    elif validation_reset_active:
         mode = "validation_reset"
         max_position_pct = 0.01
         reasons.append(
@@ -226,7 +250,11 @@ def get_guard_context(state_path: Path = DEFAULT_STATE_PATH) -> dict[str, Any]:
 
     block_reason = ""
     if block_new_positions:
-        if isinstance(weekly_gate, dict) and _to_bool(
+        if quarantine_blocks_new:
+            block_reason = (
+                "North Star guard: mathematical quarantine blocked new position openings."
+            )
+        elif isinstance(weekly_gate, dict) and _to_bool(
             weekly_gate.get("block_new_positions"), default=False
         ):
             block_reason = (

--- a/src/safety/north_star_operating_plan.py
+++ b/src/safety/north_star_operating_plan.py
@@ -34,6 +34,11 @@ DEFAULT_MIN_CLOSED_TRADES_PER_WEEK = 1
 DEFAULT_MIN_CLOSED_TRADES_FOR_SCALING = 30
 DEFAULT_MIN_LIQUIDITY_VOLUME_RATIO = 0.20
 DEFAULT_GATE_OVERRIDES_PATH = Path("runtime/north_star_gate_overrides.json")
+DEFAULT_VALIDATION_HYPOTHESIS_PATH = Path("runtime/strategy_validation_hypothesis.json")
+DEFAULT_QUARANTINE_MIN_COHORT_TRADES = 30
+DEFAULT_QUARANTINE_MIN_PROFIT_FACTOR = 1.0
+DEFAULT_QUARANTINE_MIN_EXPECTANCY = 0.0
+DEFAULT_QUARANTINE_MIN_REALIZED_PNL = 0.0
 DEFAULT_MAX_TARGET_DTE = 45
 DEFAULT_MIN_TARGET_DTE = 21
 DEFAULT_AI_CREDIT_STRESS_PATH = Path("market_signals/ai_credit_stress_signal.json")
@@ -138,6 +143,68 @@ def _load_json_list(path: Path) -> list[dict[str, Any]]:
 def _load_gate_overrides(data_dir: Path) -> dict[str, Any]:
     payload = _load_json_dict(data_dir / DEFAULT_GATE_OVERRIDES_PATH)
     return payload if isinstance(payload, dict) else {}
+
+
+def _validation_hypothesis_status(data_dir: Path) -> dict[str, Any]:
+    """Validate the written hypothesis required to restart a losing strategy."""
+    path = data_dir / DEFAULT_VALIDATION_HYPOTHESIS_PATH
+    payload = _load_json_dict(path)
+    errors: list[str] = []
+
+    if not payload:
+        errors.append(f"{path} missing or empty")
+    if _as_bool(payload.get("enabled"), default=False) is not True:
+        errors.append("enabled must be true")
+
+    strategy_family = str(payload.get("strategy_family") or "").strip().lower()
+    if strategy_family not in {"iron_condor", "ic_simple", "options_income"}:
+        errors.append("strategy_family must be iron_condor, ic_simple, or options_income")
+
+    hypothesis = str(payload.get("hypothesis") or "").strip()
+    if len(hypothesis) < 25:
+        errors.append("hypothesis must describe the changed edge thesis")
+
+    changed_rules = payload.get("changed_rules", [])
+    if not isinstance(changed_rules, list) or not [
+        item for item in changed_rules if str(item).strip()
+    ]:
+        errors.append("changed_rules must contain at least one concrete rule change")
+
+    kill = payload.get("kill_criteria", {})
+    if not isinstance(kill, dict):
+        kill = {}
+        errors.append("kill_criteria must be an object")
+
+    min_closed = _as_int(kill.get("min_closed_trades"), 0)
+    min_expectancy = _as_float(kill.get("min_expectancy_per_trade"), -999999.0)
+    min_profit_factor = _as_float(kill.get("min_profit_factor"), 0.0)
+    min_total_pnl = _as_float(kill.get("min_total_realized_pnl"), -999999.0)
+    if min_closed < DEFAULT_QUARANTINE_MIN_COHORT_TRADES:
+        errors.append(
+            f"kill_criteria.min_closed_trades must be >= {DEFAULT_QUARANTINE_MIN_COHORT_TRADES}"
+        )
+    if min_expectancy <= DEFAULT_QUARANTINE_MIN_EXPECTANCY:
+        errors.append("kill_criteria.min_expectancy_per_trade must be > 0")
+    if min_profit_factor <= DEFAULT_QUARANTINE_MIN_PROFIT_FACTOR:
+        errors.append("kill_criteria.min_profit_factor must be > 1")
+    if min_total_pnl <= DEFAULT_QUARANTINE_MIN_REALIZED_PNL:
+        errors.append("kill_criteria.min_total_realized_pnl must be > 0")
+
+    valid = not errors
+    return {
+        "path": str(path),
+        "valid": valid,
+        "errors": errors,
+        "strategy_family": strategy_family or None,
+        "hypothesis": hypothesis if valid else None,
+        "changed_rules": changed_rules if valid else [],
+        "kill_criteria": {
+            "min_closed_trades": min_closed,
+            "min_expectancy_per_trade": min_expectancy,
+            "min_profit_factor": min_profit_factor,
+            "min_total_realized_pnl": min_total_pnl,
+        },
+    }
 
 
 def _live_account_inactive(state: dict[str, Any]) -> bool:
@@ -759,6 +826,7 @@ def compute_weekly_gate(
     recent_closed = _extract_recent_closed_trades(trades_payload, today=today)
     data_dir = trades_path.parent
     min_liquidity_volume_ratio = _resolve_min_liquidity_volume_ratio(data_dir)
+    validation_hypothesis = _validation_hypothesis_status(data_dir)
     recent_decisions = _extract_recent_session_decisions(
         data_dir=data_dir,
         today=today,
@@ -1018,10 +1086,27 @@ def compute_weekly_gate(
 
     contradiction_detected = False
     contradiction_reason = None
+    north_star_claims_frozen = False
+    strategy_quarantine: dict[str, Any] = {
+        "active": False,
+        "block_new_positions": False,
+        "paper_validation_allowed": allow_validation_entries,
+        "north_star_claims_frozen": False,
+        "reason": "",
+        "required_action": "",
+        "validation_hypothesis": validation_hypothesis,
+        "kill_criteria": {
+            "min_closed_trades": DEFAULT_QUARANTINE_MIN_COHORT_TRADES,
+            "min_expectancy_per_trade": DEFAULT_QUARANTINE_MIN_EXPECTANCY,
+            "min_profit_factor": DEFAULT_QUARANTINE_MIN_PROFIT_FACTOR,
+            "min_total_realized_pnl": DEFAULT_QUARANTINE_MIN_REALIZED_PNL,
+        },
+    }
     if (
         lifetime_ledger["closed_trades"] >= DEFAULT_MIN_CLOSED_TRADES_FOR_SCALING
         and not lifetime_ledger["edge_confirmed"]
     ):
+        north_star_claims_frozen = True
         contradiction_detected = samples > 0 and expectancy > 0
         lifetime_ledger_evidence = (
             "CRITICAL: Lifetime paired-trade ledger remains negative despite the recent weekly window. "
@@ -1030,10 +1115,15 @@ def compute_weekly_gate(
             f"total realized P/L ${_as_float(lifetime_ledger.get('total_realized_pnl'), 0.0):.2f} "
             f"over {lifetime_ledger['closed_trades']} closed trades."
         )
-        if _live_account_inactive(state) and not block_new_positions:
+        validation_restart_authorized = bool(
+            _live_account_inactive(state)
+            and not block_new_positions
+            and validation_hypothesis["valid"]
+        )
+        if validation_restart_authorized:
             contradiction_reason = (
                 f"{lifetime_ledger_evidence} Live/scaling remains blocked while controlled "
-                "paper validation continues at minimum size."
+                "paper validation continues at minimum size under a written changed-rule hypothesis."
             )
             validation_reset_active = True
             validation_reset_reason = contradiction_reason
@@ -1044,7 +1134,57 @@ def compute_weekly_gate(
             reason = (
                 "CRITICAL: Lifetime paired-trade ledger remains negative. "
                 "Live/scaling stays blocked, but controlled paper validation remains allowed "
-                "at minimum size until a fresh cohort proves edge."
+                "at minimum size under a written changed-rule hypothesis until a fresh cohort proves edge."
+            )
+            strategy_quarantine.update(
+                {
+                    "active": True,
+                    "block_new_positions": False,
+                    "paper_validation_allowed": True,
+                    "north_star_claims_frozen": True,
+                    "reason": (
+                        "Negative lifetime expectancy freezes North Star claims; only "
+                        "minimum-size paper validation is allowed because a valid changed-rule "
+                        "hypothesis is present."
+                    ),
+                    "required_action": (
+                        "Complete the fresh validation cohort. If the cohort misses kill criteria, "
+                        "remove IC Simple as a North Star candidate."
+                    ),
+                    "kill_criteria": validation_hypothesis["kill_criteria"],
+                }
+            )
+        elif _live_account_inactive(state) and not block_new_positions:
+            contradiction_reason = (
+                f"{lifetime_ledger_evidence} All new entries are quarantined until a written "
+                "changed-rule validation hypothesis with hard kill criteria is present."
+            )
+            validation_reset_active = False
+            validation_reset_reason = None
+            allow_validation_entries = False
+            block_live_new_positions = True
+            block_new_positions = True
+            mode = "quarantine"
+            recommended_max = 0.0
+            reason = (
+                "MATHEMATICAL QUARANTINE: negative lifetime expectancy means the current "
+                "strategy cannot reach the North Star. New entries are blocked until "
+                f"{data_dir / DEFAULT_VALIDATION_HYPOTHESIS_PATH} defines a changed-rule "
+                "hypothesis and hard kill criteria."
+            )
+            strategy_quarantine.update(
+                {
+                    "active": True,
+                    "block_new_positions": True,
+                    "paper_validation_allowed": False,
+                    "north_star_claims_frozen": True,
+                    "reason": reason,
+                    "required_action": (
+                        "Audit the failed ledger, write strategy_validation_hypothesis.json, "
+                        "then run only minimum-size paper validation. If the next cohort fails "
+                        "positive expectancy, profit factor, and realized-P/L criteria, kill IC Simple."
+                    ),
+                }
             )
         else:
             contradiction_reason = f"{lifetime_ledger_evidence} Trading halted."
@@ -1052,6 +1192,16 @@ def compute_weekly_gate(
             recommended_max = min(recommended_max, 0.01)
             block_new_positions = True
             reason = contradiction_reason
+            strategy_quarantine.update(
+                {
+                    "active": True,
+                    "block_new_positions": True,
+                    "paper_validation_allowed": False,
+                    "north_star_claims_frozen": True,
+                    "reason": reason,
+                    "required_action": "Stop new entries until lifetime edge is positive.",
+                }
+            )
 
     weekly_history_path.parent.mkdir(parents=True, exist_ok=True)
     new_weekly_payload = json.dumps(weekly_history, indent=2) + "\n"
@@ -1074,6 +1224,7 @@ def compute_weekly_gate(
         "allow_validation_entries": allow_validation_entries,
         "validation_reset_active": validation_reset_active,
         "validation_reset_reason": validation_reset_reason,
+        "north_star_claims_frozen": north_star_claims_frozen,
         "reason": reason,
         "positive_weeks_streak": positive_streak,
         "evidence_source": evidence_source,
@@ -1090,6 +1241,7 @@ def compute_weekly_gate(
         "scale_multiplier_from_ai_cycle": round(ai_cycle_multiplier, 4),
         "scaling_sample_gate": scaling_sample_gate,
         "lifetime_ledger": lifetime_ledger,
+        "strategy_quarantine": strategy_quarantine,
         "contradiction_detected": contradiction_detected,
         "contradiction_reason": contradiction_reason,
         "liquidity_min_volume_ratio": round(min_liquidity_volume_ratio, 4),

--- a/tests/test_build_public_status.py
+++ b/tests/test_build_public_status.py
@@ -203,6 +203,34 @@ def test_build_public_status_preserves_controlled_validation_reset(tmp_path: Pat
     assert "controlled paper validation" in status["gate"]["blocker_reason"].lower()
 
 
+def test_build_public_status_surfaces_strategy_quarantine(tmp_path: Path):
+    repo = _seed_repo(tmp_path)
+    state = json.loads((repo / "data/system_state.json").read_text(encoding="utf-8"))
+    state["north_star_weekly_gate"].update(
+        {
+            "mode": "quarantine",
+            "block_new_positions": True,
+            "block_live_new_positions": True,
+            "allow_validation_entries": False,
+            "verified_edge_available": False,
+            "reason": "MATHEMATICAL QUARANTINE: negative expectancy blocks new entries.",
+            "strategy_quarantine": {
+                "active": True,
+                "block_new_positions": True,
+                "paper_validation_allowed": False,
+                "reason": "MATHEMATICAL QUARANTINE: negative expectancy blocks new entries.",
+            },
+        }
+    )
+    (repo / "data/system_state.json").write_text(json.dumps(state), encoding="utf-8")
+
+    status = build_public_status(repo)
+
+    assert status["system"]["public_status"] == "quarantine"
+    assert status["gate"]["block_new_positions"] is True
+    assert "mathematical quarantine" in status["gate"]["blocker_reason"].lower()
+
+
 def test_build_public_status_cli_runs_from_repo_root(tmp_path: Path):
     repo = _seed_repo(tmp_path)
     script = Path(__file__).resolve().parents[1] / "scripts" / "build_public_status.py"

--- a/tests/test_iron_condor_trader.py
+++ b/tests/test_iron_condor_trader.py
@@ -7,7 +7,7 @@ Coverage:
 - IronCondorStrategy.execute (live & simulated, position limits, RAG blocking)
 - IronCondorLegs dataclass
 - 4-leg validation (all legs present)
-- Position sizing (5% limit via config)
+- Position sizing (canonical limit via config)
 - Error handling (API failures, credential failures, position check failures)
 
 All Alpaca API calls are mocked. No real API calls.
@@ -28,7 +28,7 @@ pytest.importorskip("dotenv")
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
 from scripts.iron_condor_trader import IronCondorLegs, IronCondorStrategy
-from src.core.trading_constants import MAX_POSITIONS
+from src.core.trading_constants import MAX_POSITION_PCT, MAX_POSITIONS
 
 
 class TestIronCondorLegs:
@@ -174,10 +174,10 @@ class TestStrategyConfig:
         strategy = IronCondorStrategy()
         assert strategy.config["underlying"] == "SPY"
 
-    def test_position_size_is_5_percent(self):
-        """Per CLAUDE.md: 5% of portfolio per position."""
+    def test_position_size_matches_canonical_limit(self):
+        """Per CLAUDE.md: use the canonical position cap."""
         strategy = IronCondorStrategy()
-        assert strategy.config["position_size_pct"] == 0.05
+        assert strategy.config["position_size_pct"] == MAX_POSITION_PCT
 
     def test_max_positions_derived_from_canonical_leg_limit(self):
         """Max iron-condor count is derived from canonical option-leg budget."""

--- a/tests/test_mandatory_trade_gate.py
+++ b/tests/test_mandatory_trade_gate.py
@@ -91,13 +91,12 @@ class TestValidateTradeMandatory:
     """Test validate_trade_mandatory function."""
 
     def test_valid_trade_approved(self):
-        """Test that valid trade is approved (within 10% position limit)."""
+        """Test that valid trade is approved within the 2% position limit."""
         from src.safety.mandatory_trade_gate import validate_trade_mandatory
 
-        # Trade must be <5% of equity to pass (per CLAUDE.md)
         result = validate_trade_mandatory(
             symbol="SPY",
-            amount=200.0,  # 4% of 5000 - within 5% limit
+            amount=100.0,  # 2% of 5000 - within limit
             side="BUY",
             strategy="CSP",
             context={"equity": 5000.0},
@@ -490,7 +489,7 @@ class TestPolicyGate:
 
         result = validate_trade_mandatory(
             symbol="SPY",
-            amount=200.0,
+            amount=100.0,
             side="BUY",
             strategy="iron_condor",
             context={"equity": 5000.0},
@@ -514,7 +513,7 @@ class TestPolicyGate:
 
         result = gate_mod.validate_trade_mandatory(
             symbol="SPY",
-            amount=200.0,
+            amount=100.0,
             side="BUY",
             strategy="iron_condor",
             context={"equity": 5000.0},
@@ -543,7 +542,7 @@ class TestPolicyGate:
 
         result = gate_mod.validate_trade_mandatory(
             symbol="SPY",
-            amount=200.0,
+            amount=100.0,
             side="BUY",
             strategy="iron_condor",
             context={"equity": 5000.0},
@@ -563,7 +562,7 @@ class TestRegimeCheck:
 
         result = validate_trade_mandatory(
             symbol="SPY",
-            amount=200.0,
+            amount=100.0,
             side="BUY",
             strategy="iron_condor",
             context={"equity": 5000.0},

--- a/tests/test_mandatory_trade_gate.py
+++ b/tests/test_mandatory_trade_gate.py
@@ -249,6 +249,28 @@ class TestValidateTradeMandatory:
         assert result.approved is False
         assert "guard blocked" in result.reason.lower()
 
+    def test_weekly_gate_validation_override_rejects_strategy_quarantine(self):
+        """Validation-reset ML bypass must fail closed under math quarantine."""
+        from src.safety.mandatory_trade_gate import (
+            _weekly_gate_allows_validation_entries,
+        )
+
+        assert (
+            _weekly_gate_allows_validation_entries(
+                {
+                    "mode": "validation_reset",
+                    "allow_validation_entries": True,
+                    "block_live_new_positions": True,
+                    "strategy_quarantine": {
+                        "active": True,
+                        "block_new_positions": True,
+                        "paper_validation_allowed": False,
+                    },
+                }
+            )
+            is False
+        )
+
     def test_trading_halt_blocks_new_openings(self, monkeypatch):
         """Repo halt sentinel must block new openings regardless of strategy details."""
         import src.safety.trading_halt as halt_mod

--- a/tests/test_mcp_governance.py
+++ b/tests/test_mcp_governance.py
@@ -132,8 +132,8 @@ class TestInputValidation:
         expected = frozenset(ALLOWED_TICKERS)
         assert expected == ALLOWED_SYMBOLS
 
-    def test_max_order_amount_matches_5_percent_rule(self):
-        """Max order amount enforces 5% sizing for $100K validation account."""
+    def test_max_order_amount_matches_canonical_position_rule(self):
+        """Max order amount enforces canonical sizing for $100K validation account."""
         expected_max = MAX_POSITION_PCT * 100_000.0
         assert expected_max == MAX_ORDER_AMOUNT_USD
 

--- a/tests/test_north_star_guard.py
+++ b/tests/test_north_star_guard.py
@@ -181,3 +181,36 @@ def test_guard_allows_validation_reset_entries_while_live_risk_stays_blocked(tmp
     assert guard["allow_validation_entries"] is True
     assert guard["block_live_new_positions"] is True
     assert guard["max_position_pct"] <= 0.01
+
+
+def test_guard_blocks_quarantined_validation_reset_entries(tmp_path):
+    state = tmp_path / "system_state.json"
+    state.write_text(
+        """
+{
+  "paper_account": {"equity": 93838.3, "win_rate": 24.24, "win_rate_sample_size": 66},
+  "paper_trading": {"current_day": 91, "target_duration_days": 90},
+  "north_star_weekly_gate": {
+    "mode": "quarantine",
+    "recommended_max_position_pct": 0.0,
+    "block_new_positions": true,
+    "block_live_new_positions": true,
+    "allow_validation_entries": false,
+    "strategy_quarantine": {
+      "active": true,
+      "block_new_positions": true,
+      "paper_validation_allowed": false,
+      "reason": "MATHEMATICAL QUARANTINE: negative expectancy blocks new entries."
+    }
+  }
+}
+""".strip(),
+        encoding="utf-8",
+    )
+
+    guard = get_guard_context(state)
+    assert guard["mode"] == "quarantine"
+    assert guard["block_new_positions"] is True
+    assert guard["allow_validation_entries"] is False
+    assert guard["max_position_pct"] == 0.0
+    assert "quarantine" in guard["block_reason"].lower()

--- a/tests/test_north_star_operating_plan.py
+++ b/tests/test_north_star_operating_plan.py
@@ -11,7 +11,31 @@ from src.safety.north_star_operating_plan import (
 
 
 def _write_json(path, payload):
+    path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(json.dumps(payload), encoding="utf-8")
+
+
+def _write_valid_hypothesis(root):
+    _write_json(
+        root / "runtime" / "strategy_validation_hypothesis.json",
+        {
+            "enabled": True,
+            "strategy_family": "ic_simple",
+            "hypothesis": (
+                "Use changed entry, exit, DTE, and regime rules to test whether the "
+                "fresh validation cohort can restore positive expectancy."
+            ),
+            "changed_rules": [
+                "Require changed entry timing and exits before restarting validation."
+            ],
+            "kill_criteria": {
+                "min_closed_trades": 30,
+                "min_expectancy_per_trade": 0.01,
+                "min_profit_factor": 1.01,
+                "min_total_realized_pnl": 0.01,
+            },
+        },
+    )
 
 
 def test_weekly_gate_blocks_when_recent_expectancy_negative(tmp_path):
@@ -85,10 +109,58 @@ def test_weekly_gate_blocks_early_when_two_recent_losses_show_negative_expectanc
     assert "negative expectancy" in gate["reason"].lower()
 
 
-def test_weekly_gate_keeps_live_block_but_allows_paper_validation_reset(tmp_path):
+def test_weekly_gate_quarantines_negative_lifetime_ledger_without_hypothesis(tmp_path):
     trades_path = tmp_path / "trades.json"
     history_path = tmp_path / "weekly_history.json"
     today = date(2026, 4, 9)
+    _write_json(
+        trades_path,
+        {
+            "stats": {
+                "closed_trades": 66,
+                "win_rate_pct": 24.24,
+                "profit_factor": 0.25,
+                "total_realized_pnl": -3402.0,
+            },
+            "trades": [
+                {
+                    "status": "closed",
+                    "strategy": "iron_condor",
+                    "realized_pnl": 96.0,
+                    "outcome": "win",
+                    "exit_date": today.isoformat(),
+                }
+            ],
+        },
+    )
+
+    gate, _history = compute_weekly_gate(
+        {
+            "paper_account": {"equity": 93838.3, "win_rate": 24.24, "win_rate_sample_size": 66},
+            "live_account": {"equity": 0.0, "positions_count": 0},
+        },
+        trades_path=trades_path,
+        weekly_history_path=history_path,
+        today=today,
+    )
+
+    assert gate["mode"] == "quarantine"
+    assert gate["block_new_positions"] is True
+    assert gate["block_live_new_positions"] is True
+    assert gate["allow_validation_entries"] is False
+    assert gate["validation_reset_active"] is False
+    assert gate["north_star_claims_frozen"] is True
+    assert gate["strategy_quarantine"]["active"] is True
+    assert gate["strategy_quarantine"]["block_new_positions"] is True
+    assert gate["strategy_quarantine"]["paper_validation_allowed"] is False
+    assert "mathematical quarantine" in gate["reason"].lower()
+
+
+def test_weekly_gate_allows_changed_rule_validation_hypothesis(tmp_path):
+    trades_path = tmp_path / "trades.json"
+    history_path = tmp_path / "weekly_history.json"
+    today = date(2026, 4, 9)
+    _write_valid_hypothesis(tmp_path)
     _write_json(
         trades_path,
         {
@@ -125,6 +197,10 @@ def test_weekly_gate_keeps_live_block_but_allows_paper_validation_reset(tmp_path
     assert gate["block_live_new_positions"] is True
     assert gate["allow_validation_entries"] is True
     assert gate["validation_reset_active"] is True
+    assert gate["north_star_claims_frozen"] is True
+    assert gate["strategy_quarantine"]["active"] is True
+    assert gate["strategy_quarantine"]["paper_validation_allowed"] is True
+    assert gate["strategy_quarantine"]["validation_hypothesis"]["valid"] is True
     assert "paper validation" in gate["reason"].lower()
     assert "trading halted" not in gate["validation_reset_reason"].lower()
     assert "live/scaling remains blocked" in gate["validation_reset_reason"].lower()

--- a/tests/test_pre_trade_checklist.py
+++ b/tests/test_pre_trade_checklist.py
@@ -4,7 +4,7 @@ Tests for Pre-Trade Checklist Module - CLAUDE.md Enforcement
 
 Comprehensive test suite covering:
 - Ticker validation (SPY only)
-- Position size limits (5% max)
+- Position size limits (2% max)
 - Spread requirement enforcement
 - Earnings blackout detection
 - DTE range validation (30-45)
@@ -30,7 +30,7 @@ class TestPreTradeChecklistInitialization:
         """Checklist initializes correctly with valid equity."""
         checklist = PreTradeChecklist(account_equity=5000.0)
         assert checklist.account_equity == 5000.0
-        assert checklist.max_risk == 250.0  # 5% of $5000
+        assert checklist.max_risk == 100.0  # 2% of $5000
 
     def test_initialization_with_zero_equity(self):
         """Checklist handles zero equity."""
@@ -46,7 +46,7 @@ class TestPreTradeChecklistInitialization:
     def test_constants_match_claude_md(self):
         """Verify constants match trading_constants.py specification."""
         assert {"SPY"} == PreTradeChecklist.ALLOWED_TICKERS
-        assert PreTradeChecklist.MAX_POSITION_PCT == 0.05
+        assert PreTradeChecklist.MAX_POSITION_PCT == 0.02
         assert PreTradeChecklist.MIN_DTE == 30
         assert PreTradeChecklist.MAX_DTE == 45
 
@@ -184,31 +184,31 @@ class TestPositionSizeValidation:
 
     @pytest.fixture
     def checklist(self):
-        """Create a checklist with $5000 equity (max risk = $250)."""
+        """Create a checklist with $5000 equity (max risk = $100)."""
         return PreTradeChecklist(account_equity=5000.0)
 
     def test_position_within_limit_passes(self, checklist):
-        """Position at 3% ($150) should pass."""
-        passed, failures = checklist.validate(symbol="SPY", max_loss=150.0, dte=35, is_spread=True)
+        """Position at 1.5% ($75) should pass."""
+        passed, failures = checklist.validate(symbol="SPY", max_loss=75.0, dte=35, is_spread=True)
         assert passed is True
 
     def test_position_at_exactly_limit_passes(self, checklist):
-        """Position at exactly 5% ($250) should pass."""
-        passed, failures = checklist.validate(symbol="SPY", max_loss=250.0, dte=35, is_spread=True)
+        """Position at exactly 2% ($100) should pass."""
+        passed, failures = checklist.validate(symbol="SPY", max_loss=100.0, dte=35, is_spread=True)
         assert passed is True
 
     def test_position_exceeds_limit_fails(self, checklist):
-        """Position at 6% ($300) should fail."""
-        passed, failures = checklist.validate(symbol="SPY", max_loss=300.0, dte=35, is_spread=True)
+        """Position at 3% ($150) should fail."""
+        passed, failures = checklist.validate(symbol="SPY", max_loss=150.0, dte=35, is_spread=True)
         assert passed is False
-        assert any("exceeds 5% limit" in f for f in failures)
+        assert any("exceeds 2% limit" in f for f in failures)
 
     def test_large_position_fails(self, checklist):
         """Large position ($500 = 10%) should fail."""
         passed, failures = checklist.validate(symbol="SPY", max_loss=500.0, dte=35, is_spread=True)
         assert passed is False
         assert any("$500.00" in f for f in failures)
-        assert any("$250.00" in f for f in failures)
+        assert any("$100.00" in f for f in failures)
 
     def test_zero_loss_passes(self, checklist):
         """Zero max loss should pass."""
@@ -218,19 +218,19 @@ class TestPositionSizeValidation:
     def test_small_account_proportional_limit(self):
         """Smaller account should have proportionally smaller limit."""
         small_checklist = PreTradeChecklist(account_equity=1000.0)
-        # 5% of $1000 = $50
+        # 2% of $1000 = $20
         passed, failures = small_checklist.validate(
-            symbol="SPY", max_loss=60.0, dte=35, is_spread=True
+            symbol="SPY", max_loss=25.0, dte=35, is_spread=True
         )
         assert passed is False
-        assert any("$50.00" in f for f in failures)
+        assert any("$20.00" in f for f in failures)
 
     def test_large_account_proportional_limit(self):
         """Larger account should have proportionally larger limit."""
         large_checklist = PreTradeChecklist(account_equity=50000.0)
-        # 5% of $50000 = $2500
+        # 2% of $50000 = $1000
         passed, failures = large_checklist.validate(
-            symbol="SPY", max_loss=2000.0, dte=35, is_spread=True
+            symbol="SPY", max_loss=900.0, dte=35, is_spread=True
         )
         assert passed is True
 
@@ -458,7 +458,7 @@ class TestMultipleFailures:
         """Trade violating all rules should have all failures."""
         passed, failures = checklist.validate(
             symbol="AAPL",  # Not allowed
-            max_loss=500.0,  # Exceeds 5%
+            max_loss=500.0,  # Exceeds 2%
             dte=7,  # Too short
             is_spread=False,  # Naked
             stop_loss_defined=False,  # No stop
@@ -466,7 +466,7 @@ class TestMultipleFailures:
         assert passed is False
         assert len(failures) == 5
         assert any("AAPL not allowed" in f for f in failures)
-        assert any("exceeds 5%" in f for f in failures)
+        assert any("exceeds 2%" in f for f in failures)
         assert any("DTE 7 outside range" in f for f in failures)
         assert any("Naked positions" in f for f in failures)
         assert any("Stop-loss" in f for f in failures)
@@ -551,7 +551,7 @@ class TestChecklistStatus:
 
         # CLAUDE.md: SPY only - best liquidity, tightest spreads
         assert "SPY" in status["ticker_allowed"]["requirement"]
-        assert "5%" in status["position_size"]["requirement"]
+        assert "2%" in status["position_size"]["requirement"]
         assert "spread" in status["is_spread"]["requirement"].lower()
         assert "30-45" in status["dte_range"]["requirement"]
 
@@ -562,11 +562,11 @@ class TestEquityUpdate:
     def test_update_equity(self):
         """Equity update should recalculate max risk."""
         checklist = PreTradeChecklist(account_equity=5000.0)
-        assert checklist.max_risk == 250.0
+        assert checklist.max_risk == 100.0
 
         checklist.update_equity(10000.0)
         assert checklist.account_equity == 10000.0
-        assert checklist.max_risk == 500.0
+        assert checklist.max_risk == 200.0
 
     def test_update_equity_negative_raises(self):
         """Negative equity update should raise."""
@@ -578,13 +578,13 @@ class TestEquityUpdate:
         """Equity update should affect validation."""
         checklist = PreTradeChecklist(account_equity=5000.0)
 
-        # $300 exceeds 5% of $5000 ($250)
-        passed, _ = checklist.validate(symbol="SPY", max_loss=300.0, dte=35, is_spread=True)
+        # $150 exceeds 2% of $5000 ($100)
+        passed, _ = checklist.validate(symbol="SPY", max_loss=150.0, dte=35, is_spread=True)
         assert passed is False
 
-        # Update equity to $10000 - now $300 is within 5% ($500)
+        # Update equity to $10000 - now $150 is within 2% ($200)
         checklist.update_equity(10000.0)
-        passed, _ = checklist.validate(symbol="SPY", max_loss=300.0, dte=35, is_spread=True)
+        passed, _ = checklist.validate(symbol="SPY", max_loss=150.0, dte=35, is_spread=True)
         assert passed is True
 
 
@@ -648,19 +648,19 @@ class TestCLAUDEMDCompliance:
         return PreTradeChecklist(account_equity=4959.26)
 
     def test_max_risk_matches_claude_md(self, checklist_4959):
-        """Max risk should be ~$248 per CLAUDE.md."""
-        # CLAUDE.md: 5% max = $248 risk (5% of $4959.26 = $247.96)
-        assert checklist_4959.max_risk == pytest.approx(247.96, rel=0.01)
+        """Max risk should be ~$99 per CLAUDE.md."""
+        # CLAUDE.md: 2% max = $99 risk (2% of $4959.26 = $99.19)
+        assert checklist_4959.max_risk == pytest.approx(99.19, rel=0.01)
 
     def test_valid_credit_spread_passes(self, checklist_4959):
         """Valid credit spread per CLAUDE.md should pass."""
         # CLAUDE.md: Sell 30-delta put, buy 20-delta put = ~$500 collateral, ~$50-70 premium
         # Max loss on credit spread = spread width - premium = ~$430-450
-        # This exceeds our 5% limit, so we need smaller position
-        # Let's say max loss is $200 (within limit)
+        # This exceeds our 2% limit, so we need smaller position
+        # Let's say max loss is $90 (within limit)
         passed, failures = checklist_4959.validate(
             symbol="SPY",
-            max_loss=200.0,  # Within $248 limit
+            max_loss=90.0,  # Within $99 limit
             dte=35,  # Within 30-45 DTE
             is_spread=True,  # Required
             stop_loss_defined=True,
@@ -706,16 +706,16 @@ class TestCLAUDEMDCompliance:
         assert any("DTE 7 outside range" in f for f in failures)
 
     def test_oversized_position_rejected(self, checklist_4959):
-        """Position >5% should be rejected per CLAUDE.md."""
-        # CLAUDE.md: "Position limit: 1 spread at a time (5% max = $248 risk)"
+        """Position >2% should be rejected per CLAUDE.md."""
+        # CLAUDE.md: "Position limit: 1 spread at a time (2% max = $99 risk)"
         passed, failures = checklist_4959.validate(
             symbol="SPY",
-            max_loss=300.0,  # > $248
+            max_loss=150.0,  # > $99
             dte=35,
             is_spread=True,
         )
         assert passed is False
-        assert any("exceeds 5% limit" in f for f in failures)
+        assert any("exceeds 2% limit" in f for f in failures)
 
 
 class TestPhilTownRule1:
@@ -723,8 +723,8 @@ class TestPhilTownRule1:
 
     def test_conservative_defaults(self):
         """Default settings should be conservative."""
-        # 5% max position is conservative for capital preservation
-        assert PreTradeChecklist.MAX_POSITION_PCT == 0.05
+        # 2% max position is conservative for capital preservation
+        assert PreTradeChecklist.MAX_POSITION_PCT == 0.02
 
     def test_spread_requirement_protects_capital(self):
         """Spread requirement limits max loss."""

--- a/tests/test_risk_manager.py
+++ b/tests/test_risk_manager.py
@@ -3,14 +3,14 @@
 Tests for Risk Manager Module - Phil Town Rule #1: Don't Lose Money
 
 Comprehensive test suite covering:
-- Position size limits (max 5% per position per CLAUDE.md)
+- Position size limits (max 2% per position per CLAUDE.md)
 - Daily loss limits (2% max daily drawdown)
 - Cash reserve requirements (20% minimum)
 - Concentration limits (40% max in single sector)
 - Contract calculations and trade approval
 
 Created: January 13, 2026
-Updated: January 19, 2026 - Changed 20% to 5% per CLAUDE.md mandate
+Updated: April 14, 2026 - Changed 5% to 2% per validation-risk mandate
 """
 
 from datetime import date, datetime
@@ -59,7 +59,7 @@ class TestRiskManagerInitialization:
         """RiskManager initializes with default values."""
         rm = RiskManager()
         assert rm.portfolio_value == 5000.0
-        assert rm.max_position_pct == 0.05  # 5% per CLAUDE.md
+        assert rm.max_position_pct == 0.02  # 2% per CLAUDE.md
         assert rm.max_daily_loss_pct == 0.02  # 2%
         assert rm.min_cash_reserve_pct == 0.20  # 20%
 
@@ -83,14 +83,14 @@ class TestRiskManagerInitialization:
 
     def test_default_constants_match_docstring(self):
         """Verify default constants match documented values."""
-        assert RiskManager.DEFAULT_MAX_POSITION_PCT == 0.05  # 5% per CLAUDE.md
+        assert RiskManager.DEFAULT_MAX_POSITION_PCT == 0.02  # 2% per CLAUDE.md
         assert RiskManager.DEFAULT_MAX_DAILY_LOSS_PCT == 0.02
         assert RiskManager.DEFAULT_MIN_CASH_RESERVE_PCT == 0.20
         assert RiskManager.DEFAULT_MAX_SECTOR_CONCENTRATION == 0.40
 
 
 class TestPositionSizeLimits:
-    """Tests for position size limit enforcement (max 5% per position per CLAUDE.md)."""
+    """Tests for position size limit enforcement (max 2% per position per CLAUDE.md)."""
 
     @pytest.fixture
     def risk_manager(self):
@@ -98,26 +98,26 @@ class TestPositionSizeLimits:
         return RiskManager(portfolio_value=5000.0)
 
     def test_position_within_limit_passes(self, risk_manager):
-        """Position at 4% of portfolio should pass (under 5% limit)."""
-        # $200 is 4% of $5000
-        check = risk_manager.check_position_size("SPY", 200.0)
+        """Position at 1.5% of portfolio should pass (under 2% limit)."""
+        # $75 is 1.5% of $5000
+        check = risk_manager.check_position_size("SPY", 75.0)
         assert check.passed is True
         assert "within limit" in check.reason.lower()
-        assert check.risk_score == pytest.approx(0.04, rel=0.01)
+        assert check.risk_score == pytest.approx(0.015, rel=0.01)
 
     def test_position_at_exactly_limit_passes(self, risk_manager):
-        """Position at exactly 5% of portfolio should pass."""
-        # $250 is exactly 5% of $5000
-        check = risk_manager.check_position_size("F", 250.0)
+        """Position at exactly 2% of portfolio should pass."""
+        # $100 is exactly 2% of $5000
+        check = risk_manager.check_position_size("F", 100.0)
         assert check.passed is True
 
     def test_position_exceeds_limit_fails(self, risk_manager):
-        """Position exceeding 5% of portfolio should fail."""
-        # $300 is 6% of $5000 - exceeds 5% limit
-        check = risk_manager.check_position_size("SOFI", 300.0)
+        """Position exceeding 2% of portfolio should fail."""
+        # $150 is 3% of $5000 - exceeds 2% limit
+        check = risk_manager.check_position_size("SOFI", 150.0)
         assert check.passed is False
         assert "exceeds max" in check.reason.lower()
-        assert check.risk_score == pytest.approx(0.06, rel=0.01)
+        assert check.risk_score == pytest.approx(0.03, rel=0.01)
 
     def test_position_check_includes_symbol_in_reason(self, risk_manager):
         """Position check reason should include the symbol."""
@@ -142,8 +142,8 @@ class TestPositionSizeLimits:
         small_rm = RiskManager(portfolio_value=5000.0)
         large_rm = RiskManager(portfolio_value=50000.0)
 
-        assert small_rm.get_position_limit("SPY") == 250.0  # 5% of 5000
-        assert large_rm.get_position_limit("SPY") == 2500.0  # 5% of 50000
+        assert small_rm.get_position_limit("SPY") == 100.0  # 2% of 5000
+        assert large_rm.get_position_limit("SPY") == 1000.0  # 2% of 50000
 
 
 class TestDailyLossLimits:
@@ -292,11 +292,11 @@ class TestMaxContractsCalculation:
         return RiskManager(portfolio_value=5000.0)
 
     def test_max_contracts_basic(self, risk_manager):
-        """Calculate max contracts for $5 strike CSP (5% max position)."""
+        """Calculate max contracts for $5 strike CSP (2% max position)."""
         # $5 strike = $500 collateral per contract
         # Usable cash = $5000 * 0.80 = $4000
         # Max by cash = $4000 / $500 = 8 contracts
-        # Max by position = $250 (5%) / $500 = 0 contracts (can't afford 1)
+        # Max by position = $100 (2%) / $500 = 0 contracts (can't afford 1)
         # Result should be min(8, 0, 10) = 0 (position limit too restrictive)
         max_contracts = risk_manager.get_max_contracts(strike_price=5.0, cash_available=5000.0)
         assert max_contracts == 0
@@ -315,12 +315,12 @@ class TestMaxContractsCalculation:
         rm = RiskManager(portfolio_value=100000.0)
         # $5 strike with $100K cash
         max_contracts = rm.get_max_contracts(strike_price=5.0, cash_available=100000.0)
-        assert max_contracts == 10  # Capped
+        assert max_contracts == 4  # Limited by 2% position cap
 
     def test_max_contracts_higher_strike(self, risk_manager):
-        """Higher strike price requires more collateral (5% max position)."""
+        """Higher strike price requires more collateral (2% max position)."""
         # $10 strike = $1000 collateral per contract
-        # Max by position = $250 (5%) / $1000 = 0 contracts (can't afford 1)
+        # Max by position = $100 (2%) / $1000 = 0 contracts (can't afford 1)
         max_contracts = risk_manager.get_max_contracts(strike_price=10.0, cash_available=5000.0)
         assert max_contracts == 0
 
@@ -341,10 +341,10 @@ class TestComprehensiveRiskCalculation:
         return RiskManager(portfolio_value=5000.0)
 
     def test_calculate_risk_all_pass(self, risk_manager):
-        """All checks passing should return approved (5% max position)."""
+        """All checks passing should return approved (2% max position)."""
         result = risk_manager.calculate_risk(
             symbol="F",
-            notional_value=200.0,  # 4% - within 5% limit
+            notional_value=75.0,  # 1.5% - within 2% limit
             cash_available=3000.0,  # Leaves $2500 reserve
             potential_loss=50.0,  # 1% - within limit
         )
@@ -408,9 +408,9 @@ class TestTradeApproval:
         return RiskManager(portfolio_value=5000.0)
 
     def test_approve_valid_trade(self, risk_manager):
-        """Valid trade should be approved (under 5% position limit)."""
+        """Valid trade should be approved (under 2% position limit)."""
         approved, reason = risk_manager.approve_trade(
-            symbol="F", notional_value=200.0, cash_available=3000.0, potential_loss=0.0
+            symbol="F", notional_value=75.0, cash_available=3000.0, potential_loss=0.0
         )
         assert approved is True
         assert "approved" in reason.lower()
@@ -485,16 +485,16 @@ class TestEdgeCases:
         assert check.passed is True
 
     def test_very_small_portfolio(self):
-        """Very small portfolio should still enforce percentages (5%)."""
+        """Very small portfolio should still enforce percentages (2%)."""
         rm = RiskManager(portfolio_value=100.0)
         max_position = rm.get_position_limit("F")
-        assert max_position == 5.0  # 5% of $100
+        assert max_position == 2.0  # 2% of $100
 
     def test_very_large_portfolio(self):
-        """Very large portfolio should still enforce percentages (5%)."""
+        """Very large portfolio should still enforce percentages (2%)."""
         rm = RiskManager(portfolio_value=1000000.0)
         max_position = rm.get_position_limit("SPY")
-        assert max_position == 50000.0  # 5% of $1M
+        assert max_position == 20000.0  # 2% of $1M
 
     def test_custom_higher_risk_tolerance(self):
         """Higher risk tolerance configuration."""
@@ -552,14 +552,14 @@ class TestPhilTownRule1:
         assert max_contracts == 0
 
     def test_minimum_capital_for_f_csp(self):
-        """Calculate minimum capital needed for 1 F CSP at $5 strike (5% limit)."""
+        """Calculate minimum capital needed for 1 F CSP at $5 strike (2% limit)."""
         # Need: $500 collateral + keep 20% reserve
         # If using 80% of capital: capital * 0.80 >= $500
-        # Also: position limit 5% >= $500
-        # $500 / 0.05 = $10000 minimum for position limit
-        rm = RiskManager(portfolio_value=10000.0)
-        max_contracts = rm.get_max_contracts(strike_price=5.0, cash_available=10000.0)
-        assert max_contracts == 1  # Can now trade 1 contract with $10K
+        # Also: position limit 2% >= $500
+        # $500 / 0.02 = $25000 minimum for position limit
+        rm = RiskManager(portfolio_value=25000.0)
+        max_contracts = rm.get_max_contracts(strike_price=5.0, cash_available=25000.0)
+        assert max_contracts == 1  # Can now trade 1 contract with $25K
 
     def test_protect_capital_after_loss(self, conservative_rm):
         """After daily loss, trading should be restricted."""

--- a/tests/test_trade_gateway.py
+++ b/tests/test_trade_gateway.py
@@ -234,7 +234,7 @@ class TestTradeGatewayAllocationLimits:
             positions=[{"symbol": "XOM", "market_value": 400}],  # 4% already
         )
 
-        # Trying to add $200 more would push to 6% (> 5% limit)
+        # Trying to add $200 more would push to 6% (> 2% limit)
         request = TradeRequest(
             symbol="XOM",
             side="buy",
@@ -247,18 +247,18 @@ class TestTradeGatewayAllocationLimits:
         assert RejectionReason.MAX_ALLOCATION_EXCEEDED in decision.rejection_reasons
 
     def test_under_allocation_approved(self):
-        """Test that < 5% allocation is approved (per CLAUDE.md)."""
+        """Test that allocation below the canonical cap is not rejected."""
         gateway = TradeGateway(executor=None, paper=True)
         gateway.executor = MockExecutor(
             account_equity=10000,
-            positions=[{"symbol": "TSLA", "market_value": 100}],  # 1% already
+            positions=[{"symbol": "SPY", "market_value": 100}],  # 1% already
         )
 
-        # Adding $300 more would be 4% total (under 5%)
+        # Adding $75 more would be 1.75% total (under 2%)
         request = TradeRequest(
-            symbol="TSLA",
+            symbol="SPY",
             side="buy",
-            notional=300,
+            notional=75,
             source="test",
         )
         decision = gateway.evaluate(request)

--- a/tests/test_trading_profiles.py
+++ b/tests/test_trading_profiles.py
@@ -25,7 +25,7 @@ def test_default_iron_condor_profile_values():
     assert profile.stop_loss_pct == 1.0
     assert profile.exit_dte == 7
     assert profile.min_hold_hours == 24
-    assert profile.position_size_pct == 0.05
+    assert profile.position_size_pct == trading_constants.MAX_POSITION_PCT
     assert profile.max_contracts_per_trade == 1
     assert profile.max_concurrent_positions == 2  # CLAUDE.md mandate: 2 ICs max
     assert profile.max_daily_structures == 1
@@ -44,7 +44,7 @@ def test_strategy_config_bridge_matches_profile():
     assert config["stop_loss_pct"] == 1.0
     assert config["exit_dte"] == 7
     assert config["min_hold_hours"] == 24
-    assert config["position_size_pct"] == 0.05
+    assert config["position_size_pct"] == trading_constants.MAX_POSITION_PCT
     assert config["max_contracts_per_trade"] == 1
     assert config["max_positions"] == 2  # CLAUDE.md mandate: 2 ICs max
 


### PR DESCRIPTION
## Summary
- Add a mathematical quarantine mode when the lifetime ledger has enough samples but no confirmed edge.
- Block new positions when negative expectancy is present and no valid changed-rule validation hypothesis exists.
- Freeze North Star claims until validation proves positive expectancy.
- Surface quarantine state in guard checks and public status output.

## Verification
- `uv run pytest tests/test_north_star_operating_plan.py tests/test_north_star_guard.py tests/test_mandatory_trade_gate.py tests/test_build_public_status.py` -> 62 passed.
- `trunk check ...` on changed files -> No new issues.
- Rebased onto current origin/main before push.

## Current-ledger behavior verified locally before rebase
- Computed mode: quarantine.
- block_new_positions: true.
- allow_validation_entries: false when no valid strategy_validation_hypothesis exists.
