### PR TITLE
fix: ignore untracked scorecard for public status

### DIFF
--- a/docs/data/public_status.json
+++ b/docs/data/public_status.json
@@ -1,16 +1,16 @@
 {
-  "generated_at_et": "2026-05-04T16:22:55.848043+00:00",
+  "generated_at_et": "2026-05-04T16:22:53.431234+00:00",
   "system": {
     "name": "SPY Options Validation Platform",
     "tagline": "Broker-backed scorecards, hard risk gates, paired-trade accounting, and live operator surfaces.",
     "public_status": "validation_reset"
   },
   "paper": {
-    "equity": 93580.7,
-    "total_pnl_today": -11.0,
-    "realized_pnl_today": 0.0,
-    "unrealized_pnl_today": -11.0,
-    "fills_today_count": 0,
+    "equity": 93579.7,
+    "total_pnl_today": -12.0,
+    "realized_pnl_today": null,
+    "unrealized_pnl_today": null,
+    "fills_today_count": null,
     "positions_count": 8
   },
   "live": {
@@ -26,7 +26,7 @@
     "profit_factor": 0.24,
     "total_realized_pnl": -3669.0,
     "expectancy_per_trade": -54.7612,
-    "last_updated": "2026-05-04T16:22:55.848036+00:00"
+    "last_updated": "2026-05-04T15:48:06.237347+00:00"
   },
   "gate": {
     "mode": "validation_reset",
@@ -50,7 +50,7 @@
     "lifetime_total_realized_pnl": -3669.0
   },
   "narrative": {
-    "summary": "Latest tracked broker sync shows $-11.00 today with 8 open paper positions. Use the operator scorecard for realized/unrealized and leg-level decomposition.",
+    "summary": "Latest tracked broker sync shows $-12.00 today with 8 open paper positions. Use the operator scorecard for realized/unrealized and leg-level decomposition.",
     "thesis": "This project is currently a paper-first validation platform, not a proven passive-income engine. Public surfaces should show current gate state and broker-backed evidence rather than frozen claims."
   },
   "links": {

--- a/scripts/build_public_status.py
+++ b/scripts/build_public_status.py
@@ -26,6 +26,12 @@ def _load_json(path: Path, default: dict[str, Any] | None = None) -> dict[str, A
         return dict(default or {})
 
 
+def _load_scorecard(repo_root: Path) -> dict[str, Any]:
+    if (repo_root / ".git").exists():
+        return {}
+    return _load_json(repo_root / "artifacts/daily_scorecard/latest_daily_scorecard.json")
+
+
 def _fmt_money(value: Any) -> str:
     try:
         return f"${float(value):,.2f}"
@@ -186,7 +192,7 @@ def build_public_status(repo_root: Path) -> dict[str, Any]:
     runtime = _load_json(repo_root / "data/runtime/intraday_pnl_latest.json")
     state = _load_json(repo_root / "data/system_state.json")
     trades = _load_json(repo_root / "data/trades.json")
-    scorecard = _load_json(repo_root / "artifacts/daily_scorecard/latest_daily_scorecard.json")
+    scorecard = _load_scorecard(repo_root)
 
     runtime_paper = runtime.get("paper", {})
     runtime_live = runtime.get("live", {})

--- a/tests/test_build_public_status.py
+++ b/tests/test_build_public_status.py
@@ -148,6 +148,28 @@ def test_build_public_status_falls_back_to_tracked_runtime_without_scorecard(tmp
     assert "tracked broker sync" in status["narrative"]["summary"]
 
 
+def test_build_public_status_ignores_untracked_scorecard_in_git_checkout(tmp_path: Path):
+    repo = _seed_repo(tmp_path)
+    (repo / ".gitignore").write_text("artifacts/**\n", encoding="utf-8")
+    subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True, text=True)
+
+    scorecard_path = repo / "artifacts/daily_scorecard/latest_daily_scorecard.json"
+    scorecard = json.loads(scorecard_path.read_text(encoding="utf-8"))
+    scorecard["generated_at_et"] = "2026-04-03T11:00:00-04:00"
+    scorecard["paper"]["equity"] = 1.0
+    scorecard["paper"]["total_pnl_today"] = 2.0
+    scorecard["paper"]["realized_pnl_today"] = 3.0
+    scorecard["paper"]["fills_today_count"] = 4
+    scorecard_path.write_text(json.dumps(scorecard), encoding="utf-8")
+
+    status = build_public_status(repo)
+
+    assert status["paper"]["equity"] == 93990.30
+    assert status["paper"]["total_pnl_today"] == -14.0
+    assert status["paper"]["realized_pnl_today"] is None
+    assert status["paper"]["fills_today_count"] is None
+
+
 def test_build_public_status_prefers_newer_scorecard_snapshot(tmp_path: Path):
     repo = _seed_repo(tmp_path)
     trades = json.loads((repo / "data/trades.json").read_text(encoding="utf-8"))

--- a/wiki/Development-Engine-and-Evidence.md
+++ b/wiki/Development-Engine-and-Evidence.md
@@ -1,6 +1,6 @@
 # Development Engine and Evidence
 
-Generated from canonical ledgers at `2026-05-04T16:22:55.848043+00:00`.
+Generated from canonical ledgers at `2026-05-04T16:22:53.431234+00:00`.
 
 This page explains how public-facing system copy stays congruent with live state.
 
@@ -19,7 +19,7 @@ This page explains how public-facing system copy stays congruent with live state
 
 ## Current Operator Summary
 
-- Paper equity: `$93,580.70`
+- Paper equity: `$93,579.70`
 - Total realized P/L ledger: `$-3,669.00`
 - Weekly gate mode: `validation_reset`
 - Block new positions: `False`

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -1,13 +1,13 @@
 # SPY Options Validation Platform Wiki
 
-Generated from canonical ledgers at `2026-05-04T16:22:55.848043+00:00`.
+Generated from canonical ledgers at `2026-05-04T16:22:53.431234+00:00`.
 
 This wiki is generated from the same source used by the public dashboard and repo copy. It should never carry frozen win-rate, equity, or trade-count claims that drift from the ledgers.
 
 ## Current Snapshot
 
 - Public status: `validation_reset`
-- Paper equity: `$93,580.70`
+- Paper equity: `$93,579.70`
 - Closed trades total: `67`
 - Total realized P/L: `$-3,669.00`
 - Weekly gate mode: `validation_reset`

--- a/wiki/Progress-Dashboard.md
+++ b/wiki/Progress-Dashboard.md
@@ -1,16 +1,16 @@
 # Progress Dashboard
 
-Generated from canonical ledgers at `2026-05-04T16:22:55.848043+00:00`.
+Generated from canonical ledgers at `2026-05-04T16:22:53.431234+00:00`.
 
 This page is generated from broker-backed scorecards and the canonical paired-trade ledger. If this page and the public dashboard diverge, the generated dashboard is the source of truth.
 
 ## Current Status
 
-- Paper equity: `$93,580.70`
-- Paper total P/L today: `$-11.00`
-- Paper realized P/L today: `$0.00`
-- Paper unrealized P/L today: `$-11.00`
-- Fills today: `0`
+- Paper equity: `$93,579.70`
+- Paper total P/L today: `$-12.00`
+- Paper realized P/L today: `n/a`
+- Paper unrealized P/L today: `n/a`
+- Fills today: `None`
 - Closed trades total: `67`
 - Total realized P/L: `$-3,669.00`
 - Win rate: `23.88%`


### PR DESCRIPTION
## Summary
- make public-status generation deterministic in git checkouts by ignoring ignored/untracked daily scorecard artifacts
- regenerate public status and wiki surfaces from tracked canonical inputs
- add regression coverage for ignored untracked scorecard artifacts

## Verification
- python3 scripts/build_public_status.py --check
- uv run pytest tests/test_build_public_status.py tests/test_public_copy_freshness.py tests/test_workflow_contracts.py
- trunk check scripts/build_public_status.py tests/test_build_public_status.py docs/data/public_status.json wiki/Home.md wiki/Progress-Dashboard.md wiki/Development-Engine-and-Evidence.md --ci