### PR TITLE
fix(risk): wire the 2 legacy bypass workflows through get_guarded_trading_client + bump ws 8.20.1

### DIFF
--- a/.github/workflows/iron-condor-autonomous.yml
+++ b/.github/workflows/iron-condor-autonomous.yml
@@ -191,7 +191,13 @@ jobs:
 
           api_key = os.environ.get('ALPACA_PAPER_TRADING_API_KEY')
           secret = os.environ.get('ALPACA_PAPER_TRADING_API_SECRET')
-          client = TradingClient(api_key, secret, paper=True)
+          # Order-submitting client routes through the mandatory trade gate.
+          # Read-only data client below uses raw creds (no submit_order surface).
+          from src.utils.alpaca_client import get_guarded_trading_client
+          client = get_guarded_trading_client(paper=True)
+          if client is None:
+              print("❌ ABORT: guarded TradingClient unavailable (creds?)")
+              import sys; sys.exit(1)
 
           # Validate symbols exist before submitting order
           from alpaca.data.historical.option import OptionHistoricalDataClient
@@ -219,7 +225,7 @@ jobs:
               limit_credit = 0.50
           print(f"Limit credit: ${limit_credit:.2f}")
 
-          order = client.submit_order(LimitOrderRequest(  # noqa: direct-submit-order  -- TODO(security): refactor to get_guarded_trading_client() per PR-bypass-fix punch list
+          order = client.submit_order(LimitOrderRequest(  # noqa: direct-submit-order  -- client is get_guarded_trading_client() above; submit routes through mandatory trade gate
               qty=1,
               order_class=OrderClass.MLEG,
               legs=legs,

--- a/.github/workflows/iron-condor-scan.yml
+++ b/.github/workflows/iron-condor-scan.yml
@@ -107,7 +107,12 @@ jobs:
 
           api_key = os.environ.get('ALPACA_PAPER_TRADING_API_KEY')
           secret = os.environ.get('ALPACA_PAPER_TRADING_API_SECRET')
-          client = TradingClient(api_key, secret, paper=True)
+          # Order-submitting client routes through the mandatory trade gate.
+          from src.utils.alpaca_client import get_guarded_trading_client
+          client = get_guarded_trading_client(paper=True)
+          if client is None:
+              print("❌ ABORT: guarded TradingClient unavailable (creds?)")
+              import sys; sys.exit(1)
 
           # Validate symbols exist before submitting order
           from alpaca.data.historical.option import OptionHistoricalDataClient
@@ -129,7 +134,7 @@ jobs:
           ]
 
           # 2 contracts per IC: $1,600 max risk (well under 5% of $101K)
-          order = client.submit_order(MarketOrderRequest(  # noqa: direct-submit-order  -- TODO(security): refactor to get_guarded_trading_client() per PR-bypass-fix punch list
+          order = client.submit_order(MarketOrderRequest(  # noqa: direct-submit-order  -- client is get_guarded_trading_client() above; submit routes through mandatory trade gate
               qty=2,
               order_class=OrderClass.MLEG,
               legs=legs,

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,8 @@
       "name": "trading-triggers",
       "version": "1.0.0",
       "dependencies": {
-        "@trigger.dev/sdk": "^4.4.1"
+        "@trigger.dev/sdk": "^4.4.1",
+        "ws": "^8.20.1"
       },
       "devDependencies": {
         "@types/node": "^22.0.0",
@@ -1702,27 +1703,6 @@
         }
       }
     },
-    "node_modules/engine.io-client/node_modules/ws": {
-      "version": "8.17.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
-      "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": ">=5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/engine.io-parser": {
       "version": "5.2.3",
       "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.2.3.tgz",
@@ -1745,27 +1725,6 @@
       },
       "peerDependenciesMeta": {
         "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/engine.io/node_modules/ws": {
-      "version": "8.17.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
-      "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": ">=5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
           "optional": true
         }
       }
@@ -2496,27 +2455,6 @@
         "ws": "~8.18.3"
       }
     },
-    "node_modules/socket.io-adapter/node_modules/ws": {
-      "version": "8.18.3",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
-      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": ">=5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/socket.io-client": {
       "version": "4.7.5",
       "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-4.7.5.tgz",
@@ -3000,9 +2938,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.19.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
-      "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
+      "version": "8.20.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
+      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/package.json
+++ b/package.json
@@ -14,16 +14,18 @@
     "memory:capture": "printf 'thumbs down' | python3 scripts/capture_hook_feedback.py"
   },
   "dependencies": {
-    "@trigger.dev/sdk": "^4.4.1"
+    "@trigger.dev/sdk": "^4.4.1",
+    "ws": "^8.20.1"
   },
   "overrides": {
     "systeminformation": "^5.31.6",
-    "cookie": "0.7.0"
+    "cookie": "0.7.0",
+    "ws": "^8.20.1"
   },
   "devDependencies": {
+    "@types/node": "^22.0.0",
     "typescript": "^5.7.0",
-    "vitest": "^3.0.0",
-    "@types/node": "^22.0.0"
+    "vitest": "^3.0.0"
   },
   "engines": {
     "node": ">=20.0.0"


### PR DESCRIPTION
## Why
Follow-up to #4028. That PR added the runtime helper and CI grep guard but the 2 actual bypass call sites kept "# noqa: direct-submit-order -- TODO(security)" markers. This PR closes the gap end-to-end.

## What
1. **iron-condor-autonomous.yml** — replace \`client = TradingClient(api_key, secret, paper=True)\` with \`client = get_guarded_trading_client(paper=True)\`. Submit on line 222 now routes through \`validate_trade_mandatory\`. Added abort if guarded client returns None (creds missing).
2. **iron-condor-scan.yml** — same migration.
3. **bump ws -> ^8.20.1** with override so transitive 8.17.1/8.18.3 copies in \`engine.io\` / \`engine.io-client\` / \`socket.io-adapter\` also bump. Closes Dependabot #132 (CVE-2026-45736 MEDIUM, uninitialized-memory disclosure).

## Runtime effect
Next autonomous-trader or daily-scan run: any oversized order request (e.g. >2% of equity, or whatever \`mandatory_trade_gate\` rules block) is rejected BEFORE the broker is touched. The structural bypass that allowed the 50-lot SPY 2026-06-18 IC is now closed.

## Verified
- grep guard rehearsed locally on this tree -> "OK"
- \`npm audit\` post-bump -> 0 vulnerabilities

## Not in this PR (deliberate)
\`src/strategies/iron_condor/__init__.py:52\` is still commented. That controller is unused-stub code; the real production paths are these 2 workflows + \`scripts/iron_condor_trader.py\` + \`ic_simple.py\`. Wiring line 52 without the executor plumbing would be theater.

## Test plan
- [ ] CI green
- [ ] grep-guard workflow passes
- [ ] No new Dependabot alerts open after merge