### PR TITLE
chore: refresh public status after exit-only check

### DIFF
--- a/docs/data/public_status.json
+++ b/docs/data/public_status.json
@@ -1,13 +1,13 @@
 {
-  "generated_at_et": "2026-05-05T15:42:04.669174+00:00",
+  "generated_at_et": "2026-05-05T15:50:54.053926+00:00",
   "system": {
     "name": "SPY Options Validation Platform",
     "tagline": "Broker-backed scorecards, hard risk gates, paired-trade accounting, and live operator surfaces.",
     "public_status": "validation_reset"
   },
   "paper": {
-    "equity": 93523.7,
-    "total_pnl_today": -68.0,
+    "equity": 93521.7,
+    "total_pnl_today": -70.0,
     "realized_pnl_today": null,
     "unrealized_pnl_today": null,
     "fills_today_count": null,
@@ -26,7 +26,7 @@
     "profit_factor": 0.24,
     "total_realized_pnl": -3669.0,
     "expectancy_per_trade": -54.7612,
-    "last_updated": "2026-05-05T15:09:33.188803+00:00"
+    "last_updated": "2026-05-05T15:50:53.160137+00:00"
   },
   "gate": {
     "mode": "validation_reset",
@@ -50,7 +50,7 @@
     "lifetime_total_realized_pnl": -3669.0
   },
   "narrative": {
-    "summary": "Latest tracked broker sync shows $-68.00 today with 8 open paper positions. Use the operator scorecard for realized/unrealized and leg-level decomposition.",
+    "summary": "Latest tracked broker sync shows $-70.00 today with 8 open paper positions. Use the operator scorecard for realized/unrealized and leg-level decomposition.",
     "thesis": "This project is currently a paper-first validation platform, not a proven passive-income engine. Public surfaces should show current gate state and broker-backed evidence rather than frozen claims."
   },
   "links": {

--- a/wiki/Development-Engine-and-Evidence.md
+++ b/wiki/Development-Engine-and-Evidence.md
@@ -1,6 +1,6 @@
 # Development Engine and Evidence
 
-Generated from canonical ledgers at `2026-05-05T15:42:04.669174+00:00`.
+Generated from canonical ledgers at `2026-05-05T15:50:54.053926+00:00`.
 
 This page explains how public-facing system copy stays congruent with live state.
 
@@ -19,7 +19,7 @@ This page explains how public-facing system copy stays congruent with live state
 
 ## Current Operator Summary
 
-- Paper equity: `$93,523.70`
+- Paper equity: `$93,521.70`
 - Total realized P/L ledger: `$-3,669.00`
 - Weekly gate mode: `validation_reset`
 - Block new positions: `False`

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -1,13 +1,13 @@
 # SPY Options Validation Platform Wiki
 
-Generated from canonical ledgers at `2026-05-05T15:42:04.669174+00:00`.
+Generated from canonical ledgers at `2026-05-05T15:50:54.053926+00:00`.
 
 This wiki is generated from the same source used by the public dashboard and repo copy. It should never carry frozen win-rate, equity, or trade-count claims that drift from the ledgers.
 
 ## Current Snapshot
 
 - Public status: `validation_reset`
-- Paper equity: `$93,523.70`
+- Paper equity: `$93,521.70`
 - Closed trades total: `67`
 - Total realized P/L: `$-3,669.00`
 - Weekly gate mode: `validation_reset`

--- a/wiki/Progress-Dashboard.md
+++ b/wiki/Progress-Dashboard.md
@@ -1,13 +1,13 @@
 # Progress Dashboard
 
-Generated from canonical ledgers at `2026-05-05T15:42:04.669174+00:00`.
+Generated from canonical ledgers at `2026-05-05T15:50:54.053926+00:00`.
 
 This page is generated from broker-backed scorecards and the canonical paired-trade ledger. If this page and the public dashboard diverge, the generated dashboard is the source of truth.
 
 ## Current Status
 
-- Paper equity: `$93,523.70`
-- Paper total P/L today: `$-68.00`
+- Paper equity: `$93,521.70`
+- Paper total P/L today: `$-70.00`
 - Paper realized P/L today: `n/a`
 - Paper unrealized P/L today: `n/a`
 - Fills today: `None`


### PR DESCRIPTION
## Summary
- Refresh public status and wiki surfaces after exit-only IC Simple run 25386777329.
- Reflect latest broker-backed paper equity and daily P/L after the run held both open ICs.

## Verification
- python3 scripts/build_public_status.py && python3 scripts/build_public_status.py --check
- trunk check --force docs/data/public_status.json wiki/Home.md wiki/Progress-Dashboard.md wiki/Development-Engine-and-Evidence.md --ci
