### PR TITLE
feat(safety): daily broker-vs-paired P/L reconciliation alert (Sentry, threshold $150)

### DIFF
--- a/.github/workflows/daily-reconciliation.yml
+++ b/.github/workflows/daily-reconciliation.yml
@@ -1,0 +1,106 @@
+name: Daily Broker-vs-Paired Reconciliation
+
+# LL-354 prevention layer: each weekday after market close, diff broker truth
+# (data/system_state.json trade_history fills) against the paired ledger
+# (data/trades.json stats.total_pnl + stats.unpaired_realized_pnl). Sentry-alert
+# and fail the workflow if |delta| > $150.
+
+on:
+  schedule:
+    - cron: "0 21 * * 1-5" # 4 PM ET weekdays (post-close)
+  workflow_dispatch: {}
+
+permissions:
+  contents: write
+
+concurrency:
+  group: ${{ format('daily-reconciliation-{0}-{1}', github.repository, github.ref_name || 'main') }}
+  cancel-in-progress: false
+
+env:
+  SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
+
+jobs:
+  reconcile:
+    name: Reconcile broker vs paired
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          token: ${{ secrets.GH_PAT || github.token }}
+          fetch-depth: 0
+
+      - name: Refresh to latest main
+        run: |
+          git fetch origin main
+          git checkout -B main origin/main
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+        with:
+          python-version: "3.11"
+          cache: "pip"
+
+      - name: Install dependencies
+        run: |
+          pip install -q -r requirements-minimal.txt || pip install -q alpaca-py requests python-dotenv
+          pip install -q sentry-sdk || echo "sentry-sdk install failed - reconciler will log CRITICAL instead of capturing"
+
+      - name: Refresh broker state
+        env:
+          ALPACA_PAPER_TRADING_API_KEY: ${{ secrets.ALPACA_PAPER_TRADING_API_KEY }}
+          ALPACA_PAPER_TRADING_API_SECRET: ${{ secrets.ALPACA_PAPER_TRADING_API_SECRET }}
+          ALPACA_BROKERAGE_TRADING_API_KEY: ${{ secrets.ALPACA_BROKERAGE_TRADING_API_KEY }}
+          ALPACA_BROKERAGE_TRADING_API_SECRET: ${{ secrets.ALPACA_BROKERAGE_TRADING_API_SECRET }}
+          REQUIRE_ALPACA_KEYS: "true"
+        run: python3 scripts/sync_alpaca_state.py
+
+      - name: Refresh paired ledger
+        env:
+          ALPACA_PAPER_TRADING_API_KEY: ${{ secrets.ALPACA_PAPER_TRADING_API_KEY }}
+          ALPACA_PAPER_TRADING_API_SECRET: ${{ secrets.ALPACA_PAPER_TRADING_API_SECRET }}
+          ALPACA_BROKERAGE_TRADING_API_KEY: ${{ secrets.ALPACA_BROKERAGE_TRADING_API_KEY }}
+          ALPACA_BROKERAGE_TRADING_API_SECRET: ${{ secrets.ALPACA_BROKERAGE_TRADING_API_SECRET }}
+          REQUIRE_ALPACA_KEYS: "true"
+        run: python3 scripts/sync_closed_positions.py
+
+      - name: Run reconciliation
+        id: reconcile
+        continue-on-error: true
+        env:
+          SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
+        run: |
+          set +e
+          python3 scripts/reconcile_broker_vs_paired.py
+          echo "reconcile_exit=$?" >> "$GITHUB_OUTPUT"
+
+      - name: Commit reconciliation report
+        run: |
+          set -euo pipefail
+          git config user.name "GitHub Actions Bot"
+          git config user.email "actions@github.com"
+
+          git add data/reports/reconciliation_*.json 2>/dev/null || true
+          if git diff --staged --quiet; then
+            echo "No reconciliation report changes to commit"
+            exit 0
+          fi
+          git commit -m "chore: daily reconciliation [auto]"
+
+          if [ -n "${{ secrets.GH_PAT }}" ]; then
+            git remote set-url origin "https://x-access-token:${{ secrets.GH_PAT }}@github.com/${{ github.repository }}.git"
+          fi
+          git pull --ff-only origin main
+          git push origin HEAD:main
+
+      - name: Fail workflow if reconciliation alerted
+        run: |
+          rc="${{ steps.reconcile.outputs.reconcile_exit }}"
+          echo "reconcile exit code: $rc"
+          if [ "$rc" != "0" ]; then
+            echo "::error::Broker-vs-paired reconciliation breach (exit $rc). See data/reports/reconciliation_*.json."
+            exit 1
+          fi

