### PR TITLE
fix: stage pre-market public surfaces

### DIFF
--- a/.github/workflows/pre-market-sync.yml
+++ b/.github/workflows/pre-market-sync.yml
@@ -7,8 +7,8 @@ on:
   workflow_dispatch: # Allow manual trigger
 
 concurrency:
-  group: pre-market-sync-${{ github.ref }}
-  cancel-in-progress: true
+  group: ${{ format('state-writer-{0}-{1}', github.repository, github.ref_name || 'main') }}
+  cancel-in-progress: false
 
 permissions:
   contents: write # Required to push commits
@@ -26,6 +26,11 @@ jobs:
         with:
           token: ${{ secrets.GH_PAT || github.token }}
           fetch-depth: 0
+
+      - name: Refresh to latest main
+        run: |
+          git fetch origin main
+          git checkout -B main origin/main
 
       - name: Set up Python
         uses: actions/setup-python@v6
@@ -69,16 +74,18 @@ jobs:
 
       - name: Commit sync data
         run: |
+          set -euo pipefail
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add data/system_state.json data/heartbeat.json data/runtime/
+          git add data/system_state.json data/heartbeat.json data/runtime/ docs/data/public_status.json
+          git add -f wiki/Home.md wiki/Progress-Dashboard.md wiki/Development-Engine-and-Evidence.md
           if git diff --staged --quiet; then
             echo "No changes to commit"
           else
             git commit -m "chore: pre-market data sync $(date +%Y-%m-%d)"
-            git pull --rebase origin main || git rebase --abort
             if [ -n "${{ secrets.GH_PAT }}" ]; then
               git remote set-url origin "https://x-access-token:${{ secrets.GH_PAT }}@github.com/${{ github.repository }}.git"
             fi
-            git push origin HEAD:main || echo "Push failed (protected branch or conflict)"
+            git pull --ff-only origin main
+            git push origin HEAD:main
           fi

