### PR TITLE
fix: allow validation reset through legacy ML halt

### DIFF
--- a/.github/workflows/daily-trading.yml
+++ b/.github/workflows/daily-trading.yml
@@ -134,6 +134,34 @@ jobs:
 
           # Check 2: TRADING_HALTED file (LL-282 circuit breaker)
           if [ -f "data/TRADING_HALTED" ]; then
+            if python3 - <<'PY'
+          import json
+          from pathlib import Path
+
+          halt_text = Path("data/TRADING_HALTED").read_text(encoding="utf-8", errors="ignore")
+          state = json.loads(Path("data/system_state.json").read_text(encoding="utf-8"))
+          gate = state.get("north_star_weekly_gate") or {}
+
+          ml_halt = "ML GATE BLOCKED" in halt_text.upper()
+          validation_reset = str(gate.get("mode") or "").lower() == "validation_reset"
+          allow_validation = bool(gate.get("allow_validation_entries"))
+          live_blocked = bool(gate.get("block_live_new_positions"))
+          new_positions_blocked = bool(gate.get("block_new_positions"))
+
+          if ml_halt and validation_reset and allow_validation and live_blocked and not new_positions_blocked:
+              raise SystemExit(0)
+          raise SystemExit(1)
+          PY
+            then
+              echo "⚠️ Legacy ML halt is active, but validation_reset allows controlled paper validation"
+              echo "Reason:"
+              cat data/TRADING_HALTED
+              echo ""
+              echo "✅ Trading ALLOWED for controlled paper validation only; live/scaling remains blocked"
+              echo "halted=false" >> $GITHUB_OUTPUT
+              exit 0
+            fi
+
             echo "🚨 TRADING_HALTED file exists - crisis mode active"
             echo "Reason:"
             cat data/TRADING_HALTED

--- a/scripts/build_north_star_blocker_report.py
+++ b/scripts/build_north_star_blocker_report.py
@@ -119,6 +119,7 @@ def compute_report(
     state: dict[str, Any],
     weekly_history: list[dict[str, Any]],
     halt_exists: bool,
+    halt_reason: str = "",
     now_utc: datetime,
 ) -> dict[str, Any]:
     meta = state.get("meta", {}) if isinstance(state.get("meta"), dict) else {}
