### PR TITLE
fix(ic_simple): atomic entries write + loud corruption errors

### DIFF
--- a/scripts/ic_simple.py
+++ b/scripts/ic_simple.py
@@ -1269,17 +1269,39 @@ def _thumbgate_matches(rule: dict) -> bool:
 
 
 def _load_entries() -> dict:
+    if not ENTRIES_FILE.exists():
+        return {}
     try:
-        if ENTRIES_FILE.exists():
-            return json.loads(ENTRIES_FILE.read_text())
-    except Exception:
-        pass
-    return {}
+        return json.loads(ENTRIES_FILE.read_text())
+    except json.JSONDecodeError as exc:
+        # File corruption is high-impact: a silently-empty entries dict means
+        # check_exits cannot manage live legs (no 50%/stop/7DTE close) AND the
+        # MAX_IC=2 gate counts zero, allowing a duplicate IC on top of the
+        # orphaned position. Log loudly so the operator can investigate
+        # rather than discovering corruption days later via missing exits.
+        logger.error(
+            f"ENTRIES FILE CORRUPT at {ENTRIES_FILE}: {exc}. "
+            "Treating as empty — open positions WILL NOT be tracked. "
+            "Restore from backup or re-derive from broker positions."
+        )
+        return {}
+    except OSError as exc:
+        logger.error(f"ENTRIES FILE UNREADABLE at {ENTRIES_FILE}: {exc}")
+        return {}
 
 
 def _save_entries(entries: dict):
+    # Atomic write: serialize to a sibling .tmp file, then os.replace into
+    # place. This guarantees that a SIGINT/OOM/container-kill mid-write
+    # leaves either the old file intact or the new file complete — never
+    # a truncated/half-JSON state that would silently zero out position
+    # tracking on the next _load_entries.
+    import os
+
     ENTRIES_FILE.parent.mkdir(parents=True, exist_ok=True)
-    ENTRIES_FILE.write_text(json.dumps(entries, indent=2))
+    tmp_path = ENTRIES_FILE.with_suffix(ENTRIES_FILE.suffix + ".tmp")
+    tmp_path.write_text(json.dumps(entries, indent=2))
+    os.replace(tmp_path, ENTRIES_FILE)
 
 
 def _check_recent_fills(client):


### PR DESCRIPTION
\`_save_entries\` did a direct \`write_text\` on \`ENTRIES_FILE\`. A SIGINT, OOM, container-kill, or disk-full mid-write produces a truncated JSON file. \`_load_entries\` then swallowed every exception with bare \`except: pass\` and returned \`{}\` — silently disabling position tracking:

- \`check_exits\` cannot manage live legs (no 50% target, no stop, no 7-DTE close)
- \`MAX_IC=2\` gate counts 0 → duplicate IC on top of the orphan is allowed
- Re-creates the LL-281 position-accumulation failure mode

## Fix

- **\`_save_entries\`**: write to \`ENTRIES_FILE + ".tmp"\` then \`os.replace\`. Atomic on POSIX — either the old file stays intact or the new is complete; never a half-JSON state.
- **\`_load_entries\`**: narrow except to \`json.JSONDecodeError\` / \`OSError\` with \`logger.error\`. Corruption is loud, not silent.

## Smoke

- Round-trip write/read works
- Corrupted fixture → returns \`{}\` with \`ERROR\` logged

## Test plan

- [x] 65/65 ic_simple + guardian tests pass
- [x] Trunk fmt clean
- [ ] CI green

Net diff: +30 / -7 lines, single file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)