### PR TITLE
fix(pl_validator): count completed condors as open+close pairs

### DIFF
--- a/src/utils/pl_validator.py
+++ b/src/utils/pl_validator.py
@@ -137,9 +137,19 @@ def count_completed_iron_condors(orders: list) -> int:
             spy_option_groups[created] = []
         spy_option_groups[created].append(symbol)
 
-    # Count groups with exactly 4 legs (iron condor)
-    condor_count = sum(1 for legs in spy_option_groups.values() if len(legs) == 4)
-    return condor_count
+    # A completed iron condor requires BOTH an opening 4-leg group AND a
+    # closing 4-leg group — so the number of *completed* condors is
+    # (qualifying 4-leg groups) // 2. Requiring 4 distinct symbols filters
+    # out a 4-fill single-leg split or two 2-leg verticals that happen to
+    # share the same minute timestamp.
+    # Previously this returned the raw 4-leg group count, double-counting
+    # opens and closes. `can_project` then unlocked the 30-trade projection
+    # gate at ~15 actual completed condors, violating .claude/CLAUDE.md's
+    # "0 trades = 0 projections" mandate.
+    qualifying_groups = sum(
+        1 for legs in spy_option_groups.values() if len(legs) == 4 and len(set(legs)) == 4
+    )
+    return qualifying_groups // 2
 
 
 def validate_pl_report(

--- a/tests/test_pl_validator.py
+++ b/tests/test_pl_validator.py
@@ -166,7 +166,9 @@ class TestClassifyOrder:
 
 
 class TestCountCompletedIronCondors:
-    def test_four_legs_same_minute_is_condor(self):
+    def test_four_legs_open_only_is_not_completed(self):
+        # A condor that is OPENED but not yet CLOSED is not "completed."
+        # Per the docstring: "A completed iron condor = opened AND closed."
         orders = [
             {
                 "symbol": "SPY260220P00660000",
@@ -192,6 +194,23 @@ class TestCountCompletedIronCondors:
                 "created_at": "2026-02-06T18:48",
                 "status": "filled",
             },
+        ]
+        assert count_completed_iron_condors(orders) == 0
+
+    def test_open_and_close_groups_is_one_condor(self):
+        # Open (4 distinct legs) + close (same 4 legs at a later minute) = 1 completed.
+        legs = [
+            "SPY260220P00660000",
+            "SPY260220P00655000",
+            "SPY260220C00725000",
+            "SPY260220C00720000",
+        ]
+        orders = [
+            {"symbol": s, "side": "sell", "created_at": "2026-02-06T18:48", "status": "filled"}
+            for s in legs
+        ] + [
+            {"symbol": s, "side": "buy", "created_at": "2026-02-13T19:00", "status": "filled"}
+            for s in legs
         ]
         assert count_completed_iron_condors(orders) == 1
 
@@ -310,9 +329,10 @@ class TestValidatePLReport:
         assert report.can_project is False
 
     def test_projection_blocked_under_30_trades(self):
-        # 2 iron condors = 8 legs, but only 2 completed condors
+        # 2 *completed* iron condors require 4 distinct minute-buckets:
+        # open T1 + close T2 = condor #1, open T3 + close T4 = condor #2.
         orders = []
-        for minute in ["18:48", "19:00"]:
+        for minute in ["18:48", "19:00", "19:30", "20:00"]:
             orders.extend(
                 [
                     {


### PR DESCRIPTION
`count_completed_iron_condors` returned the raw 4-leg-group count. The docstring says 'opened AND closed' but the code counted opens and closes as separate condors — 2x inflation. Unlocked the 30-trade projection gate at ~15 actual round trips, violating the No-Hallucination Mandate.

Fix: require 4 distinct legs per group + divide by 2. Tests updated to use both open and close buckets.

32/32 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)