### PR TITLE
feat(ci): multi-provider AI PR review (free default) + SonarCloud + GH Copilot docs

### DIFF
--- a/.github/workflows/ai-pr-review.yml
+++ b/.github/workflows/ai-pr-review.yml
@@ -1,0 +1,59 @@
+name: AI PR Review
+
+# Provider-agnostic AI code review. Default provider is OpenRouter with
+# a free model (deepseek/deepseek-v4-flash:free) so reviews cost $0
+# unless explicitly overridden. The script tries keys in this order:
+# OPENROUTER_API_KEY -> LLM_GATEWAY_API_KEY -> ANTHROPIC_API_KEY ->
+# GOOGLE_API_KEY. Override with AI_REVIEW_PROVIDER + AI_REVIEW_MODEL.
+#
+# Triggers on PR open / reopen / ready_for_review. Skips drafts, bot
+# authors, and deterministic-fix branches (dependabot, auto/ruff-format,
+# auto/lint) — those are handled by the deterministic-fix auto-merger.
+
+on:
+  pull_request:
+    types: [opened, reopened, ready_for_review]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: ai-pr-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    if: |
+      github.event.pull_request.draft == false &&
+      github.event.pull_request.user.type != 'Bot' &&
+      !startsWith(github.event.pull_request.head.ref, 'dependabot/') &&
+      !startsWith(github.event.pull_request.head.ref, 'auto/ruff-format') &&
+      !startsWith(github.event.pull_request.head.ref, 'auto/lint')
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+        with:
+          python-version: "3.11"
+
+      - name: Run AI PR review
+        env:
+          OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
+          LLM_GATEWAY_API_KEY: ${{ secrets.LLM_GATEWAY_API_KEY }}
+          LLM_GATEWAY_BASE_URL: ${{ secrets.LLM_GATEWAY_BASE_URL }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: python3 scripts/ci/ai_pr_review.py

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -1,0 +1,57 @@
+name: SonarCloud
+
+# Static analysis + code-quality + coverage gating via SonarCloud
+# (free tier for public repos). Complements the AI PR review workflow
+# (semantic review) and OpenSSF Scorecard (supply-chain). Requires the
+# SONAR_TOKEN secret — generate at https://sonarcloud.io and add via
+# repo Settings → Secrets and variables → Actions.
+#
+# If SONAR_TOKEN is not set, the scan job no-ops cleanly so the workflow
+# is non-blocking. CEO action to enable: (1) sign up SonarCloud free,
+# (2) bind the org "igorganapolsky" to the repo, (3) set SONAR_TOKEN.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    types: [opened, reopened, ready_for_review, synchronize]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: sonarcloud-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  scan:
+    name: SonarCloud Scan
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.draft != true
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 0 # full history for blame-based new-code analysis
+
+      - name: Skip if no token
+        id: token_check
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        run: |
+          if [ -z "${SONAR_TOKEN:-}" ]; then
+            echo "no_token=true" >> "$GITHUB_OUTPUT"
+            echo "SONAR_TOKEN not set; skipping SonarCloud scan (non-blocking)."
+            echo "## SonarCloud" >> "$GITHUB_STEP_SUMMARY"
+            echo "Skipped: SONAR_TOKEN not set. Add it at repo Settings → Secrets → Actions to enable." >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "no_token=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: SonarCloud Scan
+        if: steps.token_check.outputs.no_token != 'true'
+        uses: SonarSource/sonarqube-scan-action@fd88b7d7ccbaefd23d8f36f73b59db7a3d246602 # v6
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/scripts/ci/ai_pr_review.py
+++ b/scripts/ci/ai_pr_review.py
@@ -1,0 +1,326 @@
+"""AI PR review — provider-agnostic in-repo equivalent of Sonar/Gitar.
+
+Reads the PR diff + repo context (CLAUDE.md + .claude/rules), asks the
+configured LLM provider for a focused review against this repo's risk
+mandates, and posts the result as a single rolling PR comment.
+
+Provider chain (first non-empty key wins, in order):
+    1. OPENROUTER_API_KEY    -> default model `deepseek/deepseek-v4-flash:free` ($0)
+    2. LLM_GATEWAY_API_KEY   -> internal gateway at LLM_GATEWAY_BASE_URL
+    3. ANTHROPIC_API_KEY     -> claude-sonnet-4-6 (paid; ~$0.02/PR)
+    4. GOOGLE_API_KEY        -> gemini-2.5-flash via Google AI Studio (free tier)
+
+Override the default model with AI_REVIEW_MODEL. Override the provider
+with AI_REVIEW_PROVIDER (one of: openrouter, llm_gateway, anthropic, google).
+
+Comment is identified by a deterministic HTML marker so subsequent runs
+PATCH the prior comment instead of stacking.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess  # trunk-ignore(bandit/B404)
+import sys
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+MAX_DIFF_BYTES = 200_000
+MAX_RULES_BYTES = 60_000
+COMMENT_MARKER = "<!-- ai-pr-review:v2 -->"
+
+DEFAULT_MODELS = {
+    "openrouter": "deepseek/deepseek-v4-flash:free",
+    "anthropic": "claude-sonnet-4-6",
+    "google": "gemini-2.5-flash",
+    "llm_gateway": "default",
+}
+
+REVIEW_SYSTEM_PROMPT = """You are reviewing a pull request against the
+IgorGanapolsky/trading repo. Surface only the issues that matter; do not
+narrate what the PR does.
+
+Hard mandates (enforce ruthlessly):
+- Phil Town Rule #1: don't lose money. Iron Condors on SPY only, 15-20
+  delta, 30-45 DTE, defined risk both sides, MAX_CONTRACTS_PER_TRADE=1.
+- Never hardcode credentials. Use src.utils.alpaca_client.get_alpaca_credentials.
+- TradeGateway is the mandatory checkpoint. No trade may bypass it.
+  Direct submit_order calls outside the gateway are violations.
+- Closing positions outside the guardian workflow is a hard block
+  (.claude/rules/boundary-policy.md).
+- Trading remains paper-only under controlled-experiment.md until 30
+  trades with positive expectancy.
+- North Star is now framed as B2B guardrail SaaS, not paper IC P/L.
+  Trading is the demo, not the cash register.
+
+Review priorities (in order):
+1. Risk/safety regressions: bypass TradeGateway, kill-switch removal,
+   position-close shortcuts, hardcoded credentials, leaked PATs.
+2. Bug risk: logic errors, off-by-one, type errors, exception
+   swallowing, race conditions in trade execution.
+3. CI/security regressions: unpinned actions, missing permissions blocks,
+   force-push to main, --no-verify hook bypass without justification.
+4. Hypothesis-bound bias: re-introducing the disproved Thursday-only
+   entry gate (Bonferroni adj_p=0.190, retired 2026-05-20).
+5. P/L misreporting: citing the paired-ledger -$3,958 number without
+   acknowledging the ~$2.6K gap to broker truth.
+6. Style/quality nits last and briefly.
+
+OUTPUT FORMAT (markdown, terse):
+- Top verdict: "APPROVE", "REQUEST_CHANGES", or "COMMENT".
+- A "Why" line, one sentence.
+- A short list of findings: severity (P0/P1/P2), file:line if
+  applicable, one-line description. Skip the list if no findings.
+- Optional "Suggested patch" block if the fix is small and obvious.
+
+Do NOT:
+- Praise. Do NOT summarize what the PR does. Do NOT thank the author.
+- Speculate about runtime behavior you cannot verify from the diff.
+- Cite line numbers you didn't see in the diff.
+"""
+
+
+def run(cmd: list[str], check: bool = True) -> str:
+    # Args from controlled sources (env vars set by workflow + constants);
+    # no shell expansion. Calling system gh/git binaries.
+    # trunk-ignore(bandit/B603)
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    if check and result.returncode != 0:
+        sys.stderr.write(f"command failed: {' '.join(cmd)}\n{result.stderr}\n")
+        sys.exit(1)
+    return result.stdout
+
+
+def select_provider() -> tuple[str, str, str | None]:
+    """Return (provider, model, api_key). Picks first non-empty key in order."""
+    forced = os.environ.get("AI_REVIEW_PROVIDER", "").strip().lower()
+    candidates = (
+        ("openrouter", "OPENROUTER_API_KEY"),
+        ("llm_gateway", "LLM_GATEWAY_API_KEY"),
+        ("anthropic", "ANTHROPIC_API_KEY"),
+        ("google", "GOOGLE_API_KEY"),
+    )
+    if forced:
+        candidates = tuple(c for c in candidates if c[0] == forced)
+    for provider, env in candidates:
+        key = os.environ.get(env)
+        if key:
+            model = os.environ.get("AI_REVIEW_MODEL", DEFAULT_MODELS[provider])
+            return provider, model, key
+    return "none", "", None
+
+
+def load_context() -> str:
+    parts: list[str] = []
+    candidates = [
+        Path("CLAUDE.md"),
+        Path(".claude/CLAUDE.md"),
+        Path(".claude/rules/risk-management.md"),
+        Path(".claude/rules/controlled-experiment.md"),
+        Path(".claude/rules/boundary-policy.md"),
+        Path(".claude/rules/trading.md"),
+    ]
+    budget = MAX_RULES_BYTES
+    for p in candidates:
+        if not p.exists():
+            continue
+        text = p.read_text(encoding="utf-8")[: budget // len(candidates)]
+        parts.append(f"# {p}\n{text}")
+        budget -= len(text)
+        if budget <= 0:
+            break
+    return "\n\n".join(parts)
+
+
+def get_diff(base: str, head: str) -> str:
+    diff = run(["git", "diff", "--unified=3", f"{base}...{head}"])
+    if len(diff.encode("utf-8")) > MAX_DIFF_BYTES:
+        diff = diff[:MAX_DIFF_BYTES] + "\n\n[diff truncated at 200K bytes]"
+    return diff
+
+
+def _http_post_json(url: str, headers: dict, body: dict) -> dict:
+    req = urllib.request.Request(
+        url,
+        data=json.dumps(body).encode("utf-8"),
+        headers={"content-type": "application/json", **headers},
+        method="POST",
+    )
+    # URL is a hardcoded provider endpoint (not user-controlled).
+    # trunk-ignore(bandit/B310)
+    with urllib.request.urlopen(req, timeout=90) as r:
+        return json.loads(r.read())
+
+
+def call_openrouter(model: str, key: str, system: str, user: str) -> str:
+    body = {
+        "model": model,
+        "messages": [
+            {"role": "system", "content": system},
+            {"role": "user", "content": user},
+        ],
+        "max_tokens": 2048,
+    }
+    headers = {
+        "authorization": f"Bearer {key}",
+        "http-referer": "https://github.com/IgorGanapolsky/trading",
+        "x-title": "ai-pr-review",
+    }
+    payload = _http_post_json("https://openrouter.ai/api/v1/chat/completions", headers, body)
+    choices = payload.get("choices") or []
+    if not choices:
+        return ""
+    return (choices[0].get("message") or {}).get("content", "").strip()
+
+
+def call_llm_gateway(model: str, key: str, system: str, user: str) -> str:
+    base = os.environ.get("LLM_GATEWAY_BASE_URL", "").rstrip("/")
+    if not base:
+        sys.stderr.write("LLM_GATEWAY_BASE_URL not set; cannot use llm_gateway\n")
+        sys.exit(2)
+    body = {
+        "model": model,
+        "messages": [
+            {"role": "system", "content": system},
+            {"role": "user", "content": user},
+        ],
+        "max_tokens": 2048,
+    }
+    payload = _http_post_json(f"{base}/chat/completions", {"authorization": f"Bearer {key}"}, body)
+    choices = payload.get("choices") or []
+    if not choices:
+        return ""
+    return (choices[0].get("message") or {}).get("content", "").strip()
+
+
+def call_anthropic(model: str, key: str, system: str, user: str) -> str:
+    body = {
+        "model": model,
+        "max_tokens": 2048,
+        "system": system,
+        "messages": [{"role": "user", "content": user}],
+    }
+    headers = {
+        "x-api-key": key,
+        "anthropic-version": "2023-06-01",
+    }
+    payload = _http_post_json("https://api.anthropic.com/v1/messages", headers, body)
+    blocks = payload.get("content") or []
+    return "".join(b.get("text", "") for b in blocks if b.get("type") == "text").strip()
+
+
+def call_google(model: str, key: str, system: str, user: str) -> str:
+    url = f"https://generativelanguage.googleapis.com/v1beta/models/{model}:generateContent?key={key}"
+    body = {
+        "system_instruction": {"parts": [{"text": system}]},
+        "contents": [{"parts": [{"text": user}]}],
+        "generationConfig": {"maxOutputTokens": 2048},
+    }
+    payload = _http_post_json(url, {}, body)
+    cands = payload.get("candidates") or []
+    if not cands:
+        return ""
+    parts = (cands[0].get("content") or {}).get("parts") or []
+    return "".join(p.get("text", "") for p in parts).strip()
+
+
+PROVIDER_DISPATCH = {
+    "openrouter": call_openrouter,
+    "llm_gateway": call_llm_gateway,
+    "anthropic": call_anthropic,
+    "google": call_google,
+}
+
+
+def call_review(system: str, user: str) -> tuple[str, str, str]:
+    provider, model, key = select_provider()
+    if provider == "none" or not key:
+        sys.stderr.write(
+            "no LLM provider key in env. set one of OPENROUTER_API_KEY, "
+            "LLM_GATEWAY_API_KEY, ANTHROPIC_API_KEY, GOOGLE_API_KEY.\n"
+        )
+        sys.exit(2)
+    print(f"using provider={provider} model={model}", file=sys.stderr)
+    try:
+        text = PROVIDER_DISPATCH[provider](model, key, system, user)
+    except urllib.error.HTTPError as e:
+        msg = e.read().decode("utf-8", errors="replace")
+        sys.stderr.write(f"{provider} api error {e.code}: {msg}\n")
+        sys.exit(2)
+    return provider, model, text
+
+
+def find_existing_comment(repo: str, pr: str) -> int | None:
+    raw = run(["gh", "api", f"repos/{repo}/issues/{pr}/comments", "--paginate"])
+    try:
+        comments = json.loads(raw)
+    except json.JSONDecodeError:
+        return None
+    for c in comments:
+        if COMMENT_MARKER in (c.get("body") or ""):
+            return c["id"]
+    return None
+
+
+def post_or_update_comment(repo: str, pr: str, body: str) -> None:
+    body_full = f"{COMMENT_MARKER}\n{body}"
+    existing = find_existing_comment(repo, pr)
+    if existing is not None:
+        run(
+            [
+                "gh",
+                "api",
+                "-X",
+                "PATCH",
+                f"repos/{repo}/issues/comments/{existing}",
+                "-f",
+                f"body={body_full}",
+            ]
+        )
+        print(f"updated existing comment {existing}")
+    else:
+        run(
+            [
+                "gh",
+                "api",
+                "-X",
+                "POST",
+                f"repos/{repo}/issues/{pr}/comments",
+                "-f",
+                f"body={body_full}",
+            ]
+        )
+        print("posted new comment")
+
+
+def main() -> int:
+    pr = os.environ["PR_NUMBER"]
+    repo = os.environ["REPO"]
+    base = os.environ["PR_BASE_SHA"]
+    head = os.environ["PR_HEAD_SHA"]
+
+    diff = get_diff(base, head)
+    if not diff.strip():
+        print("empty diff — skipping review")
+        return 0
+
+    context = load_context()
+    user_msg = (
+        "Review the following pull request diff under the repo mandates above.\n\n"
+        f"## Repo context (CLAUDE.md + key rules)\n\n{context}\n\n"
+        f"## PR #{pr} diff\n\n```diff\n{diff}\n```\n"
+    )
+    provider, model, review = call_review(REVIEW_SYSTEM_PROMPT, user_msg)
+    if not review:
+        print("empty review from model — skipping post")
+        return 0
+
+    footer = f"\n\n---\n*Reviewed by `{model}` via `{provider}`.*"
+    post_or_update_comment(repo, pr, review + footer)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,20 @@
+# SonarCloud project config — bound to the IgorGanapolsky GitHub org
+# project on sonarcloud.io. Requires the SONAR_TOKEN secret in repo
+# settings. Free tier covers this repo (public).
+
+sonar.projectKey=IgorGanapolsky_trading
+sonar.organization=igorganapolsky
+
+# Source layout
+sonar.sources=src,scripts
+sonar.tests=tests
+sonar.python.version=3.11
+
+# Exclusions: anything not first-party code
+sonar.exclusions=data/**,artifacts/**,docs/assets/snapshots/**,models/**,rag_knowledge/**,trigger/**,**/__pycache__/**,**/*.min.js,**/.venv/**
+
+# Coverage report (produced by scripts/ci/run_all_tests.sh under --cov).
+sonar.python.coverage.reportPaths=artifacts/test-reports/coverage.xml
+
+# Coverage exclusions: don't fail on test or CI scaffolding coverage.
+sonar.coverage.exclusions=tests/**,scripts/ci/**


### PR DESCRIPTION
## Summary
You called out: *"instead of spending money on claude pr review, we have other options ... we also have SonarQube, gh copilot, etc."* This PR uses **the options we already have** and supersedes the Anthropic-only #4043.

## Three layered reviewers (free or already-paid)

### 1. AI PR Review (in-repo) — multi-provider
\`scripts/ci/ai_pr_review.py\` is now provider-agnostic. Provider chain (first non-empty key wins):

| Order | Provider | Default Model | Cost |
|---|---|---|---|
| 1 | OpenRouter | \`deepseek/deepseek-v4-flash:free\` | **\$0** |
| 2 | LLM Gateway (internal) | \`default\` | internal |
| 3 | Anthropic | \`claude-sonnet-4-6\` | ~\$0.02/PR |
| 4 | Google AI Studio | \`gemini-2.5-flash\` | free tier |

The previous Anthropic-only version (#4043) failed its self-test because the API key has \$0 balance. With OpenRouter as default, **no top-up is required** — uses \`OPENROUTER_API_KEY\` which is already in repo secrets.

Override via env: \`AI_REVIEW_PROVIDER\` + \`AI_REVIEW_MODEL\`. Footer attribution shows which model/provider produced each review.

### 2. SonarCloud (free tier)
\`.github/workflows/sonarcloud.yml\` + \`sonar-project.properties\`. Free for public repos. **Non-blocking when SONAR_TOKEN is not set** — workflow no-ops cleanly with a step-summary note.

**To enable** (CEO-only):
1. Sign up free at https://sonarcloud.io
2. Bind the \`igorganapolsky\` GitHub org to this repo
3. Add \`SONAR_TOKEN\` in repo Settings → Secrets and variables → Actions

\`SonarSource/sonarqube-scan-action\` SHA-pinned to \`fd88b7d7\` per #4041 supply-chain policy.

### 3. GitHub Copilot review (manual)
Not a workflow primitive — request it via the PR sidebar "Reviewers → Copilot" or \`gh pr edit <N> --add-reviewer Copilot\` if you have Copilot Pro+. Documented here for completeness; cost is included in any existing Copilot subscription. No new CI infra needed.

## Net cost
**\$0/PR by default** (OpenRouter free model + Sonar free tier + Copilot as a manual request). Falls back to paid providers only if a specific key is set and OpenRouter is unavailable.

## Renames
- Workflow \`claude-pr-review.yml\` → \`ai-pr-review.yml\`
- Script \`claude_pr_review.py\` → \`ai_pr_review.py\`
- Comment marker \`<!-- claude-pr-review:v1 -->\` → \`<!-- ai-pr-review:v2 -->\`

## Test plan
- [x] \`py_compile\` + \`ruff check\` + \`trunk check\` on all 4 new files → 0 issues
- [x] \`yaml.safe_load\` on both new workflows → 0 errors
- [x] SonarSource action SHA-pinned (resolved via \`gh api repos/SonarSource/sonarqube-scan-action/git/refs/tags/v6\`)
- [x] Provider chain logic: \`select_provider()\` correctly walks env keys in order; falls through cleanly
- [ ] CI green on this PR (the new ai-pr-review workflow will self-test on this PR)
- [ ] CEO action to enable SonarCloud (above)

Closes #4043.

🤖 Generated with [Claude Code](https://claude.com/claude-code)