### PR TITLE
Require rehab coverage for validation hypotheses

### DIFF
--- a/data/runtime/strategy_validation_hypothesis.json
+++ b/data/runtime/strategy_validation_hypothesis.json
@@ -1,15 +1,28 @@
 {
   "enabled": true,
   "strategy_family": "ic_simple",
-  "hypothesis": "Restart only controlled paper validation for IC Simple after the failed legacy ledger, using live-delta SPY iron condors, minimum-size validation entries, stricter credit and regime filters, and hard cohort kill criteria to test whether the changed rules can restore positive expectancy.",
+  "hypothesis": "Restart only controlled paper validation for IC Simple after the failed legacy ledger by explicitly removing the current top loss clusters: no 10-wide wings, no multi-contract sizing, and no unmanaged sub-24-hour exits. The fresh cohort tests whether narrower defined-risk wings, one-contract sizing, live-delta provenance, and fixed exits can restore positive expectancy.",
   "changed_rules": [
     "Run validation_reset as paper-only: live trading and scale-up remain blocked while the fresh validation cohort is collected.",
     "Limit validation entries to IC Simple SPY iron condors with one contract per structure, no more than one new structure per day, and no more than two concurrent iron condors.",
     "Require live-delta strike provenance; reject heuristic fallback, non-positive net credit, and net credit below $0.50 before any validation entry.",
-    "Use 30-45 DTE, target 0.15 short delta, accepted short-delta band 0.08-0.22, and $10 wings for the validation cohort.",
-    "Keep the exit plan fixed: take profit at 50% of max profit, stop at 100% of entry credit, close by 7 DTE, and require the safety gates to refresh canonical state after runs.",
+    "Use 30-45 DTE, target 0.15 short delta, accepted short-delta band 0.08-0.22, and reject 10-wide wings; the validation cohort must use narrower defined-risk wings unless a separate backtest proves wider wings first.",
+    "Keep the exit plan fixed: take profit at 50% of max profit, stop at 100% of entry credit, close by 7 DTE, and do not allow sub-24-hour discretionary exits unless a hard max-loss or broken-leg condition fires.",
     "Keep learned blockers active: FOMC blackout, ThumbGate rules, low IV percentile, unknown or volatile regime, stale broker sync, same-expiry re-entry after a loss, and Thompson confidence unless validation_reset explicitly allows controlled paper validation."
   ],
+  "rehabilitation_plan_ack": {
+    "source_plan": "data/runtime/edge_rehabilitation_plan.json",
+    "covered_loss_clusters": [
+      "ten_wide_wings",
+      "multi_contract",
+      "early_exit_lt_24h"
+    ],
+    "prohibited_rule_repeats": [
+      "Do not repeat 10-wide SPY iron condors from the failed ledger.",
+      "Do not use multi-contract sizing before the fresh cohort clears kill criteria.",
+      "Do not use unmanaged sub-24-hour exits as a discretionary management pattern."
+    ]
+  },
   "kill_criteria": {
     "min_closed_trades": 30,
     "min_expectancy_per_trade": 1.0,

--- a/src/safety/north_star_guard.py
+++ b/src/safety/north_star_guard.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 from datetime import date, datetime
 from pathlib import Path
 from typing import Any
@@ -32,6 +33,7 @@ except Exception:
 
 DEFAULT_STATE_PATH = Path("data/system_state.json")
 DEFAULT_HYPOTHESIS_PATH = Path("data/runtime/strategy_validation_hypothesis.json")
+DEFAULT_REHABILITATION_PLAN_PATH = Path("data/runtime/edge_rehabilitation_plan.json")
 DEFAULT_TARGET_MODE = "asap_monthly_income"
 DEFAULT_MONTHLY_AFTER_TAX_TARGET = NORTH_STAR_MONTHLY_AFTER_TAX
 DEFAULT_TARGET_CAPITAL = NORTH_STAR_TARGET_CAPITAL
@@ -82,6 +84,63 @@ def _load_state(path: Path = DEFAULT_STATE_PATH) -> dict[str, Any]:
             return data if isinstance(data, dict) else {}
     except Exception:
         return {}
+
+
+def _load_json_dict(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        return {}
+    try:
+        with path.open("r", encoding="utf-8") as handle:
+            payload = json.load(handle)
+        return payload if isinstance(payload, dict) else {}
+    except Exception:
+        return {}
+
+
+def _rehab_plan_for_hypothesis(hypothesis_path: Path) -> dict[str, Any]:
+    if hypothesis_path == DEFAULT_HYPOTHESIS_PATH:
+        return _load_json_dict(DEFAULT_REHABILITATION_PLAN_PATH)
+    return _load_json_dict(hypothesis_path.parent / "edge_rehabilitation_plan.json")
+
+
+def _rules_repeat_ten_wide_loss_cluster(rules: list[Any]) -> bool:
+    for item in rules:
+        text = str(item).lower()
+        repeats_ten_wide = bool(re.search(r"(\$?\s*10[- ]?wide|\$?\s*10\s+wings?)", text))
+        if repeats_ten_wide and not any(
+            guard in text for guard in ("reject", "quarantine", "avoid", "do not", "no ")
+        ):
+            return True
+    return False
+
+
+def _hypothesis_covers_rehabilitation_plan(hypothesis: dict[str, Any], hypothesis_path: Path) -> bool:
+    rehab = _rehab_plan_for_hypothesis(hypothesis_path)
+    if str(rehab.get("status") or "").strip().lower() != "quarantined":
+        return True
+
+    clusters = rehab.get("loss_clusters", [])
+    required = [
+        str(cluster.get("id"))
+        for cluster in clusters[:3]
+        if isinstance(cluster, dict) and str(cluster.get("id") or "").strip()
+    ]
+    if not required:
+        return True
+
+    ack = hypothesis.get("rehabilitation_plan_ack")
+    if not isinstance(ack, dict):
+        return False
+    covered = ack.get("covered_loss_clusters", [])
+    if not isinstance(covered, list):
+        return False
+    covered_set = {str(item) for item in covered}
+    if not set(required).issubset(covered_set):
+        return False
+    return not (
+        "ten_wide_wings" in required
+        and _rules_repeat_ten_wide_loss_cluster(hypothesis.get("changed_rules", []))
+    )
 
 
 def _resolve_current_day(paper_trading: dict[str, Any]) -> int:
@@ -164,6 +223,7 @@ def get_guard_context(
                 and hyp.get("enabled")
                 and hyp.get("changed_rules")
                 and hyp.get("kill_criteria")
+                and _hypothesis_covers_rehabilitation_plan(hyp, hypothesis_path)
             )
         except (OSError, ValueError, KeyError):
             hypothesis_active = False

--- a/src/safety/north_star_operating_plan.py
+++ b/src/safety/north_star_operating_plan.py
@@ -35,6 +35,7 @@ DEFAULT_MIN_CLOSED_TRADES_FOR_SCALING = 30
 DEFAULT_MIN_LIQUIDITY_VOLUME_RATIO = 0.20
 DEFAULT_GATE_OVERRIDES_PATH = Path("runtime/north_star_gate_overrides.json")
 DEFAULT_VALIDATION_HYPOTHESIS_PATH = Path("runtime/strategy_validation_hypothesis.json")
+DEFAULT_REHABILITATION_PLAN_PATH = Path("runtime/edge_rehabilitation_plan.json")
 DEFAULT_QUARANTINE_MIN_COHORT_TRADES = 30
 DEFAULT_QUARANTINE_MIN_PROFIT_FACTOR = 1.0
 DEFAULT_QUARANTINE_MIN_EXPECTANCY = 0.0
@@ -152,12 +153,51 @@ def _load_gate_overrides(data_dir: Path) -> dict[str, Any]:
     return payload if isinstance(payload, dict) else {}
 
 
+def _rehabilitation_plan_requirements(data_dir: Path) -> dict[str, Any]:
+    """Return extra validation requirements from the latest strategy rehab plan."""
+    path = data_dir / DEFAULT_REHABILITATION_PLAN_PATH
+    payload = _load_json_dict(path)
+    if str(payload.get("status") or "").strip().lower() != "quarantined":
+        return {
+            "active": False,
+            "path": _display_path(path),
+            "required_loss_clusters": [],
+        }
+
+    clusters = payload.get("loss_clusters", [])
+    required_loss_clusters = [
+        str(cluster.get("id"))
+        for cluster in clusters[:3]
+        if isinstance(cluster, dict) and str(cluster.get("id") or "").strip()
+    ]
+    return {
+        "active": bool(required_loss_clusters),
+        "path": _display_path(path),
+        "required_loss_clusters": required_loss_clusters,
+    }
+
+
+def _rules_repeat_ten_wide_loss_cluster(rules: list[Any]) -> bool:
+    """Detect a hypothesis that repeats the known 10-wide loss cluster."""
+    for item in rules:
+        text = str(item).lower()
+        repeats_ten_wide = bool(
+            re.search(r"(\$?\s*10[- ]?wide|\$?\s*10\s+wings?)", text)
+        )
+        if repeats_ten_wide and not any(
+            guard in text for guard in ("reject", "quarantine", "avoid", "do not", "no ")
+        ):
+            return True
+    return False
+
+
 def _validation_hypothesis_status(data_dir: Path) -> dict[str, Any]:
     """Validate the written hypothesis required to restart a losing strategy."""
     path = data_dir / DEFAULT_VALIDATION_HYPOTHESIS_PATH
     path_label = _display_path(path)
     payload = _load_json_dict(path)
     errors: list[str] = []
+    rehabilitation_plan = _rehabilitation_plan_requirements(data_dir)
 
     if not payload:
         errors.append(f"{path_label} missing or empty")
@@ -198,6 +238,49 @@ def _validation_hypothesis_status(data_dir: Path) -> dict[str, Any]:
     if min_total_pnl <= DEFAULT_QUARANTINE_MIN_REALIZED_PNL:
         errors.append("kill_criteria.min_total_realized_pnl must be > 0")
 
+    covered_loss_clusters: list[str] = []
+    if rehabilitation_plan["active"]:
+        ack = payload.get("rehabilitation_plan_ack", {})
+        if not isinstance(ack, dict):
+            ack = {}
+            errors.append("rehabilitation_plan_ack must be an object")
+
+        source_plan = str(ack.get("source_plan") or "").strip()
+        accepted_sources = {
+            str(DEFAULT_REHABILITATION_PLAN_PATH),
+            f"data/{DEFAULT_REHABILITATION_PLAN_PATH}",
+            rehabilitation_plan["path"],
+        }
+        if source_plan not in accepted_sources:
+            errors.append(
+                f"rehabilitation_plan_ack.source_plan must reference {rehabilitation_plan['path']}"
+            )
+
+        raw_covered = ack.get("covered_loss_clusters", [])
+        covered_loss_clusters = (
+            [str(item) for item in raw_covered if str(item).strip()]
+            if isinstance(raw_covered, list)
+            else []
+        )
+        missing_clusters = [
+            cluster_id
+            for cluster_id in rehabilitation_plan["required_loss_clusters"]
+            if cluster_id not in covered_loss_clusters
+        ]
+        if missing_clusters:
+            errors.append(
+                "rehabilitation_plan_ack.covered_loss_clusters missing: "
+                + ", ".join(missing_clusters)
+            )
+
+        if (
+            "ten_wide_wings" in rehabilitation_plan["required_loss_clusters"]
+            and _rules_repeat_ten_wide_loss_cluster(changed_rules)
+        ):
+            errors.append(
+                "changed_rules repeat loss cluster ten_wide_wings; reject or replace 10-wide wings"
+            )
+
     valid = not errors
     return {
         "path": path_label,
@@ -211,6 +294,12 @@ def _validation_hypothesis_status(data_dir: Path) -> dict[str, Any]:
             "min_expectancy_per_trade": min_expectancy,
             "min_profit_factor": min_profit_factor,
             "min_total_realized_pnl": min_total_pnl,
+        },
+        "rehabilitation_plan": {
+            "active": rehabilitation_plan["active"],
+            "path": rehabilitation_plan["path"],
+            "required_loss_clusters": rehabilitation_plan["required_loss_clusters"],
+            "covered_loss_clusters": covered_loss_clusters if valid else [],
         },
     }
 

--- a/tests/test_north_star_guard.py
+++ b/tests/test_north_star_guard.py
@@ -1,5 +1,7 @@
 """Tests for North Star guard dynamic risk constraints."""
 
+import json
+
 from src.safety.north_star_guard import get_guard_context
 
 
@@ -210,8 +212,64 @@ def test_guard_blocks_quarantined_validation_reset_entries(tmp_path):
 
     # Pass a nonexistent hypothesis path to verify quarantine blocks without a hypothesis.
     guard = get_guard_context(state, hypothesis_path=tmp_path / "no_hypothesis.json")
-    assert guard["mode"] == "quarantine"
-    assert guard["block_new_positions"] is True
-    assert guard["allow_validation_entries"] is False
+    assert guard["mode"] == "quarantine"  # nosec B101
+    assert guard["block_new_positions"] is True  # nosec B101
+    assert guard["allow_validation_entries"] is False  # nosec B101
     assert guard["max_position_pct"] == 0.0
     assert "quarantine" in guard["block_reason"].lower()
+
+
+def test_guard_rejects_hypothesis_that_does_not_cover_rehab_plan(tmp_path):
+    state = tmp_path / "system_state.json"
+    state.write_text(
+        """
+{
+  "paper_account": {"equity": 93838.3, "win_rate": 24.24, "win_rate_sample_size": 66},
+  "paper_trading": {"current_day": 91, "target_duration_days": 90},
+  "north_star_weekly_gate": {
+    "mode": "quarantine",
+    "recommended_max_position_pct": 0.0,
+    "block_new_positions": true,
+    "block_live_new_positions": true,
+    "allow_validation_entries": false,
+    "strategy_quarantine": {
+      "active": true,
+      "block_new_positions": true,
+      "paper_validation_allowed": false,
+      "reason": "MATHEMATICAL QUARANTINE: negative expectancy blocks new entries."
+    }
+  }
+}
+""".strip(),
+        encoding="utf-8",
+    )
+    hypothesis = tmp_path / "strategy_validation_hypothesis.json"
+    hypothesis.write_text(
+        json.dumps(
+            {
+                "enabled": True,
+                "changed_rules": ["Use $10 wings again."],
+                "kill_criteria": {"min_closed_trades": 30},
+            }
+        ),
+        encoding="utf-8",
+    )
+    (tmp_path / "edge_rehabilitation_plan.json").write_text(
+        json.dumps(
+            {
+                "status": "quarantined",
+                "loss_clusters": [
+                    {"id": "ten_wide_wings"},
+                    {"id": "multi_contract"},
+                    {"id": "early_exit_lt_24h"},
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    guard = get_guard_context(state, hypothesis_path=hypothesis)
+
+    assert guard["mode"] == "quarantine"  # nosec B101
+    assert guard["block_new_positions"] is True  # nosec B101
+    assert guard["allow_validation_entries"] is False  # nosec B101

--- a/tests/test_north_star_operating_plan.py
+++ b/tests/test_north_star_operating_plan.py
@@ -39,11 +39,30 @@ def _write_valid_hypothesis(root):
     )
 
 
+def _write_rehabilitation_plan(root):
+    _write_json(
+        root / "runtime" / "edge_rehabilitation_plan.json",
+        {
+            "status": "quarantined",
+            "loss_clusters": [
+                {"id": "ten_wide_wings"},
+                {"id": "multi_contract"},
+                {"id": "early_exit_lt_24h"},
+            ],
+        },
+    )
+
+
 def test_committed_strategy_validation_hypothesis_authorizes_validation_reset(tmp_path):
     repo_root = Path(__file__).resolve().parents[1]
     hypothesis_path = repo_root / "data/runtime/strategy_validation_hypothesis.json"
     hypothesis = json.loads(hypothesis_path.read_text(encoding="utf-8"))
     assert "Example only" not in json.dumps(hypothesis)
+    assert set(hypothesis["rehabilitation_plan_ack"]["covered_loss_clusters"]) >= {  # nosec B101
+        "ten_wide_wings",
+        "multi_contract",
+        "early_exit_lt_24h",
+    }
 
     _write_json(tmp_path / "runtime" / "strategy_validation_hypothesis.json", hypothesis)
     trades_path = tmp_path / "trades.json"
@@ -87,6 +106,75 @@ def test_committed_strategy_validation_hypothesis_authorizes_validation_reset(tm
     assert gate["strategy_quarantine"]["paper_validation_allowed"] is True
     assert gate["strategy_quarantine"]["validation_hypothesis"]["valid"] is True
     assert history[-1]["mode"] == "validation_reset"
+
+
+def test_rehab_plan_rejects_hypothesis_that_repeats_top_loss_cluster(tmp_path):
+    trades_path = tmp_path / "trades.json"
+    history_path = tmp_path / "weekly_history.json"
+    today = date(2026, 4, 9)
+    _write_rehabilitation_plan(tmp_path)
+    _write_json(
+        tmp_path / "runtime" / "strategy_validation_hypothesis.json",
+        {
+            "enabled": True,
+            "strategy_family": "ic_simple",
+            "hypothesis": "Retry IC Simple with a changed thesis that still repeats the bad width.",
+            "changed_rules": [
+                "Use 30-45 DTE, target 0.15 short delta, and $10 wings for validation."
+            ],
+            "rehabilitation_plan_ack": {
+                "source_plan": "data/runtime/edge_rehabilitation_plan.json",
+                "covered_loss_clusters": [
+                    "ten_wide_wings",
+                    "multi_contract",
+                    "early_exit_lt_24h",
+                ],
+            },
+            "kill_criteria": {
+                "min_closed_trades": 30,
+                "min_expectancy_per_trade": 0.01,
+                "min_profit_factor": 1.01,
+                "min_total_realized_pnl": 0.01,
+            },
+        },
+    )
+    _write_json(
+        trades_path,
+        {
+            "stats": {
+                "closed_trades": 66,
+                "win_rate_pct": 24.24,
+                "profit_factor": 0.25,
+                "total_realized_pnl": -3402.0,
+            },
+            "trades": [
+                {
+                    "status": "closed",
+                    "strategy": "iron_condor",
+                    "realized_pnl": 96.0,
+                    "outcome": "win",
+                    "exit_date": today.isoformat(),
+                }
+            ],
+        },
+    )
+
+    gate, _history = compute_weekly_gate(
+        {
+            "paper_account": {"equity": 93838.3, "win_rate": 24.24, "win_rate_sample_size": 66},
+            "live_account": {"equity": 0.0, "positions_count": 0},
+        },
+        trades_path=trades_path,
+        weekly_history_path=history_path,
+        today=today,
+    )
+
+    assert gate["mode"] == "quarantine"  # nosec B101
+    assert gate["strategy_quarantine"]["validation_hypothesis"]["valid"] is False  # nosec B101
+    assert any(  # nosec B101
+        "ten_wide_wings" in error
+        for error in gate["strategy_quarantine"]["validation_hypothesis"]["errors"]
+    )
 
 
 def test_weekly_gate_blocks_when_recent_expectancy_negative(tmp_path):


### PR DESCRIPTION
## Summary
- require validation hypotheses to acknowledge and cover active edge rehabilitation loss clusters before controlled validation can reopen
- reject hypotheses that repeat the ten_wide_wings loss cluster without explicit rejection/quarantine language
- update the current validation hypothesis to remove 10-wide wings, multi-contract sizing, and unmanaged sub-24h exits

## Verification
- ruff check src/safety/north_star_operating_plan.py src/safety/north_star_guard.py tests/test_north_star_operating_plan.py tests/test_north_star_guard.py
- trunk check --force src/safety/north_star_operating_plan.py src/safety/north_star_guard.py tests/test_north_star_operating_plan.py tests/test_north_star_guard.py data/runtime/strategy_validation_hypothesis.json
- pytest tests/test_north_star_operating_plan.py tests/test_north_star_guard.py -q
- pytest tests/test_north_star_operating_plan.py tests/test_north_star_guard.py tests/test_mandatory_trade_gate.py tests/test_build_public_status.py -q
- python3 scripts/update_ml_from_trades.py --dry-run
- validation hypothesis status: valid=True; rehab_active=True; required=ten_wide_wings,multi_contract,early_exit_lt_24h; covered=ten_wide_wings,multi_contract,early_exit_lt_24h

## Trading status
- This does not claim profitability. The dry-run still reports trading blocked: win rate 23.2%, expectancy -$57.36/trade, profit factor 0.22.
