### PR TITLE
fix: enforce IC same-expiry loss block

### DIFF
--- a/scripts/ic_simple.py
+++ b/scripts/ic_simple.py
@@ -1082,6 +1082,46 @@ def _allows_controlled_paper_validation_entry() -> bool:
     )
 
 
+def _load_losing_expiries(trades_file: Path | None = None) -> set[str]:
+    """Return IC expiries that already produced a closed loss."""
+    path = trades_file or TRADE_LEDGER_FILE
+    try:
+        trades_data = json.loads(path.read_text(encoding="utf-8")) if path.exists() else {}
+    except Exception as exc:
+        logger.debug(f"Re-entry check skipped: {exc}")
+        return set()
+
+    closed = trades_data.get("trades", []) if isinstance(trades_data, dict) else []
+    losing_expiries: set[str] = set()
+    for trade in closed:
+        if not isinstance(trade, dict):
+            continue
+
+        realized_raw = trade.get("realized_pnl", 0)
+        try:
+            realized_pnl = float(realized_raw)
+        except (TypeError, ValueError):
+            realized_pnl = 0.0
+
+        outcome = str(trade.get("outcome", "")).strip().lower()
+        if realized_pnl >= 0 and outcome != "loss":
+            continue
+
+        legs = trade.get("legs")
+        if isinstance(legs, dict):
+            expiry = str(legs.get("expiry") or "").strip()
+            if expiry:
+                losing_expiries.add(expiry)
+                continue
+
+        signature = str(trade.get("signature") or "")
+        parts = signature.split("_")
+        if len(parts) >= 2 and parts[0] == "SPY" and parts[1]:
+            losing_expiries.add(parts[1])
+
+    return losing_expiries
+
+
 def _should_skip_for_thompson(confidence: float) -> tuple[bool, str]:
     if confidence >= THOMPSON_MIN_CONFIDENCE:
         return False, (f"Thompson confidence {confidence:.3f} >= {THOMPSON_MIN_CONFIDENCE:.2f}")
@@ -1401,23 +1441,9 @@ def main():
             regime_blocked = True
 
         # SAME-EXPIRY RE-ENTRY BLOCK: no re-entry on an expiry that already lost
-        reentry_blocked = False
-        try:
-            trades_file = Path(__file__).parent.parent / "data" / "trades.json"
-            trades_data = json.loads(trades_file.read_text()) if trades_file.exists() else {}
-            closed = trades_data.get("trades", []) if isinstance(trades_data, dict) else []
-            losing_expiries = set()
-            for t in closed:
-                if t.get("realized_pnl", 0) < 0:
-                    sig = t.get("signature", "")
-                    # Extract expiry from signature like "SPY_2026-05-08_P628-638_C712-715"
-                    parts = sig.split("_")
-                    if len(parts) >= 2:
-                        losing_expiries.add(parts[1] if parts[0] == "SPY" else "")
-            if losing_expiries:
-                logger.info(f"Losing expiries (re-entry blocked): {losing_expiries}")
-        except Exception as e:
-            logger.debug(f"Re-entry check skipped: {e}")
+        losing_expiries = _load_losing_expiries()
+        if losing_expiries:
+            logger.info(f"Losing expiries (re-entry blocked): {losing_expiries}")
 
         # BROKER SYNC FRESHNESS GATE: no entry if sync is stale (>2h)
         sync_blocked = False
@@ -1481,7 +1507,7 @@ def main():
                 logger.info(f"Position limit: {ic_count}/{MAX_IC} ICs. No new entry.")
             else:
                 opp = find_opportunity(spy_price)
