### PR TITLE
fix(risk): credit-spread max-loss must scale with spread_width (control gap, 50% under-count)

### DIFF
--- a/src/risk/trade_gateway.py
+++ b/src/risk/trade_gateway.py
@@ -416,9 +416,20 @@ class TradeGateway:
             strike = request.limit_price or 25  # Default assumption
             max_loss = strike * 100 * (request.quantity or 1)
         elif request.strategy_type in ["bull_put_spread", "credit_spread", "bear_call_spread"]:
-            # Max loss = spread width * 100 * quantity
-            # Typically $5 wide spreads = $500 max loss
-            max_loss = 500 * (request.quantity or 1)
+            # Max loss = (spread_width * 100 - credit * 100) * quantity
+            # Prior hardcode of $500 * quantity silently under-counted by 50%
+            # on $10-wide spreads (paper-account uses $10 wings @ >= $100K equity).
+            inferred_width = request.spread_width
+            if inferred_width is None:
+                inferred_width = 10.0 if account_equity >= 100_000 else 5.0
+            inferred_credit = (
+                request.premium_received
+                if request.premium_received is not None
+                else (0.7 if inferred_width <= 5 else 1.0)
+            )
+            max_loss = max(0.0, (inferred_width * 100) - (inferred_credit * 100)) * (
+                request.quantity or 1
+            )
         elif request.strategy_type == "iron_condor":
             # Dynamic IC profile: widen wings for larger accounts.
             inferred_width = request.spread_width
@@ -482,8 +493,12 @@ class TradeGateway:
             "bear_call_spread",
             "credit_spread",
         ]:
-            # Default $5 spread, $0.50 premium = $450 max loss per contract
-            return 450.0 * contracts
+            # Fallback when spread_width unspecified. Account-tier-aware
+            # default mirrors the iron_condor branch to avoid silent
+            # under-counting on $10-wide spreads.
+            default_width = float(os.getenv("DEFAULT_SPREAD_WIDTH", "10"))
+            default_credit = float(os.getenv("DEFAULT_SPREAD_CREDIT", "0.7"))
+            return max(0.0, (default_width * 100) - (default_credit * 100)) * contracts
         elif request.strategy_type == "iron_condor":
             default_wing = float(os.getenv("DEFAULT_IC_WING_WIDTH", "10"))
             default_credit = float(os.getenv("DEFAULT_IC_TOTAL_CREDIT", "2.0"))

--- a/tests/test_trade_gateway.py
+++ b/tests/test_trade_gateway.py
@@ -472,3 +472,55 @@ class TestEarningsPositionMonitor:
         gateway = TradeGateway(executor=None, paper=True)
         action = gateway._get_earnings_action(days_to_blackout=0, unrealized_pl=-50, symbol="SOFI")
         assert "MONITOR_CLOSELY" in action
+
+
+class TestCreditSpreadMaxLoss:
+    """Regression: credit-spread max-loss must scale with spread_width, not hardcoded $500.
+
+    Bug history: trade_gateway.py:421 used `max_loss = 500 * quantity` for any
+    credit-spread strategy_type, silently under-counting max loss by 50% on the
+    $10-wide spreads the paper account uses at >=$100K equity. A 50-contract
+    $10-wide credit spread should report $40,000 max loss (= ($10*100 - $2*100) * 50),
+    not $25,000.
+    """
+
+    def test_credit_spread_max_loss_scales_with_width(self):
+        gateway = TradeGateway(executor=None, paper=True)
+        gateway.executor = MockExecutor(account_equity=95_000)
+        request = TradeRequest(
+            symbol="SPY260618P00686000",
+            side="sell",
+            notional=10_000,
+            source="test",
+            is_option=True,
+            strategy_type="credit_spread",
+            spread_width=10.0,
+            premium_received=2.0,
+            quantity=50,
+        )
+        rejected, reason = gateway._check_position_size_risk(request, account_equity=95_000)
+        assert rejected, "50-lot $10-wide credit spread must trip 2% max-position cap"
+        # True max loss = ($10*100 - $2*100) * 50 = $40,000
+        # Buggy max loss would have been $500 * 50 = $25,000
+        assert "$40000" in reason or "40000" in reason, (
+            f"Expected max-loss of $40,000 in rejection reason, got: {reason}"
+        )
+
+    def test_credit_spread_max_loss_uses_premium(self):
+        """Premium reduces max loss: ($10*100 - $1*100) * 1 = $900 for 1-lot."""
+        gateway = TradeGateway(executor=None, paper=True)
+        gateway.executor = MockExecutor(account_equity=200_000)
+        request = TradeRequest(
+            symbol="SPY260618P00686000",
+            side="sell",
+            notional=900,
+            source="test",
+            is_option=True,
+            strategy_type="bull_put_spread",
+            spread_width=10.0,
+            premium_received=1.0,
+            quantity=1,
+        )
+        rejected, _ = gateway._check_position_size_risk(request, account_equity=200_000)
+        # 1-lot $900 max loss vs $200K equity = 0.45% << 2% -> not rejected on size
+        assert not rejected, "1-lot $10-wide spread should pass on a $200K account"


### PR DESCRIPTION
## Why

Forensics on the live 50-lot SPY 2026-06-18 IC surfaced three control gaps. This PR fixes one of them: \`src/risk/trade_gateway.py:421\` hardcoded \`max_loss = 500 * quantity\` for credit-spread strategy types, assuming \$5 wings.

The paper account uses \$10 wings at >=\$100K equity (and lower equity tiers as low as \$5). For a 50-contract \$10-wide credit spread the bug reported **\$25,000 max loss instead of the true \$40,000** — a 50% under-count. With the 2% position-size gate at \$1,899 on a \$94,966 account, the gate was checking against the wrong number.

## What

- Fix lines 418-434 to mirror the existing iron_condor branch: \`max(0, (width*100 - credit*100)) * quantity\`
- Same fix applied to the \`_calculate_credit_spread_max_loss\` fallback (was \`450.0 * contracts\`); replaced with env-driven width-aware defaults
- Two regression tests added in \`tests/test_trade_gateway.py::TestCreditSpreadMaxLoss\`

## What this PR does NOT fix (separate PRs needed)

Per the forensics:
1. **Direct \`client.submit_order(...)\` bypass** in 3 workflow files (\`iron-condor-autonomous.yml:222\`, \`iron-condor-scan.yml:132\`, \`daily-trading.yml:766\`) — these never reach the gateway at all. This is how the 50-lot got in.
2. **\`IronCondorRisk.calculate_quantity()\` is a commented-out stub** in \`src/strategies/iron_condor/__init__.py:52-54\`.

Tracking: PR #4021 (CTO decisions doc) records both.

## Test plan
- [ ] \`pytest tests/test_trade_gateway.py -q\` green
- [ ] CI green
- [ ] Manual: confirm a 50-lot $10-wide credit_spread is now rejected with the correct \$40,000 reason string