### PR TITLE
fix(cancel_stale_orders): honor cancel-ALL on clock-skewed orders

### DIFF
--- a/scripts/cancel_stale_orders.py
+++ b/scripts/cancel_stale_orders.py
@@ -85,7 +85,11 @@ def main() -> int:
         logger.info(f"  Created: {order.created_at}")
         logger.info(f"  Age: {age_hours:.1f} hours")
 
-        if created_at < stale_threshold:
+        # Honor a "cancel ALL" policy (MAX_ORDER_AGE_HOURS <= 0) even when
+        # the broker reports a future-dated created_at (clock skew across
+        # services). The plain `created_at < stale_threshold` comparison
+        # silently skipped such orders.
+        if MAX_ORDER_AGE_HOURS <= 0 or created_at < stale_threshold:
             logger.warning("  ⚠️ STALE ORDER - Cancelling...")
             try:
                 client.cancel_order_by_id(order.id)


### PR DESCRIPTION
MAX_ORDER_AGE_HOURS=0 is the 'cancel ALL' switch but the comparison silently skipped future-dated broker timestamps. Short-circuit to cancel when <= 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)