-                if opp and reentry_blocked and opp.get("expiry", "") in losing_expiries:
+                if opp and opp.get("expiry", "") in losing_expiries:
                     logger.warning(
                         f"RE-ENTRY BLOCKED: expiry {opp['expiry']} already had a losing trade. "
                         f"No same-expiry re-entry after loss."

--- a/tests/unit/test_ic_simple.py
+++ b/tests/unit/test_ic_simple.py
@@ -517,9 +517,7 @@ class TestThompsonValidationResetGate:
         assert should_skip is True
         assert "skip entry" in reason
 
-    def test_low_thompson_allows_controlled_paper_validation_reset(
-        self, tmp_path, monkeypatch
-    ):
+    def test_low_thompson_allows_controlled_paper_validation_reset(self, tmp_path, monkeypatch):
         import scripts.ic_simple as ic
 
         state_file = tmp_path / "system_state.json"
@@ -544,7 +542,51 @@ class TestThompsonValidationResetGate:
 
 
 # ══════════════════════════════════════════════════════════════════════════════
-# 6. Reporting: validation slice must not mask lifetime ledger
+# 6. Same-expiry re-entry loss block
+# ══════════════════════════════════════════════════════════════════════════════
+
+
+class TestSameExpiryReentryBlock:
+    def test_load_losing_expiries_from_signature_and_legs(self, tmp_path):
+        import scripts.ic_simple as ic
+
+        trades_file = tmp_path / "trades.json"
+        trades_file.write_text(
+            json.dumps(
+                {
+                    "trades": [
+                        {
+                            "strategy": "iron_condor",
+                            "status": "closed",
+                            "realized_pnl": -42.0,
+                            "signature": "SPY_2026-05-15_P628-638_C712-715",
+                        },
+                        {
+                            "strategy": "iron_condor",
+                            "status": "closed",
+                            "outcome": "loss",
+                            "realized_pnl": "0",
+                            "legs": {"expiry": "2026-05-22"},
+                        },
+                        {
+                            "strategy": "iron_condor",
+                            "status": "closed",
+                            "realized_pnl": 31.0,
+                            "signature": "SPY_2026-05-29_P620-630_C720-730",
+                        },
+                    ]
+                }
+            )
+        )
+
+        assert ic._load_losing_expiries(trades_file) == {  # nosec B101
+            "2026-05-15",
+            "2026-05-22",
+        }
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# 7. Reporting: validation slice must not mask lifetime ledger
 # ══════════════════════════════════════════════════════════════════════════════
 
 
@@ -619,7 +661,7 @@ class TestNorthStarReadinessReport:
 
 
 # ══════════════════════════════════════════════════════════════════════════════
-# 7. E2E: Full pipeline mock
+# 8. E2E: Full pipeline mock
 # ══════════════════════════════════════════════════════════════════════════════
 
 
@@ -690,22 +732,26 @@ class TestE2EPipeline:
         import json
         from datetime import datetime, timezone
 
-        fresh_sync = {"sync_health": {"last_successful_sync": datetime.now(timezone.utc).isoformat()}}
+        fresh_sync = {
+            "sync_health": {"last_successful_sync": datetime.now(timezone.utc).isoformat()}
+        }
         original_read = Path.read_text
 
-        def _patched_read(self):
+        def _patched_read(self, *args, **kwargs):
             if "system_state" in str(self):
                 return json.dumps(fresh_sync)
             if "trades.json" in str(self):
                 return json.dumps({"trades": []})
-            return original_read(self)
+            return original_read(self, *args, **kwargs)
 
         sys.argv = ["ic_simple.py", "--mode", "both"]
-        with patch(
-            "src.utils.regime_detector.RegimeDetector.detect_live_regime_with_prediction",
-            return_value=_Snapshot(),
-        ), patch.object(Path, "read_text", _patched_read), patch(
-            "scripts.ic_simple._fomc_blackout_reason", return_value=None
+        with (
+            patch(
+                "src.utils.regime_detector.RegimeDetector.detect_live_regime_with_prediction",
+                return_value=_Snapshot(),
+            ),
+            patch.object(Path, "read_text", _patched_read),
+            patch("scripts.ic_simple._fomc_blackout_reason", return_value=None),
         ):
             ic.main()
 
@@ -724,6 +770,84 @@ class TestE2EPipeline:
         assert abs(limit_price) == pytest.approx(2.45, abs=0.25), (
             f"Expected ~$2.45 limit (net $2.50 - $0.05), got ${abs(limit_price):.2f}"
         )
+
+    @patch("src.safety.mandatory_trade_gate.safe_submit_order")
+    @patch("scripts.ic_simple.find_opportunity")
+    @patch("scripts.ic_simple._get_thompson_confidence", return_value=0.90)
+    @patch("scripts.ic_simple._count_open_ics", return_value=0)
+    @patch("scripts.ic_simple._cancel_stale_orders")
+    @patch("scripts.ic_simple._refresh_canonical_state")
+    @patch("scripts.ic_simple.get_spy_price", return_value=650.0)
+    @patch("scripts.ic_simple.get_client")
+    def test_same_expiry_loss_blocks_entry(
+        self,
+        mock_client_fn,
+        mock_spy,
+        mock_refresh,
+        mock_stale,
+        mock_count,
+        mock_thompson,
+        mock_opp,
+        mock_submit,
+    ):
+        mock_client_fn.return_value = MagicMock()
+        mock_opp.return_value = {
+            "expiry": "2026-05-15",
+            "long_put": 610.0,
+            "short_put": 620.0,
+            "short_call": 680.0,
+            "long_call": 690.0,
+            "est_credit": 2.50,
+            "method": "live_delta",
+        }
+
+        import scripts.ic_simple as ic
+
+        class _Snapshot:
+            label = "calm"
+            regime_id = 0
+            confidence = 0.85
+            vix_level = 18.0
+            transition_prediction = None
+
+        import json
+        from datetime import datetime, timezone
+
+        fresh_sync = {
+            "sync_health": {"last_successful_sync": datetime.now(timezone.utc).isoformat()}
+        }
+        loss_ledger = {
+            "trades": [
+                {
+                    "strategy": "iron_condor",
+                    "status": "closed",
+                    "realized_pnl": -123.0,
+                    "signature": "SPY_2026-05-15_P628-638_C712-715",
+                }
+            ]
+        }
+        original_read = Path.read_text
+
+        def _patched_read(self, *args, **kwargs):
+            if "system_state" in str(self):
+                return json.dumps(fresh_sync)
+            if "trades.json" in str(self):
+                return json.dumps(loss_ledger)
+            return original_read(self, *args, **kwargs)
+
+        sys.argv = ["ic_simple.py", "--mode", "entry"]
+        with (
+            patch(
+                "src.utils.regime_detector.RegimeDetector.detect_live_regime_with_prediction",
+                return_value=_Snapshot(),
+            ),
+            patch.object(Path, "read_text", _patched_read),
+            patch("scripts.ic_simple._fomc_blackout_reason", return_value=None),
+        ):
+            ic.main()
+
+        assert mock_opp.called  # nosec B101
+        assert not mock_submit.called  # nosec B101
 
     @patch("scripts.ic_simple._save_entries")
     @patch("scripts.ic_simple._load_entries", return_value={})


### PR DESCRIPTION
## Summary
- fixes IC Simple same-expiry re-entry guard so prior losing expiries actually block new entries
- extracts losing-expiry ledger parsing for signatures and legs.expiry
- adds unit and E2E coverage proving a same-expiry loss prevents order submission

## Verification
- ruff format scripts/ic_simple.py tests/unit/test_ic_simple.py
- ruff check scripts/ic_simple.py tests/unit/test_ic_simple.py
- trunk check --force scripts/ic_simple.py tests/unit/test_ic_simple.py --ci
- pytest tests/test_behavioral_guard.py tests/unit/test_ic_simple.py -q

## Evidence
- local commit: 8736f5e64
- tests: 43 passed in 28.25s
- Trunk: No new issues on touched files

## Trading impact
This does not force a trade. It prevents repeating a same-expiry IC after that expiry already produced a closed loss, which supports the validation-reset kill/learning discipline.