### PR TITLE
fix: keep sync public surfaces ledger-clean

### DIFF
--- a/.github/workflows/sync-alpaca-status.yml
+++ b/.github/workflows/sync-alpaca-status.yml
@@ -74,6 +74,14 @@ jobs:
           python3 scripts/post_market_analysis.py || echo "⚠️ Post-market analysis failed"
           python3 scripts/update_north_star_operating_plan.py || echo "⚠️ North Star operating plan update failed"
 
+      - name: Restore IC-owned ledger before public surfaces
+        run: |
+          set -euo pipefail
+          # sync_closed_positions.py may refresh data/trades.json for learning, but
+          # Sync Alpaca does not own or commit that ledger. Public surfaces must be
+          # generated from committed inputs only.
+          git restore data/trades.json
+
       - name: Build public status surfaces
         env:
           ALPACA_PAPER_TRADING_API_KEY: ${{ secrets.ALPACA_PAPER_TRADING_API_KEY }}

--- a/docs/data/public_status.json
+++ b/docs/data/public_status.json
@@ -1,5 +1,5 @@
 {
-  "generated_at_et": "2026-05-04T20:27:33.674341+00:00",
+  "generated_at_et": "2026-05-04T20:27:30.685106+00:00",
   "system": {
     "name": "SPY Options Validation Platform",
     "tagline": "Broker-backed scorecards, hard risk gates, paired-trade accounting, and live operator surfaces.",
@@ -26,7 +26,7 @@
     "profit_factor": 0.24,
     "total_realized_pnl": -3669.0,
     "expectancy_per_trade": -54.7612,
-    "last_updated": "2026-05-04T20:27:33.674334+00:00"
+    "last_updated": "2026-05-04T20:04:47.357196+00:00"
   },
   "gate": {
     "mode": "validation_reset",

--- a/tests/test_workflow_contracts.py
+++ b/tests/test_workflow_contracts.py
@@ -178,6 +178,11 @@ def test_sync_alpaca_status_updates_public_surfaces():
     assert "docs/data/public_status.json" in workflow_text
     assert "wiki/Progress-Dashboard.md" in workflow_text
     assert "gh repo edit" in workflow_text
+    assert "name: Restore IC-owned ledger before public surfaces" in workflow_text
+    assert "git restore data/trades.json" in workflow_text
+    assert workflow_text.index("git restore data/trades.json") < workflow_text.index(
+        "scripts/build_public_status.py --repo-root ."
+    )
     # ML models are now owned by IC Simple, not Sync Alpaca (commit race fix)
     assert "models/ml/trade_confidence_model.json" not in workflow_text
 

--- a/wiki/Development-Engine-and-Evidence.md
+++ b/wiki/Development-Engine-and-Evidence.md
@@ -1,6 +1,6 @@
 # Development Engine and Evidence
 
-Generated from canonical ledgers at `2026-05-04T20:27:33.674341+00:00`.
+Generated from canonical ledgers at `2026-05-04T20:27:30.685106+00:00`.
 
 This page explains how public-facing system copy stays congruent with live state.
 

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -1,6 +1,6 @@
 # SPY Options Validation Platform Wiki
 
-Generated from canonical ledgers at `2026-05-04T20:27:33.674341+00:00`.
+Generated from canonical ledgers at `2026-05-04T20:27:30.685106+00:00`.
 
 This wiki is generated from the same source used by the public dashboard and repo copy. It should never carry frozen win-rate, equity, or trade-count claims that drift from the ledgers.
 

--- a/wiki/Progress-Dashboard.md
+++ b/wiki/Progress-Dashboard.md
@@ -1,6 +1,6 @@
 # Progress Dashboard
 
-Generated from canonical ledgers at `2026-05-04T20:27:33.674341+00:00`.
+Generated from canonical ledgers at `2026-05-04T20:27:30.685106+00:00`.
 
 This page is generated from broker-backed scorecards and the canonical paired-trade ledger. If this page and the public dashboard diverge, the generated dashboard is the source of truth.
 


### PR DESCRIPTION
## Summary
- restore Sync Alpaca's uncommitted IC-owned trade ledger changes before public surface generation
- regenerate public status/wiki surfaces from committed inputs on current main
- add workflow contract coverage so Sync cannot publish surfaces from uncommitted data/trades.json

## Verification
- python3 scripts/build_public_status.py --check
- uv run pytest tests/test_build_public_status.py tests/test_public_copy_freshness.py tests/test_workflow_contracts.py
- trunk check .github/workflows/sync-alpaca-status.yml tests/test_workflow_contracts.py docs/data/public_status.json wiki/Home.md wiki/Progress-Dashboard.md wiki/Development-Engine-and-Evidence.md --ci