### PR TITLE
fix(safety): retire Thursday-only weekday gate (Bonferroni adj_p=0.190)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,38 +1,38 @@
 <div align="center">
 
-# Systematic SPY Options Alpha: RAG-Governed Algotrading Lab
+# Systematic SPY Options Lab — Guardrail-First Autonomous Trading
 
-### High-Alpha Thursday Discovery | RAG-ML Safety Governance | Broker-Backed Evidence
+### Autonomous-Agent Safety Layer | RAG Memory | Broker-Backed Audit Trail
 
-**Transforming discretionary options trading into a disciplined, data-driven, and autonomous asset.**
+**An honest validation platform: deterministic guardrails on top of a still-unproven SPY iron-condor signal. Trading is the lab; the safety layer is the product.**
 
-[Public Status](https://igorganapolsky.github.io/trading/) | [Investor Pitch](docs/INVESTOR_PITCH.md) | [Operator Dashboard](https://igorganapolsky.github.io/trading/rag-query/) | [Live Strategy Spec](docs/LIVE_STRATEGY.md)
+[Investor Pitch](docs/INVESTOR_PITCH.md) | [Live Strategy Spec](docs/LIVE_STRATEGY.md) | [Edge Audit (2026-05-19)](docs/research/2026-05-19-edge-analysis.md)
 
 </div>
 
 ---
 
-## 🚀 The Thesis: Evidence-Backed Exclusion
+## 🚀 The Thesis: Operational Excellence, Not Prediction
 
-Most algorithmic trading systems fail due to "over-trading" in low-probability regimes. Our lab is built on a single, verified discovery: **The Thursday Alpha Anomaly.**
+Most algorithmic trading systems fail because they bet on a directional edge that adapts away. This lab inverts that: it bets on **operational guardrails** — deterministic, broker-side, agent-bypass-proof — and uses iron condors only as the in-house workload that proves the safety layer in production.
 
-Following a quantitative audit of 69 paired trades, we identified a **60% win-rate window on Thursdays**, contrasted against a <20% win rate on other weekdays. This repo is the technical implementation of that edge.
+The earlier framing of this repo (a "60% Thursday win-rate anomaly") **was retracted** on 2026-05-20: the apparent effect did not survive Bonferroni correction across the 14 buckets examined (adj_p = 0.190 vs α=0.05). See `docs/research/2026-05-19-edge-analysis.md` for the full audit. The Thursday-only entry gate has been removed from the code; entries are no longer filtered by weekday.
 
-## 🧠 The Edge: RAG-Governed Machine Learning
+## 🧠 What This Lab Builds
 
-We solve the "Black Box" problem of ML through a unique **RAG-to-ML Feedback Loop**:
-
-- **Semantic RAG (LanceDB)**: 249 historical lessons act as a real-time safety "governor."
-- **GRPO Policy Optimization**: Our ML model is penalized during training for violating documented RAG lessons.
-- **Deterministic Hard-Gating**: 7-DTE exit mandates and 14-DTE entry buffers are enforced at the code level to eliminate gamma risk.
+- **`TradeGateway` (`src/risk/trade_gateway.py`)**: the mandatory pre-broker checkpoint. Lot-size cap, IV-rank floor, daily-loss circuit breaker, drawdown circuit breaker, position-count cap, illiquid-option rejection, FOMC blackout, magic-word override, RAG-lesson-driven blocks. **Every decision is appended to `data/gateway_decisions.jsonl`** for audit and product analytics.
+- **`TRADING_HALTED` kill-switch (`src/safety/crisis_monitor.py`)**: file-flag global halt; auto-armed when position count, unrealized loss, or single-position loss cross thresholds.
+- **Lessons-Learned RAG (`src/rag/lessons_learned_rag.py`)**: 249 audited prior incidents — gateway queries this before approving credit strategies.
+- **Iron-condor execution loop (`scripts/iron_condor_trader.py`)**: 1-lot, 30-45 DTE, 15-20 delta, defined-risk-both-sides, 7 DTE / 50% profit exits.
 
 ## 📊 Performance & Operational Truth
 
-This is not a "get rich quick" bot. It is a **validation infrastructure** that prioritizes broker-backed proof over marketing claims:
+This is **not** a profitable system today. Honest current state (verifiable in `data/system_state.json`):
 
-- **North Star**: Target `$6,000/month` yield on a `$300,000` capital base.
-- **Reliability Score**: **100% recent safety approval rate** with 72 repeat mistakes prevented.
-- **Verification**: Fully auditable via Alpaca broker syncs and daily scorecards.
+- **North Star**: $6,000/mo after-tax — currently unrealized. No proven edge yet (PF 0.22, 23.2% win rate over 69 closed trades).
+- **Validation cohort**: 3 / 30 trades under `.claude/rules/controlled-experiment.md`. Too small to claim anything.
+- **Paper equity drawdown**: ~5% from $100K start. Auto-kill floor at $84,351 per `.claude/rules/kill-criteria.md`.
+- **Live brokerage equity**: $0 (inactive). No customer capital. No real money at risk.
 
 But the repo should be understood for what it actually is today:
 

--- a/docs/LIVE_STRATEGY.md
+++ b/docs/LIVE_STRATEGY.md
@@ -7,7 +7,7 @@ This document describes the current validated playbook surface, not a promise of
 - Underlying: `SPY`
 - Structure family: defined-risk options premium structures
 - Primary template: iron-condor style entries
-- **Entry Window**: Thursdays ONLY (Weekday 3) — optimized for 60% historical win rate.
+- **Entry Window**: any weekday (Thursday-only gate retired 2026-05-20 — the "60% Thursday" claim did not survive Bonferroni correction at α=0.05; see `docs/research/2026-05-19-edge-analysis.md`).
 - **Entry Buffer**: Minimum `14 DTE` required for all new positions.
 - **Exit Discipline**:
   - Profit Target: `15%` to `20%` of credit received (May 2026 Defensive Regime).
@@ -19,8 +19,6 @@ This document describes the current validated playbook surface, not a promise of
 
 Current operating truth should be pulled from the canonical ledgers and public dashboard:
 
-- [Public status bundle](data/public_status.json)
-- [Operator dashboard](https://github.com/IgorGanapolsky/trading/wiki/Progress-Dashboard)
 - [System state](../data/system_state.json)
 - [Paired-trade ledger](../data/trades.json)
 

--- a/scripts/iron_condor_trader.py
+++ b/scripts/iron_condor_trader.py
@@ -34,7 +34,6 @@ from typing import Optional
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
 from dotenv import load_dotenv
-
 from src.core.trading_constants import MAX_POSITIONS as MAX_OPTION_LEGS
 from src.core.trading_profiles import get_iron_condor_strategy_config
 from src.orchestrator.telemetry import OrchestratorTelemetry
@@ -234,7 +233,6 @@ class IronCondorStrategy:
         try:
             from alpaca.data.historical import StockHistoricalDataClient
             from alpaca.data.requests import StockLatestQuoteRequest
-
             from src.utils.alpaca_client import get_alpaca_credentials
 
             api_key, secret = get_alpaca_credentials()
@@ -530,7 +528,6 @@ class IronCondorStrategy:
             from alpaca.data.historical import StockHistoricalDataClient
             from alpaca.data.requests import StockBarsRequest
             from alpaca.data.timeframe import TimeFrame
-
             from src.utils.alpaca_client import get_alpaca_credentials
 
             api_key, secret = get_alpaca_credentials()
@@ -641,7 +638,6 @@ class IronCondorStrategy:
             logger.info("=" * 60)
             try:
                 from alpaca.trading.client import TradingClient
-
                 from src.utils.alpaca_client import get_alpaca_credentials
 
                 api_key, secret = get_alpaca_credentials()
@@ -873,7 +869,6 @@ class IronCondorStrategy:
                 from alpaca.trading.client import TradingClient
                 from alpaca.trading.enums import OrderClass, OrderSide
                 from alpaca.trading.requests import OptionLegRequest
-
                 from src.utils.alpaca_client import get_alpaca_credentials
 
                 api_key, secret = get_alpaca_credentials()
@@ -1134,8 +1129,8 @@ def main():
             )
             return {"success": False, "reason": halt_state.reason}
 
-        # HIGH-ALPHA INTEGRATION (SafeBooks Playbook)
-        # Use ExecutionAgent to enforce Thursday-Only Alpha and Volume Throttles
+        # ExecutionAgent enforces VIX gate, DTE gate, and daily throttle.
+        # Thursday-only gate was removed 2026-05-20 (Bonferroni adj_p=0.190).
         try:
             from src.agents.execution_agent import ExecutionAgent
 
@@ -1149,7 +1144,7 @@ def main():
                 "market_conditions": {},
             }
 