@@ -137,8 +138,36 @@ def compute_report(
     blockers: list[Blocker] = []
     warnings: list[Blocker] = []
     root_causes: list[str] = []
+    validation_reset_active = bool(
+        str(weekly_gate.get("mode") or "").strip().lower() == "validation_reset"
+        and _to_bool(weekly_gate.get("allow_validation_entries"), default=False)
+        and _to_bool(weekly_gate.get("block_live_new_positions"), default=False)
+        and not _to_bool(weekly_gate.get("block_new_positions"), default=False)
+    )
+    ml_halt_allows_validation = bool(
+        halt_exists
+        and validation_reset_active
+        and "ML GATE BLOCKED" in str(halt_reason or "").upper()
+    )
 
-    if halt_exists:
+    if ml_halt_allows_validation:
+        warnings.append(
+            Blocker(
+                id="ml_halt_validation_reset_bypass",
+                severity="warning",
+                message=(
+                    "Legacy ML halt is active, but controlled paper validation "
+                    "entries remain allowed."
+                ),
+                evidence=(
+                    "data/TRADING_HALTED contains an ML gate halt and "
+                    "north_star_weekly_gate is validation_reset with "
+                    "allow_validation_entries=true and block_live_new_positions=true."
+                ),
+            )
+        )
+        root_causes.append("Legacy ML halt still blocks live/scaling, but not paper validation.")
+    elif halt_exists:
         blockers.append(
             Blocker(
                 id="trading_halted",
@@ -524,6 +553,9 @@ def main() -> int:
         state=state,
         weekly_history=history,
         halt_exists=halt_file.exists(),
+        halt_reason=halt_file.read_text(encoding="utf-8", errors="ignore")
+        if halt_file.exists()
+        else "",
         now_utc=now_utc,
     )
     markdown = render_markdown(report)

--- a/tests/test_build_north_star_blocker_report.py
+++ b/tests/test_build_north_star_blocker_report.py
@@ -218,3 +218,45 @@ def test_compute_report_marks_live_block_only_validation_reset() -> None:
         "expectancy > 0" in item and "profit factor > 1" in item
         for item in report["action_lane"]["resolution_criteria"]
     )
+
+
+def test_compute_report_treats_ml_halt_as_validation_reset_warning() -> None:
+    now = datetime(2026, 5, 5, 12, 0, tzinfo=timezone.utc)
+    state = {
+        "meta": {"last_updated": "2026-05-05T11:30:00Z"},
+        "last_updated": "2026-05-05T11:30:00Z",
+        "north_star_weekly_gate": {
+            "updated_at": "2026-05-05T11:30:00Z",
+            "mode": "validation_reset",
+            "sample_size": 0,
+            "expectancy_per_trade": 0.0,
+            "block_new_positions": False,
+            "block_live_new_positions": True,
+            "allow_validation_entries": True,
+            "validation_reset_active": True,
+            "validation_reset_reason": "Legacy lifetime ledger remains negative.",
+            "cadence_kpi": {
+                "passed": False,
+                "summary": "Cadence KPI miss",
+                "qualified_setups_observed": 0,
+                "min_qualified_setups_per_week": 1,
+                "closed_trades_observed": 0,
+                "min_closed_trades_per_week": 1,
+            },
+        },
+    }
+
+    report = compute_report(
+        state=state,
+        weekly_history=[],
+        halt_exists=True,
+        halt_reason="ML GATE BLOCKED: Win rate 23.9% < 50.0%",
+        now_utc=now,
+    )
+
+    blocker_ids = {item["id"] for item in report["blockers"]}
+    warning_ids = {item["id"] for item in report["warnings"]}
+    assert "trading_halted" not in blocker_ids
+    assert "ml_halt_validation_reset_bypass" in warning_ids
+    assert report["action_lane"]["paper_validation_allowed"] is True
+    assert report["action_lane"]["live_scaling_blocked"] is True

--- a/tests/test_workflow_contracts.py
+++ b/tests/test_workflow_contracts.py
@@ -112,6 +112,8 @@ def test_daily_trading_workflow_checks_both_halt_sentinels():
     assert "data/TRADING_HALTED" in workflow_text
     assert "data/trading_halt.txt" in workflow_text
     assert "TRADING_HALTED file exists - crisis mode active" in workflow_text
+    assert "Legacy ML halt is active, but validation_reset allows controlled paper validation" in workflow_text
+    assert "Trading ALLOWED for controlled paper validation only" in workflow_text
     assert "manual halt active" in workflow_text
 
 


### PR DESCRIPTION
Unblocks the controlled paper-validation lane without enabling live/scaled trading.\n\nWhat changed:\n- Daily trading treats an ML GATE BLOCKED halt as bypassable only when north_star_weekly_gate is validation_reset, allow_validation_entries=true, block_live_new_positions=true, and block_new_positions=false.\n- North Star blocker report downgrades that specific legacy ML halt to a warning while keeping live/scaling and cadence blockers active.\n\nLocal verification:\n- trunk check .github/workflows/daily-trading.yml scripts/build_north_star_blocker_report.py tests/test_build_north_star_blocker_report.py tests/test_workflow_contracts.py --ci\n- uv run pytest tests/test_build_north_star_blocker_report.py tests/test_workflow_contracts.py::test_daily_trading_workflow_checks_both_halt_sentinels tests/test_mandatory_trade_gate.py::TestValidateTradeMandatory::test_ml_halt_allows_controlled_paper_validation_reset tests/test_mandatory_trade_gate.py::TestValidateTradeMandatory::test_ml_halt_still_blocks_live_or_scaling_entries\n- python3 scripts/build_public_status.py --check