### PR TITLE
fix: tolerate Actions PR permission limits

### DIFF
--- a/.github/workflows/openrouter-price-monitor.yml
+++ b/.github/workflows/openrouter-price-monitor.yml
@@ -42,9 +42,17 @@ jobs:
             git add data/openrouter_pricing_baseline.json
             git commit -m "chore: update OpenRouter pricing baseline [auto]"
             git push -u origin "$BRANCH"
-            gh pr create \
+            PR_BODY="Automated OpenRouter pricing baseline update from run ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}."
+            if gh pr create \
               --base main \
               --head "$BRANCH" \
               --title "chore: update OpenRouter pricing baseline" \
-              --body "Automated OpenRouter pricing baseline update from run ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}."
+              --body "$PR_BODY"; then
+              echo "Created pricing baseline PR for $BRANCH"
+            else
+              echo "::warning::Could not create PR with GITHUB_TOKEN; update branch pushed: $BRANCH"
+              gh issue create \
+                --title "OpenRouter pricing baseline update ready" \
+                --body "$PR_BODY"$'\n\n'"Branch: $BRANCH" || true
+            fi
           fi


### PR DESCRIPTION
## Summary
- keep OpenRouter pricing branch pushes working
- make GitHub Actions PR creation permission failures non-fatal
- create an issue as a fallback when Actions cannot open a PR

## Evidence
- actionlint .github/workflows/openrouter-price-monitor.yml
- ruby YAML parse
- trunk check .github/workflows/openrouter-price-monitor.yml --ci

Follow-up to manual proof run 25318277440, which showed Actions can push the update branch but cannot create PRs with GITHUB_TOKEN in this repo.