### PR TITLE
fix(manage): credit_received uses net (short − long), not gross

### DIFF
--- a/scripts/manage_iron_condor_positions.py
+++ b/scripts/manage_iron_condor_positions.py
@@ -148,11 +148,22 @@ def group_iron_condors(positions: list[dict]) -> list[dict]:
         pass
 
     for ic in by_expiry.values():
-        credit = 0
+        # Net credit = short-leg premiums collected − long-leg debits paid.
+        # The previous implementation summed only shorts, inflating the
+        # "credit_received" denominator by the long-wing cost (~50% on a
+        # 15-delta SPY IC). Downstream profit-target/stop-loss thresholds
+        # then fire late vs canonical 50%/100%-of-true-credit. iron_condor_
+        # guardian.py:347-349 already computes net credit correctly; this
+        # brings manage_iron_condor_positions.py into line.
+        short_premium = 0.0
+        long_debit = 0.0
         for leg in ic["legs"]:
-            if leg["qty"] < 0:  # Short leg
-                credit += abs(leg["avg_entry_price"] * leg["qty"] * 100)
-        ic["credit_received"] = credit
+            cash = abs(leg["avg_entry_price"] * leg["qty"] * 100)
+            if leg["qty"] < 0:
+                short_premium += cash
+            elif leg["qty"] > 0:
+                long_debit += cash
+        ic["credit_received"] = short_premium - long_debit
 
         # Populate entry_date so 4-hour holding period works
         expiry_yymmdd = ic["expiry_str"].replace("-", "")[2:]


### PR DESCRIPTION
`scripts/manage_iron_condor_positions.py:150-155` summed only short premiums into `credit_received`, never subtracting the long-wing debit. For a 15-delta SPY IC, this inflates the denominator ~50%, so the 50% profit target and 100% stop-loss both fire LATE vs canonical thresholds.

`scripts/iron_condor_guardian.py:347-349` already computes net credit correctly. This brings manage into line.

Workflow currently scheduled-disabled (cron commented out) but invokable via `workflow_dispatch`. Any future re-enable would silently violate Phil Town Rule #1.

Tests pass. Trunk clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)