-            logger.info("🛡️ Running High-Alpha Validation (Thursday Gate, VIX, Throttle)...")
+            logger.info("🛡️ Running High-Alpha Validation (VIX, Throttle)...")
             analysis = agent.analyze(validation_data)
 
             if analysis.get("action") == "CANCEL":

--- a/src/safety/constraint_engine.py
+++ b/src/safety/constraint_engine.py
@@ -21,12 +21,17 @@ class ConstraintEngine:
     max_trades_per_day: int = 5
 
     def __post_init__(self):
-        # Win Rate Optimization Constants (Verified via empirical audit)
         self.VIX_MAX_GATE = 25.0
         self.MIN_LEG_WIDTH = 10.0
-        self.ALLOWED_WEEKDAYS = [3]  # Thursday is 3. Achieves 60% win rate in backtest.
-        self.MIN_ENTRY_DTE = 14  # Prevent entering late-cycle trades with high gamma risk
-        self.MANDATORY_EXIT_DTE = 7  # Lesson LL-268: Exit at 7 DTE for 80%+ win rate
+        # ALLOWED_WEEKDAYS: empty list = no weekday restriction. The prior value
+        # `[3]` (Thursday-only) was retired 2026-05-20 because
+        # docs/research/2026-05-19-edge-analysis.md showed the "60% Thursday"
+        # claim does not survive Bonferroni correction (adj_p = 0.190 at α=0.05,
+        # n=10). Enforcing it silently blocked Mon/Tue/Wed/Fri entries on bad
+        # evidence. Re-enable only with a fresh, statistically valid hypothesis.
+        self.ALLOWED_WEEKDAYS: list[int] = []
+        self.MIN_ENTRY_DTE = 14
+        self.MANDATORY_EXIT_DTE = 7  # LL-268
 
     def validate_trade(
         self,
@@ -51,16 +56,20 @@ class ConstraintEngine:
         else:
             out_metadata["vix_gate"] = "PASSED"
 
-        # 2. Weekday Gate (P0 Win Rate Driver)
-        current_weekday = trade_meta.get("weekday", -1)
-        if current_weekday not in self.ALLOWED_WEEKDAYS:
-            violations.append(
-                f"Weekday {current_weekday} not in allowed list {self.ALLOWED_WEEKDAYS}. "
-                "Win rate optimization blocks non-Thursday entries."
-            )
-            out_metadata["weekday_gate"] = "FAILED"
+        # 2. Weekday Gate — only enforced when ALLOWED_WEEKDAYS is non-empty.
+        # The prior Thursday-only restriction was removed 2026-05-20 (see
+        # docs/research/2026-05-19-edge-analysis.md: Bonferroni adj_p = 0.190).
+        if self.ALLOWED_WEEKDAYS:
+            current_weekday = trade_meta.get("weekday", -1)
+            if current_weekday not in self.ALLOWED_WEEKDAYS:
+                violations.append(
+                    f"Weekday {current_weekday} not in allowed list {self.ALLOWED_WEEKDAYS}."
+                )
+                out_metadata["weekday_gate"] = "FAILED"
+            else:
+                out_metadata["weekday_gate"] = "PASSED"
         else:
-            out_metadata["weekday_gate"] = "PASSED"
+            out_metadata["weekday_gate"] = "DISABLED"
 
         # 3. DTE Entry Gate (P0 Win Rate Driver - LL-268).
         # FAIL CLOSED on missing dte. The previous `get("dte", 30)` silently


### PR DESCRIPTION
## Summary
Production code was enforcing a "Thursday-only entries" rule based on a claim that \`docs/research/2026-05-19-edge-analysis.md\` (PR #4024) explicitly disproved. This PR removes the gate from code and the marketing copy that propagated the same disproved hypothesis.

## The disproof, restated
Audit of n=69 paired trades:
- Thursday raw win rate 60% on n=10 (p_raw = 0.0136)
- 14 day-of-week / DTE buckets tested
- **Bonferroni-corrected adj_p = 0.0136 × 14 = 0.190** — fails α=0.05
- Wilson 95% CI lower bound on Thursday is 31.3% — below the cohort's ~58% break-even

Verdict from the audit: *"Not supported. ... does not survive a basic look-elsewhere correction."*

## Why this couldn't wait
\`src/safety/constraint_engine.py:27\` had \`ALLOWED_WEEKDAYS=[3]\` and silently blocked Mon/Tue/Wed/Fri entries with rationale "Win rate optimization blocks non-Thursday entries." Enforcing a hypothesis we know doesn't survive multiple-comparison correction is actively harmful — it shrinks the validation cohort to one weekday and biases every future statistic.

## Changes
- **\`src/safety/constraint_engine.py\`**: \`ALLOWED_WEEKDAYS\` defaults to \`[]\` (no restriction). The weekday-gate block only runs when the list is non-empty. \`weekday_gate\` metadata now reports "DISABLED" when no restriction is in force. Re-enabling requires a fresh statistically valid hypothesis.
- **\`scripts/iron_condor_trader.py\`**: log line + comment no longer call this "Thursday-Only Alpha".
- **\`README.md\`**: rewrote the top section. Removed the "60% Thursday Anomaly" framing. Replaced with the honest current state — guardrail-first validation lab, edge unproven, North Star aspirational, paper-only. Removed dead public-dashboard links (those surfaces were ripped out in #4036).
- **\`docs/LIVE_STRATEGY.md\`**: Entry Window now says "any weekday" with pointer to the audit doc; removed dead wiki/public_status.json links.

## Test plan
- [x] \`pytest tests/test_trade_gateway.py\` → 30 passed
- [x] \`ruff check src/safety/ scripts/iron_condor_trader.py\` → clean
- [x] Smoke test: \`ConstraintEngine.validate_trade\` approves all 5 weekdays (Mon-Fri) with VIX=15, DTE=35, leg_width=10, short_delta=0.18 (previously only Thursday=approved)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)