### PR TITLE
feat(ci): Claude AI PR review — in-repo equivalent of Sonar/Gitar

### DIFF
--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -1,0 +1,60 @@
+name: Claude PR Review
+
+# In-repo equivalent of Sonar/Gitar AI code review. Triggers on every
+# PR open / reopen / ready_for_review. Reads the diff + CLAUDE.md +
+# .claude/rules and posts a single rolling review comment with a
+# deterministic marker so subsequent runs replace the prior comment
+# instead of stacking.
+#
+# Skips on draft PRs and PRs authored by bots (dependabot/auto-format
+# etc.) — those are handled by the deterministic-fix auto-merger.
+# Triggers only on opened/reopened/ready_for_review (NOT synchronize)
+# to avoid re-reviewing every push within a PR; reviewers can re-trigger
+# manually via workflow_dispatch.
+
+on:
+  pull_request:
+    types: [opened, reopened, ready_for_review]
+  # Manual re-trigger: close + reopen the PR. The workflow_dispatch
+  # input form was removed because checkov/CKV_GHA_7 requires
+  # workflow_dispatch inputs to be empty for supply-chain hardening.
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: claude-pr-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    if: |
+      github.event.pull_request.draft == false &&
+      github.event.pull_request.user.type != 'Bot' &&
+      !startsWith(github.event.pull_request.head.ref, 'dependabot/') &&
+      !startsWith(github.event.pull_request.head.ref, 'auto/ruff-format') &&
+      !startsWith(github.event.pull_request.head.ref, 'auto/lint')
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+        with:
+          python-version: "3.11"
+
+      - name: Run Claude PR review
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: python3 scripts/ci/claude_pr_review.py

