### PR TITLE
fix(ml-gate): fold post-cohort singleton P/L into expectancy + PF so kill criteria sees broker truth

### DIFF
--- a/scripts/update_ml_from_trades.py
+++ b/scripts/update_ml_from_trades.py
@@ -499,20 +499,47 @@ def update_thompson_sampler(trades_data: dict, model: dict) -> dict:
 
 
 def check_trading_gate(stats: dict) -> dict:
-    """Check if trading should be allowed based on empirical performance."""
+    """Check if trading should be allowed based on empirical performance.
+
+    Folds `unpaired_in_cohort_pnl` (post-cohort singleton legs that never paired
+    into a closed iron condor) into the expectancy denominator and profit-factor
+    gross-loss denominator so the gate sees broker truth, not paired-only truth.
+
+    Win rate is NOT adjusted: singleton orphan legs do not carry a meaningful
+    win/loss flag — counting them as losses would double-count and counting
+    them as wins would be dishonest. The paired-trade win-rate is the cleanest
+    available signal.
+    """
     total = stats.get("closed_trades", 0)
     win_rate = _as_float(stats.get("win_rate_pct"), 0.0)
     avg_win = _as_float(stats.get("avg_win"), 0.0)
     avg_loss = _as_float(stats.get("avg_loss"), 0.0)
 
+    # Singleton (unpaired-in-cohort) adjustment from PR #4076 surface.
+    # Negative number = singleton legs net to a loss inside the validation cohort.
+    singleton_pnl = _as_float(stats.get("unpaired_in_cohort_pnl"), 0.0)
+    singleton_order_count = int(_as_float(stats.get("unpaired_order_count"), 0.0))
+    cohort_start = str(stats.get("unpaired_cohort_start") or "")
+
+    paired_realized_pnl = _as_float(
+        stats.get("total_realized_pnl"), _as_float(stats.get("total_pnl"), 0.0)
+    )
+    realized_pnl_including_singletons = paired_realized_pnl + singleton_pnl
+
     if "expectancy_per_trade" in stats:
-        expectancy = _as_float(stats.get("expectancy_per_trade"), 0.0)
-    elif "total_realized_pnl" in stats and total > 0:
-        expectancy = _as_float(stats.get("total_realized_pnl"), 0.0) / total
+        paired_expectancy = _as_float(stats.get("expectancy_per_trade"), 0.0)
     elif total > 0:
-        expectancy = (win_rate / 100 * avg_win) - ((100 - win_rate) / 100 * avg_loss)
+        paired_expectancy = paired_realized_pnl / total
     else:
-        expectancy = 0.0
+        paired_expectancy = 0.0
+
+    # Broker-truth expectancy folds singleton P/L into the same denominator.
+    # Keeping denominator = paired closed_trades avoids double-counting singleton
+    # orders (which were never paired and so are not in `total`).
+    if total > 0:
+        expectancy = realized_pnl_including_singletons / total
+    else:
+        expectancy = paired_expectancy
 
     profit_factor_raw = stats.get("profit_factor")
     if profit_factor_raw is None:
@@ -522,13 +549,25 @@ def check_trading_gate(stats: dict) -> dict:
             gross_profit = (win_rate / 100) * total * avg_win
         if gross_loss <= 0 and avg_loss > 0 and total > 0:
             gross_loss = ((100 - win_rate) / 100) * total * avg_loss
+    else:
+        gross_profit = _as_float(stats.get("gross_profit"), 0.0)
+        gross_loss = _as_float(stats.get("gross_loss"), 0.0)
+        if gross_profit <= 0 and avg_win > 0 and total > 0:
+            gross_profit = (win_rate / 100) * total * avg_win
+        if gross_loss <= 0 and avg_loss > 0 and total > 0:
+            gross_loss = ((100 - win_rate) / 100) * total * avg_loss
 
-        if gross_loss > 0:
-            profit_factor = gross_profit / gross_loss
-        elif gross_profit > 0:
-            profit_factor = math.inf
-        else:
-            profit_factor = 0.0
+    # Fold negative singleton P/L into gross_loss (broker-truth PF denominator).
+    # Positive singleton P/L (rare) is added to gross_profit.
+    if singleton_pnl < 0:
+        gross_loss = gross_loss + abs(singleton_pnl)
+    elif singleton_pnl > 0:
+        gross_profit = gross_profit + singleton_pnl
+
+    if gross_loss > 0:
+        profit_factor = gross_profit / gross_loss
+    elif gross_profit > 0:
+        profit_factor = math.inf
     else:
         profit_factor = _as_float(profit_factor_raw, 0.0)
 
