### PR TITLE
feat(pl): stamp OPEN/CLOSE intent in client_order_id so singleton closes pair authoritatively

### DIFF
--- a/scripts/ic_simple.py
+++ b/scripts/ic_simple.py
@@ -213,6 +213,7 @@ def place_ic(client, opp: dict) -> str | None:
     from alpaca.trading.requests import LimitOrderRequest, OptionLegRequest
 
     from src.safety.mandatory_trade_gate import safe_submit_order
+    from src.utils.order_intent import build_client_order_id
 
     expiry_yymmdd = opp["expiry"].replace("-", "")[2:]
 
@@ -250,6 +251,8 @@ def place_ic(client, opp: dict) -> str | None:
         logger.info(f"MLEG limit order: credit >= ${current_credit:.2f} (walk ${walk_total:.2f})")
 
         try:
+            # LL-354: stamp OPEN-IC on the parent so the paired ledger can
+            # identify it without relying on broker position_intent.
             order = safe_submit_order(
                 client,
                 LimitOrderRequest(
@@ -258,6 +261,7 @@ def place_ic(client, opp: dict) -> str | None:
                     legs=legs,
                     time_in_force=TimeInForce.DAY,
                     limit_price=round(-current_credit, 2),
+                    client_order_id=build_client_order_id("OPEN", "IC"),
                 ),
                 strategy="iron_condor",
             )
@@ -504,6 +508,18 @@ def _close_ic(client, legs: list[dict], qty: int):
     )
 
     from src.safety.mandatory_trade_gate import safe_submit_order
+    from src.utils.order_intent import build_client_order_id
+
+    def _leg_intent_tag(symbol: str, qty: int) -> tuple[str, str]:
+        """LL-354: map a leg about to be CLOSED to (INTENT, LEG_TAG).
+        BPS/BPL = bull put short/long; BCS/BCL = bear call short/long."""
+        # OCC: SPY{YYMMDD}{C|P}{NNNNNNNN}. C/P sits at index -9 (one char
+        # before the 8-digit strike). Default to "P" if we can't read it.
+        opt_type = symbol[-9] if len(symbol) >= 9 else "P"
+        is_short = qty < 0
+        if opt_type == "P":
+            return ("BPS", "SP") if is_short else ("BPL", "LP")
+        return ("BCS", "SC") if is_short else ("BCL", "LC")
 
     # Calculate current debit
     current_debit = abs(sum(leg["current"] * (1 if leg["qty"] < 0 else -1) for leg in legs))
@@ -527,6 +543,7 @@ def _close_ic(client, legs: list[dict], qty: int):
                 legs=option_legs,
                 time_in_force=TimeInForce.DAY,
                 limit_price=round(limit_debit, 2),
+                client_order_id=build_client_order_id("CLOSE", "IC"),
             ),
             strategy="iron_condor",
         )
@@ -536,6 +553,10 @@ def _close_ic(client, legs: list[dict], qty: int):
         for leg in legs:
             try:
                 side = OrderSide.BUY if leg["qty"] < 0 else OrderSide.SELL
+                # LL-354: this is the singleton-SIMPLE-close path that the
+                # paired ledger used to lose. Stamp role+intent+leg so
+                # sync_closed_positions can pair authoritatively.
+                intent, tag = _leg_intent_tag(str(leg["symbol"]), int(leg["qty"]))
                 safe_submit_order(
                     client,
                     MarketOrderRequest(
@@ -543,6 +564,7 @@ def _close_ic(client, legs: list[dict], qty: int):
                         qty=abs(leg["qty"]),
                         side=side,
                         time_in_force=TimeInForce.DAY,
+                        client_order_id=build_client_order_id("CLOSE", intent, tag),
                     ),
                     strategy="iron_condor",
                 )

--- a/scripts/iron_condor_guardian.py
+++ b/scripts/iron_condor_guardian.py
@@ -28,6 +28,16 @@ from src.core.trading_constants import (
     IRON_CONDOR_STOP_LOSS_MULTIPLIER,
 )
 from src.safety.mandatory_trade_gate import safe_submit_order
+from src.utils.order_intent import build_client_order_id
+
+
+def _guardian_leg_intent_tag(symbol: str, qty: int) -> tuple[str, str]:
+    """LL-354: map a leg about to be CLOSED to (INTENT, LEG_TAG)."""
+    opt_type = symbol[-9] if len(symbol) >= 9 else "P"
+    is_short = qty < 0
+    if opt_type == "P":
+        return ("BPS", "SP") if is_short else ("BPL", "LP")
+    return ("BCS", "SC") if is_short else ("BCL", "LC")
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
 logger = logging.getLogger(__name__)
