### PR TITLE
fix: prefer freshest public status snapshot

### DIFF
--- a/docs/data/public_status.json
+++ b/docs/data/public_status.json
@@ -26,7 +26,7 @@
     "profit_factor": 0.24,
     "total_realized_pnl": -3669.0,
     "expectancy_per_trade": -54.7612,
-    "last_updated": "2026-05-03T15:13:54.290152+00:00"
+    "last_updated": "2026-05-01T19:55:59.268012+00:00"
   },
   "gate": {
     "mode": "validation_reset",

--- a/scripts/build_public_status.py
+++ b/scripts/build_public_status.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 import argparse
 import json
 import sys
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
@@ -127,6 +127,43 @@ def _pick_first(*values: Any) -> Any:
     return None
 
 
+def _parse_iso(value: Any) -> datetime | None:
+    if not isinstance(value, str) or not value.strip():
+        return None
+    raw = value.strip().replace("Z", "+00:00")
+    try:
+        parsed = datetime.fromisoformat(raw)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def _latest_timestamp(*values: Any) -> str | None:
+    ranked: list[tuple[datetime, str]] = []
+    for value in values:
+        parsed = _parse_iso(value)
+        if parsed is not None and isinstance(value, str):
+            ranked.append((parsed, value))
+    if not ranked:
+        return None
+    ranked.sort(key=lambda item: item[0])
+    return ranked[-1][1]
+
+
+def _select_latest_snapshot(*sources: tuple[str | None, dict[str, Any]]) -> dict[str, Any]:
+    ranked: list[tuple[datetime, dict[str, Any]]] = []
+    for timestamp, payload in sources:
+        parsed = _parse_iso(timestamp)
+        if parsed is not None and isinstance(payload, dict):
+            ranked.append((parsed, payload))
+    if not ranked:
+        return {}
+    ranked.sort(key=lambda item: item[0])
+    return ranked[-1][1]
+
+
 def _why_today_summary(total: Any, positions_count: Any) -> str:
     if total is not None and positions_count == 0:
         return (
@@ -154,23 +191,36 @@ def build_public_status(repo_root: Path) -> dict[str, Any]:
 
     runtime_paper = runtime.get("paper", {})
     runtime_live = runtime.get("live", {})
+    scorecard_paper = scorecard.get("paper", {})
+    scorecard_live = scorecard.get("live", {})
     weekly = state.get("north_star_weekly_gate") or {}
     cadence = weekly.get("cadence_kpi") or {}
     scaling = weekly.get("scaling_sample_gate") or {}
     stats = trades.get("stats") or {}
     congruence = assess_gate_congruence(weekly, trades)
-    paper_total_pnl_today = _pick_first(
-        runtime_paper.get("daily_change"),
-        scorecard.get("paper", {}).get("total_pnl_today"),
+    paper_snapshot = _select_latest_snapshot(
+        (runtime.get("captured_at"), runtime_paper),
+        (scorecard.get("generated_at_et"), scorecard_paper),
     )
-    generated_at_et = _pick_first(
+    live_snapshot = _select_latest_snapshot(
+        (runtime.get("captured_at"), runtime_live),
+        (scorecard.get("generated_at_et"), scorecard_live),
+    )
+    paper_total_pnl_today = _pick_first(
+        paper_snapshot.get("daily_change"),
+        paper_snapshot.get("total_pnl_today"),
+        runtime_paper.get("daily_change"),
+        scorecard_paper.get("total_pnl_today"),
+    )
+    generated_at_et = _latest_timestamp(
         runtime.get("captured_at"),
+        scorecard.get("generated_at_et"),
         state.get("last_updated"),
         stats.get("last_updated"),
         trades.get("meta", {}).get("last_sync"),
-        scorecard.get("generated_at_et"),
-        datetime.now().astimezone().isoformat(),
     )
+    if generated_at_et is None:
+        generated_at_et = datetime.now().astimezone().isoformat()
 
     closed_total = stats.get("closed_trades", scaling.get("closed_trades_observed", 0))
     total_realized = stats.get("total_realized_pnl", stats.get("total_pnl"))
@@ -189,22 +239,40 @@ def build_public_status(repo_root: Path) -> dict[str, Any]:
         },
         "paper": {
             "equity": _pick_first(
+                paper_snapshot.get("equity"),
                 runtime_paper.get("equity"),
-                scorecard.get("paper", {}).get("equity"),
+                scorecard_paper.get("equity"),
             ),
             "total_pnl_today": paper_total_pnl_today,
-            "realized_pnl_today": None,
-            "unrealized_pnl_today": None,
-            "fills_today_count": None,
-            "positions_count": runtime_paper.get("positions_count"),
+            "realized_pnl_today": _pick_first(
+                paper_snapshot.get("realized_pnl_today"),
+                scorecard_paper.get("realized_pnl_today"),
+            ),
+            "unrealized_pnl_today": _pick_first(
+                paper_snapshot.get("unrealized_pnl_today"),
+                scorecard_paper.get("unrealized_pnl_today"),
+            ),
+            "fills_today_count": _pick_first(
+                paper_snapshot.get("fills_today_count"),
+                scorecard_paper.get("fills_today_count"),
+            ),
+            "positions_count": _pick_first(
+                paper_snapshot.get("positions_count"),
+                runtime_paper.get("positions_count"),
+                scorecard_paper.get("positions_count"),
+            ),
         },
         "live": {
             "equity": _pick_first(
-                runtime_live.get("equity"), scorecard.get("live", {}).get("equity")
+                live_snapshot.get("equity"),
+                runtime_live.get("equity"),
+                scorecard_live.get("equity"),
             ),
             "total_pnl_today": _pick_first(
+                live_snapshot.get("daily_change"),
+                live_snapshot.get("total_pnl_today"),
                 runtime_live.get("daily_change"),
-                scorecard.get("live", {}).get("total_pnl_today"),
+                scorecard_live.get("total_pnl_today"),
             ),
         },
         "ledger": {
@@ -244,7 +312,11 @@ def build_public_status(repo_root: Path) -> dict[str, Any]:
         "narrative": {
             "summary": _why_today_summary(
                 paper_total_pnl_today,
-                runtime_paper.get("positions_count"),
+                _pick_first(
+                    paper_snapshot.get("positions_count"),
+                    runtime_paper.get("positions_count"),
+                    scorecard_paper.get("positions_count"),
+                ),
             ),
             "thesis": (
                 "This project is currently a paper-first validation platform, not a proven passive-income engine. "

--- a/scripts/ic_simple.py
+++ b/scripts/ic_simple.py
@@ -72,6 +72,28 @@ SYSTEM_STATE_FILE = Path(__file__).parent.parent / "data" / "system_state.json"
 THOMPSON_MIN_CONFIDENCE = 0.40
 MIN_ACCEPTABLE_SHORT_DELTA = 0.08
 MAX_ACCEPTABLE_SHORT_DELTA = 0.22
+FOMC_DATES = [
+    "2026-01-28",
+    "2026-03-18",
+    "2026-05-06",
+    "2026-06-17",
+    "2026-07-29",
+    "2026-09-16",
+    "2026-11-04",
+    "2026-12-16",
+]
+
+
+def _fomc_blackout_reason(as_of=None) -> str | None:
+    """Return the FOMC announcement date when new entries are blocked."""
+    from datetime import timedelta
+
+    today = as_of or datetime.now().date()
+    for fomc_str in FOMC_DATES:
+        fomc_date = datetime.strptime(fomc_str, "%Y-%m-%d").date()
+        if (fomc_date - timedelta(days=2)) <= today <= (fomc_date + timedelta(days=1)):
+            return fomc_str
+    return None
 
 
 # ── Alpaca Client ────────────────────────────────────────────────────────────
@@ -1300,26 +1322,10 @@ def main():
         logger.info("\n--- ENTRY CHECK ---")
 
         # FOMC blackout check (2 days before through 1 day after)
-        from datetime import timedelta
-
-        FOMC_DATES = [
-            "2026-01-28",
-            "2026-03-18",
-            "2026-05-06",
-            "2026-06-17",
-            "2026-07-29",
-            "2026-09-16",
-            "2026-11-04",
-            "2026-12-16",
-        ]
-        today = datetime.now().date()
-        fomc_blocked = False
-        for fomc_str in FOMC_DATES:
-            fomc_date = datetime.strptime(fomc_str, "%Y-%m-%d").date()
-            if (fomc_date - timedelta(days=2)) <= today <= (fomc_date + timedelta(days=1)):
-                logger.warning(f"FOMC blackout: {fomc_str}. No entry.")
-                fomc_blocked = True
-                break
+        fomc_str = _fomc_blackout_reason()
+        fomc_blocked = fomc_str is not None
+        if fomc_str is not None:
+            logger.warning(f"FOMC blackout: {fomc_str}. No entry.")
 
         # ThumbGate pre-entry check: block patterns from past losses
         thumbgate_blocked = False

--- a/src/risk/trade_gateway.py
+++ b/src/risk/trade_gateway.py
@@ -350,7 +350,7 @@ class TradeGateway:
         """
         return _extract_underlying_shared(symbol)
 
-    def _check_earnings_blackout(self, symbol: str) -> tuple[bool, str]:
+    def _check_earnings_blackout(self, symbol: str, as_of=None) -> tuple[bool, str]:
         """
         Check if symbol is in FOMC blackout period.
 
@@ -359,7 +359,12 @@ class TradeGateway:
         """
         from datetime import timedelta
 
-        today = datetime.now().date()
+        if as_of is None:
+            today = datetime.now().date()
+        elif hasattr(as_of, "date"):
+            today = as_of.date()
+        else:
+            today = as_of
 
         for fomc_str in self.FOMC_DATES:
             fomc_date = datetime.strptime(fomc_str, "%Y-%m-%d").date()
@@ -942,7 +947,9 @@ class TradeGateway:
         # CHECK 0.5: EARNINGS BLACKOUT (LL-190)
         # Don't open NEW positions during earnings blackout periods
         # ============================================================
-        is_blackout, blackout_reason = self._check_earnings_blackout(request.symbol)
+        is_blackout, blackout_reason = self._check_earnings_blackout(
+            request.symbol, request.request_time
+        )
         if is_blackout and request.side.lower() in ["buy", "sell"]:
             # Only block NEW positions, not closing existing ones
             rejection_reasons.append(RejectionReason.EARNINGS_BLACKOUT)

--- a/tests/test_build_public_status.py
+++ b/tests/test_build_public_status.py
@@ -91,7 +91,9 @@ def test_build_public_status_uses_canonical_inputs(tmp_path: Path):
 
     assert status["paper"]["equity"] == 93990.30
     assert status["paper"]["total_pnl_today"] == -14.0
-    assert status["paper"]["realized_pnl_today"] is None
+    assert status["paper"]["realized_pnl_today"] == 0.0
+    assert status["paper"]["unrealized_pnl_today"] == -14.0
+    assert status["paper"]["fills_today_count"] == 0
     assert status["ledger"]["closed_trades_total"] == 134
     assert status["gate"]["block_new_positions"] is True
     assert status["system"]["public_status"] == "halted"
@@ -140,10 +142,51 @@ def test_build_public_status_falls_back_to_tracked_runtime_without_scorecard(tmp
 
     status = build_public_status(repo)
 
-    assert status["generated_at_et"] == "2026-04-03T14:33:34+00:00"
+    assert status["generated_at_et"] == "2026-04-03T14:33:35+00:00"
     assert status["paper"]["equity"] == 93990.30
     assert status["paper"]["total_pnl_today"] == -14.0
     assert "tracked broker sync" in status["narrative"]["summary"]
+
+
+def test_build_public_status_prefers_newer_scorecard_snapshot(tmp_path: Path):
+    repo = _seed_repo(tmp_path)
+    trades = json.loads((repo / "data/trades.json").read_text(encoding="utf-8"))
+    trades["meta"]["last_sync"] = "2026-04-03T14:20:00+00:00"
+    trades["stats"]["last_updated"] = "2026-04-03T14:20:00+00:00"
+    (repo / "data/trades.json").write_text(json.dumps(trades), encoding="utf-8")
+
+    runtime = json.loads((repo / "data/runtime/intraday_pnl_latest.json").read_text(encoding="utf-8"))
+    runtime["captured_at"] = "2026-04-03T14:30:00+00:00"
+    runtime["paper"]["equity"] = 93980.30
+    runtime["paper"]["daily_change"] = -9.0
+    runtime["paper"]["positions_count"] = 1
+    (repo / "data/runtime/intraday_pnl_latest.json").write_text(
+        json.dumps(runtime), encoding="utf-8"
+    )
+
+    scorecard = json.loads(
+        (repo / "artifacts/daily_scorecard/latest_daily_scorecard.json").read_text(encoding="utf-8")
+    )
+    scorecard["generated_at_et"] = "2026-04-03T10:33:34-04:00"
+    scorecard["paper"]["equity"] = 93990.30
+    scorecard["paper"]["total_pnl_today"] = -14.0
+    scorecard["paper"]["realized_pnl_today"] = -2.0
+    scorecard["paper"]["unrealized_pnl_today"] = -12.0
+    scorecard["paper"]["fills_today_count"] = 3
+    scorecard["paper"]["positions_count"] = 4
+    (repo / "artifacts/daily_scorecard/latest_daily_scorecard.json").write_text(
+        json.dumps(scorecard), encoding="utf-8"
+    )
+
+    status = build_public_status(repo)
+
+    assert status["generated_at_et"] == "2026-04-03T10:33:34-04:00"
+    assert status["paper"]["equity"] == 93990.30
+    assert status["paper"]["total_pnl_today"] == -14.0
+    assert status["paper"]["realized_pnl_today"] == -2.0
+    assert status["paper"]["unrealized_pnl_today"] == -12.0
+    assert status["paper"]["fills_today_count"] == 3
+    assert status["paper"]["positions_count"] == 4
 
 
 def test_build_public_status_fails_closed_when_weekly_gate_and_lifetime_ledger_conflict(

--- a/tests/test_trade_gateway.py
+++ b/tests/test_trade_gateway.py
@@ -10,6 +10,7 @@ Tests key gateway functionality:
 These tests ensure the gateway properly rejects risky trades.
 """
 
+from datetime import datetime as real_datetime
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -121,6 +122,7 @@ class TestTradeGatewayLiquidityCheck:
             is_spread=True,  # Mark as spread to pass checklist (debit spread)
             max_loss=200.0,  # Within 5% of $50000 equity
             dte=35,  # Within 30-45 DTE range
+            request_time=real_datetime(2026, 5, 11),
         )
         decision = gateway.evaluate(request)
 
@@ -177,6 +179,7 @@ class TestTradeGatewayIVRankCheck:
             source="test",
             strategy_type="iron_condor",
             iv_rank=60.0,
+            request_time=real_datetime(2026, 5, 11),
         )
         decision = gateway.evaluate(request)
 
@@ -198,6 +201,7 @@ class TestTradeGatewayCapitalEfficiency:
             source="test",
             strategy_type="iron_condor",
             iv_rank=50.0,
+            request_time=real_datetime(2026, 5, 11),
         )
         decision = gateway.evaluate(request)
 
@@ -216,6 +220,7 @@ class TestTradeGatewayCapitalEfficiency:
             source="test",
             strategy_type="iron_condor",
             iv_rank=50.0,
+            request_time=real_datetime(2026, 5, 11),
         )
         decision = gateway.evaluate(request)
 
@@ -303,9 +308,6 @@ class TestEarningsBlackoutEnforcement:
             mock_dt.now.return_value.date.return_value = type(
                 "Date", (), {"__le__": lambda s, o: True, "__ge__": lambda s, o: True}
             )()
-            # Use actual date parsing
-            from datetime import datetime as real_datetime
-
             mock_dt.strptime = real_datetime.strptime
             mock_dt.now.return_value = real_datetime(2026, 1, 25)  # During blackout
 
@@ -314,6 +316,7 @@ class TestEarningsBlackoutEnforcement:
                 side="buy",
                 notional=500,
                 source="test",
+                request_time=real_datetime(2026, 1, 25),
             )
             decision = gateway.evaluate(request)
 
@@ -327,8 +330,6 @@ class TestEarningsBlackoutEnforcement:
         gateway.TICKER_WHITELIST_ENABLED = False
 
         with patch("src.risk.trade_gateway.datetime") as mock_dt:
-            from datetime import datetime as real_datetime
-
             mock_dt.strptime = real_datetime.strptime
             mock_dt.now.return_value = real_datetime(2026, 1, 28)  # During blackout
 
@@ -339,6 +340,7 @@ class TestEarningsBlackoutEnforcement:
                 quantity=1,
                 source="test",
                 is_option=True,
+                request_time=real_datetime(2026, 1, 28),
             )
             decision = gateway.evaluate(request)
 