@@ -550,6 +589,11 @@ def check_trading_gate(stats: dict) -> dict:
         "min_win_rate_met": win_rate >= MIN_WIN_RATE_TO_TRADE,
         "positive_expectancy_met": positive_expectancy_met,
         "min_profit_factor_met": min_profit_factor_met,
+        "realized_pnl_paired": round(paired_realized_pnl, 2),
+        "realized_pnl_including_singletons": round(realized_pnl_including_singletons, 2),
+        "singleton_adjustment": round(singleton_pnl, 2),
+        "singleton_order_count": singleton_order_count,
+        "singleton_cohort_start": cohort_start,
     }
 
     if not gate["should_trade"]:
@@ -786,11 +830,22 @@ def main(dry_run: bool = False):
         # See .claude/rules/controlled-experiment.md
         halt_file = PROJECT_ROOT / "data" / "TRADING_HALTED"
         if not gate["should_trade"] and not validation_reset:
+            paired_pnl = gate.get("realized_pnl_paired", 0.0)
+            broker_truth_pnl = gate.get("realized_pnl_including_singletons", paired_pnl)
+            singleton_adj = gate.get("singleton_adjustment", 0.0)
+            singleton_orders = gate.get("singleton_order_count", 0)
+            cohort_start = gate.get("singleton_cohort_start", "")
             halt_file.write_text(
                 f"ML GATE BLOCKED: {gate.get('block_reason', 'unknown')}\n"
                 f"Updated: {datetime.now(timezone.utc).isoformat()}\n"
-                f"Win rate: {stats.get('win_rate_pct', 0):.1f}% | Trades: {stats.get('closed_trades', 0)}\n"
-                f"Unblock: improve win rate above {MIN_WIN_RATE_TO_TRADE}% over {MIN_TRADES_FOR_GATE}+ trades"
+                f"Win rate: {stats.get('win_rate_pct', 0):.1f}% | "
+                f"Paired trades: {stats.get('closed_trades', 0)}\n"
+                f"Realized P/L (paired): ${paired_pnl:.2f}\n"
+                f"Realized P/L (broker-truth): ${broker_truth_pnl:.2f}\n"
+                f"Singleton adjustment: ${singleton_adj:.2f} over "
+                f"{singleton_orders} orders since {cohort_start or 'n/a'}\n"
+                f"Unblock: improve win rate above {MIN_WIN_RATE_TO_TRADE}% "
+                f"over {MIN_TRADES_FOR_GATE}+ trades"
             )
             logger.warning(f"  HALT FILE WRITTEN: {halt_file}")
         elif not gate["should_trade"] and validation_reset:

--- a/tests/test_mandatory_trade_gate.py
+++ b/tests/test_mandatory_trade_gate.py
@@ -629,3 +629,33 @@ class TestTradeBlockedError:
         error = TradeBlockedError(gate_result)
         assert error.gate_result is gate_result
         assert "Test block" in str(error)
+
+
+class TestMlGateHaltMatcher:
+    """Halt-file matcher must accept the broker-truth multi-line format (LL-354)."""
+
+    def test_multiline_broker_truth_format_matches(self):
+        from src.safety.mandatory_trade_gate import _is_ml_gate_halt_reason
+
+        # Mirrors the new format written by scripts/update_ml_from_trades.py
+        reason = (
+            "ML GATE BLOCKED: Win rate 11.7% < 50.0%\n"
+            "Updated: 2026-05-29T19:00:00+00:00\n"
+            "Win rate: 11.7% | Paired trades: 163\n"
+            "Realized P/L (paired): $-8033.00\n"
+            "Realized P/L (broker-truth): $-8160.00\n"
+            "Singleton adjustment: $-127.00 over 7 orders since 2026-04-09\n"
+            "Unblock: improve win rate above 50.0% over 30+ trades"
+        )
+        assert _is_ml_gate_halt_reason(reason) is True
+
+    def test_legacy_single_line_format_still_matches(self):
+        from src.safety.mandatory_trade_gate import _is_ml_gate_halt_reason
+
+        assert _is_ml_gate_halt_reason("ML GATE BLOCKED: Win rate 24.2% < 50.0%") is True
+
+    def test_unrelated_halt_reasons_do_not_match(self):
+        from src.safety.mandatory_trade_gate import _is_ml_gate_halt_reason
+
+        assert _is_ml_gate_halt_reason("Manual halt by operator") is False
+        assert _is_ml_gate_halt_reason("ML GATE BLOCKED") is False  # no "WIN RATE" token

