### PR TITLE
fix(ic_simple): clamp ML bounds to canonical policy constants

### DIFF
--- a/scripts/ic_simple.py
+++ b/scripts/ic_simple.py
@@ -839,15 +839,36 @@ def _adjust_strategy_params(adjustments: dict, reason: str, source: str, confide
 
     Safety: only adjusts if confidence >= 0.7 and changes are within bounds.
     """
+    # Pull canonical caps from trading_constants so ML adjustments cannot
+    # silently breach .claude/CLAUDE.md policy. Falls back to defensive
+    # defaults if the import path is broken.
+    try:
+        from src.core.trading_constants import (
+            IRON_CONDOR_STOP_LOSS_MULTIPLIER,
+            MAX_CONCURRENT_IRON_CONDORS,
+        )
+
+        canonical_max_ic = int(MAX_CONCURRENT_IRON_CONDORS)
+        canonical_stop_loss = float(IRON_CONDOR_STOP_LOSS_MULTIPLIER)
+    except ImportError:
+        canonical_max_ic = 2
+        canonical_stop_loss = 1.0
+
     BOUNDS = {
         "target_delta": (0.10, 0.25),  # Never go below 10-delta or above 25-delta
         "wing_width": (5, 15),  # $5-$15 wide
         "target_dte": (21, 60),  # 21-60 DTE
         "min_credit": (0.30, 2.00),  # Floor $0.30, cap $2.00
         "profit_target": (0.25, 0.75),  # 25-75% profit take
-        "stop_loss": (0.75, 2.0),  # 75-200% stop
+        # Stop-loss is canonical (1.0× credit). Allow a tighter stop down to
+        # 0.75× but never relax beyond canonical — looser stops would let
+        # losses run past the policy cap.
+        "stop_loss": (0.75, canonical_stop_loss),
         "exit_dte": (3, 14),  # 3-14 DTE exit
-        "max_ic": (1, 4),  # 1-4 concurrent ICs
+        # max_ic upper bound is the canonical MAX_CONCURRENT_IRON_CONDORS
+        # (currently 2). A previous bound of 4 silently allowed ML to double
+        # the capital-at-risk envelope vs .claude/CLAUDE.md policy.
+        "max_ic": (1, canonical_max_ic),
     }
 
     if confidence < 0.7:


### PR DESCRIPTION
\`scripts/ic_simple.py:850\` had \`"max_ic": (1, 4)\` — the upper bound silently permitted ML to set MAX_IC=4 (16 legs), double the canonical \`MAX_CONCURRENT_IRON_CONDORS=2\` (8 legs) from \`.claude/CLAUDE.md\`.

GRPO writes with confidence ≥0.7 get clamped to bounds — within (1, 4) is "within bounds", so no warning, no log line, persisted to \`data/strategy_params.json\`. Next session loads MAX_IC=4 and runs 4 concurrent ICs, breaching:

- \`.claude/CLAUDE.md\`: "Up to 2 concurrent SPY Iron Condors (8 legs max)"
- \`src/core/trading_constants.py:14-15\`: \`MAX_POSITIONS = MAX_CONCURRENT_IRON_CONDORS * 4\` (8)
- \`.claude/rules/risk-management.md\`: "2 iron condors max concurrent"
- \`MAX_CUMULATIVE_RISK_PCT = 5% × 2 = 10%\` — at MAX_IC=4 the cap is silently 20%

Same defect class for \`stop_loss\`: bounded (0.75, 2.0) but canonical \`IRON_CONDOR_STOP_LOSS_MULTIPLIER=1.0\`. ML could push stops to 2× credit → losses run past the policy cap.

## Fix

Import canonical constants inside \`_adjust_strategy_params\`. \`max_ic\` upper = \`MAX_CONCURRENT_IRON_CONDORS\`. \`stop_loss\` upper = \`IRON_CONDOR_STOP_LOSS_MULTIPLIER\`. Lower bounds unchanged (ML can tighten, not loosen). Fallback (2, 1.0) on import failure.

Single source of truth: change \`.claude/CLAUDE.md\` or \`trading_constants.py\` → ML autonomy bounds tighten on next deploy.

## Test plan

- [x] 89/89 tests pass in ic_simple + guardian + manage suites
- [x] Compile + trunk fmt clean
- [ ] CI green

Net diff: +23 / -2 lines, single file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)