### PR TITLE
chore(ci): harden Trunk + GitHub Actions per 2026 best practices

### DIFF
--- a/.github/workflows/agent-health-check.yml
+++ b/.github/workflows/agent-health-check.yml
@@ -12,6 +12,9 @@ on:
     - cron: "0 9,10 * * *"
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 env:
   SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
   SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,6 +78,14 @@ jobs:
     name: Trunk Check
     if: github.event_name == 'pull_request' || github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
+    # checks/pull-requests write are required for trunk-io/trunk-action to
+    # post annotations to the PR. Without them the action returns exit 1 with
+    # "Resource not accessible by integration" 403 (recurring noise on every
+    # recent PR). Job-level permissions narrow the broader workflow scope.
+    permissions:
+      contents: read
+      checks: write
+      pull-requests: write
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/.github/workflows/claude-agent-utility.yml
+++ b/.github/workflows/claude-agent-utility.yml
@@ -55,6 +55,9 @@ on:
         type: boolean
         default: true
 
+permissions:
+  contents: read
+
 env:
   PYTHON_VERSION: "3.11"
 

--- a/.github/workflows/close-orphan-position.yml
+++ b/.github/workflows/close-orphan-position.yml
@@ -19,6 +19,9 @@ on:
           - "false"
           - "true"
 
+permissions:
+  contents: read
+
 # CRITICAL: Global trade concurrency - prevents race conditions (LL-281)
 concurrency:
   group: global-trade-execution

--- a/.github/workflows/close-orphan-spy-puts.yml
+++ b/.github/workflows/close-orphan-spy-puts.yml
@@ -8,6 +8,9 @@ on:
         required: true
         default: ""
 
+permissions:
+  contents: read
+
 # Prevent concurrent trade execution (LL-281 race condition fix)
 concurrency:
   group: global-trade-execution

--- a/.github/workflows/diagnose-alpaca-connection.yml
+++ b/.github/workflows/diagnose-alpaca-connection.yml
@@ -5,6 +5,9 @@ name: Diagnose Alpaca Connection
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 env:
   SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
   SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}

--- a/.github/workflows/emergency-protection.yml
+++ b/.github/workflows/emergency-protection.yml
@@ -14,6 +14,9 @@ on:
         default: "1.00"
         type: string
 
+permissions:
+  contents: read
+
 env:
   SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
   SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}

--- a/.github/workflows/event-router.yml
+++ b/.github/workflows/event-router.yml
@@ -25,6 +25,11 @@ on:
           - test-coverage
           - health-check
 
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
 concurrency:
   group: event-router-${{ github.event_name }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/execute-credit-spread.yml
+++ b/.github/workflows/execute-credit-spread.yml
@@ -23,6 +23,9 @@ on:
         required: true
         default: "1"
 
+permissions:
+  contents: read
+
 # CRITICAL: Global trade concurrency - prevents race conditions (LL-281)
 concurrency:
   group: global-trade-execution

--- a/.github/workflows/fix-broken-spread.yml
+++ b/.github/workflows/fix-broken-spread.yml
@@ -3,6 +3,9 @@ name: Fix Broken 653 Spread
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 env:
   SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
   SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}

--- a/.github/workflows/iron-condor-autonomous.yml
+++ b/.github/workflows/iron-condor-autonomous.yml
@@ -21,6 +21,9 @@ on:
           - status
           - force_scan
 
+permissions:
+  contents: read
+
 # Prevent concurrent trade execution (LL-281 race condition fix)
 concurrency:
   group: global-trade-execution

--- a/.github/workflows/no-direct-submit-order.yml
+++ b/.github/workflows/no-direct-submit-order.yml
@@ -23,6 +23,9 @@ on:
   push:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   grep-guard:
     runs-on: ubuntu-latest

--- a/.github/workflows/notify-alert.yml
+++ b/.github/workflows/notify-alert.yml
@@ -27,6 +27,10 @@ on:
       GH_PAT:
         required: true
 
+permissions:
+  contents: read
+  issues: write
+
 env:
   SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
   SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}

--- a/.github/workflows/offline-evals.yml
+++ b/.github/workflows/offline-evals.yml
@@ -17,6 +17,10 @@ on:
       - "tests/evals/**"
   workflow_dispatch:
 
+permissions:
+  contents: read
+  actions: read
+
 jobs:
   offline-evals:
     runs-on: ubuntu-latest

--- a/.github/workflows/one-time-secret-update.yml
+++ b/.github/workflows/one-time-secret-update.yml
@@ -9,6 +9,9 @@ on:
     paths:
       - "UPDATE_SECRETS.json"
 
+permissions:
+  contents: read
+
 env:
   SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
   SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}

--- a/.github/workflows/position-monitor.yml
+++ b/.github/workflows/position-monitor.yml
@@ -3,8 +3,11 @@ name: Position Monitor
 on:
   schedule:
     # Every 30 minutes during market hours (9:30 AM - 4:00 PM ET = 14:30 - 21:00 UTC), Mon-Fri