@@ -352,8 +354,6 @@ class TestEarningsBlackoutEnforcement:
         gateway.TICKER_WHITELIST_ENABLED = False
 
         with patch("src.risk.trade_gateway.datetime") as mock_dt:
-            from datetime import datetime as real_datetime
-
             mock_dt.strptime = real_datetime.strptime
             mock_dt.now.return_value = real_datetime(2026, 2, 5)  # During F blackout (Feb 3-11)
 
@@ -362,6 +362,7 @@ class TestEarningsBlackoutEnforcement:
                 side="buy",
                 notional=500,
                 source="test",
+                request_time=real_datetime(2026, 2, 5),
             )
             decision = gateway.evaluate(request)
 
@@ -378,6 +379,7 @@ class TestEarningsBlackoutEnforcement:
             side="buy",
             notional=500,
             source="test",
+            request_time=real_datetime(2026, 5, 11),
         )
         decision = gateway.evaluate(request)
 
@@ -387,14 +389,21 @@ class TestEarningsBlackoutEnforcement:
     def test_check_earnings_blackout_method(self):
         """Test the _check_earnings_blackout method directly.
 
-        SOFI/F blackout dates (Jan-Feb 2026) have passed. SPY should never be blocked.
+        SPY has no earnings, but new entries are blocked around FOMC announcements.
         """
         gateway = TradeGateway(executor=None, paper=True)
 
