### PR TITLE
fix: restore ledger after scorecard sync

### DIFF
--- a/.github/workflows/sync-alpaca-status.yml
+++ b/.github/workflows/sync-alpaca-status.yml
@@ -91,6 +91,11 @@ jobs:
           REQUIRE_ALPACA_KEYS: "true"
         run: |
           python3 scripts/daily_scorecard.py --repo-root .
+          # daily_scorecard.py refreshes the paired ledger by default for
+          # operator artifacts, but Sync Alpaca does not own data/trades.json.
+          # Restore it again before building committed public surfaces.
+          git restore data/trades.json
+          git diff --quiet -- data/trades.json
           python3 scripts/build_public_status.py --repo-root .
 
       # DISABLED: ic_simple.py is the sole position manager (2026-04-01)

--- a/docs/data/public_status.json
+++ b/docs/data/public_status.json
@@ -1,5 +1,5 @@
 {
-  "generated_at_et": "2026-05-04T20:57:01.127254+00:00",
+  "generated_at_et": "2026-05-04T20:56:58.891861+00:00",
   "system": {
     "name": "SPY Options Validation Platform",
     "tagline": "Broker-backed scorecards, hard risk gates, paired-trade accounting, and live operator surfaces.",
@@ -26,7 +26,7 @@
     "profit_factor": 0.24,
     "total_realized_pnl": -3669.0,
     "expectancy_per_trade": -54.7612,
-    "last_updated": "2026-05-04T20:57:01.127247+00:00"
+    "last_updated": "2026-05-04T20:04:47.357196+00:00"
   },
   "gate": {
     "mode": "validation_reset",

--- a/tests/test_workflow_contracts.py
+++ b/tests/test_workflow_contracts.py
@@ -183,6 +183,13 @@ def test_sync_alpaca_status_updates_public_surfaces():
     assert workflow_text.index("git restore data/trades.json") < workflow_text.index(
         "scripts/build_public_status.py --repo-root ."
     )
+    assert workflow_text.index("scripts/daily_scorecard.py --repo-root .") < workflow_text.rindex(
+        "git restore data/trades.json"
+    )
+    assert "git diff --quiet -- data/trades.json" in workflow_text
+    assert workflow_text.index("git diff --quiet -- data/trades.json") < workflow_text.index(
+        "scripts/build_public_status.py --repo-root ."
+    )
     # ML models are now owned by IC Simple, not Sync Alpaca (commit race fix)
     assert "models/ml/trade_confidence_model.json" not in workflow_text
 

--- a/wiki/Development-Engine-and-Evidence.md
+++ b/wiki/Development-Engine-and-Evidence.md
@@ -1,6 +1,6 @@
 # Development Engine and Evidence
 
-Generated from canonical ledgers at `2026-05-04T20:57:01.127254+00:00`.
+Generated from canonical ledgers at `2026-05-04T20:56:58.891861+00:00`.
 
 This page explains how public-facing system copy stays congruent with live state.
 

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -1,6 +1,6 @@
 # SPY Options Validation Platform Wiki
 
-Generated from canonical ledgers at `2026-05-04T20:57:01.127254+00:00`.
+Generated from canonical ledgers at `2026-05-04T20:56:58.891861+00:00`.
 
 This wiki is generated from the same source used by the public dashboard and repo copy. It should never carry frozen win-rate, equity, or trade-count claims that drift from the ledgers.
 

--- a/wiki/Progress-Dashboard.md
+++ b/wiki/Progress-Dashboard.md
@@ -1,6 +1,6 @@
 # Progress Dashboard
 
-Generated from canonical ledgers at `2026-05-04T20:57:01.127254+00:00`.
+Generated from canonical ledgers at `2026-05-04T20:56:58.891861+00:00`.
 
 This page is generated from broker-backed scorecards and the canonical paired-trade ledger. If this page and the public dashboard diverge, the generated dashboard is the source of truth.
 


### PR DESCRIPTION
## Summary
- restore data/trades.json after daily_scorecard.py because that CLI refreshes the paired ledger internally
- fail closed with git diff --quiet before build_public_status.py can publish committed public surfaces
- repair current public status/wiki drift from the latest fixed sync commit

## Verification
- python3 scripts/build_public_status.py && python3 scripts/build_public_status.py --check
- uv run pytest tests/test_build_public_status.py tests/test_public_copy_freshness.py tests/test_workflow_contracts.py
- trunk check .github/workflows/sync-alpaca-status.yml tests/test_workflow_contracts.py docs/data/public_status.json wiki/Home.md wiki/Progress-Dashboard.md wiki/Development-Engine-and-Evidence.md --ci