-    - cron: '0,30 14-20 * * 1-5'
+    - cron: "0,30 14-20 * * 1-5"
   workflow_dispatch:
+
+permissions:
+  contents: write
 
 concurrency:
   group: position-monitor-${{ github.ref }}
@@ -23,7 +26,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: '3.11'
+          python-version: "3.11"
           cache: "pip"
 
       - name: Install dependencies

--- a/.github/workflows/ralph-loop-ai.yml
+++ b/.github/workflows/ralph-loop-ai.yml
@@ -40,6 +40,11 @@ on:
         default: ""
         type: string
 
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+
 env:
   PYTHON_VERSION: "3.11"
 
@@ -225,7 +230,7 @@ jobs:
           pip install -q -r requirements.txt || true
 
       - name: Query RAG for lessons
-        continue-on-error: true  # Non-critical: RAG context is advisory, AI loop works without it
+        continue-on-error: true # Non-critical: RAG context is advisory, AI loop works without it
         run: |
           echo "=== Querying local LanceDB RAG for recent lessons ==="
           python3 - << 'PY'

--- a/.github/workflows/ralph-mode-cto.yml
+++ b/.github/workflows/ralph-mode-cto.yml
@@ -17,6 +17,10 @@ on:
           - lint-only
           - cleanup-only
 
+permissions:
+  contents: write
+  pull-requests: write
+
 env:
   PYTHON_VERSION: "3.11"
 
@@ -111,7 +115,7 @@ jobs:
 
       - name: Run pytest
         id: tests
-        continue-on-error: true  # Intentional: captures pass/fail in outputs, downstream step creates report
+        continue-on-error: true # Intentional: captures pass/fail in outputs, downstream step creates report
         run: |
           pytest tests/ -q --tb=no 2>&1 | tee test_output.txt
           if grep -q "passed" test_output.txt; then
@@ -124,7 +128,7 @@ jobs:
 
       - name: Run ruff lint
         id: lint
-        continue-on-error: true  # Intentional: captures pass/fail in outputs, downstream step creates report
+        continue-on-error: true # Intentional: captures pass/fail in outputs, downstream step creates report
         run: |
           if ruff check src/ scripts/ 2>&1; then
             echo "passed=true" >> $GITHUB_OUTPUT

--- a/.github/workflows/ralph-proactive-scanner.yml
+++ b/.github/workflows/ralph-proactive-scanner.yml
@@ -24,6 +24,10 @@ on:
           - dead_code
           - code_quality
 
+permissions:
+  contents: write
+  pull-requests: write
+
 env:
   PYTHON_VERSION: "3.11"
 
@@ -51,7 +55,7 @@ jobs:
 
       - name: Run Bandit security scan
         id: scan
-        continue-on-error: true  # Intentional: captures scan results in outputs, downstream steps create issues
+        continue-on-error: true # Intentional: captures scan results in outputs, downstream steps create issues
         run: |
           echo "## Security Scan Results" >> $GITHUB_STEP_SUMMARY
 
@@ -97,7 +101,7 @@ jobs:
 
       - name: Run dead code scan
         id: scan
-        continue-on-error: true  # Intentional: captures scan results in outputs, downstream steps create issues
+        continue-on-error: true # Intentional: captures scan results in outputs, downstream steps create issues
         run: |
           echo "## Dead Code Scan" >> $GITHUB_STEP_SUMMARY
 

--- a/.github/workflows/swarm-orchestration.yml
+++ b/.github/workflows/swarm-orchestration.yml
@@ -33,6 +33,10 @@ on:
         type: boolean
         default: false
 
+permissions:
+  contents: write
+  pull-requests: write
+
 env:
   SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
   SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}

--- a/.github/workflows/test-coverage-agent.yml
+++ b/.github/workflows/test-coverage-agent.yml
@@ -6,6 +6,10 @@ on:
     - cron: "0 13 * * 0"
   workflow_dispatch:
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   find-gaps:
     runs-on: ubuntu-latest

--- a/.github/workflows/update-alpaca-secrets.yml
+++ b/.github/workflows/update-alpaca-secrets.yml
@@ -12,6 +12,9 @@ on:
         required: true
         type: string
 
+permissions:
+  contents: read
+
 env:
   SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
   SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}

--- a/.github/workflows/webhook-health-check.yml
+++ b/.github/workflows/webhook-health-check.yml
@@ -10,6 +10,9 @@ on:
   #   - cron: '0 15 * * 1-5'  # 10 AM ET on trading days
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 env:
   SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
   SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}

--- a/.github/workflows/webhook-integration-test.yml
+++ b/.github/workflows/webhook-integration-test.yml
@@ -10,6 +10,9 @@ on:
   #   - cron: '0 15,18,21 * * 1-5'  # 3x during market hours
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 env:
   SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
   SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}

