### PR TITLE
fix(analytics): strip Thursday bias from metrics tracker + GRPO reward

### DIFF
--- a/src/analytics/alpha_metrics_tracker.py
+++ b/src/analytics/alpha_metrics_tracker.py
@@ -1,10 +1,18 @@
-"""
-Alpha Metrics Tracker - Advanced tracking for high-alpha gates and regime performance.
+"""Risk-Gate Metrics Tracker — durable counters for safety gates + win-rate by weekday.
 
-This component tracks:
-1. Defense Alpha: P/L prevented by blocking low-probability trades.
-2. Regime Drift: How market conditions are shifting relative to our 'High-Alpha' windows.
-3. ML Alignment: Correlation between RAG lessons and ML policy decisions.
+Tracks:
+1. Defense alpha: how many trades were blocked at each safety gate (generic dict
+   so we don't bake gate names into the schema — yesterday's `thursday_gate_blocks`
+   field outlasted the gate itself).
+2. Win-rate by weekday: honest 5-bucket split with sample sizes, instead of the
+   prior Thursday-vs-other split that prejudged the conclusion.
+3. ML alignment: how often RAG penalties fired during GRPO training.
+
+The previous shape (thursday_win_rate / monday_win_rate / other_days_win_rate +
+thursday_gate_blocks) was retired 2026-05-20: it embedded the Thursday-only
+hypothesis that docs/research/2026-05-19-edge-analysis.md disproved at
+Bonferroni adj_p=0.190. Backward compatibility for old persisted JSON is
+preserved via _migrate_legacy().
 """
 
 import json
@@ -18,6 +26,8 @@ logger = logging.getLogger(__name__)
 PROJECT_ROOT = Path(__file__).parent.parent.parent
 ALPHA_METRICS_PATH = PROJECT_ROOT / "data" / "alpha_metrics.json"
 
+_WEEKDAY_LABELS = ["mon", "tue", "wed", "thu", "fri", "sat", "sun"]
+
 
 class AlphaMetricsTracker:
     def __init__(self, repo_root: Path = PROJECT_ROOT):
@@ -28,7 +38,8 @@ class AlphaMetricsTracker:
     def _load_metrics(self) -> dict[str, Any]:
         if self.metrics_file.exists():
             try:
-                return json.loads(self.metrics_file.read_text())
+                raw = json.loads(self.metrics_file.read_text())
+                return self._migrate_legacy(raw)
             except Exception as e:
                 logger.warning(f"Failed to load metrics: {e}")
                 return self._default_metrics()
@@ -39,40 +50,85 @@ class AlphaMetricsTracker:
             "last_updated": datetime.now().isoformat(),
             "defense_alpha": {
                 "blocked_trades_total": 0,
-                "thursday_gate_blocks": 0,
-                "dte_gate_blocks": 0,
-                "vix_gate_blocks": 0,
+                "gate_blocks": {},  # gate_name -> count
                 "estimated_loss_prevented": 0.0,
             },
-            "regime_performance": {
-                "thursday_win_rate": 0.0,
-                "monday_win_rate": 0.0,
-                "other_days_win_rate": 0.0,
+            "weekday_performance": {
+                "win_rate": {label: 0.0 for label in _WEEKDAY_LABELS[:5]},
+                "sample_size": {label: 0 for label in _WEEKDAY_LABELS[:5]},
             },
             "ml_alignment": {"rag_penalties_applied": 0, "policy_compliance_rate": 0.0},
         }
 
-    def record_block(self, gate_type: str, estimated_loss: float = 0.0):
-        """Record a trade blocked by our safety gates."""
+    def _migrate_legacy(self, raw: dict[str, Any]) -> dict[str, Any]:
+        # Old schema had top-level thursday_gate_blocks + dte_gate_blocks +
+        # vix_gate_blocks as siblings of gate_blocks, and thursday/monday/other
+        # win_rate keys directly under regime_performance. Coerce both to the
+        # new shape so loading old data is non-destructive.
+        new = self._default_metrics()
+        new["last_updated"] = raw.get("last_updated", new["last_updated"])
+
+        legacy_defense = raw.get("defense_alpha") or {}
+        new["defense_alpha"]["blocked_trades_total"] = int(
+            legacy_defense.get("blocked_trades_total", 0)
+        )
+        new["defense_alpha"]["estimated_loss_prevented"] = float(
+            legacy_defense.get("estimated_loss_prevented", 0.0)
+        )
+        gate_blocks: dict[str, int] = dict(legacy_defense.get("gate_blocks") or {})
+        for legacy_key, value in legacy_defense.items():
+            if legacy_key.endswith("_gate_blocks") and isinstance(value, (int, float)):
+                gate_name = legacy_key.removesuffix("_gate_blocks")
+                # Skip thursday — gate was retired, counter is meaningless going forward
+                if gate_name == "thursday":
+                    continue
+                gate_blocks[gate_name] = int(value)
+        new["defense_alpha"]["gate_blocks"] = gate_blocks
+
+        # Discard regime_performance entirely — the bucket boundaries assumed
+        # the Thursday anomaly. Old win_rate numbers (e.g. 60% Thursday) are
+        # exactly the disproved claim we should not propagate.
+        new["weekday_performance"] = new["weekday_performance"]
+
+        legacy_ml = raw.get("ml_alignment") or {}
+        new["ml_alignment"]["rag_penalties_applied"] = int(
+            legacy_ml.get("rag_penalties_applied", 0)
+        )
+        new["ml_alignment"]["policy_compliance_rate"] = float(
+            legacy_ml.get("policy_compliance_rate", 0.0)
+        )
+        return new
+
+    def record_block(self, gate_type: str, estimated_loss: float = 0.0) -> None:
+        """Increment the blocked-trades counter for `gate_type` (e.g. 'dte', 'vix')."""
+        gate = gate_type.lower()
         self.metrics["defense_alpha"]["blocked_trades_total"] += 1
-        key = f"{gate_type.lower()}_gate_blocks"
-        if key in self.metrics["defense_alpha"]:
-            self.metrics["defense_alpha"][key] += 1
-        self.metrics["defense_alpha"]["estimated_loss_prevented"] += estimated_loss
+        gate_blocks = self.metrics["defense_alpha"].setdefault("gate_blocks", {})
+        gate_blocks[gate] = int(gate_blocks.get(gate, 0)) + 1
+        self.metrics["defense_alpha"]["estimated_loss_prevented"] += float(estimated_loss)
         self.save()
 
-    def update_regime_stats(self, trades: list[dict[str, Any]]):
-        """Calculate win rates by weekday to verify the alpha anomaly."""
-        thursday_trades = [t for t in trades if self._get_weekday(t.get("entry_date")) == 3]
-        monday_trades = [t for t in trades if self._get_weekday(t.get("entry_date")) == 0]
-        other_trades = [t for t in trades if self._get_weekday(t.get("entry_date")) not in [0, 3]]
+    def update_weekday_stats(self, trades: list[dict[str, Any]]) -> None:
+        """Compute win rate + sample size for each of the 5 trading weekdays.
 