--- a/scripts/ci/claude_pr_review.py
+++ b/scripts/ci/claude_pr_review.py
@@ -1,0 +1,232 @@
+"""Claude AI PR review — in-repo equivalent of Sonar/Gitar.
+
+Reads the PR diff + repo context (CLAUDE.md / .claude/rules), asks Claude
+to produce a focused review against this repo's coding standards and risk
+mandates, and posts the result as a single PR comment with a deterministic
+marker so subsequent runs replace the prior comment instead of stacking.
+
+Triggered by .github/workflows/claude-pr-review.yml on pull_request open /
+reopened / ready_for_review. Required env:
+    ANTHROPIC_API_KEY  - Anthropic API key
+    GH_TOKEN           - GitHub token with pull-requests:write
+    PR_NUMBER          - The pull request number to review
+    REPO               - "owner/name"
+    PR_BASE_SHA        - Base ref SHA of the PR
+    PR_HEAD_SHA        - Head ref SHA of the PR
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess  # nosec B404 — used to call `gh`/`git` CLIs from CI with controlled args
+import sys
+import urllib.request
+from pathlib import Path
+
+API_URL = "https://api.anthropic.com/v1/messages"
+MODEL = os.environ.get("CLAUDE_REVIEW_MODEL", "claude-sonnet-4-6")
+MAX_DIFF_BYTES = 200_000
+MAX_RULES_BYTES = 60_000
+COMMENT_MARKER = "<!-- claude-pr-review:v1 -->"
+
+REVIEW_SYSTEM_PROMPT = """You are reviewing a pull request against the
+IgorGanapolsky/trading repo. You read the diff and surface ONLY the issues
+that matter; you do not narrate what the PR does.
+
+Hard mandates from this repo (enforce ruthlessly):
+- Phil Town Rule #1: don't lose money. Iron Condors on SPY only, 15-20
+  delta, 30-45 DTE, defined risk both sides, MAX_CONTRACTS_PER_TRADE=1.
+- Never hardcode credentials. Use src.utils.alpaca_client.get_alpaca_credentials.
+- TradeGateway is the mandatory checkpoint — no trade may bypass it.
+  All direct submit_order calls outside the gateway are violations.
+- Closing positions outside the guardian workflow is a hard block
+  (.claude/rules/boundary-policy.md).
+- Trading remains paper-only under the controlled-experiment.md gate
+  until 30 trades with positive expectancy.
+- North Star ($6K/mo after-tax) is now framed as B2B guardrail SaaS,
+  not paper IC P/L. The trading account is the demo, not the cash register.
+
+Review priorities (in order):
+1. Risk/safety regressions: new ways to bypass TradeGateway, kill-switch
+   removal, position-close shortcuts, hardcoded credentials, leaked PATs.
+2. Bug risk: logic errors, off-by-one, type errors, exception swallowing,
+   race conditions in trade execution.
+3. CI/security regressions: unpinned actions, missing permissions blocks,
+   force-push to main, --no-verify hook bypass without justification.
+4. Hypothesis-bound bias: enforcing or re-introducing the disproved
+   Thursday-only entry gate (Bonferroni adj_p=0.190, retired 2026-05-20).
+5. P/L misreporting: citing the paired-ledger -$3,958 number without
+   acknowledging the ~$2.6K gap to broker truth.
+6. Style/quality nits last and briefly.
+
+OUTPUT FORMAT (markdown, terse):
+- A one-line top verdict: "APPROVE", "REQUEST_CHANGES", or "COMMENT".
+- A "Why" line, one sentence.
+- A short list of findings, each with: severity (P0/P1/P2), file:line if
+  applicable, and a one-line description. Skip the list if there are no
+  findings.
+- Optional "Suggested patch" block with concrete code if the fix is small
+  and obvious.
+
+Do NOT:
+- Praise. Do NOT summarize what the PR does. Do NOT thank the author.
+- Speculate about runtime behavior you cannot verify from the diff.
+- Cite line numbers you didn't see in the diff.
+"""
+
+
+def run(cmd: list[str], check: bool = True) -> str:
+    # Args are constructed from controlled sources (env vars set by the
+    # workflow and module-level constants); no shell expansion. Calling
+    # the system gh/git binaries via the resolved PATH on the runner.
+    # trunk-ignore(bandit/B603)
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    if check and result.returncode != 0:
+        sys.stderr.write(f"command failed: {' '.join(cmd)}\n{result.stderr}\n")
+        sys.exit(1)
+    return result.stdout
+
+
+def load_context() -> str:
+    parts: list[str] = []
+    candidates = [
+        Path("CLAUDE.md"),
+        Path(".claude/CLAUDE.md"),
+        Path(".claude/rules/risk-management.md"),
+        Path(".claude/rules/controlled-experiment.md"),
+        Path(".claude/rules/boundary-policy.md"),
+        Path(".claude/rules/trading.md"),
+    ]
+    budget = MAX_RULES_BYTES
+    for p in candidates:
+        if not p.exists():
+            continue
+        text = p.read_text(encoding="utf-8")[: budget // len(candidates)]
+        parts.append(f"# {p}\n{text}")
+        budget -= len(text)
+        if budget <= 0:
+            break
+    return "\n\n".join(parts)
+
+
+def get_diff(base: str, head: str) -> str:
+    diff = run(["git", "diff", "--unified=3", f"{base}...{head}"])
+    if len(diff.encode("utf-8")) > MAX_DIFF_BYTES:
+        diff = diff[:MAX_DIFF_BYTES] + "\n\n[diff truncated at 200K bytes]"
+    return diff
+
+
+def call_claude(system: str, user: str) -> str:
+    key = os.environ["ANTHROPIC_API_KEY"]
+    body = json.dumps(
+        {
+            "model": MODEL,
+            "max_tokens": 2048,
+            "system": system,
+            "messages": [{"role": "user", "content": user}],
+        }
+    ).encode("utf-8")
+    req = urllib.request.Request(
+        API_URL,
+        data=body,
+        headers={
+            "x-api-key": key,
+            "anthropic-version": "2023-06-01",
+            "content-type": "application/json",
+        },
+        method="POST",
+    )
+    try:
+        # URL is the hardcoded constant API_URL (https://api.anthropic.com);
+        # not user-controlled, scheme is fixed https.
+        # trunk-ignore(bandit/B310)
+        with urllib.request.urlopen(req, timeout=90) as r:
+            payload = json.loads(r.read())
+    except urllib.error.HTTPError as e:
+        msg = e.read().decode("utf-8", errors="replace")
+        sys.stderr.write(f"anthropic api error {e.code}: {msg}\n")
+        sys.exit(2)
+    blocks = payload.get("content") or []
+    text = "".join(b.get("text", "") for b in blocks if b.get("type") == "text")
+    return text.strip()
+
+
+def find_existing_comment(repo: str, pr: str) -> int | None:
+    raw = run(
+        [
+            "gh",
+            "api",
+            f"repos/{repo}/issues/{pr}/comments",
+            "--paginate",
+        ]
+    )
+    try:
+        comments = json.loads(raw)
+    except json.JSONDecodeError:
+        return None
+    for c in comments:
+        if COMMENT_MARKER in (c.get("body") or ""):
+            return c["id"]
+    return None
+
+
+def post_or_update_comment(repo: str, pr: str, body: str) -> None:
+    body_full = f"{COMMENT_MARKER}\n{body}"
+    existing = find_existing_comment(repo, pr)
+    if existing is not None:
+        run(
+            [
+                "gh",
+                "api",
+                "-X",
+                "PATCH",
+                f"repos/{repo}/issues/comments/{existing}",
+                "-f",
+                f"body={body_full}",
+            ]
+        )
+        print(f"updated existing comment {existing}")
+    else:
+        run(
+            [
+                "gh",
+                "api",
+                "-X",
+                "POST",
+                f"repos/{repo}/issues/{pr}/comments",
+                "-f",
+                f"body={body_full}",
+            ]
+        )
+        print("posted new comment")
+
+
+def main() -> int:
+    pr = os.environ["PR_NUMBER"]
+    repo = os.environ["REPO"]
+    base = os.environ["PR_BASE_SHA"]
+    head = os.environ["PR_HEAD_SHA"]
+
+    diff = get_diff(base, head)
+    if not diff.strip():
+        print("empty diff — skipping review")
+        return 0
+
+    context = load_context()
+    user_msg = (
+        "Review the following pull request diff under the repo mandates above.\n\n"
+        f"## Repo context (CLAUDE.md + key rules)\n\n{context}\n\n"
+        f"## PR #{pr} diff\n\n```diff\n{diff}\n```\n"
+    )
+    review = call_claude(REVIEW_SYSTEM_PROMPT, user_msg)
+    if not review:
+        print("empty review from model — skipping post")
+        return 0
+
+    post_or_update_comment(repo, pr, review)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
You sent the Sonar Gitar PDF asking to "implement this on our CI/CD." Gitar is a commercial AI code review product Sonar just acquired — installing it would require a **paid SonarQube subscription** plus the **CEO installing the Sonar GitHub App via OAuth**, neither of which can be done from this shell.

Built the **in-repo equivalent** instead. Same described behavior (reviews every PR, focused fixes, terse output), runs on the \`ANTHROPIC_API_KEY\` already in repo secrets, costs ~\$0.02/PR, no vendor lock-in, and the review prompt is tailored to *this repo's* risk mandates (Phil Town Rule #1, TradeGateway, kill-switch boundary, controlled-experiment, North Star pivot, P/L paired-ledger caveat).

## Files added
| File | Purpose |
|---|---|
| \`.github/workflows/claude-pr-review.yml\` | Triggers on \`pull_request\` opened/reopened/ready_for_review. Skips drafts, bot authors, and deterministic-fix branches (dependabot/, auto/ruff-format, auto/lint). Concurrency-grouped per PR. Permissions: \`contents: read\` + \`pull-requests: write\`. |
| \`scripts/ci/claude_pr_review.py\` | Reads diff (200KB cap) + CLAUDE.md + .claude/rules (60KB cap), calls claude-sonnet-4-6 with a system prompt scoped to this repo's mandates, posts a single rolling PR comment with marker \`<!-- claude-pr-review:v1 -->\` so re-runs PATCH the prior comment instead of stacking. |

## Review prompt enforces (in priority order)
1. Risk/safety regressions (bypass TradeGateway, kill-switch removal, hardcoded credentials)
2. Bug risk (logic errors, race conditions in trade execution)
3. CI/security regressions (unpinned actions, missing permissions, force-push, \`--no-verify\`)
4. Hypothesis-bound bias (re-introducing the retired Thursday-only gate)
5. P/L misreporting (citing the −\$3,958 paired-ledger number without the ~\$2.6K gap to broker truth)
6. Style/quality nits last and briefly

Output is **terse**: verdict (APPROVE / REQUEST_CHANGES / COMMENT) + one-line "Why" + findings list + optional small patch. **No** praise, no PR-what-it-does summary, no fabricated line numbers.

## Manual re-trigger
Close + reopen the PR. (workflow_dispatch with inputs was removed because it trips checkov/CKV_GHA_7 supply-chain hardening — workflow_dispatch inputs MUST be empty.)

## Test plan
- [x] \`python3 -m py_compile scripts/ci/claude_pr_review.py\` → syntax OK
- [x] \`ruff check\` → clean
- [x] \`trunk check\` (bandit/actionlint/yamllint/checkov/prettier) → 0 issues
- [x] \`yaml.safe_load\` → workflow parses
- [x] **Self-test: this very PR will be the first one reviewed by the new workflow.** Watch the PR comments after merge for the bootstrap review.

## Why not Sonar/Gitar
- Requires paid SonarQube subscription
- Requires CEO to install Sonar GitHub App via OAuth
- Locks us into Sonar's review prompt (not tailored to our risk mandates)
- We already pay for Anthropic API and have a deeper repo-context model

🤖 Generated with [Claude Code](https://claude.com/claude-code)