--- a/docs/data/public_status.json
+++ b/docs/data/public_status.json
@@ -1,16 +1,16 @@
 {
-  "generated_at_et": "2026-05-04T15:43:42.889540+00:00",
+  "generated_at_et": "2026-05-04T15:43:40.297046+00:00",
   "system": {
     "name": "SPY Options Validation Platform",
     "tagline": "Broker-backed scorecards, hard risk gates, paired-trade accounting, and live operator surfaces.",
     "public_status": "validation_reset"
   },
   "paper": {
-    "equity": 93576.7,
-    "total_pnl_today": -15.0,
-    "realized_pnl_today": 0.0,
-    "unrealized_pnl_today": -15.0,
-    "fills_today_count": 0,
+    "equity": 93574.7,
+    "total_pnl_today": -17.0,
+    "realized_pnl_today": null,
+    "unrealized_pnl_today": null,
+    "fills_today_count": null,
     "positions_count": 8
   },
   "live": {
@@ -26,7 +26,7 @@
     "profit_factor": 0.24,
     "total_realized_pnl": -3669.0,
     "expectancy_per_trade": -54.7612,
-    "last_updated": "2026-05-04T15:43:42.889529+00:00"
+    "last_updated": "2026-05-04T14:40:47.128299+00:00"
   },
   "gate": {
     "mode": "validation_reset",
@@ -50,7 +50,7 @@
     "lifetime_total_realized_pnl": -3669.0
   },
   "narrative": {
-    "summary": "Latest tracked broker sync shows $-15.00 today with 8 open paper positions. Use the operator scorecard for realized/unrealized and leg-level decomposition.",
+    "summary": "Latest tracked broker sync shows $-17.00 today with 8 open paper positions. Use the operator scorecard for realized/unrealized and leg-level decomposition.",
     "thesis": "This project is currently a paper-first validation platform, not a proven passive-income engine. Public surfaces should show current gate state and broker-backed evidence rather than frozen claims."
   },
   "links": {

--- a/tests/test_workflow_contracts.py
+++ b/tests/test_workflow_contracts.py
@@ -221,6 +221,24 @@ def test_state_writer_workflows_refresh_to_latest_main_before_mutating_state():
     assert "git checkout -B main origin/main" in ic_text
 
 
+def test_pre_market_sync_commits_all_generated_surfaces_fail_closed():
+    """Pre-market sync must not leave generated public surfaces unstaged or hide push failures."""
+    workflow_text = Path(".github/workflows/pre-market-sync.yml").read_text()
+
+    assert "state-writer-{0}-{1}" in workflow_text
+    assert "cancel-in-progress: false" in workflow_text
+    assert "name: Refresh to latest main" in workflow_text
+    assert "git checkout -B main origin/main" in workflow_text
+    assert "set -euo pipefail" in workflow_text
+    assert "docs/data/public_status.json" in workflow_text
+    assert "wiki/Home.md" in workflow_text
+    assert "wiki/Progress-Dashboard.md" in workflow_text
+    assert "wiki/Development-Engine-and-Evidence.md" in workflow_text
+    assert "git pull --ff-only origin main" in workflow_text
+    assert "git push origin HEAD:main ||" not in workflow_text
+    assert "git pull --rebase origin main" not in workflow_text
+
+
 def test_public_surface_guard_workflow_exists():
     """Public-facing copy must have its own lightweight guard workflow."""
     workflow_text = Path(".github/workflows/public-surface-guard.yml").read_text()

--- a/wiki/Development-Engine-and-Evidence.md
+++ b/wiki/Development-Engine-and-Evidence.md
@@ -1,6 +1,6 @@
 # Development Engine and Evidence
 
-Generated from canonical ledgers at `2026-05-04T15:43:42.889540+00:00`.
+Generated from canonical ledgers at `2026-05-04T15:43:40.297046+00:00`.
 
 This page explains how public-facing system copy stays congruent with live state.
 
@@ -19,7 +19,7 @@ This page explains how public-facing system copy stays congruent with live state
 
 ## Current Operator Summary
 
-- Paper equity: `$93,576.70`
+- Paper equity: `$93,574.70`
 - Total realized P/L ledger: `$-3,669.00`
 - Weekly gate mode: `validation_reset`
 - Block new positions: `False`

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -1,13 +1,13 @@
 # SPY Options Validation Platform Wiki
 
-Generated from canonical ledgers at `2026-05-04T15:43:42.889540+00:00`.
+Generated from canonical ledgers at `2026-05-04T15:43:40.297046+00:00`.
 
 This wiki is generated from the same source used by the public dashboard and repo copy. It should never carry frozen win-rate, equity, or trade-count claims that drift from the ledgers.
 
 ## Current Snapshot
 
 - Public status: `validation_reset`
-- Paper equity: `$93,576.70`
+- Paper equity: `$93,574.70`
 - Closed trades total: `67`
 - Total realized P/L: `$-3,669.00`
 - Weekly gate mode: `validation_reset`

--- a/wiki/Progress-Dashboard.md
+++ b/wiki/Progress-Dashboard.md
@@ -1,16 +1,16 @@
 # Progress Dashboard
 
-Generated from canonical ledgers at `2026-05-04T15:43:42.889540+00:00`.
+Generated from canonical ledgers at `2026-05-04T15:43:40.297046+00:00`.
 
 This page is generated from broker-backed scorecards and the canonical paired-trade ledger. If this page and the public dashboard diverge, the generated dashboard is the source of truth.
 
 ## Current Status
 
-- Paper equity: `$93,576.70`
-- Paper total P/L today: `$-15.00`
-- Paper realized P/L today: `$0.00`
-- Paper unrealized P/L today: `$-15.00`
-- Fills today: `0`
+- Paper equity: `$93,574.70`
+- Paper total P/L today: `$-17.00`
+- Paper realized P/L today: `n/a`
+- Paper unrealized P/L today: `n/a`
+- Fills today: `None`
 - Closed trades total: `67`
 - Total realized P/L: `$-3,669.00`
 - Win rate: `23.88%`


### PR DESCRIPTION
## Summary
- serialize pre-market sync with the shared state-writer queue
- refresh to latest main before mutating broker state
- stage generated public-status/wiki surfaces so rebase is not blocked by unstaged files
- fail closed on ff-only pull or push errors instead of hiding push failures
- refresh public surfaces from tracked canonical state

## Verification
- python3 scripts/build_public_status.py --check
- uv run pytest tests/test_build_public_status.py tests/test_workflow_contracts.py tests/test_workflow_dependencies.py tests/test_workflow_integrity.py
- trunk check .github/workflows/pre-market-sync.yml tests/test_workflow_contracts.py docs/data/public_status.json wiki/Home.md wiki/Progress-Dashboard.md wiki/Development-Engine-and-Evidence.md --ci
