### PR TITLE
chore: refresh public status after pre-market fix

### DIFF
--- a/docs/data/public_status.json
+++ b/docs/data/public_status.json
@@ -1,13 +1,13 @@
 {
-  "generated_at_et": "2026-05-04T15:43:40.297046+00:00",
+  "generated_at_et": "2026-05-04T15:48:07.004667+00:00",
   "system": {
     "name": "SPY Options Validation Platform",
     "tagline": "Broker-backed scorecards, hard risk gates, paired-trade accounting, and live operator surfaces.",
     "public_status": "validation_reset"
   },
   "paper": {
-    "equity": 93574.7,
-    "total_pnl_today": -17.0,
+    "equity": 93575.7,
+    "total_pnl_today": -16.0,
     "realized_pnl_today": null,
     "unrealized_pnl_today": null,
     "fills_today_count": null,
@@ -26,7 +26,7 @@
     "profit_factor": 0.24,
     "total_realized_pnl": -3669.0,
     "expectancy_per_trade": -54.7612,
-    "last_updated": "2026-05-04T14:40:47.128299+00:00"
+    "last_updated": "2026-05-04T15:48:06.237347+00:00"
   },
   "gate": {
     "mode": "validation_reset",
@@ -50,7 +50,7 @@
     "lifetime_total_realized_pnl": -3669.0
   },
   "narrative": {
-    "summary": "Latest tracked broker sync shows $-17.00 today with 8 open paper positions. Use the operator scorecard for realized/unrealized and leg-level decomposition.",
+    "summary": "Latest tracked broker sync shows $-16.00 today with 8 open paper positions. Use the operator scorecard for realized/unrealized and leg-level decomposition.",
     "thesis": "This project is currently a paper-first validation platform, not a proven passive-income engine. Public surfaces should show current gate state and broker-backed evidence rather than frozen claims."
   },
   "links": {

--- a/wiki/Development-Engine-and-Evidence.md
+++ b/wiki/Development-Engine-and-Evidence.md
@@ -1,6 +1,6 @@
 # Development Engine and Evidence
 
-Generated from canonical ledgers at `2026-05-04T15:43:40.297046+00:00`.
+Generated from canonical ledgers at `2026-05-04T15:48:07.004667+00:00`.
 
 This page explains how public-facing system copy stays congruent with live state.
 
@@ -19,7 +19,7 @@ This page explains how public-facing system copy stays congruent with live state
 
 ## Current Operator Summary
 
-- Paper equity: `$93,574.70`
+- Paper equity: `$93,575.70`
 - Total realized P/L ledger: `$-3,669.00`
 - Weekly gate mode: `validation_reset`
 - Block new positions: `False`

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -1,13 +1,13 @@
 # SPY Options Validation Platform Wiki
 
-Generated from canonical ledgers at `2026-05-04T15:43:40.297046+00:00`.
+Generated from canonical ledgers at `2026-05-04T15:48:07.004667+00:00`.
 
 This wiki is generated from the same source used by the public dashboard and repo copy. It should never carry frozen win-rate, equity, or trade-count claims that drift from the ledgers.
 
 ## Current Snapshot
 
 - Public status: `validation_reset`
-- Paper equity: `$93,574.70`
+- Paper equity: `$93,575.70`
 - Closed trades total: `67`
 - Total realized P/L: `$-3,669.00`
 - Weekly gate mode: `validation_reset`

--- a/wiki/Progress-Dashboard.md
+++ b/wiki/Progress-Dashboard.md
@@ -1,13 +1,13 @@
 # Progress Dashboard
 
-Generated from canonical ledgers at `2026-05-04T15:43:40.297046+00:00`.
+Generated from canonical ledgers at `2026-05-04T15:48:07.004667+00:00`.
 
 This page is generated from broker-backed scorecards and the canonical paired-trade ledger. If this page and the public dashboard diverge, the generated dashboard is the source of truth.
 
 ## Current Status
 
-- Paper equity: `$93,574.70`
-- Paper total P/L today: `$-17.00`
+- Paper equity: `$93,575.70`
+- Paper total P/L today: `$-16.00`
 - Paper realized P/L today: `n/a`
 - Paper unrealized P/L today: `n/a`
 - Fills today: `None`


### PR DESCRIPTION
## Summary
- regenerate public status JSON and wiki surfaces from current canonical main state
- fix post-merge drift detected by scripts/build_public_status.py --check after #3933

## Verification
- python3 scripts/build_public_status.py --check
- uv run pytest tests/test_build_public_status.py tests/test_public_copy_freshness.py
- trunk check docs/data/public_status.json wiki/Home.md wiki/Progress-Dashboard.md wiki/Development-Engine-and-Evidence.md --ci