-        self.metrics["regime_performance"]["thursday_win_rate"] = self._win_rate(thursday_trades)
-        self.metrics["regime_performance"]["monday_win_rate"] = self._win_rate(monday_trades)
-        self.metrics["regime_performance"]["other_days_win_rate"] = self._win_rate(other_trades)
+        No bucket is treated as special. All 5 are equal columns.
+        """
+        win_rate: dict[str, float] = {}
+        sample_size: dict[str, int] = {}
+        for weekday_index, label in enumerate(_WEEKDAY_LABELS[:5]):
+            bucket = [t for t in trades if self._get_weekday(t.get("entry_date")) == weekday_index]
+            win_rate[label] = self._win_rate(bucket)
+            sample_size[label] = len(bucket)
+        self.metrics["weekday_performance"]["win_rate"] = win_rate
+        self.metrics["weekday_performance"]["sample_size"] = sample_size
         self.save()
 
-    def _get_weekday(self, date_str: str) -> int:
+    # Back-compat alias (used by the __main__ self-test and any older callers).
+    update_regime_stats = update_weekday_stats
+
+    def _get_weekday(self, date_str: str | None) -> int:
+        if not date_str:
+            return -1
         try:
             return datetime.fromisoformat(date_str).weekday()
         except (ValueError, TypeError):
@@ -84,16 +140,16 @@ class AlphaMetricsTracker:
         wins = len([t for t in trades if t.get("outcome") == "win" or t.get("realized_pnl", 0) > 0])
         return round((wins / len(trades)) * 100, 2)
 
-    def save(self):
+    def save(self) -> None:
         self.metrics["last_updated"] = datetime.now().isoformat()
+        self.metrics_file.parent.mkdir(parents=True, exist_ok=True)
         self.metrics_file.write_text(json.dumps(self.metrics, indent=2))
 
 
 if __name__ == "__main__":
-    # Self-test / Initial scan
     tracker = AlphaMetricsTracker()
     trades_file = PROJECT_ROOT / "data" / "trades.json"
     if trades_file.exists():
         trades_data = json.loads(trades_file.read_text())
-        tracker.update_regime_stats(trades_data.get("trades", []))
-    print(f"Alpha Metrics Updated: {tracker.metrics_file}")
+        tracker.update_weekday_stats(trades_data.get("trades", []))
+    print(f"Alpha metrics updated: {tracker.metrics_file}")

--- a/src/ml/grpo_trade_learner.py
+++ b/src/ml/grpo_trade_learner.py
@@ -38,6 +38,7 @@ from pathlib import Path
 from typing import Any, Optional
 
 import numpy as np
+
 from src.analytics.alpha_metrics_tracker import AlphaMetricsTracker
 from src.rag.lessons_learned_rag import LessonsLearnedRAG
 
@@ -728,17 +729,19 @@ class GRPOTradeLearner:
         """Calculate penalty for violating historical RAG lessons."""
         penalty = 0.0
 
-        # 1. Day of Week Penalty (P0 Win Rate Driver)
-        # Thursday=3. Mon=0, Tue=1, Wed=2, Fri=4
-        if record.features.day_of_week * 4 < 3:  # Before Thursday
-            penalty -= 100.0  # Significant penalty for early-week entries
+        # Day-of-week penalty was removed 2026-05-20: the prior -$100 reward
+        # penalty on Mon/Tue/Wed entries enforced the same Thursday-only
+        # hypothesis that docs/research/2026-05-19-edge-analysis.md disproved
+        # at Bonferroni adj_p=0.190. Training a policy against a refuted
+        # hypothesis biases it toward false confidence on Thursday entries.
 
-        # 2. DTE Penalty (Gamma Risk protection)
+        # DTE penalty (Gamma Risk protection)
         if record.params.dte < 14:
-            penalty -= 50.0  # Penalty for entering late-cycle trades
+            penalty -= 50.0
 
-        # 3. Dynamic RAG Query (Check for specific failure patterns)
-        query = f"Iron Condor trade on weekday {record.features.day_of_week * 4} with {record.params.dte} DTE"
+        # Dynamic RAG query for known critical failure patterns.
+        weekday_int = round(record.features.day_of_week * 4)
+        query = f"Iron Condor trade on weekday {weekday_int} with {record.params.dte} DTE"
         lessons = self.rag.query(query, top_k=2, severity_filter="CRITICAL")
 
         for lesson in lessons:

--- a/tests/test_alpha_metrics_tracker.py
+++ b/tests/test_alpha_metrics_tracker.py
@@ -1,0 +1,121 @@
+"""Tests for AlphaMetricsTracker — analytics layer after Thursday-bias retirement.
+
+The prior schema had `thursday_gate_blocks` and `thursday_win_rate` baked in.
+Both fields and the regime split that fed them were retired 2026-05-20 after
+the May 19 edge audit disproved the Thursday hypothesis (Bonferroni adj_p=0.190).
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from src.analytics.alpha_metrics_tracker import AlphaMetricsTracker
+
+
+@pytest.fixture()
+def tracker(tmp_path):
+    t = AlphaMetricsTracker(repo_root=tmp_path)
+    (tmp_path / "data").mkdir(parents=True, exist_ok=True)
+    return t
+
+
+class TestSchemaShape:
+    def test_default_schema_has_no_thursday_fields(self, tracker):
+        m = tracker.metrics
+        defense = m["defense_alpha"]
+        weekday = m["weekday_performance"]
+        # No baked-in Thursday gate counter
+        assert "thursday_gate_blocks" not in defense
+        # Gate blocks is generic dict
+        assert defense["gate_blocks"] == {}
+        # All 5 weekdays present as equal columns
+        assert set(weekday["win_rate"].keys()) == {"mon", "tue", "wed", "thu", "fri"}
+        assert set(weekday["sample_size"].keys()) == {"mon", "tue", "wed", "thu", "fri"}
+        # Old top-level keys not present
+        assert "thursday_win_rate" not in weekday
+        assert "monday_win_rate" not in weekday
+        assert "other_days_win_rate" not in weekday
+
+
+class TestRecordBlock:
+    def test_record_block_increments_named_gate(self, tracker):
+        tracker.record_block("dte", estimated_loss=100.0)
+        tracker.record_block("dte", estimated_loss=50.0)
+        tracker.record_block("vix")
+        gb = tracker.metrics["defense_alpha"]["gate_blocks"]
+        assert gb == {"dte": 2, "vix": 1}
+        assert tracker.metrics["defense_alpha"]["blocked_trades_total"] == 3
+        assert tracker.metrics["defense_alpha"]["estimated_loss_prevented"] == 150.0
+
+    def test_record_block_persists(self, tracker):
+        tracker.record_block("dte", estimated_loss=100.0)
+        reloaded = AlphaMetricsTracker(repo_root=tracker.repo_root)
+        assert reloaded.metrics["defense_alpha"]["gate_blocks"]["dte"] == 1
+
+
+class TestWeekdayStats:
+    def test_all_weekdays_treated_equally(self, tracker):
+        trades = [
+            {"entry_date": "2026-05-04T10:00", "realized_pnl": 100},  # Mon win
+            {"entry_date": "2026-05-04T10:00", "realized_pnl": -50},  # Mon loss
+            {"entry_date": "2026-05-05T10:00", "realized_pnl": -50},  # Tue loss
+            {"entry_date": "2026-05-06T10:00", "realized_pnl": 100},  # Wed win
+            {"entry_date": "2026-05-07T10:00", "realized_pnl": 100},  # Thu win
+            {"entry_date": "2026-05-08T10:00", "realized_pnl": -50},  # Fri loss
+        ]
+        tracker.update_weekday_stats(trades)
+        wr = tracker.metrics["weekday_performance"]["win_rate"]
+        ss = tracker.metrics["weekday_performance"]["sample_size"]
+        assert wr == {"mon": 50.0, "tue": 0.0, "wed": 100.0, "thu": 100.0, "fri": 0.0}
+        assert ss == {"mon": 2, "tue": 1, "wed": 1, "thu": 1, "fri": 1}
+
+    def test_empty_trades_keep_default_zeros(self, tracker):
+        tracker.update_weekday_stats([])
+        wr = tracker.metrics["weekday_performance"]["win_rate"]
+        assert all(v == 0.0 for v in wr.values())
+
+    def test_legacy_alias_works(self, tracker):
+        # update_regime_stats is the back-compat alias; should not crash
+        tracker.update_regime_stats(
+            [{"entry_date": "2026-05-07T10:00", "realized_pnl": 100}]
+        )
+        assert tracker.metrics["weekday_performance"]["win_rate"]["thu"] == 100.0
+
+
+class TestLegacyMigration:
+    def test_migrate_old_schema_strips_thursday_bias(self, tmp_path):
+        # Write a file in the old schema with the disproved 60% Thursday number
+        legacy = {
+            "last_updated": "2026-05-15T12:18:34.129093",
+            "defense_alpha": {
+                "blocked_trades_total": 7,
+                "thursday_gate_blocks": 3,
+                "dte_gate_blocks": 2,
+                "vix_gate_blocks": 2,
+                "estimated_loss_prevented": 100.0,
+            },
+            "regime_performance": {
+                "thursday_win_rate": 60.0,
+                "monday_win_rate": 13.33,
+                "other_days_win_rate": 18.18,
+            },
+            "ml_alignment": {"rag_penalties_applied": 2, "policy_compliance_rate": 0.0},
+        }
+        (tmp_path / "data").mkdir()
+        (tmp_path / "data" / "alpha_metrics.json").write_text(json.dumps(legacy))
+
+        t = AlphaMetricsTracker(repo_root=tmp_path)
+        defense = t.metrics["defense_alpha"]
+        # blocked_trades_total preserved
+        assert defense["blocked_trades_total"] == 7
+        # Thursday counter dropped, others migrated to gate_blocks dict
+        assert "thursday_gate_blocks" not in defense
+        assert defense["gate_blocks"] == {"dte": 2, "vix": 2}
+        # Disproved Thursday win rate not propagated
+        weekday = t.metrics["weekday_performance"]
+        assert "thursday_win_rate" not in weekday
+        assert weekday["win_rate"]["thu"] == 0.0  # reset to default — old number discarded
+        # ML alignment preserved
+        assert t.metrics["ml_alignment"]["rag_penalties_applied"] == 2