--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -1,13 +1,18 @@
 # This file controls the behavior of Trunk: https://docs.trunk.io/cli
 # To learn more about the format of this file, see https://docs.trunk.io/reference/trunk-yaml
 version: 0.1
+# Required statuses must match the GitHub check-context names emitted by
+# .github/workflows/ci.yml — names not in that workflow have no enforcement.
+# Audit 2026-05-20: prior list named "Lint & Format / Type Check / Security
+# Scan / Smoke Test" — none of those job names exist in ci.yml, so the gate
+# was advisory-only even before branch protection was disabled.
 merge:
   required_statuses:
-    - "Lint & Format"
-    - "Type Check"
-    - "Security Scan"
-    - "Run All Tests"
-    - "Smoke Test"
+    - Detect Changed Paths
+    - Run All Tests
+    - Validate Workflows
+    - CodeQL
+    - Analyze (python)
 cli:
   version: 1.25.0
 # Trunk provides extensibility via plugins. (https://docs.trunk.io/plugins)
@@ -27,6 +32,10 @@ lint:
   disabled:
     - mypy
     - black # CI uses ruff format, not black
+    - isort # ruff handles import sorting (rule I001); isort and ruff
+      # actively conflict on the third-party-vs-local group split in
+      # src/ml/grpo_trade_learner.py. Keeping ruff as the single
+      # source of truth per CLAUDE.md.
   enabled:
     - gofmt@1.20.4
     - golangci-lint2@2.11.4
@@ -36,7 +45,6 @@ lint:
     - checkov@3.2.513
     - git-diff-check
     - hadolint@2.14.0
-    - isort@8.0.1
     - markdownlint@0.48.0
     - osv-scanner@2.3.5
     - prettier@3.8.1


### PR DESCRIPTION
## Summary
Three independent CI-config gaps from the 2026-05-20 deep-research audit, fixed atomically.

### 1. \`permissions:\` blocks → 23 workflows
Per post-2025 GitHub Actions hardening guidance, declaring any \`permissions:\` flips the workflow from permissive default to explicit mode. Minimum scope, no over-grants:
- **read-only (15 workflows)**: agent-health-check, claude-agent-utility, close-orphan-{position,spy-puts}, diagnose-alpaca-connection, emergency-protection, execute-credit-spread, fix-broken-spread, iron-condor-autonomous, no-direct-submit-order, one-time-secret-update, update-alpaca-secrets, webhook-{health-check,integration-test}, offline-evals (+ \`actions: read\`)
- **issues:write (notify-alert + event-router** also gets \`pull-requests: write\`)
- **contents:write (position-monitor** commits ledger data)
- **contents:write + pull-requests:write (4 ralph/swarm/test-coverage** loops open PRs)

Workflows using \`secrets.GH_PAT\` are unaffected — PAT scopes bypass the workflow \`permissions:\` block entirely.

### 2. Trunk Check 403 → fixed at the job level
\`ci.yml\` Trunk Check job now declares \`checks: write\` + \`pull-requests: write\`. This is the root cause of the recurring "Resource not accessible by integration" 403 we hit on every PR including #4036 and #4037 — \`trunk-io/trunk-action\` was trying to post annotations but the job only inherited \`contents: read\` from the workflow.

### 3. \`.trunk/trunk.yaml\`
- **\`required_statuses\` rewritten** to match actual ci.yml job names (\`Detect Changed Paths / Run All Tests / Validate Workflows / CodeQL / Analyze (python)\`). Prior list named \`Lint & Format / Type Check / Security Scan / Smoke Test\` — **none** were job names in ci.yml, making the merge gate advisory-only even before branch protection was disabled.
- **\`isort@8.0.1\` disabled**. Actively conflicted with \`ruff@0.15.8\` on I001 import ordering in \`src/ml/grpo_trade_learner.py\`. Verified by oscillation: after \`ruff --fix\`, trunk fmt complains; after \`trunk fmt\`, ruff complains. CLAUDE.md already names ruff as the source of truth.

## Out of scope for this PR
- **Branch protection on \`main\` is still OFF** (HTTP 404 "Branch not protected"). The corrected \`required_statuses\` list lands here so we can enable branch protection in the next step with the right context names.
- **0 / 216 actions SHA-pinned.** Post-CVE-2025-30066, this is the next P0; deferred to a separate sweep PR to keep this one reviewable.

## Test plan
- [x] All 77 workflows parse with \`yaml.safe_load\` — 0 errors
- [x] Missing-permissions count: 0 (was 23)
- [x] \`ruff check src/ml/grpo_trade_learner.py\` → clean
- [x] \`trunk check .trunk/trunk.yaml .github/workflows/ci.yml\` → no issues
- [ ] CI green (especially Trunk Check, which should now post annotations without the 403)

🤖 Generated with [Claude Code](https://claude.com/claude-code)