-        # SPY should never be in earnings blackout
-        is_blocked, reason = gateway._check_earnings_blackout("SPY")
+        is_blocked, reason = gateway._check_earnings_blackout(
+            "SPY", as_of=real_datetime(2026, 5, 11)
+        )
         assert not is_blocked
         assert reason == ""
+
+        is_blocked, reason = gateway._check_earnings_blackout(
+            "SPY", as_of=real_datetime(2026, 5, 4)
+        )
+        assert is_blocked
+        assert "FOMC blackout 2026-05-04 to 2026-05-07" in reason
 
 
 class TestEarningsPositionMonitor:

--- a/tests/unit/test_ic_simple.py
+++ b/tests/unit/test_ic_simple.py
@@ -704,7 +704,9 @@ class TestE2EPipeline:
         with patch(
             "src.utils.regime_detector.RegimeDetector.detect_live_regime_with_prediction",
             return_value=_Snapshot(),
-        ), patch.object(Path, "read_text", _patched_read):
+        ), patch.object(Path, "read_text", _patched_read), patch(
+            "scripts.ic_simple._fomc_blackout_reason", return_value=None
+        ):
             ic.main()
 
         # Verify order was submitted


### PR DESCRIPTION
## Summary
- salvage the useful code from the stale north-star refresh worktree
- choose the freshest broker snapshot between runtime and scorecard data when building public status
- surface realized/unrealized/fill details when the freshest snapshot has them
- regenerate public status from current main data

## Evidence
- uv run pytest tests/test_build_public_status.py
- python3 scripts/build_public_status.py --check
- trunk check scripts/build_public_status.py tests/test_build_public_status.py docs/data/public_status.json --ci
- actionlint .github/workflows/openrouter-price-monitor.yml

Cleanup note: this intentionally excludes stale April broker-data commits from chore/north-star-refresh-20260423.