### PR DESCRIPTION
## Summary
After PR #4037 retired the Thursday-only entry gate in production, the analytics layer was still shaped around the disproved hypothesis (Bonferroni adj_p=0.190). This PR brings analytics into alignment with the research.

### Concrete brokenness fixed
1. **\`data/alpha_metrics.json\` persisted \`thursday_win_rate: 60.0\`** — the exact disproved claim, sitting in our live metrics file (gitignored, not in repo, but generated on every analytics run).
2. **\`AlphaMetricsTracker._default_metrics\`** had \`thursday_gate_blocks\` as a hard field — a counter for a gate that no longer exists in code.
3. **\`update_regime_stats\`** singled out Thursday + Monday and lumped everything else as \"other_days\" — schema-level prejudice toward the refuted claim.
4. **\`grpo_trade_learner._calculate_rag_penalty\`** applied -\$100 reward penalty to Mon/Tue/Wed entries. The GRPO policy was being trained AGAINST the disproved hypothesis.

### New schema
\`\`\`json
{
  "defense_alpha": {
    "blocked_trades_total": 7,
    "gate_blocks": {"dte": 2, "vix": 5},
    "estimated_loss_prevented": 1250.0
  },
  "weekday_performance": {
    "win_rate":    {"mon": 0.0, "tue": 0.0, "wed": 0.0, "thu": 0.0, "fri": 0.0},
    "sample_size": {"mon": 0,   "tue": 0,   "wed": 0,   "thu": 0,   "fri": 0}
  },
  "ml_alignment": {"rag_penalties_applied": 0, "policy_compliance_rate": 0.0}
}
\`\`\`
All 5 weekdays are equal columns. \`gate_blocks\` is a generic dict so adding/removing gates doesn't require schema changes.

### Migration path
\`_migrate_legacy()\` ingests the old shape non-destructively:
- ✅ \`dte_gate_blocks: 2\` → \`gate_blocks.dte: 2\`
- ✅ \`vix_gate_blocks: 5\` → \`gate_blocks.vix: 5\`
- ✅ \`blocked_trades_total\`, \`estimated_loss_prevented\`, \`rag_penalties_applied\` preserved
- ❌ \`thursday_gate_blocks\` discarded (gate retired, counter meaningless)
- ❌ \`thursday_win_rate: 60.0\` / \`monday_win_rate: 13.33\` / \`other_days_win_rate: 18.18\` discarded — propagating the disproved numbers would be the bug

### Test plan
- [x] \`pytest tests/test_alpha_metrics_tracker.py\` → **7 passed** (schema shape, gate counter dict, all-weekdays-equal, legacy migration discards disproved numbers, persistence round-trips, empty trades, back-compat alias)
- [x] \`ruff check\` → clean
- [x] \`trunk fmt\` → clean
- [x] Live smoke: tracker correctly tallies 5-bucket win rates + per-gate block counts on synthetic trades
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)