--- a/tests/unit/test_update_ml_from_trades.py
+++ b/tests/unit/test_update_ml_from_trades.py
@@ -1,0 +1,115 @@
+"""Unit tests for `scripts/update_ml_from_trades.py` gate computation.
+
+Verifies that singleton (post-cohort unpaired) P/L is folded into the gate's
+expectancy and profit-factor denominators per LL-354, while paired-only
+win-rate is preserved.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from scripts.update_ml_from_trades import check_trading_gate
+
+
+PAIRED_STATS = {
+    "total_trades": 163,
+    "closed_trades": 163,
+    "open_trades": 0,
+    "wins": 19,
+    "losses": 143,
+    "breakeven": 1,
+    "win_rate_pct": 11.66,
+    "avg_win": 71.63,
+    "avg_loss": 65.69,
+    "profit_factor": 0.14,
+    "total_pnl": -8033.0,
+    "total_realized_pnl": -8033.0,
+    "gross_profit": 1361.0,
+    "gross_loss": 9394.0,
+    "unpaired_realized_pnl": 574.0,
+    "unpaired_in_cohort_pnl": -127.0,
+    "unpaired_order_count": 7,
+    "unpaired_cohort_start": "2026-04-09",
+}
+
+
+def test_gate_folds_singleton_pnl_into_expectancy() -> None:
+    gate = check_trading_gate(PAIRED_STATS)
+    # paired total -8033, singleton -127, denominator 163
+    assert gate["realized_pnl_paired"] == -8033.0
+    assert gate["realized_pnl_including_singletons"] == -8160.0
+    assert gate["singleton_adjustment"] == -127.0
+    assert gate["singleton_order_count"] == 7
+    assert gate["singleton_cohort_start"] == "2026-04-09"
+    # -8160 / 163 = -50.06 (vs. paired-only -49.28)
+    assert gate["expectancy_per_trade"] == pytest.approx(-50.06, abs=0.01)
+
+
+def test_gate_preserves_paired_only_win_rate() -> None:
+    """Singletons must NOT shift the win-rate denominator (LL-354 rationale)."""
+    gate = check_trading_gate(PAIRED_STATS)
+    assert gate["win_rate"] == 11.66
+    assert gate["total_trades"] == 163  # paired closed_trades, not orders
+
+
+def test_gate_folds_negative_singleton_into_profit_factor() -> None:
+    gate = check_trading_gate(PAIRED_STATS)
+    # gross_profit 1361 / (gross_loss 9394 + |−127|) = 1361 / 9521 ≈ 0.1430
+    assert gate["profit_factor"] == pytest.approx(0.14, abs=0.005)
+    assert gate["min_profit_factor_met"] is False
+
+
+def test_gate_blocks_when_broker_truth_is_negative() -> None:
+    gate = check_trading_gate(PAIRED_STATS)
+    assert gate["should_trade"] is False
+    assert "Win rate" in gate["block_reason"]
+
+
+def test_gate_handles_missing_singleton_keys() -> None:
+    """Backward-compat: trades.json without PR #4076 fields still works."""
+    stats = {k: v for k, v in PAIRED_STATS.items() if not k.startswith("unpaired_")}
+    gate = check_trading_gate(stats)
+    assert gate["singleton_adjustment"] == 0.0
+    assert gate["realized_pnl_paired"] == gate["realized_pnl_including_singletons"]
+    # Falls back to paired-only expectancy ≈ -8033/163 = -49.28
+    assert gate["expectancy_per_trade"] == pytest.approx(-49.28, abs=0.01)
+
+
+def test_halt_file_content_includes_broker_truth_numbers(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """End-to-end: main() writes the new multi-line halt-file format."""
+    import scripts.update_ml_from_trades as mod
+
+    project_root = tmp_path
+    (project_root / "data").mkdir()
+    (project_root / "models" / "ml").mkdir(parents=True)
+    (project_root / "data" / "trades.json").write_text(
+        json.dumps({"stats": PAIRED_STATS, "trades": []})
+    )
+
+    monkeypatch.setattr(mod, "PROJECT_ROOT", project_root)
+    monkeypatch.setattr(mod, "TRADES_FILE", project_root / "data" / "trades.json")
+    monkeypatch.setattr(mod, "MODEL_FILE", project_root / "models" / "ml" / "trade_confidence_model.json")
+    monkeypatch.setattr(mod, "LESSONS_DIR", project_root / "rag_knowledge" / "lessons_learned")
+    monkeypatch.setattr(mod, "REHAB_PLAN_FILE", project_root / "data" / "runtime" / "edge_rehabilitation_plan.json")
+
+    mod.main(dry_run=False)
+
+    halt_file = project_root / "data" / "TRADING_HALTED"
+    assert halt_file.exists(), "halt file should be written when gate blocks"
+    content = halt_file.read_text()
+
+    # Pattern check used by src/safety/mandatory_trade_gate.py::_is_ml_gate_halt_reason
+    normalized = content.upper()
+    assert "ML GATE BLOCKED" in normalized
+    assert "WIN RATE" in normalized
+
+    # Broker-truth surface
+    assert "Realized P/L (paired): $-8033.00" in content
+    assert "Realized P/L (broker-truth): $-8160.00" in content
+    assert "Singleton adjustment: $-127.00 over 7 orders since 2026-04-09" in content


### PR DESCRIPTION
## Summary

PR #4076 surfaced `stats.unpaired_in_cohort_pnl` in `data/trades.json` but did **not** wire it into the ML gate math that writes `data/TRADING_HALTED`. The gate read expectancy and profit factor from paired-only stats, which under-reports losses by the magnitude of orphan legs that never paired into a closed iron condor.

This PR folds the unpaired-in-cohort number into the gate inputs so the kill criteria sees broker truth.

Refs: **LL-354** (post-cohort singleton legs under-report drawdown)

## Changes

- `scripts/update_ml_from_trades.py::check_trading_gate`
  - Folds `unpaired_in_cohort_pnl` into the expectancy numerator: `(paired_total_pnl + singleton_pnl) / closed_trades`
  - Folds `|negative singleton_pnl|` into the profit-factor `gross_loss` denominator
  - Emits new gate fields: `realized_pnl_paired`, `realized_pnl_including_singletons`, `singleton_adjustment`, `singleton_order_count`, `singleton_cohort_start`
- Halt-file content rewritten to a multi-line broker-truth format. Pattern matcher in `src/safety/mandatory_trade_gate.py::_is_ml_gate_halt_reason` still satisfies (`"ML GATE BLOCKED"` and `"WIN RATE"` both present after `.upper()`).

## Before / After (current `data/trades.json`, n=163, cohort start 2026-04-09)

| field | before (paired-only) | after (broker-truth) |
|---|---|---|
| `realized_pnl_paired` | -8033.00 | -8033.00 |
| `realized_pnl_including_singletons` | n/a | **-8160.00** |
| `singleton_adjustment` | n/a | **-127.00 over 7 orders** |
| `expectancy_per_trade` | -49.28 | **-50.06** |
| `profit_factor` | 0.14 | 0.143 |
| `should_trade` | False | False |
| `block_reason` | win rate + expectancy + PF | win rate + expectancy + PF (unchanged verdict, more honest numbers) |

The gate already blocks (win rate 11.66% < 50%); this PR makes it block with **broker-truth** numbers instead of paired-only ones. When the cohort eventually turns positive, the singleton drag will be visible at the gate boundary instead of hidden.

## Why win-rate is left paired-only

Singleton orphan legs do not carry a meaningful win/loss flag — they are partial fills, manual cleanups, or fills that never paired with a counter-side. Counting them as losses would double-count against the singleton P/L already folded into expectancy; counting them as wins would be dishonest. The paired-trade ledger is the cleanest win-rate signal we have, so `win_rate_pct` stays paired-only.

## Thresholds unchanged

`MIN_WIN_RATE_TO_TRADE = 50.0`, `MIN_TRADES_FOR_GATE = 30`, `MIN_EXPECTANCY_TO_TRADE = 0.0`, `MIN_PROFIT_FACTOR_TO_TRADE = 1.0`. Per the LL-354 directive: the numbers are honest now — let them speak for themselves.

## Test plan

- [x] `pytest tests/unit/test_update_ml_from_trades.py tests/test_mandatory_trade_gate.py -x -v` — 36 passed locally
- [x] `ruff check scripts/update_ml_from_trades.py src/safety/mandatory_trade_gate.py` — clean
- [x] New test `test_halt_file_content_includes_broker_truth_numbers` asserts both paired and broker-truth lines render
- [x] New test `test_multiline_broker_truth_format_matches` asserts `_is_ml_gate_halt_reason` accepts the new multi-line format
- [x] New test `test_legacy_single_line_format_still_matches` asserts backwards-compatibility with the existing halt-file format

🤖 Generated with [Claude Code](https://claude.com/claude-code)