### PR TITLE
chore: update OpenRouter pricing baseline

### DIFF
--- a/data/openrouter_pricing_baseline.json
+++ b/data/openrouter_pricing_baseline.json
@@ -1,32 +1,32 @@
 {
   "moonshotai/kimi-k2-0905": {
     "name": "Kimi K2",
-    "input_cost_per_1m": 0.39,
-    "output_cost_per_1m": 1.9,
-    "fetched_at": "2026-02-13T15:51:47.616519"
+    "input_cost_per_1m": 0.4,
+    "output_cost_per_1m": 2.0,
+    "fetched_at": "2026-05-05T11:28:26.646557"
   },
   "mistralai/mistral-medium-3": {
     "name": "Mistral Medium 3",
     "input_cost_per_1m": 0.4,
     "output_cost_per_1m": 2.0,
-    "fetched_at": "2026-02-13T15:51:47.616554"
+    "fetched_at": "2026-05-05T11:28:26.646645"
   },
   "qwen/qwen3-235b-a22b": {
     "name": "Qwen3 235B",
-    "input_cost_per_1m": 0.3,
-    "output_cost_per_1m": 1.2,
-    "fetched_at": "2026-02-13T15:51:47.616572"
+    "input_cost_per_1m": 0.455,
+    "output_cost_per_1m": 1.82,
+    "fetched_at": "2026-05-05T11:28:26.646719"
   },
   "deepseek/deepseek-r1": {
     "name": "DeepSeek-R1 (reasoning)",
     "input_cost_per_1m": 0.7,
     "output_cost_per_1m": 2.5,
-    "fetched_at": "2026-02-13T15:51:47.616588"
+    "fetched_at": "2026-05-05T11:28:26.646816"
   },
   "deepseek/deepseek-chat": {
     "name": "DeepSeek V3 (chat)",
-    "input_cost_per_1m": 0.3,
-    "output_cost_per_1m": 1.2,
-    "fetched_at": "2026-02-13T15:51:47.616600"
+    "input_cost_per_1m": 0.32,
+    "output_cost_per_1m": 0.89,
+    "fetched_at": "2026-05-05T11:28:26.646875"
   }
 }


### PR DESCRIPTION
Salvages the current OpenRouter pricing baseline from stale branch chore/openrouter-pricing-baseline-25373645549 without reverting #3941.\n\nLocal verification:\n- python3 -m json.tool data/openrouter_pricing_baseline.json\n- trunk check data/openrouter_pricing_baseline.json --ci (no applicable linters; data path ignored)