### PR TITLE
fix(behavioral_guard): prune respects STOP_LOSS_COOLING_HOURS

### DIFF
--- a/src/safety/behavioral_guard.py
+++ b/src/safety/behavioral_guard.py
@@ -199,8 +199,12 @@ class BehavioralGuard:
                 "timestamp": datetime.now().isoformat(),
             }
         )
-        # Prune entries older than 48h
-        cutoff = datetime.now() - timedelta(hours=48)
+        # Prune entries older than the cooling window (never tighter than 48h).
+        # A hardcoded 48h prune silently dropped cooling records before the
+        # actual cooling window expired whenever STOP_LOSS_COOLING_HOURS was
+        # configured above 48 — defeating the cooling guard.
+        prune_hours = max(STOP_LOSS_COOLING_HOURS, 48)
+        cutoff = datetime.now() - timedelta(hours=prune_hours)
         exits = [e for e in exits if datetime.fromisoformat(e["timestamp"]) > cutoff]
         state["stop_loss_exits"] = exits
         BehavioralGuard._save_state(state)


### PR DESCRIPTION
Hardcoded 48h prune dropped cooling entries before the cooling window expired whenever STOP_LOSS_COOLING_HOURS > 48. Use max(cooling, 48).

🤖 Generated with [Claude Code](https://claude.com/claude-code)