--- a/scripts/reconcile_broker_vs_paired.py
+++ b/scripts/reconcile_broker_vs_paired.py
@@ -1,0 +1,238 @@
+#!/usr/bin/env python3
+"""Daily broker-vs-paired P/L reconciliation alert.
+
+Prevention layer for LL-354 (the $2.6K paired-vs-broker gap that stayed hidden
+for ~4 months because nothing diffed the two numbers).
+
+Compares:
+  - broker_realized: sum of signed_cash for every fill in
+    data/system_state.json -> trade_history
+  - paired_realized: data/trades.json -> stats.total_pnl
+    + stats.unpaired_realized_pnl
+
+If |delta| > THRESHOLD_DOLLARS ($150, set above the ~$103 fee/spread noise
+floor), capture a Sentry message and exit 2 so the workflow surfaces it.
+The daily JSON report is always written.
+
+Karpathy-style: single script, plain functions, no classes.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as _dt
+import json
+import logging
+import os
+import sys
+from pathlib import Path
+from typing import Any
+
+THRESHOLD_DOLLARS = 150.0
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DEFAULT_SYSTEM_STATE = REPO_ROOT / "data" / "system_state.json"
+DEFAULT_TRADES = REPO_ROOT / "data" / "trades.json"
+DEFAULT_REPORT_DIR = REPO_ROOT / "data" / "reports"
+
+logger = logging.getLogger("reconcile_broker_vs_paired")
+
+
+def _to_float(value: Any, default: float = 0.0) -> float:
+    if value is None:
+        return default
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _fill_signed_cash(row: dict[str, Any]) -> float:
+    """Return signed cash flow (in dollars) for one fill row.
+
+    Convention (options, contract multiplier = 100):
+      - For MLEG parent rows side is None/"None"; the parent ``price`` is
+        already signed (negative = net debit paid, positive = net credit
+        received), so cash = qty * price * 100.
+      - For SIMPLE single-leg rows side is OrderSide.BUY/OrderSide.SELL;
+        SELL = +qty*price*100, BUY = -qty*price*100.
+    """
+    status = str(row.get("status") or "")
+    if "FILLED" not in status:
+        return 0.0
+
+    qty = _to_float(row.get("qty"), 0.0)
+    price = _to_float(row.get("price"), 0.0)
+    side = str(row.get("side") or "")
+    order_class = str(row.get("order_class") or "")
+
+    if "MLEG" in order_class:
+        # Parent price is already signed (debit negative, credit positive).
+        return qty * price * 100.0
+
+    if "SELL" in side:
+        return qty * price * 100.0
+    if "BUY" in side:
+        return -qty * price * 100.0
+
+    return 0.0
+
+
+def compute_broker_realized(system_state: dict[str, Any]) -> tuple[float, int]:
+    """Return (broker_realized_dollars, fill_count) from system_state.json."""
+    history = system_state.get("trade_history") or []
+    fills = [row for row in history if "FILLED" in str(row.get("status") or "")]
+    total = sum(_fill_signed_cash(row) for row in fills)
+    return round(total, 2), len(fills)
+
+
+def compute_paired_realized(trades: dict[str, Any]) -> tuple[float, int, int]:
+    """Return (paired_realized_dollars, paired_trade_count, unpaired_order_count).
+
+    Schema (post PR #4076):
+      stats.total_pnl            -> paired closed-trade P/L
+      stats.unpaired_realized_pnl -> singleton fills not yet paired (optional)
+    """
+    stats = trades.get("stats") or {}
+    total_pnl = _to_float(stats.get("total_pnl"), 0.0)
+    unpaired = _to_float(stats.get("unpaired_realized_pnl"), 0.0)
+    paired_trade_count = int(stats.get("closed_trades") or 0)
+    unpaired_order_count = int(stats.get("unpaired_order_count") or 0)
+    return round(total_pnl + unpaired, 2), paired_trade_count, unpaired_order_count
+
+
+def compute_delta(broker_realized: float, paired_realized: float) -> float:
+    return round(broker_realized - paired_realized, 2)
+
+
+def write_report(report_dir: Path, payload: dict[str, Any]) -> Path:
+    report_dir.mkdir(parents=True, exist_ok=True)
+    date_str = payload["date"]
+    path = report_dir / f"reconciliation_{date_str}.json"
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n")
+    return path
+
+
+def maybe_alert(payload: dict[str, Any]) -> bool:
+    """Fire Sentry alert if |delta| > threshold.
+
+    Returns True if alert was fired (regardless of whether Sentry transport
+    succeeded). If SENTRY_DSN is unset or sentry_sdk is unavailable, log a
+    CRITICAL line and continue — per spec, do not crash.
+    """
+    delta = abs(payload["delta_dollars"])
+    threshold = payload["threshold_dollars"]
+    if delta <= threshold:
+        return False
+
+    msg = (
+        f"Broker-vs-paired P/L reconciliation breach: "
+        f"|delta|=${delta:.2f} > ${threshold:.2f} "
+        f"(broker={payload['broker_realized_pnl']:.2f}, "
+        f"paired={payload['paired_realized_pnl']:.2f}, "
+        f"date={payload['date']})"
+    )
+
+    dsn = os.environ.get("SENTRY_DSN", "").strip()
+    if not dsn:
+        logger.critical("[NO SENTRY_DSN] %s", msg)
+        return True
+
+    try:
+        import sentry_sdk  # type: ignore
+    except ImportError:
+        logger.critical("[NO sentry_sdk] %s", msg)
+        return True
+
+    try:
+        sentry_sdk.init(dsn=dsn)
+        sentry_sdk.capture_message(msg, level="error")
+    except Exception as exc:  # noqa: BLE001 - never crash the reconciler
+        logger.critical("[SENTRY_FAILED:%s] %s", exc, msg)
+    return True
+
+
+def build_payload(
+    *,
+    date_str: str,
+    broker_realized: float,
+    paired_realized: float,
+    broker_fill_count: int,
+    paired_trade_count: int,
+    paired_unpaired_order_count: int,
+    notes: str,
+) -> dict[str, Any]:
+    delta = compute_delta(broker_realized, paired_realized)
+    alert_fired = abs(delta) > THRESHOLD_DOLLARS
+    return {
+        "date": date_str,
+        "broker_realized_pnl": broker_realized,
+        "paired_realized_pnl": paired_realized,
+        "delta_dollars": delta,
+        "threshold_dollars": THRESHOLD_DOLLARS,
+        "alert_fired": alert_fired,
+        "broker_fill_count": broker_fill_count,
+        "paired_trade_count": paired_trade_count,
+        "paired_unpaired_order_count": paired_unpaired_order_count,
+        "notes": notes,
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--system-state", type=Path, default=DEFAULT_SYSTEM_STATE)
+    parser.add_argument("--trades", type=Path, default=DEFAULT_TRADES)
+    parser.add_argument("--report-dir", type=Path, default=DEFAULT_REPORT_DIR)
+    parser.add_argument("--date", type=str, default=None,
+                        help="Override report date (YYYY-MM-DD). Default = today UTC.")
+    args = parser.parse_args(argv)
+
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s %(message)s")
+
+    if not args.system_state.exists():
+        logger.critical("system_state.json missing at %s", args.system_state)
+        return 3
+    if not args.trades.exists():
+        logger.critical("trades.json missing at %s", args.trades)
+        return 3
+
+    system_state = json.loads(args.system_state.read_text())
+    trades = json.loads(args.trades.read_text())
+
+    broker_realized, broker_fill_count = compute_broker_realized(system_state)
+    paired_realized, paired_trade_count, unpaired_order_count = compute_paired_realized(trades)
+
+    date_str = args.date or _dt.datetime.now(_dt.timezone.utc).strftime("%Y-%m-%d")
+    notes = (
+        "broker_realized = sum(signed_cash) over all FILLED rows in "
+        "system_state.trade_history. paired_realized = "
+        "trades.stats.total_pnl + trades.stats.unpaired_realized_pnl. "
+        "Threshold $150 sits above the ~$103 fee/spread noise floor "
+        "(LL-354 prevention layer)."
+    )
+
+    payload = build_payload(
+        date_str=date_str,
+        broker_realized=broker_realized,
+        paired_realized=paired_realized,
+        broker_fill_count=broker_fill_count,
+        paired_trade_count=paired_trade_count,
+        paired_unpaired_order_count=unpaired_order_count,
+        notes=notes,
+    )
+
+    report_path = write_report(args.report_dir, payload)
+    logger.info("Reconciliation report written: %s", report_path)
+    logger.info(
+        "broker=$%.2f  paired=$%.2f  delta=$%.2f  threshold=$%.2f",
+        payload["broker_realized_pnl"],
+        payload["paired_realized_pnl"],
+        payload["delta_dollars"],
+        payload["threshold_dollars"],
+    )
+
+    fired = maybe_alert(payload)
+    return 2 if fired else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/unit/test_reconciliation.py
+++ b/tests/unit/test_reconciliation.py
@@ -1,0 +1,155 @@
+"""Tests for scripts/reconcile_broker_vs_paired.py.
+
+Two scenarios per spec:
+  1. Synthetic state where broker and paired reconcile within $50
+     -> exit 0, no alert.
+  2. Synthetic state with $300 delta -> exit 2, alert fired,
+     report contents correct.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+SCRIPT = Path(__file__).resolve().parents[2] / "scripts" / "reconcile_broker_vs_paired.py"
+
+
+@pytest.fixture(scope="module")
+def recon_mod():
+    spec = importlib.util.spec_from_file_location("reconcile_mod", SCRIPT)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["reconcile_mod"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _write_state(path: Path, fills: list[dict]) -> None:
+    path.write_text(json.dumps({"trade_history": fills}))
+
+
+def _write_trades(path: Path, total_pnl: float, unpaired: float | None,
+                  closed: int = 0, unpaired_orders: int = 0) -> None:
+    stats: dict = {
+        "total_pnl": total_pnl,
+        "closed_trades": closed,
+        "unpaired_order_count": unpaired_orders,
+    }
+    if unpaired is not None:
+        stats["unpaired_realized_pnl"] = unpaired
+    path.write_text(json.dumps({"stats": stats, "trades": []}))
+
+
+def test_within_threshold_exit_zero(tmp_path: Path, recon_mod, monkeypatch):
+    """Broker = -$1000 net cash from one MLEG debit; paired ledger reports
+    -$1030. Delta $30 < $150 -> no alert, exit 0."""
+    state = tmp_path / "system_state.json"
+    trades = tmp_path / "trades.json"
+    reports = tmp_path / "reports"
+
+    # Single MLEG fill: 1 contract @ price -10.00 (net debit) -> -$1000.
+    fills = [
+        {
+            "id": "abc",
+            "symbol": None,
+            "side": "None",
+            "qty": "1",
+            "price": "-10.00",
+            "filled_at": "2026-05-29 19:00:00+00:00",
+            "status": "OrderStatus.FILLED",
+            "order_class": "OrderClass.MLEG",
+            "legs": ["A", "B", "C", "D"],
+        }
+    ]
+    _write_state(state, fills)
+    _write_trades(trades, total_pnl=-1030.0, unpaired=0.0, closed=1)
+
+    monkeypatch.delenv("SENTRY_DSN", raising=False)
+
+    code = recon_mod.main([
+        "--system-state", str(state),
+        "--trades", str(trades),
+        "--report-dir", str(reports),
+        "--date", "2026-05-29",
+    ])
+    assert code == 0
+
+    report = json.loads((reports / "reconciliation_2026-05-29.json").read_text())
+    assert report["broker_realized_pnl"] == -1000.0
+    assert report["paired_realized_pnl"] == -1030.0
+    assert report["delta_dollars"] == 30.0
+    assert report["alert_fired"] is False
+    assert report["threshold_dollars"] == 150
+    assert report["broker_fill_count"] == 1
+    assert report["paired_trade_count"] == 1
+
+
+def test_breach_threshold_exit_two_alert_fired(tmp_path: Path, recon_mod,
+                                                monkeypatch, caplog):
+    """Broker = +$500 (SIMPLE SELL 1 @ $5.00); paired reports +$200.
+    Delta = $300 > $150 -> alert fired, exit 2."""
+    state = tmp_path / "system_state.json"
+    trades = tmp_path / "trades.json"
+    reports = tmp_path / "reports"
+
+    fills = [
+        {
+            "id": "x1",
+            "symbol": "SPY260618C00500000",
+            "side": "OrderSide.SELL",
+            "qty": "1",
+            "price": "5.00",
+            "filled_at": "2026-05-29 18:00:00+00:00",
+            "status": "OrderStatus.FILLED",
+            "order_class": "OrderClass.SIMPLE",
+            "legs": [],
+        }
+    ]
+    _write_state(state, fills)
+    _write_trades(trades, total_pnl=200.0, unpaired=0.0, closed=1)
+
+    # No SENTRY_DSN -> CRITICAL log path, no crash.
+    monkeypatch.delenv("SENTRY_DSN", raising=False)
+    caplog.set_level("CRITICAL")
+
+    code = recon_mod.main([
+        "--system-state", str(state),
+        "--trades", str(trades),
+        "--report-dir", str(reports),
+        "--date", "2026-05-29",
+    ])
+    assert code == 2
+
+    report = json.loads((reports / "reconciliation_2026-05-29.json").read_text())
+    assert report["broker_realized_pnl"] == 500.0
+    assert report["paired_realized_pnl"] == 200.0
+    assert report["delta_dollars"] == 300.0
+    assert report["alert_fired"] is True
+    assert any("reconciliation breach" in rec.message.lower() for rec in caplog.records)
+
+
+def test_missing_unpaired_field_is_tolerated(tmp_path: Path, recon_mod, monkeypatch):
+    """Older ledgers without stats.unpaired_realized_pnl must default to 0."""
+    state = tmp_path / "system_state.json"
+    trades = tmp_path / "trades.json"
+    reports = tmp_path / "reports"
+
+    _write_state(state, [])
+    _write_trades(trades, total_pnl=0.0, unpaired=None, closed=0)
+
+    monkeypatch.delenv("SENTRY_DSN", raising=False)
+    code = recon_mod.main([
+        "--system-state", str(state),
+        "--trades", str(trades),
+        "--report-dir", str(reports),
+        "--date", "2026-05-29",
+    ])
+    assert code == 0
+    report = json.loads((reports / "reconciliation_2026-05-29.json").read_text())
+    assert report["paired_realized_pnl"] == 0.0
+    assert report["delta_dollars"] == 0.0


### PR DESCRIPTION
## Summary

LL-354 named the prevention layer: a daily reconciliation that diffs broker truth against the paired ledger. This PR is that layer.

- **Script** `scripts/reconcile_broker_vs_paired.py` — Karpathy-style, one file, plain functions (`compute_broker_realized`, `compute_paired_realized`, `compute_delta`, `write_report`, `maybe_alert`, `main`).
- **Workflow** `.github/workflows/daily-reconciliation.yml` — cron `0 21 * * 1-5` (4 PM ET weekdays, post-close). Refreshes broker + paired ledgers, runs the reconciler, commits the JSON report, then fails the workflow if reconcile exited non-zero so GitHub Actions surfaces the alert.
- **Tests** `tests/unit/test_reconciliation.py` — within-threshold, breach, and legacy-schema scenarios.

## Why this, why now

- **LL-354**: the $2.6K paired-vs-broker P/L gap stayed hidden for ~4 months because **nothing diffed the two numbers**. This catches future divergence within 24 hours.
- **LL-226**: paired-ledger accounting only covers paired closes; singleton fills can leak. Comparing the paired ledger against broker truth is the only end-to-end check that catches that leak.

## Threshold choice — $150

Fee + spread noise floor is approximately $103 per closed iron condor (Alpaca per-leg + bid/ask). $150 gives headroom of ~$47 over the noise floor — small enough to catch a single mis-accounted close, large enough to avoid false alerts from spread-fill jitter on busy days.

## Test scenarios (all pass: `pytest tests/unit/test_reconciliation.py -x -v`)

| Scenario | Broker | Paired | |Delta| | Expected | Result |
|---|---|---|---|---|---|
| Within threshold | -$1,000 (MLEG debit) | -$1,030 | $30 | exit 0, no alert | PASS |
| Breach threshold | +$500 (SIMPLE SELL) | +$200 | $300 | exit 2, alert fired | PASS |
| Legacy schema | $0 (no fills) | $0 (no `unpaired_realized_pnl`) | $0 | exit 0, defaults to 0 | PASS |

## Alert behavior (per spec)

- `SENTRY_DSN` env present + `sentry_sdk` importable -> `sentry_sdk.capture_message(level=error)`
- `SENTRY_DSN` unset -> log `CRITICAL [NO SENTRY_DSN] ...` and continue (do not crash)
- `sentry_sdk` not installed -> log `CRITICAL [NO sentry_sdk] ...` and continue
- Sentry transport raises -> log `CRITICAL [SENTRY_FAILED:...]` and continue

Exit codes: `0` within threshold, `2` breach (alert fired), `3` missing input file.

## Out of scope (deliberately not touched)

- `src/risk/`, `src/safety/`, `src/strategies/` — no trading code change
- No ML gate modification
- No position-close logic

## Test plan

- [ ] CI green on this PR (ruff + pytest)
- [ ] Manual workflow_dispatch run after merge to confirm cron path works end-to-end with live secrets
- [ ] Verify first scheduled run on next weekday at 21:00 UTC commits `data/reports/reconciliation_<date>.json`
- [ ] Confirm Sentry receives a test breach message (if a real breach surfaces) or that the workflow surfaces the error annotation in Actions

Refs: LL-354, LL-226, PR #4076 (schema source for `stats.unpaired_realized_pnl`).