### PR TITLE
fix(api_circuit_breaker): reset stale failure counter on load

### DIFF
--- a/src/utils/api_circuit_breaker.py
+++ b/src/utils/api_circuit_breaker.py
@@ -186,13 +186,31 @@ class APICircuitBreaker:
             logger.error(f"Failed to send circuit breaker alert: {e}")
 
     def _load_state(self) -> None:
-        """Load persisted state."""
+        """Load persisted state.
+
+        The consecutive_failures counter is session-scoped — persisting it
+        across process restarts produces spurious trips. A counter
+        accumulated days ago, from unrelated issues now fixed, would trip
+        on the first new failure of a fresh session. Discard the counter
+        if last_failure_time is older than the cooldown window.
+        """
         if STATE_FILE.exists():
             try:
                 with open(STATE_FILE) as f:
                     state = json.load(f)
                     self.consecutive_failures = state.get("consecutive_failures", 0)
                     self.trip_count = state.get("trip_count", 0)
+                    last_failure_raw = state.get("last_failure_time")
+                    if last_failure_raw:
+                        try:
+                            self.last_failure_time = datetime.fromisoformat(last_failure_raw)
+                            staleness = datetime.now() - self.last_failure_time
+                            if staleness.total_seconds() > COOLDOWN_SECONDS:
+                                # Ancient failures — reset the counter so a
+                                # fresh session does not trip on stale state.
+                                self.consecutive_failures = 0
+                        except ValueError:
+                            self.last_failure_time = None
                     if state.get("trip_time"):
                         self.trip_time = datetime.fromisoformat(state["trip_time"])
                         # Check if still in cooldown


### PR DESCRIPTION
`_load_state` restored `consecutive_failures` from disk on every process start. The counter is session-scoped — persisting it produces spurious trips when a counter from days ago meets a single new failure in a fresh session.

Fix: parse `last_failure_time`; if older than `COOLDOWN_SECONDS`, reset the counter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)