### PR TITLE
feat(risk): implement IronCondorRisk.calculate_quantity (was a commented stub)

### DIFF
--- a/src/strategies/iron_condor/risk.py
+++ b/src/strategies/iron_condor/risk.py
@@ -7,7 +7,11 @@ import logging
 from typing import Any
 
 from src.constants.trading_thresholds import RiskThresholds
-from src.core.trading_constants import MAX_POSITIONS
+from src.core.trading_constants import (
+    MAX_CONTRACTS_PER_TRADE,
+    MAX_POSITION_PCT,
+    MAX_POSITIONS,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -57,6 +61,44 @@ class IronCondorRisk:
 
         logger.info(f"Position check OK: {current_ic_count}/{self.max_positions} ICs")
         return True
+
+    def calculate_quantity(
+        self,
+        equity: float,
+        wing_width: float,
+        credit_per_contract: float,
+        max_risk_pct: float | None = None,
+        hard_cap: int | None = None,
+    ) -> int:
+        """Compute the largest legal iron-condor quantity.
+
+        Caps quantity by the strictest of three constraints:
+        1. max_risk_pct of equity per trade (default: MAX_POSITION_PCT from
+           trading_constants)
+        2. hard_cap (default: MAX_CONTRACTS_PER_TRADE from active profile;
+           controlled-experiment.md currently mandates 1)
+        3. >= 0 (returns 0 on invalid inputs rather than negative)
+
+        Per-IC max loss = (wing_width * 100 - credit_per_contract * 100).
+        That assumes equal-width wings on both sides; the risk surface is
+        symmetric so we size against one side.
+
+        Returns 0 if equity <= 0, wing_width <= 0, or credit >= wing_width
+        (would imply zero or negative max loss, which is non-physical).
+        """
+        if equity <= 0 or wing_width <= 0:
+            return 0
+        per_contract_max_loss = (wing_width - credit_per_contract) * 100
+        if per_contract_max_loss <= 0:
+            return 0
+
+        risk_pct = max_risk_pct if max_risk_pct is not None else MAX_POSITION_PCT
+        risk_dollars = equity * risk_pct
+        qty_from_risk = int(risk_dollars // per_contract_max_loss)
+
+        cap = hard_cap if hard_cap is not None else MAX_CONTRACTS_PER_TRADE
+        qty = min(qty_from_risk, cap)
+        return max(0, qty)
 
     def get_stop_prices(
         self, credit_received: float, short_put: float, short_call: float

--- a/tests/test_iron_condor_strategy_risk.py
+++ b/tests/test_iron_condor_strategy_risk.py
@@ -1,0 +1,71 @@
+"""Tests for IronCondorRisk.calculate_quantity (was a commented-out stub).
+
+The 50-lot SPY 2026-06-18 IC incident on 2026-05-19 showed that the
+strategy layer had no quantity-sizing function — quantity was a literal
+in the trader scripts. This locks in the correct behaviour.
+"""
+
+from src.strategies.iron_condor.risk import IronCondorRisk
+
+
+class TestCalculateQuantity:
+    def test_returns_zero_on_zero_equity(self):
+        r = IronCondorRisk()
+        assert r.calculate_quantity(equity=0, wing_width=10, credit_per_contract=2.0) == 0
+
+    def test_returns_zero_on_zero_or_negative_wing(self):
+        r = IronCondorRisk()
+        assert r.calculate_quantity(equity=100_000, wing_width=0, credit_per_contract=2.0) == 0
+        assert r.calculate_quantity(equity=100_000, wing_width=-1, credit_per_contract=2.0) == 0
+
+    def test_returns_zero_when_credit_geq_wing(self):
+        """Credit >= wing would imply zero or negative max loss — non-physical."""
+        r = IronCondorRisk()
+        assert r.calculate_quantity(equity=100_000, wing_width=10, credit_per_contract=10) == 0
+        assert r.calculate_quantity(equity=100_000, wing_width=10, credit_per_contract=11) == 0
+
+    def test_hard_cap_dominates_when_risk_room_is_larger(self):
+        """On a $100K account, 2% = $2,000 / $800 per-IC = 2 ICs by risk.
+        With explicit hard_cap=1 (controlled-experiment rule), result is 1."""
+        r = IronCondorRisk()
+        qty = r.calculate_quantity(
+            equity=100_000,
+            wing_width=10,
+            credit_per_contract=2.0,
+            max_risk_pct=0.02,
+            hard_cap=1,
+        )
+        assert qty == 1
+
+    def test_risk_pct_dominates_when_tighter_than_cap(self):
+        """Tiny account: 1% of $5,000 = $50 / $800 per-IC = 0 ICs."""
+        r = IronCondorRisk()
+        qty = r.calculate_quantity(
+            equity=5_000,
+            wing_width=10,
+            credit_per_contract=2.0,
+            max_risk_pct=0.01,
+            hard_cap=10,
+        )
+        assert qty == 0
+
+    def test_blocks_the_historical_50_lot(self):
+        """The actual incident: $95K paper account, $10 wing, ~$2 credit.
+        Per-IC max loss = $800. 2% of $95K = $1,900. qty_from_risk = 2.
+        With the default MAX_CONTRACTS_PER_TRADE hard cap (1 for the
+        controlled-experiment profile), legal qty == 1, NOT 50."""
+        r = IronCondorRisk()
+        qty = r.calculate_quantity(
+            equity=95_000,
+            wing_width=10,
+            credit_per_contract=2.0,
+            hard_cap=1,
+        )
+        assert qty == 1
+        assert qty != 50
+
+    def test_quantity_is_non_negative_int(self):
+        r = IronCondorRisk()
+        qty = r.calculate_quantity(equity=100_000, wing_width=10, credit_per_contract=2.0)
+        assert isinstance(qty, int)
+        assert qty >= 0


### PR DESCRIPTION
## Why
Forensics on the 50-lot SPY 2026-06-18 IC incident (2026-05-19) found that the strategy layer had no sizing function — \`src/strategies/iron_condor/__init__.py:52\` had:
\`\`\`python
# qty = self.risk.calculate_quantity(equity, max_risk=1000)
\`\`\`
quantity was a literal in the trader scripts, with no caller-independent floor.

## What
\`IronCondorRisk.calculate_quantity(equity, wing_width, credit_per_contract, max_risk_pct=None, hard_cap=None) -> int\` returns the largest legal quantity capped by:
1. \`max_risk_pct\` of equity (default \`MAX_POSITION_PCT\`)
2. \`hard_cap\` (default \`MAX_CONTRACTS_PER_TRADE\` — 1 in the controlled-experiment profile)
3. >= 0; zero on invalid inputs

Per-IC max loss = \`(wing_width - credit_per_contract) * 100\`. Returns 0 when equity<=0, wing_width<=0, or credit >= wing (non-physical).

## Tests
\`tests/test_iron_condor_strategy_risk.py\` — 7 tests including the headline:
\`\`\`
test_blocks_the_historical_50_lot:
    qty = r.calculate_quantity(equity=95_000, wing_width=10, credit_per_contract=2.0, hard_cap=1)
    assert qty == 1  # not 50
\`\`\`
Smoke-run output:
\`\`\`
zero equity -> 0
historical (95K, 10w, 2c, cap=1) -> 1
historical (cap=50) -> 2
credit==wing -> 0
default cap (no override) -> 1
\`\`\`

## What this PR does NOT do
The call-site at \`src/strategies/iron_condor/__init__.py:52\` is still commented. Un-commenting it requires \`fix/guarded-submit-order-bypass\` (in flight) so the qty hands off to a safe submit path. Wiring is left to that PR.

## Test plan
- [ ] \`pytest tests/test_iron_condor_strategy_risk.py -q\` green
- [ ] CI green