### PR TITLE
Improve RAG ML ingestion quality signals

### DIFF
--- a/scripts/build_rag_query_index.py
+++ b/scripts/build_rag_query_index.py
@@ -91,6 +91,15 @@ def _extract_tags(text: str) -> list[str]:
     return []
 
 
+def _extract_frontmatter_tags(frontmatter: dict[str, str]) -> list[str]:
+    raw_tags = frontmatter.get("tags", "")
+    if not raw_tags:
+        return []
+    if raw_tags.startswith("[") and raw_tags.endswith("]"):
+        raw_tags = raw_tags[1:-1]
+    return [tag.strip().strip('"').strip("'") for tag in raw_tags.split(",") if tag.strip()]
+
+
 def _extract_summary(text: str) -> str:
     summary = _extract_field(
         re.compile(r"^##\s+Summary\s*\n(.*?)(?=\n##|\Z)", re.DOTALL | re.MULTILINE),
@@ -126,6 +135,16 @@ def _parse_date_value(raw: str) -> datetime | None:
         return None
 
 
+def _parse_utc_iso(raw: str) -> datetime | None:
+    try:
+        parsed = datetime.fromisoformat(raw.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
 def _has_explicit_time(raw: str) -> bool:
     return bool(re.search(r"(?:T|\s)\d{1,2}:\d{2}", raw))
 
@@ -136,6 +155,79 @@ def _to_utc_iso(dt: datetime) -> str:
     else:
         dt = dt.astimezone(timezone.utc)
     return dt.isoformat().replace("+00:00", "Z")
+
+
+def _source_age_days(source_dt: datetime | None, indexed_at_utc: str) -> int | None:
+    indexed_dt = _parse_utc_iso(indexed_at_utc)
+    if source_dt is None or indexed_dt is None:
+        return None
+    if source_dt.tzinfo is None:
+        source_dt = source_dt.replace(tzinfo=timezone.utc)
+    else:
+        source_dt = source_dt.astimezone(timezone.utc)
+    return max(0, (indexed_dt - source_dt).days)
+
+
+def _recency_score(age_days: int | None) -> float:
+    if age_days is None:
+        return 0.3
+    if age_days <= 1:
+        return 1.0
+    if age_days <= 7:
+        return 0.85
+    if age_days <= 30:
+        return 0.7
+    if age_days <= 90:
+        return 0.5
+    return 0.25
+
+
+def _metadata_completeness(
+    *,
+    title: str,
+    fallback_title: str,
+    date_raw: str,
+    category_label: str,
+    severity: str,
+    summary: str,
+    tags: list[str],
+) -> float:
+    checks = [
+        bool(title and title != fallback_title),
+        bool(date_raw),
+        bool(category_label),
+        bool(severity),
+        bool(summary),
+        bool(tags),
+    ]
+    return round(sum(checks) / len(checks), 3)
+
+
+def _confidence_score(
+    *,
+    metadata_completeness: float,
+    recency_score: float,
+    text: str,
+    summary: str,
+) -> float:
+    has_source_signal = bool(re.search(r"https?://|^##\s+Citations\b", text, re.MULTILINE))
+    content_score = 1.0 if len(summary) >= 80 or len(text) >= 800 else 0.55
+    citation_score = 1.0 if has_source_signal else 0.0
+    score = (
+        metadata_completeness * 0.45
+        + recency_score * 0.3
+        + citation_score * 0.15
+        + content_score * 0.1
+    )
+    return round(max(0.0, min(1.0, score)), 3)
+
+
+def _lifecycle_for_score(score: float) -> str:
+    if score >= 0.72:
+        return "active"
+    if score >= 0.45:
+        return "watch"
+    return "archive"
 
 
 def _infer_date_from_path(path: Path) -> datetime | None:
@@ -256,7 +348,25 @@ def _build_lesson_record(
     summary = _extract_summary(text)
     if not summary:
         summary = frontmatter.get("description", "")
-    tags = _extract_tags(text)
+    tags = list(dict.fromkeys([*_extract_frontmatter_tags(frontmatter), *_extract_tags(text)]))
+    age_source_dt = date_obj or _parse_utc_iso(source_mtime_utc)
+    source_age_days = _source_age_days(age_source_dt, indexed_at_utc)
+    recency_score = _recency_score(source_age_days)
+    metadata_completeness = _metadata_completeness(
+        title=title,
+        fallback_title=item_id,
+        date_raw=date_raw,
+        category_label=category_label or category,
+        severity=severity,
+        summary=summary,
+        tags=tags,
+    )
+    confidence_score = _confidence_score(
+        metadata_completeness=metadata_completeness,
+        recency_score=recency_score,
+        text=text,
+        summary=summary,
+    )
 
     return {
         "id": item_id,
@@ -270,6 +380,11 @@ def _build_lesson_record(
         "file": source_path,
         "event_timestamp_utc": event_timestamp_utc,
         "source_mtime_utc": source_mtime_utc,
+        "source_age_days": source_age_days,
+        "metadata_completeness": metadata_completeness,
+        "recency_score": recency_score,
+        "confidence_score": confidence_score,
+        "lifecycle": _lifecycle_for_score(confidence_score),
         "indexed_at_utc": indexed_at_utc,
         "_date_sort": date_obj.isoformat() if date_obj else "",
     }

--- a/scripts/update_ml_from_trades.py
+++ b/scripts/update_ml_from_trades.py
@@ -113,17 +113,31 @@ def _round_metric(value: float, digits: int = 2) -> float:
     return value if math.isinf(value) else round(value, digits)
 
 
+def _trade_pnl(trade: dict) -> tuple[float, bool]:
+    """Return numeric P/L and whether the row had a parseable explicit value."""
+    raw = trade.get("realized_pnl")
+    if raw is None:
+        raw = trade.get("pnl")
+    if raw is None or raw == "":
+        return 0.0, False
+    try:
+        return float(raw), True
+    except (TypeError, ValueError):
+        return 0.0, False
+
+
 def stats_from_trades(trades: list[dict]) -> dict:
     """Build the stats shape expected by the Thompson updater from trade rows."""
     wins: list[float] = []
     losses: list[float] = []
+    skipped_trades = 0
+    ambiguous_outcome_trades = 0
+    missing_pnl_trades = 0
     for trade in trades:
         outcome = str(trade.get("outcome") or "").strip().lower()
-        pnl = trade.get("realized_pnl", trade.get("pnl", 0)) or 0
-        try:
-            pnl_float = float(pnl)
-        except (TypeError, ValueError):
-            pnl_float = 0.0
+        pnl_float, has_parseable_pnl = _trade_pnl(trade)
+        if not has_parseable_pnl:
+            missing_pnl_trades += 1
 
         if outcome not in {"win", "loss"}:
             if pnl_float > 0:
@@ -131,6 +145,8 @@ def stats_from_trades(trades: list[dict]) -> dict:
             elif pnl_float < 0:
                 outcome = "loss"
             else:
+                ambiguous_outcome_trades += 1
+                skipped_trades += 1
                 continue
 
         if outcome == "win":
@@ -139,10 +155,14 @@ def stats_from_trades(trades: list[dict]) -> dict:
             losses.append(pnl_float)
 
     closed = len(wins) + len(losses)
+    input_trades = len(trades)
     win_rate = (len(wins) / closed * 100) if closed else 0.0
     gross_profit = sum(pnl for pnl in wins if pnl > 0)
     gross_loss = abs(sum(pnl for pnl in losses if pnl < 0))
     total_realized_pnl = sum(wins) + sum(losses)
+    quality_denominator = max(input_trades, 1)
+    quality_penalty = (skipped_trades + min(missing_pnl_trades, closed)) / quality_denominator
+    data_quality_score = round(max(0.0, 1.0 - quality_penalty), 3)
     if gross_loss > 0:
         profit_factor = gross_profit / gross_loss
     elif gross_profit > 0:
@@ -154,6 +174,11 @@ def stats_from_trades(trades: list[dict]) -> dict:
         "wins": len(wins),
         "losses": len(losses),
         "closed_trades": closed,
+        "input_trades": input_trades,
+        "skipped_trades": skipped_trades,
+        "ambiguous_outcome_trades": ambiguous_outcome_trades,
+        "missing_pnl_trades": missing_pnl_trades,
+        "data_quality_score": data_quality_score,
         "win_rate_pct": round(win_rate, 2),
         "avg_win": sum(wins) / len(wins) if wins else 0,
         "avg_loss": abs(sum(losses) / len(losses)) if losses else 0,

--- a/src/analytics/perplexity_trading_intel.py
+++ b/src/analytics/perplexity_trading_intel.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import argparse
 import asyncio
+import hashlib
 import json
 import os
 import re
@@ -296,6 +297,38 @@ def build_paths(repo_root: Path, mode: str, now: datetime) -> IntelPaths:
     )
 
 
+def _stable_event_id(payload: dict[str, Any]) -> str:
+    event_key = {
+        "event_type": "perplexity_trading_intel",
+        "generated_at_utc": payload.get("generated_at_utc"),
+        "mode": payload.get("mode"),
+        "model": payload.get("model"),
+        "risk_score": payload.get("risk_score"),
+        "recommendation": payload.get("recommendation"),
+        "query_keys": [item.get("key") for item in payload.get("queries", [])],
+    }
+    digest = hashlib.sha256(json.dumps(event_key, sort_keys=True).encode("utf-8")).hexdigest()
+    return f"perplexity_trading_intel:{digest[:16]}"
+
+
+def _append_jsonl_once(path: Path, event: dict[str, Any], key: str = "event_id") -> bool:
+    event_key = event.get(key)
+    if event_key and path.exists():
+        for line in path.read_text(encoding="utf-8").splitlines():
+            if not line.strip():
+                continue
+            try:
+                existing = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if existing.get(key) == event_key:
+                return False
+
+    with path.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(event, sort_keys=True) + "\n")
+    return True
+
+
 class PerplexityTradingIntelRunner:
     """Run Perplexity trading research and persist gate/RAG/ML artifacts."""
 
@@ -492,8 +525,7 @@ class PerplexityTradingIntelRunner:
             )
 
         paths.rag_lesson.write_text(render_rag_lesson(payload), encoding="utf-8")
-        with paths.ml_jsonl.open("a", encoding="utf-8") as handle:
-            handle.write(json.dumps(render_ml_event(payload), sort_keys=True) + "\n")
+        _append_jsonl_once(paths.ml_jsonl, render_ml_event(payload))
 
         return paths
 
@@ -544,19 +576,34 @@ def render_ml_event(payload: dict[str, Any]) -> dict[str, Any]:
     """Return one JSONL event for downstream ML/RAG pipelines."""
 
     context = payload.get("trading_context", {})
+    queries = payload.get("queries", [])
+    unique_citations = {
+        citation
+        for item in queries
+        for citation in item.get("citations", [])
+        if isinstance(citation, str) and citation
+    }
+    gate_contract = payload.get("gate_contract", {})
     return {
+        "event_id": _stable_event_id(payload),
         "event_type": "perplexity_trading_intel",
+        "source": "perplexity_trading_intel",
         "generated_at_utc": payload.get("generated_at_utc"),
         "mode": payload.get("mode"),
         "model": payload.get("model"),
         "api_status": payload.get("api_status"),
+        "fresh_for_minutes": payload.get("fresh_for_minutes"),
+        "query_count": len(queries),
+        "citation_count": len(unique_citations),
         "risk_score": payload.get("risk_score"),
         "recommendation": payload.get("recommendation"),
         "confidence": payload.get("confidence"),
-        "blocks_new_iron_condors": payload.get("gate_contract", {}).get("blocks_new_iron_condors"),
+        "blocks_new_iron_condors": gate_contract.get("blocks_new_iron_condors"),
+        "gate_reason": gate_contract.get("reason"),
         "equity": context.get("equity"),
         "win_rate_pct": context.get("win_rate_pct"),
         "profit_factor": context.get("profit_factor"),
+        "trading_context_snapshot": context,
     }
 
 

--- a/tests/test_build_rag_query_index.py
+++ b/tests/test_build_rag_query_index.py
@@ -164,3 +164,51 @@ A: Equity improved.
     assert lessons[0]["category"] == "analytics"
     assert lessons[0]["severity"] == "INFO"
     assert lessons[0]["date"] == "2026-03-13T20:00:00Z"
+
+
+def test_build_index_adds_retrieval_quality_metadata(tmp_path: Path, monkeypatch) -> None:
+    rag_root = tmp_path / "rag_knowledge"
+    monkeypatch.setattr(build_rag_query_index, "RAG_ROOT", rag_root)
+    monkeypatch.setattr(build_rag_query_index, "ADDITIONAL_MARKDOWN_SOURCES", [])
+
+    _write(
+        rag_root / "lessons_learned" / "ll_quality_rich.md",
+        """---
+title: "Quality Rich Lesson"
+description: "A structured lesson with enough metadata for retrieval ranking."
+date: 2026-05-06T14:00:00Z
+severity: HIGH
+category: ingestion
+tags: [rag, ingestion]
+---
+
+# Quality Rich Lesson
+
+## Summary
+This lesson has current metadata, source tags, and enough text to be trusted by retrieval.
+
+## Citations
+- https://example.com/source
+""",
+    )
+    _write(
+        rag_root / "lessons_learned" / "ll_stale_sparse_20200101.md",
+        """# Sparse Historical Lesson
+
+Thin stale note.
+""",
+    )
+
+    lessons = {lesson["id"]: lesson for lesson in build_rag_query_index.build_index()}
+
+    rich = lessons["ll_quality_rich"]
+    assert rich["source_age_days"] is not None  # nosec B101
+    assert rich["metadata_completeness"] >= 0.8  # nosec B101
+    assert rich["confidence_score"] >= 0.72  # nosec B101
+    assert rich["lifecycle"] == "active"  # nosec B101
+    assert {"rag", "ingestion"}.issubset(set(rich["tags"]))  # nosec B101
+
+    stale = lessons["ll_stale_sparse_20200101"]
+    assert stale["source_age_days"] > 90  # nosec B101
+    assert stale["recency_score"] == 0.25  # nosec B101
+    assert stale["lifecycle"] in {"watch", "archive"}  # nosec B101

--- a/tests/test_ml_feedback_loop.py
+++ b/tests/test_ml_feedback_loop.py
@@ -106,6 +106,28 @@ def test_validation_phase_stats_exclude_legacy_failure_cohort():
     assert stats["total_realized_pnl"] == 21.0
     assert stats["profit_factor"] == 2.05
     assert stats["expectancy_per_trade"] == 10.5
+    assert stats["data_quality_score"] == 1.0  # nosec B101
+
+
+def test_stats_from_trades_reports_incomplete_rows_without_counting_them_as_closed():
+    """Unresolved rows should be visible instead of silently changing priors."""
+    stats = stats_from_trades(
+        [
+            {"id": "win-by-pnl", "realized_pnl": 25},
+            {"id": "loss-by-outcome", "outcome": "loss", "realized_pnl": -10},
+            {"id": "open-no-pnl", "outcome": "open"},
+            {"id": "bad-pnl", "outcome": "win", "realized_pnl": "not-a-number"},
+        ]
+    )
+
+    assert stats["input_trades"] == 4  # nosec B101
+    assert stats["closed_trades"] == 3  # nosec B101
+    assert stats["wins"] == 2  # nosec B101
+    assert stats["losses"] == 1  # nosec B101
+    assert stats["skipped_trades"] == 1  # nosec B101
+    assert stats["ambiguous_outcome_trades"] == 1  # nosec B101
+    assert stats["missing_pnl_trades"] == 2  # nosec B101
+    assert stats["data_quality_score"] == 0.25  # nosec B101
 
 
 # --- Trading Gate Tests ---

--- a/tests/test_perplexity_trading_intel.py
+++ b/tests/test_perplexity_trading_intel.py
@@ -64,6 +64,7 @@ def test_dry_run_writes_json_rag_and_ml_artifacts(tmp_path: Path) -> None:
         now=datetime(2026, 4, 13, 13, 30, tzinfo=timezone.utc),
     )
     payload = asyncio.run(runner.run("pre_market"))
