### PR TITLE
chore: upgrade ThumbGate pin to 1.4.6

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -30,8 +30,8 @@ Source of truth: `src/core/trading_constants.py`
 ```bash
 pytest tests/ -q                            # run tests
 ruff check src/                             # lint
-npx -y thumbgate@0.9.14 status              # inspect local agent feedback memory
-npx -y thumbgate@0.9.14 summary             # compact feedback summary
+npx -y thumbgate@1.4.6 status              # inspect local agent feedback memory
+npx -y thumbgate@1.4.6 summary             # compact feedback summary
 printf 'thumbs down' | python3 scripts/capture_hook_feedback.py
 python scripts/sync_alpaca_state.py          # refresh broker snapshot
 python scripts/sync_closed_positions.py      # refresh paired trade ledger

--- a/.claude/hooks/memory-gateway-pretool.sh
+++ b/.claude/hooks/memory-gateway-pretool.sh
@@ -52,7 +52,7 @@ print(json.dumps({"tool_name": "Bash", "tool_input": {"command": command}}))
 PY
 )"
 
-RESULT="$(printf '%s' "${HOOK_JSON}" | npx -y thumbgate@0.9.14 gate-check 2>/dev/null || true)"
+RESULT="$(printf '%s' "${HOOK_JSON}" | npx -y thumbgate@1.4.6 gate-check 2>/dev/null || true)"
 
 if [[ -z ${RESULT} || ${RESULT} == "{}" ]]; then
 	exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -80,7 +80,7 @@
   "mcpServers": {
     "rlhf": {
       "command": "npx",
-      "args": ["-y", "thumbgate@0.9.14", "serve"]
+      "args": ["-y", "thumbgate@1.4.6", "serve"]
     },
     "massive": {
       "command": "mcp_massive",

--- a/.github/workflows/auto-record-lesson.yml
+++ b/.github/workflows/auto-record-lesson.yml
@@ -54,14 +54,14 @@ jobs:
           CONTEXT="${{ steps.failure.outputs.workflow_name }} failed in CI: ${{ steps.failure.outputs.run_url }}"
           ERROR_MSG="${{ steps.failure.outputs.error_msg }}"
 
-          THUMBGATE_FEEDBACK_DIR="$PWD/.thumbgate" npx -y thumbgate@0.9.14 capture \
+          THUMBGATE_FEEDBACK_DIR="$PWD/.thumbgate" npx -y thumbgate@1.4.6 capture \
             --feedback=down \
             --context="$CONTEXT" \
             --what-went-wrong="${ERROR_MSG:-Workflow failed without a concise extracted error message.}" \
             --what-to-change="Fix the workflow root cause, verify the failing path locally, and re-run the workflow before the next trading session." \
             --tags="workflow-failure,ci,${{ steps.failure.outputs.workflow_slug }}" || true
 
-          THUMBGATE_FEEDBACK_DIR="$PWD/.thumbgate" npx -y thumbgate@0.9.14 rules \
+          THUMBGATE_FEEDBACK_DIR="$PWD/.thumbgate" npx -y thumbgate@1.4.6 rules \
             --output=.thumbgate/prevention-rules.md \
             --min=2 || true
 
@@ -72,7 +72,7 @@ jobs:
             echo ""
             echo "- Workflow: ${{ steps.failure.outputs.workflow_name }}"
             echo "- Run URL: ${{ steps.failure.outputs.run_url }}"
-            echo "- ThumbGate capture: attempted via \`thumbgate@0.9.14\`"
+            echo "- ThumbGate capture: attempted via \`thumbgate@1.4.6\`"
             echo "- Artifact: \`.thumbgate/\` plus extracted failure log"
           } >> "$GITHUB_STEP_SUMMARY"
 

--- a/.mcp.json
+++ b/.mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "rlhf": {
       "command": "npx",
-      "args": ["-y", "thumbgate@0.9.14", "serve"]
+      "args": ["-y", "thumbgate@1.4.6", "serve"]
     }
   }
 }

--- a/plugins/automation-plugin/skills/dynamic-agent-spawner/scripts/rlhf-integration.ts
+++ b/plugins/automation-plugin/skills/dynamic-agent-spawner/scripts/rlhf-integration.ts
@@ -15,7 +15,8 @@ import {
   openSync,
   readFileSync,
 } from "fs";
-import { join } from "path";
+import { join, resolve } from "path";
+import { fileURLToPath } from "url";
 
 interface RLHFEvent {
   taskId: string;
@@ -232,7 +233,11 @@ Memory Systems:
   }
 }
 
-if (require.main === module) {
+const isMainModule =
+  process.argv[1] !== undefined &&
+  resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+
+if (isMainModule) {
   main().catch(console.error);
 }
 

--- a/src/learning/memory_gateway_feedback.py
+++ b/src/learning/memory_gateway_feedback.py
@@ -12,7 +12,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Iterable, Sequence
 
-THUMBGATE_VERSION = "0.9.14"
+THUMBGATE_VERSION = "1.4.6"
 TRANSCRIPT_ROOT = Path.home() / ".claude" / "projects"
 
 EXPLICIT_NEGATIVE_RE = re.compile(

--- a/tests/test_capture_hook_feedback.py
+++ b/tests/test_capture_hook_feedback.py
@@ -29,7 +29,7 @@ def test_process_user_message_uses_gateway_commands(tmp_path: Path) -> None:
     assert result["status"] == "processed"
     assert result["accepted"] is True
     assert result["rules_refreshed"] is True
-    assert any("thumbgate@0.9.14" in " ".join(cmd) for cmd in commands)
+    assert any("thumbgate@1.4.6" in " ".join(cmd) for cmd in commands)
     assert any(" capture " in f" {' '.join(cmd)} " for cmd in commands)
     assert any(" rules " in f" {' '.join(cmd)} " for cmd in commands)
     assert envs[-1] is not None

--- a/tests/test_codex_notify_rlhf_bridge.py
+++ b/tests/test_codex_notify_rlhf_bridge.py
@@ -58,7 +58,7 @@ def test_process_payload_records_thumbgate_commands_and_shared_state(tmp_path: P
     result = process_payload(payload, runner=fake_runner)
 
     assert result["status"] == "processed"
-    assert any("thumbgate@0.9.14" in " ".join(cmd) for cmd in commands)
+    assert any("thumbgate@1.4.6" in " ".join(cmd) for cmd in commands)
     assert any(" capture " in f" {' '.join(cmd)} " for cmd in commands)
     assert any(" rules " in f" {' '.join(cmd)} " for cmd in commands)
     assert envs[-1] is not None

--- a/tests/test_gsd_pipeline_wiring.py
+++ b/tests/test_gsd_pipeline_wiring.py
@@ -60,4 +60,4 @@ def test_project_mcp_config_registers_gateway_server():
     config = json.loads(MCP_CONFIG_PATH.read_text(encoding="utf-8"))
     server = config["mcpServers"]["rlhf"]
     assert server["command"] == "npx"
-    assert server["args"] == ["-y", "thumbgate@0.9.14", "serve"]
+    assert server["args"] == ["-y", "thumbgate@1.4.6", "serve"]

--- a/tests/test_memory_gateway_integration.py
+++ b/tests/test_memory_gateway_integration.py
@@ -13,12 +13,12 @@ def test_mcp_config_pins_thumbgate_server() -> None:
     config = json.loads((PROJECT_ROOT / ".mcp.json").read_text(encoding="utf-8"))
     server = config["mcpServers"]["rlhf"]
     assert server["command"] == "npx"
-    assert server["args"] == ["-y", "thumbgate@0.9.14", "serve"]
+    assert server["args"] == ["-y", "thumbgate@1.4.6", "serve"]
 
     settings = json.loads((PROJECT_ROOT / ".claude" / "settings.json").read_text(encoding="utf-8"))
     claude_server = settings["mcpServers"]["rlhf"]
     assert claude_server["command"] == "npx"
-    assert claude_server["args"] == ["-y", "thumbgate@0.9.14", "serve"]
+    assert claude_server["args"] == ["-y", "thumbgate@1.4.6", "serve"]
 
 
 def test_gsd_pipeline_uses_gateway_backed_hooks_only() -> None:
@@ -54,7 +54,7 @@ def test_auto_record_lesson_workflow_uses_thumbgate_and_no_main_push() -> None:
     )
     record_job = workflow["jobs"]["record-lesson"]
     step_commands = "\n".join(step.get("run", "") for step in record_job["steps"])
-    assert "thumbgate@0.9.14 capture" in step_commands
+    assert "thumbgate@1.4.6 capture" in step_commands
     assert "git push origin main" not in step_commands
 
 


### PR DESCRIPTION
## Summary
- upgrade repo ThumbGate pins from `0.9.14` to `1.4.6`
- update tests and workflow wiring expectations for the new pin
- fix the MemAlign RLHF integration entrypoint so it does not use CommonJS `require.main` under ESM

## Verification
- `npm view thumbgate version dist-tags time.modified --json` -> latest `1.4.6`, modified `2026-04-14T16:20:50.025Z`
- `npx -y thumbgate@1.4.6 status --json`
- `npx -y thumbgate@1.4.6 gate-stats --json`
- `npx -y tsx plugins/automation-plugin/skills/dynamic-agent-spawner/scripts/rlhf-integration.ts`
- `npx tsc --noEmit --pretty false`
- `npx tsc --noEmit --pretty false -p plugins/automation-plugin/skills/dynamic-agent-spawner/scripts/tsconfig.json`
- `pytest -q tests/test_thumbgate_feedback.py tests/test_capture_hook_feedback.py tests/test_codex_notify_rlhf_bridge.py tests/test_gsd_pipeline_wiring.py tests/test_memory_gateway_integration.py`
- `trunk check .claude/CLAUDE.md .claude/hooks/memory-gateway-pretool.sh .claude/settings.json .github/workflows/auto-record-lesson.yml .mcp.json plugins/automation-plugin/skills/dynamic-agent-spawner/scripts/rlhf-integration.ts src/learning/memory_gateway_feedback.py tests/test_capture_hook_feedback.py tests/test_codex_notify_rlhf_bridge.py tests/test_gsd_pipeline_wiring.py tests/test_memory_gateway_integration.py`
- `git diff --check`