### PR TITLE
fix(learning): derive exit_reason from broker fills

### DIFF
--- a/scripts/sync_closed_positions.py
+++ b/scripts/sync_closed_positions.py
@@ -820,6 +820,48 @@ def _trade_id(signature: str, entry_ts: datetime, exit_ts: datetime) -> str:
     )
 
 
+def _derive_exit_reason(
+    entry_net_cash: float,
+    exit_net_cash: float,
+    pnl: float,
+    exit_ts: datetime,
+    legs: dict[str, Any],
+) -> str:
+    """Derive a structured exit reason from broker-fill signals.
+
+    Replaces the historical "unknown" / "SYNC_CLOSED_POSITION" placeholder so the
+    learning loop can distinguish profit-target closes from stop-loss closes
+    from DTE-driven closes. Heuristic — fills carry no semantic tag, so we
+    reconstruct from the same signals the guardian scripts use.
+    """
+    expiry_iso = (legs or {}).get("expiry")
+    if expiry_iso:
+        try:
+            expiry_date = datetime.fromisoformat(str(expiry_iso)).date()
+        except ValueError:
+            expiry_date = None
+    else:
+        expiry_date = None
+
+    if expiry_date and exit_ts.date() >= expiry_date:
+        return "expired"
+
+    if expiry_date:
+        dte_at_exit = (expiry_date - exit_ts.date()).days
+        if 0 < dte_at_exit <= 7:
+            return "7dte"
+
+    if entry_net_cash > 0:
+        # Credit-entry IC: profit-target if we captured ≥50% of the credit;
+        # stop-loss if we paid ≥100% of the credit on the way out.
+        if pnl >= 0.5 * entry_net_cash:
+            return "profit_target"
+        if pnl <= -1.0 * entry_net_cash:
+            return "stop_loss"
+
+    return "manual_close"
+
+
 def _to_closed_trade(entry: dict[str, Any], exit_event: dict[str, Any]) -> dict[str, Any]:
     signature = str(entry["signature"])
     entry_ts = entry["timestamp"]
@@ -829,6 +871,7 @@ def _to_closed_trade(entry: dict[str, Any], exit_event: dict[str, Any]) -> dict[
     legs = _signature_to_legs(signature)
     entry_net_cash = round(_parse_float(entry.get("net_cash"), 0.0), 2)
     exit_net_cash = round(_parse_float(exit_event.get("net_cash"), 0.0), 2)
+    exit_reason = _derive_exit_reason(entry_net_cash, exit_net_cash, pnl, exit_ts, legs)
 
     return {
         "id": _trade_id(signature, entry_ts, exit_ts),
@@ -850,6 +893,7 @@ def _to_closed_trade(entry: dict[str, Any], exit_event: dict[str, Any]) -> dict[
         "exit_style": "credit" if exit_net_cash > 0 else "debit",
         "realized_pnl": pnl,
         "outcome": outcome,
+        "exit_reason": exit_reason,
         "signature": signature,
         "legs": legs,
         "source": f"{entry['source']}->{exit_event['source']}",
@@ -1146,12 +1190,14 @@ def _apply_learning_update_for_trade(
     from src.learning.rlhf_storage import store_trade_outcome
     from src.learning.trade_episode_store import TradeEpisodeStore
 
+    derived_exit_reason = str(trade.get("exit_reason") or "manual_close")
+
     outcome_label = build_outcome_label(
         {
             "symbol": symbol,
             "strategy": strategy,
             "realized_pl": pnl,
-            "exit_reason": "SYNC_CLOSED_POSITION",
+            "exit_reason": derived_exit_reason,
             "won": str(trade.get("outcome") or "").strip().lower() == "win",
             "exit_time": exit_time,
         }
@@ -1192,7 +1238,7 @@ def _apply_learning_update_for_trade(
             "lost": bool(outcome_label["lost"]),
             "outcome": outcome_label["outcome"],
             "holding_minutes": outcome_label["holding_minutes"],
-            "exit_reason": "SYNC_CLOSED_POSITION",
+            "exit_reason": derived_exit_reason,
             "expiry": expiry,
             "metadata": {
                 "source": "sync_closed_positions",
@@ -1207,7 +1253,7 @@ def _apply_learning_update_for_trade(
         strategy=strategy,
         reward=float(outcome_label["reward"]),
         won=bool(outcome_label["won"]),
-        exit_reason="SYNC_CLOSED_POSITION",
+        exit_reason=derived_exit_reason,
         expiry=expiry,
         episode_id=trade_id or event_key,
         event_key=event_key,


### PR DESCRIPTION
## Summary

The audit of 69 closed iron-condor trades showed **0/69 exit reasons recorded** — every closed trade defaulted to \"unknown\" downstream. The learning loop cannot distinguish a 50%-profit-target close from a stop-loss close from a 7-DTE close. RLHF, RAG severity weighting, Thompson updates are all running blind.

This PR unblocks learning. It does **not** change strategy behavior.

## Root cause

\`scripts/sync_closed_positions.py:823\` (\`_to_closed_trade\`) omitted the field entirely from the closed-trade record. Three hard-coded \`SYNC_CLOSED_POSITION\` literals at lines 1154/1195/1210 were passed into \`outcome_label\`, \`episode_store\`, and \`store_trade_outcome\` with no semantic content.

## The fix

Add \`_derive_exit_reason()\` which reconstructs the reason from already-available signals (entry/exit net cash, pnl, exit timestamp, legs.expiry):

| Reason | Heuristic |
| --- | --- |
| \`profit_target\` | captured ≥50% of credit |
| \`stop_loss\` | paid ≥100% of credit |
| \`7dte\` | exit-time DTE ≤ 7 |
| \`expired\` | exit on/after expiry |
| \`manual_close\` | none of the above |

The three call sites that previously hard-coded \`SYNC_CLOSED_POSITION\` now read \`trade[\"exit_reason\"]\`.

Backfill is automatic — the existing 69-trade ledger gets re-derived from broker fills the next time \`sync_closed_positions\` runs.

## Why heuristic, not authoritative

Broker fills carry no semantic tag. The guardian scripts (\`iron_condor_guardian.py\`, \`ic_simple.py\`) know the reason at close-time but write it to side-files (\`trade_journal.jsonl\`, RAG markdown), not the canonical ledger. A proper join key from guardian → ledger is a bigger refactor; this PR delivers 80% of the learning-loop value with 49 lines.

## Test plan

- [x] 9/9 affected tests pass (\`test_sync_closed_positions_learning\`, \`test_outcome_labeler\`, \`test_manage_iron_condor_positions\`)
- [x] 5/5 derivation cases classify correctly via smoke test (profit_target / stop_loss / 7dte / expired / manual_close)
- [x] Trunk fmt clean
- [ ] CI on this PR green

## Net diff: +49 / -3 lines, single file

## Related

Sister PR #3982 removes the broker-side GTC race causing the 75% <4h-hold pattern. Once both land, the next paper trading session produces a clean dataset with both correct hold times AND classified exit reasons — input the controlled-experiment validation has been missing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)