@@ -276,6 +286,7 @@ def close_iron_condor(client, ic_data: dict, reason: str, expiry: str, pnl: floa
                 legs=[OptionLegRequest(**leg) for leg in option_legs],
                 time_in_force=TimeInForce.DAY,
                 limit_price=round(limit_debit, 2),
+                client_order_id=build_client_order_id("CLOSE", "IC"),
             )
             order = safe_submit_order(client, mleg_order)
             logger.info(f"  MLEG close submitted: {order.id} status={order.status}")
@@ -292,6 +303,11 @@ def close_iron_condor(client, ic_data: dict, reason: str, expiry: str, pnl: floa
         qty = abs(pos["qty"])
 
         try:
+            # LL-354: every singleton SIMPLE close from the guardian fallback
+            # was the silent contributor to the $2.6K paired-ledger gap.
+            # Stamp role/intent/leg so sync_closed_positions can pair it
+            # without reverse-lookup.
+            intent, tag = _guardian_leg_intent_tag(str(pos["symbol"]), int(pos["qty"]))
             order = safe_submit_order(
                 client,
                 MarketOrderRequest(
@@ -299,6 +315,7 @@ def close_iron_condor(client, ic_data: dict, reason: str, expiry: str, pnl: floa
                     qty=qty,
                     side=side,
                     time_in_force=TimeInForce.DAY,
+                    client_order_id=build_client_order_id("CLOSE", intent, tag),
                 ),
             )
             logger.info(f"  Closed {pos['symbol']}: {side.value} {qty} - {order.status}")

--- a/scripts/iron_condor_trader.py
+++ b/scripts/iron_condor_trader.py
@@ -936,6 +936,7 @@ class IronCondorStrategy:
                 from alpaca.trading.enums import OrderClass, OrderSide
                 from alpaca.trading.requests import OptionLegRequest
                 from src.utils.alpaca_client import get_alpaca_credentials
+                from src.utils.order_intent import build_client_order_id
 
                 api_key, secret = get_alpaca_credentials()
 
@@ -1002,12 +1003,16 @@ class IronCondorStrategy:
                         logger.info(f"   Limit price: -${limit_credit:.2f} (credit per contract)")
                         logger.info(f"   Total credit target: ~${limit_credit * ic_qty * 100:.0f}")
 
+                        # LL-354: stamp OPEN intent on the combo parent so
+                        # downstream pairing can identify our orders even if
+                        # the broker returns position_intent=None.
                         order_req = LimitOrderRequest(
                             qty=ic_qty,
                             order_class=OrderClass.MLEG,
                             legs=option_legs,
                             time_in_force=TimeInForce.DAY,
                             limit_price=round(-limit_credit, 2),  # Negative = credit
+                            client_order_id=build_client_order_id("OPEN", "IC"),
                         )
 
                         logger.info("🚀 Submitting MLeg iron condor order...")

--- a/scripts/sync_closed_positions.py
+++ b/scripts/sync_closed_positions.py
@@ -162,6 +162,37 @@ def _field(source: Any, key: str) -> Any:
     return getattr(source, key, None)
 
 
+# LL-354: leg_tag -> close action. Short legs are bought back to close;
+# long legs are sold to close.
+_LEG_TAG_TO_CLOSE_ACTION = {
+    "SP": "BUY_TO_CLOSE",   # short put
+    "SC": "BUY_TO_CLOSE",   # short call
+    "LP": "SELL_TO_CLOSE",  # long put
+    "LC": "SELL_TO_CLOSE",  # long call
+}
+
+
+def _intent_from_stamped_cid(client_order_id: Any) -> str | None:
+    """If WE stamped the order at submission, derive the close action
+    directly from `client_order_id`. Returns None for legacy / non-IC
+    orders (which fall through to the reverse-lookup heuristic)."""
+    try:
+        from src.utils.order_intent import parse_client_order_id
+    except Exception:  # pragma: no cover - import safety
+        return None
+    parsed = parse_client_order_id(
+        client_order_id if isinstance(client_order_id, str) else None
+    )
+    if parsed is None or parsed["role"] != "CLOSE":
+        return None
+    leg_tag = parsed.get("leg_tag")
+    if not leg_tag:
+        # CLOSE-IC parent: leg-level rows are handled separately in the
+        # MLEG branch of _close_inventory; nothing to do here.
+        return None
+    return _LEG_TAG_TO_CLOSE_ACTION.get(leg_tag)
+
+
 def _serialize_leg(leg: Any) -> dict[str, Any]:
     return {
         "id": str(_field(leg, "id") or ""),
@@ -172,6 +203,7 @@ def _serialize_leg(leg: Any) -> dict[str, Any]:
         "filled_avg_price": str(_field(leg, "filled_avg_price") or ""),
         "position_intent": str(_field(leg, "position_intent") or ""),
         "status": str(_field(leg, "status") or ""),
+        "client_order_id": str(_field(leg, "client_order_id") or ""),
     }
 
 
@@ -188,6 +220,7 @@ def _serialize_order(order: Any) -> dict[str, Any]:
         "status": str(_field(order, "status") or ""),
         "order_class": str(_field(order, "order_class") or ""),
         "position_intent": str(_field(order, "position_intent") or ""),
+        "client_order_id": str(_field(order, "client_order_id") or ""),
         "legs": legs,
     }
 
@@ -234,7 +267,6 @@ def _fetch_broker_trade_history(limit: int = DEFAULT_BROKER_ORDER_LIMIT) -> list
         from alpaca.trading.client import TradingClient
         from alpaca.trading.enums import QueryOrderStatus
         from alpaca.trading.requests import GetOrdersRequest
-
         from src.utils.alpaca_client import get_alpaca_credentials
     except Exception as exc:
         logger.info("Broker trade-history sync unavailable: %s", exc)
@@ -682,6 +714,15 @@ def _close_inventory(
             continue
 
         source_tag = "alpaca_simple_close"
+        # LL-354: authoritative path — if WE stamped client_order_id at
+        # submission, the intent is self-describing and beats both
+        # broker position_intent and the reverse-lookup heuristic.
+        if action is None or "CLOSE" not in action:
+            stamped = _intent_from_stamped_cid(row.get("client_order_id"))
+            if stamped is not None:
+                action = stamped
+                source_tag = "alpaca_simple_close_client_order_id"
+
         # Reverse-lookup fallback: position_intent missing on the broker row,
         # but the symbol+side matches an open parent-lot's expected-close leg.
         # Without this, singleton SIMPLE closes never enter the paired ledger

--- a/src/utils/order_intent.py
+++ b/src/utils/order_intent.py
@@ -1,0 +1,100 @@
+"""OPEN/CLOSE intent stamping for Alpaca `client_order_id`.
+
+Background (LL-354)
+-------------------
+When the guardian closes an iron condor leg-by-leg, Alpaca returns SIMPLE
+rows whose ``position_intent`` is ``None``. The paired-ledger sync then has
+to reverse-lookup intent from open parent-lots, and singleton closes that
+don't match any expected-close pattern are silently dropped — under-
+reporting realized P/L by ~$2.6K (broker truth -$6,570 vs ledger -$3,958).
+
+Fix: stamp our own intent on every order at submission via
+``client_order_id`` (free-form, broker round-trips it). Format::
+
+    IC-{ROLE}-{INTENT}-{LEGTAG}-{NANOS}
+
+Examples:
+    IC-OPEN-IC--1748549812345678901          (4-leg MLEG parent)
+    IC-OPEN-BPS-SP-1748549812345678901       (short put leg of an open)
+    IC-CLOSE-BPS-SP-1748549812345678901      (singleton close of that leg)
+
+This module is pure-function and free of side effects so it can be imported
+from `trade_gateway`, `iron_condor_trader`, `ic_simple`, `iron_condor_guardian`,
+and `sync_closed_positions` without circular deps.
+"""
+
+from __future__ import annotations
+
+import itertools
+import re
+import threading
+import time
+from typing import Final
+
+_COUNTER = itertools.count()
+_COUNTER_LOCK = threading.Lock()
+
+# Alpaca caps client_order_id at 128 chars.
+MAX_CLIENT_ORDER_ID_LEN: Final[int] = 128
+
+VALID_ROLES: Final[frozenset[str]] = frozenset({"OPEN", "CLOSE"})
+VALID_INTENTS: Final[frozenset[str]] = frozenset(
+    {"BPS", "BPL", "BCS", "BCL", "IC"}
+)
+VALID_LEG_TAGS: Final[frozenset[str]] = frozenset({"SP", "LP", "SC", "LC"})
+
+_PATTERN = re.compile(
+    r"^IC-(OPEN|CLOSE)-(BPS|BPL|BCS|BCL|IC)-([A-Z]{0,4})-(\d+)$"
+)
+
+
+def build_client_order_id(
+    role: str, intent: str, leg_tag: str | None = None
+) -> str:
+    """Build an `IC-{ROLE}-{INTENT}-{LEGTAG}-{NANOS}` client_order_id.
+
+    ``leg_tag`` is optional (empty for the 4-leg combo parent). Guaranteed
+    unique per call via ``time.time_ns()`` + monotonic counter. Result is
+    <= 128 chars.
+    """
+    if role not in VALID_ROLES:
+        raise ValueError(f"role must be one of {sorted(VALID_ROLES)}, got {role!r}")
+    if intent not in VALID_INTENTS:
+        raise ValueError(
+            f"intent must be one of {sorted(VALID_INTENTS)}, got {intent!r}"
+        )
+    tag = leg_tag or ""
+    if tag and tag not in VALID_LEG_TAGS:
+        raise ValueError(
+            f"leg_tag must be one of {sorted(VALID_LEG_TAGS)} or None, got {tag!r}"
+        )
+    # nanos suffix: time_ns()*1000 + monotonic counter. time_ns() alone has
+    # microsecond resolution on macOS, so a tight loop collides; counter
+    # guarantees uniqueness without changing the digits-only suffix shape.
+    with _COUNTER_LOCK:
+        seq = next(_COUNTER) % 1000
+    cid = f"IC-{role}-{intent}-{tag}-{time.time_ns() * 1000 + seq}"
+    if len(cid) > MAX_CLIENT_ORDER_ID_LEN:  # defensive; ~30 chars in practice
+        raise ValueError(f"client_order_id exceeds {MAX_CLIENT_ORDER_ID_LEN} chars")
+    return cid
+
+
+def parse_client_order_id(value: str | None) -> dict | None:
+    """Parse a stamped client_order_id back into its components.
+
+    Returns ``{"role", "intent", "leg_tag", "nanos"}`` on success, ``None``
+    when the input doesn't match our format (other broker IDs, legacy rows,
+    or non-IC strategies). Never raises.
+    """
+    if not isinstance(value, str) or not value:
+        return None
+    m = _PATTERN.match(value)
+    if not m:
+        return None
+    role, intent, leg_tag, nanos = m.groups()
+    return {
+        "role": role,
+        "intent": intent,
+        "leg_tag": leg_tag or None,
+        "nanos": int(nanos),
+    }

--- a/tests/unit/test_order_intent.py
+++ b/tests/unit/test_order_intent.py
@@ -1,0 +1,95 @@
+"""Tests for src/utils/order_intent.py.
+
+Locks in the wire format used to back-stamp OPEN/CLOSE intent on every
+Alpaca order so the paired ledger (LL-354) never has to guess intent for
+SIMPLE single-leg closes.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from src.utils.order_intent import (  # noqa: E402
+    MAX_CLIENT_ORDER_ID_LEN,
+    build_client_order_id,
+    parse_client_order_id,
+)
+
+
+def test_build_then_parse_roundtrips_for_open_leg():
+    cid = build_client_order_id("OPEN", "BPS", "SP")
+    parsed = parse_client_order_id(cid)
+    assert parsed is not None
+    assert parsed["role"] == "OPEN"
+    assert parsed["intent"] == "BPS"
+    assert parsed["leg_tag"] == "SP"
+    assert isinstance(parsed["nanos"], int) and parsed["nanos"] > 0
+
+
+def test_build_then_parse_roundtrips_for_close_leg():
+    cid = build_client_order_id("CLOSE", "BCS", "SC")
+    parsed = parse_client_order_id(cid)
+    assert parsed == {
+        "role": "CLOSE",
+        "intent": "BCS",
+        "leg_tag": "SC",
+        "nanos": parsed["nanos"],  # value verified above
+    }
+
+
+def test_build_combo_parent_has_empty_leg_tag():
+    cid = build_client_order_id("OPEN", "IC")
+    parsed = parse_client_order_id(cid)
+    assert parsed is not None
+    assert parsed["role"] == "OPEN"
+    assert parsed["intent"] == "IC"
+    assert parsed["leg_tag"] is None
+
+
+def test_build_id_under_128_chars():
+    # Alpaca caps client_order_id at 128. Real format is ~30 chars.
+    for role in ("OPEN", "CLOSE"):
+        for intent in ("BPS", "BPL", "BCS", "BCL", "IC"):
+            for tag in (None, "SP", "LP", "SC", "LC"):
+                cid = build_client_order_id(role, intent, tag)
+                assert len(cid) <= MAX_CLIENT_ORDER_ID_LEN
+                assert cid.startswith("IC-")
+
+
+def test_build_rejects_unknown_role():
+    with pytest.raises(ValueError):
+        build_client_order_id("REOPEN", "BPS", "SP")
+
+
+def test_build_rejects_unknown_intent():
+    with pytest.raises(ValueError):
+        build_client_order_id("OPEN", "XYZ", "SP")
+
+
+def test_build_rejects_unknown_leg_tag():
+    with pytest.raises(ValueError):
+        build_client_order_id("OPEN", "BPS", "ZZ")
+
+
+def test_parse_returns_none_for_unknown_formats():
+    # Pre-existing Alpaca order IDs / legacy rows must not raise.
+    assert parse_client_order_id(None) is None
+    assert parse_client_order_id("") is None
+    assert parse_client_order_id("3c4b8a2e-1234-abcd") is None  # uuid-ish
+    assert parse_client_order_id("IC-OPEN-BPS-SP") is None  # missing nanos
+    assert parse_client_order_id("IC-WAT-BPS-SP-1") is None  # bad role
+    assert parse_client_order_id("IC-OPEN-XXX-SP-1") is None  # bad intent
+    assert parse_client_order_id("foo IC-OPEN-BPS-SP-1") is None  # not anchored
+
+
+def test_build_is_unique_per_call():
+    # time.time_ns()+counter guarantees uniqueness even in a tight loop.
+    ids = {build_client_order_id("OPEN", "BPS", "SP") for _ in range(50)}
+    assert len(ids) == 50

--- a/tests/unit/test_sync_closed_positions.py
+++ b/tests/unit/test_sync_closed_positions.py
@@ -215,7 +215,8 @@ def test_reverse_lookup_promotes_singleton_when_open_lot_matches():
 
 
 def _make_singleton_close_for_symbol(
-    filled_at: str, *, symbol: str, order_id: str, side: str, qty: int, price: float
+    filled_at: str, *, symbol: str, order_id: str, side: str, qty: int, price: float,
+    client_order_id: str = "",
 ) -> dict:
     return {
         "id": order_id,
@@ -227,5 +228,84 @@ def _make_singleton_close_for_symbol(
         "status": "filled",
         "order_class": "simple",
         "position_intent": "",
+        "client_order_id": client_order_id,
         "legs": [],
     }
+
+
+def test_stamped_client_order_id_pairs_without_reverse_lookup():
+    """LL-354 contract test: when WE stamp `client_order_id=IC-CLOSE-*-*`
+    at submission time, `_close_inventory` must promote SIMPLE singleton
+    rows BEFORE the reverse-lookup fallback fires, and tag them with
+    `alpaca_simple_close_client_order_id`. Crucially, the pairing must
+    succeed even with NO `expected_close_index` (i.e. without the
+    reverse-lookup heuristic having anything to match against).
+    """
+    expiry = "260516"
+    open_row = _make_parent_open(
+        "2026-04-15T14:00:00Z", expiry, order_id="parent-open-stamp"
+    )
+    # All 4 closes carry our stamped client_order_id. Intents:
+    #   SP=short put close -> BPS, LP=long put close -> BPL
+    #   SC=short call close -> BCS, LC=long call close -> BCL
+    singleton_closes = [
+        _make_singleton_close_for_symbol(
+            "2026-04-16T15:00:00Z",
+            symbol=_option_symbol(expiry, "P", 540),
+            order_id="stamp-p540",
+            side="buy",
+            qty=1,
+            price=1.00,
+            client_order_id="IC-CLOSE-BPS-SP-1748549812345678901",
+        ),
+        _make_singleton_close_for_symbol(
+            "2026-04-16T15:00:01Z",
+            symbol=_option_symbol(expiry, "P", 530),
+            order_id="stamp-p530",
+            side="sell",
+            qty=1,
+            price=0.50,
+            client_order_id="IC-CLOSE-BPL-LP-1748549812345678902",
+        ),
+        _make_singleton_close_for_symbol(
+            "2026-04-16T15:00:02Z",
+            symbol=_option_symbol(expiry, "C", 600),
+            order_id="stamp-c600",
+            side="buy",
+            qty=1,
+            price=1.00,
+            client_order_id="IC-CLOSE-BCS-SC-1748549812345678903",
+        ),
+        _make_singleton_close_for_symbol(
+            "2026-04-16T15:00:03Z",
+            symbol=_option_symbol(expiry, "C", 610),
+            order_id="stamp-c610",
+            side="sell",
+            qty=1,
+            price=0.50,
+            client_order_id="IC-CLOSE-BCL-LC-1748549812345678904",
+        ),
+    ]
+    trade_history = [open_row, *singleton_closes]
+
+    # Call _close_inventory WITHOUT expected_close_index so we prove the
+    # client_order_id path is what's doing the work — not reverse-lookup.
+    inventory = scp._close_inventory(trade_history, expected_close_index=None)
+
+    # All 4 singleton closes must land in the inventory, each tagged with
+    # the stamped-CID source.
+    sources = [
+        fill["source"]
+        for fills in inventory.values()
+        for fill in fills
+        if "alpaca" in fill.get("source", "")
+    ]
+    assert sources, f"no inventory rows produced: {inventory}"
+    assert all(
+        s == "alpaca_simple_close_client_order_id" for s in sources
+    ), f"expected all closes to be stamped-CID sourced, got {sources}"
+    assert len(sources) == 4, sources
+
+    # End-to-end: the full pairing pipeline yields exactly one paired IC.
+    paired = scp._pair_closed_trades_from_inventory(trade_history)
+    assert len(paired) == 1, paired


### PR DESCRIPTION
## Summary

Root-cause fix for **LL-354** (paired ledger under-reports realized P/L by ~\$2.6K). PR #4076 added a reverse-lookup fallback as a band-aid; this PR removes the need for the band-aid by stamping our own OPEN/CLOSE intent into every order's \`client_order_id\` at submission time. The intent survives the broker round-trip even when Alpaca returns \`position_intent=None\` on the parent (which is always, for guardian-managed singleton closes).

## Wire format

\`IC-{ROLE}-{INTENT}-{LEGTAG}-{NANOS}\`

- ROLE: \`OPEN\` | \`CLOSE\`
- INTENT: \`BPS\` (bull put short), \`BPL\` (bull put long), \`BCS\` (bear call short), \`BCL\` (bear call long), \`IC\` (4-leg combo parent)
- LEGTAG: \`SP\` | \`LP\` | \`SC\` | \`LC\`
- NANOS: \`time.time_ns()\` × 1000 + monotonic counter (defeats macOS µs collisions)

Example: \`IC-OPEN-BPS-SP-1748549812345678901\` (well under Alpaca's 128-char client_order_id limit)

## Files

**New:**
- \`src/utils/order_intent.py\` — \`build_client_order_id\`, \`parse_client_order_id\`, ~100 LOC
- \`tests/unit/test_order_intent.py\` — 9 tests (round-trip, length, uniqueness, safe parse)

**Modified (every submit site):**
- \`scripts/iron_condor_trader.py\` — MLEG parent open \`IC-OPEN-IC-\`
- \`scripts/ic_simple.py\` — MLEG open + MLEG close + leg-fallback close (the canonical singleton producer)
- \`scripts/iron_condor_guardian.py\` — MLEG close + leg-fallback close per leg
- \`scripts/sync_closed_positions.py\` — \`_close_inventory\` consults stamped \`client_order_id\` BEFORE reverse-lookup; serializers persist \`client_order_id\` on orders + legs
- \`tests/unit/test_sync_closed_positions.py\` — +1 contract test: 4 stamped singletons pair correctly with \`expected_close_index=None\`

## Verification

- \`pytest tests/unit/test_order_intent.py tests/unit/test_sync_closed_positions.py -v\` → **12 passed**
- \`ruff check\` on touched files → clean
- Regression on \`test_ic_simple.py\` + \`test_iron_condor_guardian.py\`: only failures are 2 pre-existing flakes from IV-percentile gate (\`IV Percentile 12% < 20%\`), confirmed baseline.

## Constraints honored

- Metadata-only PR: no strike, expiry, delta, sizing, or risk-gate changes
- \`data/TRADING_HALTED\`, \`src/safety/crisis_monitor.py\`, \`.claude/rules/*.md\` — untouched
- Karpathy: helper is 2 pure functions, no class hierarchy
- After merge + 1 trading day, future singleton closes pair authoritatively. Existing pre-merge orders still rely on the LL-354 reverse-lookup, which is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)