### PR TITLE
chore(ci): drop Grok + simplify SonarCloud (token confirmed in secrets)

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -2,13 +2,8 @@ name: SonarCloud
 
 # Static analysis + code-quality + coverage gating via SonarCloud
 # (free tier for public repos). Complements the AI PR review workflow
-# (semantic review) and OpenSSF Scorecard (supply-chain). Requires the
-# SONAR_TOKEN secret — generate at https://sonarcloud.io and add via
-# repo Settings → Secrets and variables → Actions.
-#
-# If SONAR_TOKEN is not set, the scan job no-ops cleanly so the workflow
-# is non-blocking. CEO action to enable: (1) sign up SonarCloud free,
-# (2) bind the org "igorganapolsky" to the repo, (3) set SONAR_TOKEN.
+# (semantic review) and OpenSSF Scorecard (supply-chain). Uses the
+# SONAR_TOKEN secret already configured at the repo level.
 
 on:
   push:
@@ -35,22 +30,7 @@ jobs:
         with:
           fetch-depth: 0 # full history for blame-based new-code analysis
 
-      - name: Skip if no token
-        id: token_check
-        env:
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-        run: |
-          if [ -z "${SONAR_TOKEN:-}" ]; then
-            echo "no_token=true" >> "$GITHUB_OUTPUT"
-            echo "SONAR_TOKEN not set; skipping SonarCloud scan (non-blocking)."
-            echo "## SonarCloud" >> "$GITHUB_STEP_SUMMARY"
-            echo "Skipped: SONAR_TOKEN not set. Add it at repo Settings → Secrets → Actions to enable." >> "$GITHUB_STEP_SUMMARY"
-          else
-            echo "no_token=false" >> "$GITHUB_OUTPUT"
-          fi
-
       - name: SonarCloud Scan
-        if: steps.token_check.outputs.no_token != 'true'
         uses: SonarSource/sonarqube-scan-action@fd88b7d7ccbaefd23d8f36f73b59db7a3d246602 # v6
         env:
           GITHUB_TOKEN: ${{ github.token }}

--- a/scripts/ci/ai_pr_review.py
+++ b/scripts/ci/ai_pr_review.py
@@ -5,13 +5,15 @@ configured LLM provider for a focused review against this repo's risk
 mandates, and posts the result as a single rolling PR comment.
 
 Provider chain (first non-empty key wins, in order):
-    1. OPENROUTER_API_KEY    -> default model `deepseek/deepseek-v4-flash:free` ($0)
-    2. LLM_GATEWAY_API_KEY   -> internal gateway at LLM_GATEWAY_BASE_URL
+    1. LLM_GATEWAY_API_KEY   -> internal gateway at LLM_GATEWAY_BASE_URL ($0 internal)
+    2. GOOGLE_API_KEY        -> gemini-2.5-flash via Google AI Studio (free tier)
     3. ANTHROPIC_API_KEY     -> claude-sonnet-4-6 (paid; ~$0.02/PR)
-    4. GOOGLE_API_KEY        -> gemini-2.5-flash via Google AI Studio (free tier)
+    4. OPENROUTER_API_KEY    -> claude-sonnet-4-6 routed (last resort; the
+                                repo's key is xai-restricted, so this only
+                                works with explicit AI_REVIEW_MODEL override)
 
 Override the default model with AI_REVIEW_MODEL. Override the provider
-with AI_REVIEW_PROVIDER (one of: openrouter, llm_gateway, anthropic, google).
+with AI_REVIEW_PROVIDER (one of: llm_gateway, google, anthropic, openrouter).
 
 Comment is identified by a deterministic HTML marker so subsequent runs
 PATCH the prior comment instead of stacking.
@@ -32,10 +34,10 @@ MAX_RULES_BYTES = 60_000
 COMMENT_MARKER = "<!-- ai-pr-review:v2 -->"
 
 DEFAULT_MODELS = {
-    "openrouter": "deepseek/deepseek-v4-flash:free",
-    "anthropic": "claude-sonnet-4-6",
-    "google": "gemini-2.5-flash",
     "llm_gateway": "default",
+    "google": "gemini-2.5-flash",
+    "anthropic": "claude-sonnet-4-6",
+    "openrouter": "anthropic/claude-sonnet-4-6",
 }
 
 REVIEW_SYSTEM_PROMPT = """You are reviewing a pull request against the
@@ -94,13 +96,19 @@ def run(cmd: list[str], check: bool = True) -> str:
 
 
 def select_provider() -> tuple[str, str, str | None]:
-    """Return (provider, model, api_key). Picks first non-empty key in order."""
+    """Return (provider, model, api_key). Picks first non-empty key in order.
+
+    Order (2026-05-21): internal gateway first (zero marginal cost,
+    routed), then Google Gemini free tier, then Anthropic (paid), then
+    OpenRouter (last resort because this repo's key is provider-
+    restricted to xai which 404s most non-xai models).
+    """
     forced = os.environ.get("AI_REVIEW_PROVIDER", "").strip().lower()
     candidates = (
-        ("openrouter", "OPENROUTER_API_KEY"),
         ("llm_gateway", "LLM_GATEWAY_API_KEY"),
-        ("anthropic", "ANTHROPIC_API_KEY"),
         ("google", "GOOGLE_API_KEY"),
+        ("anthropic", "ANTHROPIC_API_KEY"),
+        ("openrouter", "OPENROUTER_API_KEY"),
     )
     if forced:
         candidates = tuple(c for c in candidates if c[0] == forced)


### PR DESCRIPTION
## Summary
Two operator-correction changes from this turn:

### 1. Drop Grok + reorder AI PR review provider chain
**Old order**: OpenRouter (deepseek free) → LLM Gateway → Anthropic → Google
**New order**: **LLM Gateway → Google Gemini → Anthropic → OpenRouter (last)**

Why:
- OpenRouter's repo key is **provider-restricted to xai only** (the deepseek-free 404 we saw on #4045 self-test, and the prior xai/grok-4.3 fix attempt in the now-closed #4046).
- Per operator: "forget grok" — Grok removed from default models entirely.
- LLM Gateway first because it's internal infra, zero marginal cost, presumably routed to a sensible default.
- Google second because \`GOOGLE_API_KEY\` is in secrets and Gemini 2.5 Flash has a 1500 req/day free tier — that's 150× our PR volume.
- Anthropic third as paid fallback (~\$0.02/PR if credits exist).
- OpenRouter last and effectively unused without explicit \`AI_REVIEW_MODEL\` override.

### 2. Simplify SonarCloud workflow
\`SONAR_TOKEN\` is confirmed in repo secrets (\`gh secret list\` output). The "skip if no token" guard step was defensive scaffolding that's no longer needed. Dropped entirely — the Scan step now runs unconditionally on non-draft PRs and push-to-main.

## Verification
- [x] \`py_compile\` + \`ruff check\` + \`trunk check\` → 0 issues
- [x] \`yaml.safe_load\` on the simplified workflow → 0 errors
- [ ] CI green (ai-pr-review self-test on this PR will pick LLM_GATEWAY or Google, not Grok)
- [ ] SonarCloud scan actually runs on this PR

Closes #4046 (the prior xai-fix attempt) as superseded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)