+    duplicate_payload = asyncio.run(runner.run("pre_market"))
 
     latest = tmp_path / "data" / "analysis" / "perplexity" / "pre_market_latest.json"
     trading_latest = tmp_path / "data" / "analysis" / "perplexity" / "trading_intel_latest.json"
@@ -72,6 +73,7 @@ def test_dry_run_writes_json_rag_and_ml_artifacts(tmp_path: Path) -> None:
     ml = tmp_path / "data" / "feedback" / "perplexity_intel_events.jsonl"
 
     assert payload["api_status"] == "dry_run"
+    assert duplicate_payload["api_status"] == "dry_run"  # nosec B101
     assert latest.exists()
     assert trading_latest.exists()
     assert legacy.exists()
@@ -81,4 +83,13 @@ def test_dry_run_writes_json_rag_and_ml_artifacts(tmp_path: Path) -> None:
     saved = json.loads(latest.read_text(encoding="utf-8"))
     assert saved["trading_context"]["equity"] == 93728.02
     assert saved["gate_contract"]["source"] == "perplexity_trading_intel"
-    assert "perplexity_trading_intel" in ml.read_text(encoding="utf-8")
+
+    ml_events = [json.loads(line) for line in ml.read_text(encoding="utf-8").splitlines()]
+    assert len(ml_events) == 1  # nosec B101
+    assert ml_events[0]["event_id"].startswith("perplexity_trading_intel:")  # nosec B101
+    assert ml_events[0]["source"] == "perplexity_trading_intel"  # nosec B101
+    assert ml_events[0]["query_count"] == len(PRE_MARKET_QUERIES)  # nosec B101
+    assert ml_events[0]["citation_count"] == 0  # nosec B101
+    assert ml_events[0]["fresh_for_minutes"] == 240  # nosec B101
+    assert ml_events[0]["gate_reason"] == saved["gate_contract"]["reason"]  # nosec B101
+    assert ml_events[0]["trading_context_snapshot"]["equity"] == 93728.02  # nosec B101


### PR DESCRIPTION
## Summary
- add RAG retrieval quality metadata: source age, recency, metadata completeness, confidence score, lifecycle
- add ML trade stats observability for skipped, ambiguous, and missing-P/L rows
- make Perplexity intel ML JSONL ingestion idempotent with stable event IDs and richer event metadata

## Verification
- ruff check scripts/build_rag_query_index.py scripts/update_ml_from_trades.py src/analytics/perplexity_trading_intel.py tests/test_build_rag_query_index.py tests/test_ml_feedback_loop.py tests/test_perplexity_trading_intel.py
- pytest tests/test_build_rag_query_index.py tests/test_ml_feedback_loop.py tests/test_perplexity_trading_intel.py -q
- trunk check --force scripts/build_rag_query_index.py scripts/update_ml_from_trades.py src/analytics/perplexity_trading_intel.py tests/test_build_rag_query_index.py tests/test_ml_feedback_loop.py tests/test_perplexity_trading_intel.py
- RAG_WRITE_PROFILE=local python3 scripts/build_rag_query_index.py
- python3 scripts/update_ml_from_trades.py --dry-run
- python3 -m src.analytics.perplexity_trading_intel --mode pre_market --dry-run --no-write