### PR TITLE
fix(reconciliation): broker_realized counts closed positions only, not all fills

### DIFF
--- a/.github/workflows/daily-reconciliation.yml
+++ b/.github/workflows/daily-reconciliation.yml
@@ -1,0 +1,106 @@
+name: Daily Broker-vs-Paired Reconciliation
+
+# LL-354 prevention layer: each weekday after market close, diff broker truth
+# (data/system_state.json trade_history fills) against the paired ledger
+# (data/trades.json stats.total_pnl + stats.unpaired_realized_pnl). Sentry-alert
+# and fail the workflow if |delta| > $150.
+
+on:
+  schedule:
+    - cron: "0 21 * * 1-5" # 4 PM ET weekdays (post-close)
+  workflow_dispatch: {}
+
+permissions:
+  contents: write
+
+concurrency:
+  group: ${{ format('daily-reconciliation-{0}-{1}', github.repository, github.ref_name || 'main') }}
+  cancel-in-progress: false
+
+env:
+  SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
+
+jobs:
+  reconcile:
+    name: Reconcile broker vs paired
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          token: ${{ secrets.GH_PAT || github.token }}
+          fetch-depth: 0
+
+      - name: Refresh to latest main
+        run: |
+          git fetch origin main
+          git checkout -B main origin/main
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+        with:
+          python-version: "3.11"
+          cache: "pip"
+
+      - name: Install dependencies
+        run: |
+          pip install -q -r requirements-minimal.txt || pip install -q alpaca-py requests python-dotenv
+          pip install -q sentry-sdk || echo "sentry-sdk install failed - reconciler will log CRITICAL instead of capturing"
+
+      - name: Refresh broker state
+        env:
+          ALPACA_PAPER_TRADING_API_KEY: ${{ secrets.ALPACA_PAPER_TRADING_API_KEY }}
+          ALPACA_PAPER_TRADING_API_SECRET: ${{ secrets.ALPACA_PAPER_TRADING_API_SECRET }}
+          ALPACA_BROKERAGE_TRADING_API_KEY: ${{ secrets.ALPACA_BROKERAGE_TRADING_API_KEY }}
+          ALPACA_BROKERAGE_TRADING_API_SECRET: ${{ secrets.ALPACA_BROKERAGE_TRADING_API_SECRET }}
+          REQUIRE_ALPACA_KEYS: "true"
+        run: python3 scripts/sync_alpaca_state.py
+
+      - name: Refresh paired ledger
+        env:
+          ALPACA_PAPER_TRADING_API_KEY: ${{ secrets.ALPACA_PAPER_TRADING_API_KEY }}
+          ALPACA_PAPER_TRADING_API_SECRET: ${{ secrets.ALPACA_PAPER_TRADING_API_SECRET }}
+          ALPACA_BROKERAGE_TRADING_API_KEY: ${{ secrets.ALPACA_BROKERAGE_TRADING_API_KEY }}
+          ALPACA_BROKERAGE_TRADING_API_SECRET: ${{ secrets.ALPACA_BROKERAGE_TRADING_API_SECRET }}
+          REQUIRE_ALPACA_KEYS: "true"
+        run: python3 scripts/sync_closed_positions.py
+
+      - name: Run reconciliation
+        id: reconcile
+        continue-on-error: true
+        env:
+          SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
+        run: |
+          set +e
+          python3 scripts/reconcile_broker_vs_paired.py
+          echo "reconcile_exit=$?" >> "$GITHUB_OUTPUT"
+
+      - name: Commit reconciliation report
+        run: |
+          set -euo pipefail
+          git config user.name "GitHub Actions Bot"
+          git config user.email "actions@github.com"
+
+          git add data/reports/reconciliation_*.json 2>/dev/null || true
+          if git diff --staged --quiet; then
+            echo "No reconciliation report changes to commit"
+            exit 0
+          fi
+          git commit -m "chore: daily reconciliation [auto]"
+
+          if [ -n "${{ secrets.GH_PAT }}" ]; then
+            git remote set-url origin "https://x-access-token:${{ secrets.GH_PAT }}@github.com/${{ github.repository }}.git"
+          fi
+          git pull --ff-only origin main
+          git push origin HEAD:main
+
+      - name: Fail workflow if reconciliation alerted
+        run: |
+          rc="${{ steps.reconcile.outputs.reconcile_exit }}"
+          echo "reconcile exit code: $rc"
+          if [ "$rc" != "0" ]; then
+            echo "::error::Broker-vs-paired reconciliation breach (exit $rc). See data/reports/reconciliation_*.json."
+            exit 1
+          fi

--- a/scripts/reconcile_broker_vs_paired.py
+++ b/scripts/reconcile_broker_vs_paired.py
@@ -132,11 +132,32 @@ def _signed_qty(row: dict[str, Any]) -> float:
     return 0.0
 
 
-def compute_broker_realized(system_state: dict[str, Any]) -> tuple[float, int]:
-    """Return (broker_realized_dollars, closed_position_count) from system_state.
+def _row_timestamp(row: dict[str, Any]) -> str | None:
+    """Return the best-available ISO timestamp for a fill row.
+
+    Prefers filled_at, then submitted_at, then created_at. Returns the raw
+    string (already ISO-ish in Alpaca data); comparison is lexicographic
+    because all rows share the same '+00:00' suffix.
+    """
+    for key in ("filled_at", "submitted_at", "created_at"):
+        val = row.get(key)
+        if val:
+            return str(val)
+    return None
+
+
+def compute_broker_realized(
+    system_state: dict[str, Any],
+) -> tuple[float, int, str | None, str | None]:
+    """Return (broker_realized_dollars, closed_position_count, window_start, window_end).
 
     Sums signed_cash only for leg-key groups whose net quantity is zero (the
     position has been fully closed). Open positions contribute $0.
+
+    The window is the [min, max] timestamp across the FILLED rows that
+    contribute to closed leg-groups. Used by compute_paired_realized to
+    apples-to-apples clip the paired ledger so the rolling 60d broker window
+    is not diff'd against the full-history paired ledger.
 
     Bug history: the v1 of this function summed signed_cash across ALL fills,
     which conflated open-position entry cash with realized P/L and produced
@@ -145,37 +166,101 @@ def compute_broker_realized(system_state: dict[str, Any]) -> tuple[float, int]:
     history = system_state.get("trade_history") or []
     fills = [row for row in history if "FILLED" in str(row.get("status") or "")]
 
-    groups: dict[tuple, dict[str, float]] = defaultdict(
-        lambda: {"net_qty": 0.0, "cash": 0.0}
+    groups: dict[tuple, dict[str, Any]] = defaultdict(
+        lambda: {"net_qty": 0.0, "cash": 0.0, "timestamps": []}
     )
     for row in fills:
         key = _leg_key(row)
         groups[key]["net_qty"] += _signed_qty(row)
         groups[key]["cash"] += _fill_signed_cash(row)
+        ts = _row_timestamp(row)
+        if ts:
+            groups[key]["timestamps"].append(ts)
 
     closed_total = 0.0
     closed_count = 0
+    closed_timestamps: list[str] = []
     for stats in groups.values():
         if abs(stats["net_qty"]) < 1e-6:
             closed_total += stats["cash"]
             closed_count += 1
+            closed_timestamps.extend(stats["timestamps"])
 
-    return round(closed_total, 2), closed_count
+    window_start = min(closed_timestamps) if closed_timestamps else None
+    window_end = max(closed_timestamps) if closed_timestamps else None
+
+    return round(closed_total, 2), closed_count, window_start, window_end
 
 
-def compute_paired_realized(trades: dict[str, Any]) -> tuple[float, int, int]:
-    """Return (paired_realized_dollars, paired_trade_count, unpaired_order_count).
+def compute_paired_realized(
+    trades: dict[str, Any],
+    window_start: str | None = None,
+    window_end: str | None = None,
+) -> dict[str, Any]:
+    """Return paired realized P/L, optionally clipped to a broker window.
+
+    When window_start/window_end are provided, the per-trade ``trades[]`` list
+    is filtered by ``exit_time`` (realized P/L is booked at exit). The bucket
+    inside the window drives the reconciliation delta; the outside bucket is
+    surfaced informationally so a long-history vs short-window mismatch
+    cannot silently train the operator to ignore alerts.
+
+    When no window is supplied, falls back to the legacy stats-only path
+    (stats.total_pnl + stats.unpaired_realized_pnl) so older callers and
+    tests keep working.
 
     Schema (post PR #4076):
       stats.total_pnl            -> paired closed-trade P/L
       stats.unpaired_realized_pnl -> singleton fills not yet paired (optional)
+
+    Returns a dict so the report payload can include both in/out bucket
+    counts without further tuple-arity churn.
     """
     stats = trades.get("stats") or {}
-    total_pnl = _to_float(stats.get("total_pnl"), 0.0)
     unpaired = _to_float(stats.get("unpaired_realized_pnl"), 0.0)
-    paired_trade_count = int(stats.get("closed_trades") or 0)
     unpaired_order_count = int(stats.get("unpaired_order_count") or 0)
-    return round(total_pnl + unpaired, 2), paired_trade_count, unpaired_order_count
+
+    if window_start is None or window_end is None:
+        # Legacy path: stats-only, no clipping.
+        total_pnl = _to_float(stats.get("total_pnl"), 0.0)
+        paired_trade_count = int(stats.get("closed_trades") or 0)
+        return {
+            "paired_realized_in_window": round(total_pnl + unpaired, 2),
+            "paired_realized_outside_window": 0.0,
+            "paired_trade_count_in_window": paired_trade_count,
+            "paired_trade_count_outside_window": 0,
+            "unpaired_order_count": unpaired_order_count,
+            "window_clipped": False,
+        }
+
+    in_pnl = 0.0
+    out_pnl = 0.0
+    in_count = 0
+    out_count = 0
+    for trade in trades.get("trades") or []:
+        if str(trade.get("status") or "").lower() != "closed":
+            continue
+        exit_time = str(trade.get("exit_time") or "")
+        pnl = _to_float(trade.get("realized_pnl"), 0.0)
+        if exit_time and window_start <= exit_time <= window_end:
+            in_pnl += pnl
+            in_count += 1
+        else:
+            out_pnl += pnl
+            out_count += 1
+
+    # Unpaired singletons fold into the in-window bucket (the broker fills
+    # that generated them are themselves window-resident by construction).
+    in_pnl += unpaired
+
+    return {
+        "paired_realized_in_window": round(in_pnl, 2),
+        "paired_realized_outside_window": round(out_pnl, 2),
+        "paired_trade_count_in_window": in_count,
+        "paired_trade_count_outside_window": out_count,
+        "unpaired_order_count": unpaired_order_count,
+        "window_clipped": True,
+    }
 
 
 def compute_delta(broker_realized: float, paired_realized: float) -> float:
@@ -233,24 +318,35 @@ def build_payload(
     *,
     date_str: str,
     broker_realized: float,
-    paired_realized: float,
+    paired: dict[str, Any],
     broker_fill_count: int,
-    paired_trade_count: int,
-    paired_unpaired_order_count: int,
+    window_start: str | None,
+    window_end: str | None,
     notes: str,
 ) -> dict[str, Any]:
-    delta = compute_delta(broker_realized, paired_realized)
+    paired_in = paired["paired_realized_in_window"]
+    delta = compute_delta(broker_realized, paired_in)
     alert_fired = abs(delta) > THRESHOLD_DOLLARS
     return {
         "date": date_str,
         "broker_realized_pnl": broker_realized,
-        "paired_realized_pnl": paired_realized,
+        # Back-compat: keep paired_realized_pnl == in-window so any
+        # downstream consumer that read the v1 field doesn't break.
+        "paired_realized_pnl": paired_in,
+        "paired_realized_in_window": paired_in,
+        "paired_realized_outside_window": paired["paired_realized_outside_window"],
+        "paired_trade_count_in_window": paired["paired_trade_count_in_window"],
+        "paired_trade_count_outside_window": paired["paired_trade_count_outside_window"],
+        "window_clipped": paired["window_clipped"],
+        "window_start": window_start,
+        "window_end": window_end,
         "delta_dollars": delta,
         "threshold_dollars": THRESHOLD_DOLLARS,
         "alert_fired": alert_fired,
         "broker_fill_count": broker_fill_count,
-        "paired_trade_count": paired_trade_count,
-        "paired_unpaired_order_count": paired_unpaired_order_count,
+        # Back-compat name for the old test (== in-window count).
+        "paired_trade_count": paired["paired_trade_count_in_window"],
+        "paired_unpaired_order_count": paired["unpaired_order_count"],
         "notes": notes,
     }
 
@@ -276,8 +372,13 @@ def main(argv: list[str] | None = None) -> int:
     system_state = json.loads(args.system_state.read_text())
     trades = json.loads(args.trades.read_text())
 
-    broker_realized, broker_closed_count = compute_broker_realized(system_state)
-    paired_realized, paired_trade_count, unpaired_order_count = compute_paired_realized(trades)
+    (
+        broker_realized,
+        broker_closed_count,
+        window_start,
+        window_end,
+    ) = compute_broker_realized(system_state)
+    paired = compute_paired_realized(trades, window_start, window_end)
 
     date_str = args.date or _dt.datetime.now(_dt.timezone.utc).strftime("%Y-%m-%d")
     notes = (
@@ -285,8 +386,11 @@ def main(argv: list[str] | None = None) -> int:
         "leg-key (SIMPLE: OCC symbol; MLEG: sorted tuple of leg symbols) "
         "where net signed_qty == 0 (position fully closed). Open positions "
         "contribute $0 so entry cash is not mistaken for realized P/L. "
-        "paired_realized = trades.stats.total_pnl + "
-        "trades.stats.unpaired_realized_pnl. "
+        "paired_realized_in_window = sum(trades[].realized_pnl) where "
+        "exit_time in [window_start, window_end] + "
+        "trades.stats.unpaired_realized_pnl. The window is the min/max "
+        "filled_at across closed broker leg-groups, so the rolling ~60d "
+        "broker history is not diff'd against the full paired ledger. "
         "Threshold $150 sits above the ~$103 fee/spread noise floor "
         "(LL-354 prevention layer)."
     )
@@ -294,21 +398,24 @@ def main(argv: list[str] | None = None) -> int:
     payload = build_payload(
         date_str=date_str,
         broker_realized=broker_realized,
-        paired_realized=paired_realized,
+        paired=paired,
         broker_fill_count=broker_closed_count,
-        paired_trade_count=paired_trade_count,
-        paired_unpaired_order_count=unpaired_order_count,
+        window_start=window_start,
+        window_end=window_end,
         notes=notes,
     )
 
     report_path = write_report(args.report_dir, payload)
     logger.info("Reconciliation report written: %s", report_path)
     logger.info(
-        "broker=$%.2f  paired=$%.2f  delta=$%.2f  threshold=$%.2f",
+        "broker=$%.2f  paired_in=$%.2f  paired_out=$%.2f  delta=$%.2f  threshold=$%.2f  window=[%s, %s]",
         payload["broker_realized_pnl"],
-        payload["paired_realized_pnl"],
+        payload["paired_realized_in_window"],
+        payload["paired_realized_outside_window"],
         payload["delta_dollars"],
         payload["threshold_dollars"],
+        payload["window_start"],
+        payload["window_end"],
     )
 
     fired = maybe_alert(payload)

--- a/scripts/reconcile_broker_vs_paired.py
+++ b/scripts/reconcile_broker_vs_paired.py
@@ -1,0 +1,319 @@
+#!/usr/bin/env python3
+"""Daily broker-vs-paired P/L reconciliation alert.
+
+Prevention layer for LL-354 (the $2.6K paired-vs-broker gap that stayed hidden
+for ~4 months because nothing diffed the two numbers).
+
+Compares:
+  - broker_realized: sum of signed_cash for every fill in
+    data/system_state.json -> trade_history
+  - paired_realized: data/trades.json -> stats.total_pnl
+    + stats.unpaired_realized_pnl
+
+If |delta| > THRESHOLD_DOLLARS ($150, set above the ~$103 fee/spread noise
+floor), capture a Sentry message and exit 2 so the workflow surfaces it.
+The daily JSON report is always written.
+
+Karpathy-style: single script, plain functions, no classes.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as _dt
+import json
+import logging
+import os
+import sys
+from collections import defaultdict
+from pathlib import Path
+from typing import Any
+
+THRESHOLD_DOLLARS = 150.0
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DEFAULT_SYSTEM_STATE = REPO_ROOT / "data" / "system_state.json"
+DEFAULT_TRADES = REPO_ROOT / "data" / "trades.json"
+DEFAULT_REPORT_DIR = REPO_ROOT / "data" / "reports"
+
+logger = logging.getLogger("reconcile_broker_vs_paired")
+
+
+def _to_float(value: Any, default: float = 0.0) -> float:
+    if value is None:
+        return default
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _fill_signed_cash(row: dict[str, Any]) -> float:
+    """Return signed cash flow (in dollars) for one fill row.
+
+    Convention (options, contract multiplier = 100):
+      - For MLEG parent rows side is None/"None"; the parent ``price`` is
+        already signed (negative = net debit paid, positive = net credit
+        received), so cash = qty * price * 100.
+      - For SIMPLE single-leg rows side is OrderSide.BUY/OrderSide.SELL;
+        SELL = +qty*price*100, BUY = -qty*price*100.
+    """
+    status = str(row.get("status") or "")
+    if "FILLED" not in status:
+        return 0.0
+
+    qty = _to_float(row.get("qty"), 0.0)
+    price = _to_float(row.get("price"), 0.0)
+    side = str(row.get("side") or "")
+    order_class = str(row.get("order_class") or "")
+
+    if "MLEG" in order_class:
+        # Parent price is already signed (debit negative, credit positive).
+        return qty * price * 100.0
+
+    if "SELL" in side:
+        return qty * price * 100.0
+    if "BUY" in side:
+        return -qty * price * 100.0
+
+    return 0.0
+
+
+def _leg_key(row: dict[str, Any]) -> tuple:
+    """Return a stable key identifying the option position this fill belongs to.
+
+    For MLEG (multi-leg) parents we key on the sorted tuple of OCC leg symbols
+    so that an opening IC and its offsetting closing IC land in the same bucket.
+    For SIMPLE (single-leg) fills we key on the OCC symbol itself.
+    """
+    order_class = str(row.get("order_class") or "")
+    if "MLEG" in order_class:
+        legs = row.get("legs") or []
+        # Legs may be OCC strings or dicts with a 'symbol' field; normalize.
+        norm = []
+        for leg in legs:
+            if isinstance(leg, dict):
+                norm.append(str(leg.get("symbol") or ""))
+            else:
+                norm.append(str(leg))
+        return ("MLEG", tuple(sorted(norm)))
+    return ("SIMPLE", str(row.get("symbol") or ""))
+
+
+def _signed_qty(row: dict[str, Any]) -> float:
+    """Return signed contract quantity (long positive, short negative).
+
+    MLEG parents have no side; we infer direction from price sign:
+      price > 0 (net credit received)  -> position opened short -> long-direction
+                                          increase by +qty when the package is
+                                          sold (we treat sell-to-open as the
+                                          'reference' direction so the offsetting
+                                          buy-to-close nets to zero).
+      price < 0 (net debit paid)       -> the offsetting buy-to-close -> -qty.
+    Convention is internal: we only care that opening + closing fills net to 0
+    when the package is fully unwound.
+
+    SIMPLE rows use the explicit side: SELL = +qty, BUY = -qty (same
+    'short-as-reference' convention).
+    """
+    qty = _to_float(row.get("qty"), 0.0)
+    order_class = str(row.get("order_class") or "")
+    if "MLEG" in order_class:
+        price = _to_float(row.get("price"), 0.0)
+        if price > 0:
+            return qty
+        if price < 0:
+            return -qty
+        return 0.0
+    side = str(row.get("side") or "")
+    if "SELL" in side:
+        return qty
+    if "BUY" in side:
+        return -qty
+    return 0.0
+
+
+def compute_broker_realized(system_state: dict[str, Any]) -> tuple[float, int]:
+    """Return (broker_realized_dollars, closed_position_count) from system_state.
+
+    Sums signed_cash only for leg-key groups whose net quantity is zero (the
+    position has been fully closed). Open positions contribute $0.
+
+    Bug history: the v1 of this function summed signed_cash across ALL fills,
+    which conflated open-position entry cash with realized P/L and produced
+    a $50K+ phantom delta against the paired ledger every day. See LL-354.
+    """
+    history = system_state.get("trade_history") or []
+    fills = [row for row in history if "FILLED" in str(row.get("status") or "")]
+
+    groups: dict[tuple, dict[str, float]] = defaultdict(
+        lambda: {"net_qty": 0.0, "cash": 0.0}
+    )
+    for row in fills:
+        key = _leg_key(row)
+        groups[key]["net_qty"] += _signed_qty(row)
+        groups[key]["cash"] += _fill_signed_cash(row)
+
+    closed_total = 0.0
+    closed_count = 0
+    for stats in groups.values():
+        if abs(stats["net_qty"]) < 1e-6:
+            closed_total += stats["cash"]
+            closed_count += 1
+
+    return round(closed_total, 2), closed_count
+
+
+def compute_paired_realized(trades: dict[str, Any]) -> tuple[float, int, int]:
+    """Return (paired_realized_dollars, paired_trade_count, unpaired_order_count).
+
+    Schema (post PR #4076):
+      stats.total_pnl            -> paired closed-trade P/L
+      stats.unpaired_realized_pnl -> singleton fills not yet paired (optional)
+    """
+    stats = trades.get("stats") or {}
+    total_pnl = _to_float(stats.get("total_pnl"), 0.0)
+    unpaired = _to_float(stats.get("unpaired_realized_pnl"), 0.0)
+    paired_trade_count = int(stats.get("closed_trades") or 0)
+    unpaired_order_count = int(stats.get("unpaired_order_count") or 0)
+    return round(total_pnl + unpaired, 2), paired_trade_count, unpaired_order_count
+
+
+def compute_delta(broker_realized: float, paired_realized: float) -> float:
+    return round(broker_realized - paired_realized, 2)
+
+
+def write_report(report_dir: Path, payload: dict[str, Any]) -> Path:
+    report_dir.mkdir(parents=True, exist_ok=True)
+    date_str = payload["date"]
+    path = report_dir / f"reconciliation_{date_str}.json"
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n")
+    return path
+
+
+def maybe_alert(payload: dict[str, Any]) -> bool:
+    """Fire Sentry alert if |delta| > threshold.
+
+    Returns True if alert was fired (regardless of whether Sentry transport
+    succeeded). If SENTRY_DSN is unset or sentry_sdk is unavailable, log a
+    CRITICAL line and continue — per spec, do not crash.
+    """
+    delta = abs(payload["delta_dollars"])
+    threshold = payload["threshold_dollars"]
+    if delta <= threshold:
+        return False
+
+    msg = (
+        f"Broker-vs-paired P/L reconciliation breach: "
+        f"|delta|=${delta:.2f} > ${threshold:.2f} "
+        f"(broker={payload['broker_realized_pnl']:.2f}, "
+        f"paired={payload['paired_realized_pnl']:.2f}, "
+        f"date={payload['date']})"
+    )
+
+    dsn = os.environ.get("SENTRY_DSN", "").strip()
+    if not dsn:
+        logger.critical("[NO SENTRY_DSN] %s", msg)
+        return True
+
+    try:
+        import sentry_sdk  # type: ignore
+    except ImportError:
+        logger.critical("[NO sentry_sdk] %s", msg)
+        return True
+
+    try:
+        sentry_sdk.init(dsn=dsn)
+        sentry_sdk.capture_message(msg, level="error")
+    except Exception as exc:  # noqa: BLE001 - never crash the reconciler
+        logger.critical("[SENTRY_FAILED:%s] %s", exc, msg)
+    return True
+
+
+def build_payload(
+    *,
+    date_str: str,
+    broker_realized: float,
+    paired_realized: float,
+    broker_fill_count: int,
+    paired_trade_count: int,
+    paired_unpaired_order_count: int,
+    notes: str,
+) -> dict[str, Any]:
+    delta = compute_delta(broker_realized, paired_realized)
+    alert_fired = abs(delta) > THRESHOLD_DOLLARS
+    return {
+        "date": date_str,
+        "broker_realized_pnl": broker_realized,
+        "paired_realized_pnl": paired_realized,
+        "delta_dollars": delta,
+        "threshold_dollars": THRESHOLD_DOLLARS,
+        "alert_fired": alert_fired,
+        "broker_fill_count": broker_fill_count,
+        "paired_trade_count": paired_trade_count,
+        "paired_unpaired_order_count": paired_unpaired_order_count,
+        "notes": notes,
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--system-state", type=Path, default=DEFAULT_SYSTEM_STATE)
+    parser.add_argument("--trades", type=Path, default=DEFAULT_TRADES)
+    parser.add_argument("--report-dir", type=Path, default=DEFAULT_REPORT_DIR)
+    parser.add_argument("--date", type=str, default=None,
+                        help="Override report date (YYYY-MM-DD). Default = today UTC.")
+    args = parser.parse_args(argv)
+
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s %(message)s")
+
+    if not args.system_state.exists():
+        logger.critical("system_state.json missing at %s", args.system_state)
+        return 3
+    if not args.trades.exists():
+        logger.critical("trades.json missing at %s", args.trades)
+        return 3
+
+    system_state = json.loads(args.system_state.read_text())
+    trades = json.loads(args.trades.read_text())
+
+    broker_realized, broker_closed_count = compute_broker_realized(system_state)
+    paired_realized, paired_trade_count, unpaired_order_count = compute_paired_realized(trades)
+
+    date_str = args.date or _dt.datetime.now(_dt.timezone.utc).strftime("%Y-%m-%d")
+    notes = (
+        "broker_realized = sum(signed_cash) over FILLED rows grouped by "
+        "leg-key (SIMPLE: OCC symbol; MLEG: sorted tuple of leg symbols) "
+        "where net signed_qty == 0 (position fully closed). Open positions "
+        "contribute $0 so entry cash is not mistaken for realized P/L. "
+        "paired_realized = trades.stats.total_pnl + "
+        "trades.stats.unpaired_realized_pnl. "
+        "Threshold $150 sits above the ~$103 fee/spread noise floor "
+        "(LL-354 prevention layer)."
+    )
+
+    payload = build_payload(
+        date_str=date_str,
+        broker_realized=broker_realized,
+        paired_realized=paired_realized,
+        broker_fill_count=broker_closed_count,
+        paired_trade_count=paired_trade_count,
+        paired_unpaired_order_count=unpaired_order_count,
+        notes=notes,
+    )
+
+    report_path = write_report(args.report_dir, payload)
+    logger.info("Reconciliation report written: %s", report_path)
+    logger.info(
+        "broker=$%.2f  paired=$%.2f  delta=$%.2f  threshold=$%.2f",
+        payload["broker_realized_pnl"],
+        payload["paired_realized_pnl"],
+        payload["delta_dollars"],
+        payload["threshold_dollars"],
+    )
+
+    fired = maybe_alert(payload)
+    return 2 if fired else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/unit/test_reconciliation.py
+++ b/tests/unit/test_reconciliation.py
@@ -1,0 +1,244 @@
+"""Tests for scripts/reconcile_broker_vs_paired.py.
+
+Two scenarios per spec:
+  1. Synthetic state where broker and paired reconcile within $50
+     -> exit 0, no alert.
+  2. Synthetic state with $300 delta -> exit 2, alert fired,
+     report contents correct.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+SCRIPT = Path(__file__).resolve().parents[2] / "scripts" / "reconcile_broker_vs_paired.py"
+
+
+@pytest.fixture(scope="module")
+def recon_mod():
+    spec = importlib.util.spec_from_file_location("reconcile_mod", SCRIPT)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["reconcile_mod"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _write_state(path: Path, fills: list[dict]) -> None:
+    path.write_text(json.dumps({"trade_history": fills}))
+
+
+def _write_trades(path: Path, total_pnl: float, unpaired: float | None,
+                  closed: int = 0, unpaired_orders: int = 0) -> None:
+    stats: dict = {
+        "total_pnl": total_pnl,
+        "closed_trades": closed,
+        "unpaired_order_count": unpaired_orders,
+    }
+    if unpaired is not None:
+        stats["unpaired_realized_pnl"] = unpaired
+    path.write_text(json.dumps({"stats": stats, "trades": []}))
+
+
+def test_within_threshold_exit_zero(tmp_path: Path, recon_mod, monkeypatch):
+    """Closed IC: opened for +$1500 credit, closed for -$2500 debit.
+    Net realized = -$1000. Paired ledger reports -$1030.
+    Delta $30 < $150 -> no alert, exit 0."""
+    state = tmp_path / "system_state.json"
+    trades = tmp_path / "trades.json"
+    reports = tmp_path / "reports"
+
+    legs = ["A", "B", "C", "D"]
+    fills = [
+        # Open: sell-to-open IC for +$15.00 credit x 1 contract = +$1500
+        {
+            "id": "open",
+            "symbol": None,
+            "side": "None",
+            "qty": "1",
+            "price": "15.00",
+            "filled_at": "2026-05-20 19:00:00+00:00",
+            "status": "OrderStatus.FILLED",
+            "order_class": "OrderClass.MLEG",
+            "legs": legs,
+        },
+        # Close: buy-to-close same IC at -$25.00 debit x 1 contract = -$2500
+        {
+            "id": "close",
+            "symbol": None,
+            "side": "None",
+            "qty": "1",
+            "price": "-25.00",
+            "filled_at": "2026-05-29 19:00:00+00:00",
+            "status": "OrderStatus.FILLED",
+            "order_class": "OrderClass.MLEG",
+            "legs": legs,
+        },
+    ]
+    _write_state(state, fills)
+    _write_trades(trades, total_pnl=-1030.0, unpaired=0.0, closed=1)
+
+    monkeypatch.delenv("SENTRY_DSN", raising=False)
+
+    code = recon_mod.main([
+        "--system-state", str(state),
+        "--trades", str(trades),
+        "--report-dir", str(reports),
+        "--date", "2026-05-29",
+    ])
+    assert code == 0
+
+    report = json.loads((reports / "reconciliation_2026-05-29.json").read_text())
+    assert report["broker_realized_pnl"] == -1000.0
+    assert report["paired_realized_pnl"] == -1030.0
+    assert report["delta_dollars"] == 30.0
+    assert report["alert_fired"] is False
+    assert report["threshold_dollars"] == 150
+    # broker_fill_count now counts CLOSED leg-groups, not raw fills
+    assert report["broker_fill_count"] == 1
+    assert report["paired_trade_count"] == 1
+
+
+def test_breach_threshold_exit_two_alert_fired(tmp_path: Path, recon_mod,
+                                                monkeypatch, caplog):
+    """Closed single-leg short: SELL 1 @ $5.00 then BUY 1 @ $0.00 to close.
+    Net realized = +$500. Paired reports +$200. Delta $300 > $150 -> alert."""
+    state = tmp_path / "system_state.json"
+    trades = tmp_path / "trades.json"
+    reports = tmp_path / "reports"
+
+    symbol = "SPY260618C00500000"
+    fills = [
+        {
+            "id": "open",
+            "symbol": symbol,
+            "side": "OrderSide.SELL",
+            "qty": "1",
+            "price": "5.00",
+            "filled_at": "2026-05-20 18:00:00+00:00",
+            "status": "OrderStatus.FILLED",
+            "order_class": "OrderClass.SIMPLE",
+            "legs": [],
+        },
+        {
+            "id": "close",
+            "symbol": symbol,
+            "side": "OrderSide.BUY",
+            "qty": "1",
+            "price": "0.00",
+            "filled_at": "2026-05-29 18:00:00+00:00",
+            "status": "OrderStatus.FILLED",
+            "order_class": "OrderClass.SIMPLE",
+            "legs": [],
+        },
+    ]
+    _write_state(state, fills)
+    _write_trades(trades, total_pnl=200.0, unpaired=0.0, closed=1)
+
+    # No SENTRY_DSN -> CRITICAL log path, no crash.
+    monkeypatch.delenv("SENTRY_DSN", raising=False)
+    caplog.set_level("CRITICAL")
+
+    code = recon_mod.main([
+        "--system-state", str(state),
+        "--trades", str(trades),
+        "--report-dir", str(reports),
+        "--date", "2026-05-29",
+    ])
+    assert code == 2
+
+    report = json.loads((reports / "reconciliation_2026-05-29.json").read_text())
+    assert report["broker_realized_pnl"] == 500.0
+    assert report["paired_realized_pnl"] == 200.0
+    assert report["delta_dollars"] == 300.0
+    assert report["alert_fired"] is True
+    assert any("reconciliation breach" in rec.message.lower() for rec in caplog.records)
+
+
+def test_open_positions_excluded_from_broker_realized(recon_mod):
+    """Synthetic snapshot: 3 closed legs + 2 still-open legs. broker_realized
+    must include only the 3 closed groups and exclude the 2 open ones.
+
+    Bug being prevented: v1 summed every signed_cash including entry fills of
+    still-open positions, producing a $50K+ phantom delta against the paired
+    ledger (LL-354 reconciliation noise floor).
+    """
+    fills = []
+
+    # Closed group 1: SIMPLE leg, SELL 1@$3 then BUY 1@$1 -> net +$200
+    fills += [
+        {"id": "c1o", "symbol": "S1", "side": "OrderSide.SELL", "qty": "1",
+         "price": "3.00", "status": "OrderStatus.FILLED",
+         "order_class": "OrderClass.SIMPLE", "legs": []},
+        {"id": "c1c", "symbol": "S1", "side": "OrderSide.BUY", "qty": "1",
+         "price": "1.00", "status": "OrderStatus.FILLED",
+         "order_class": "OrderClass.SIMPLE", "legs": []},
+    ]
+    # Closed group 2: SIMPLE leg, SELL 2@$4 then BUY 2@$2 -> net +$400
+    fills += [
+        {"id": "c2o", "symbol": "S2", "side": "OrderSide.SELL", "qty": "2",
+         "price": "4.00", "status": "OrderStatus.FILLED",
+         "order_class": "OrderClass.SIMPLE", "legs": []},
+        {"id": "c2c", "symbol": "S2", "side": "OrderSide.BUY", "qty": "2",
+         "price": "2.00", "status": "OrderStatus.FILLED",
+         "order_class": "OrderClass.SIMPLE", "legs": []},
+    ]
+    # Closed group 3: MLEG IC, open +$10 credit then close -$8 debit -> net +$200
+    legs = ["L1", "L2", "L3", "L4"]
+    fills += [
+        {"id": "c3o", "symbol": None, "side": "None", "qty": "1",
+         "price": "10.00", "status": "OrderStatus.FILLED",
+         "order_class": "OrderClass.MLEG", "legs": legs},
+        {"id": "c3c", "symbol": None, "side": "None", "qty": "1",
+         "price": "-8.00", "status": "OrderStatus.FILLED",
+         "order_class": "OrderClass.MLEG", "legs": legs},
+    ]
+    # Open group A: SIMPLE leg still short, SELL 5@$100 = +$50,000 entry cash
+    fills += [
+        {"id": "oA", "symbol": "OPEN1", "side": "OrderSide.SELL", "qty": "5",
+         "price": "100.00", "status": "OrderStatus.FILLED",
+         "order_class": "OrderClass.SIMPLE", "legs": []},
+    ]
+    # Open group B: MLEG IC still on, opened for +$20 credit x 10 = +$20,000
+    fills += [
+        {"id": "oB", "symbol": None, "side": "None", "qty": "10",
+         "price": "20.00", "status": "OrderStatus.FILLED",
+         "order_class": "OrderClass.MLEG",
+         "legs": ["X1", "X2", "X3", "X4"]},
+    ]
+
+    broker_realized, closed_count = recon_mod.compute_broker_realized(
+        {"trade_history": fills}
+    )
+
+    # Closed sum = $200 + $400 + $200 = $800
+    assert broker_realized == 800.0
+    # 3 closed leg-groups; the 2 open ones contribute $0
+    assert closed_count == 3
+
+
+def test_missing_unpaired_field_is_tolerated(tmp_path: Path, recon_mod, monkeypatch):
+    """Older ledgers without stats.unpaired_realized_pnl must default to 0."""
+    state = tmp_path / "system_state.json"
+    trades = tmp_path / "trades.json"
+    reports = tmp_path / "reports"
+
+    _write_state(state, [])
+    _write_trades(trades, total_pnl=0.0, unpaired=None, closed=0)
+
+    monkeypatch.delenv("SENTRY_DSN", raising=False)
+    code = recon_mod.main([
+        "--system-state", str(state),
+        "--trades", str(trades),
+        "--report-dir", str(reports),
+        "--date", "2026-05-29",
+    ])
+    assert code == 0
+    report = json.loads((reports / "reconciliation_2026-05-29.json").read_text())
+    assert report["paired_realized_pnl"] == 0.0
+    assert report["delta_dollars"] == 0.0

--- a/tests/unit/test_reconciliation.py
+++ b/tests/unit/test_reconciliation.py
@@ -34,7 +34,16 @@ def _write_state(path: Path, fills: list[dict]) -> None:
 
 
 def _write_trades(path: Path, total_pnl: float, unpaired: float | None,
-                  closed: int = 0, unpaired_orders: int = 0) -> None:
+                  closed: int = 0, unpaired_orders: int = 0,
+                  trades: list | None = None) -> None:
+    """Write a synthetic trades.json.
+
+    If ``trades`` is supplied it is written verbatim and stats.total_pnl is
+    treated as the sum of those trades' realized_pnl (caller's responsibility).
+    If ``trades`` is None we synthesize a single closed trade with
+    realized_pnl == total_pnl and exit_time inside the broker window used by
+    the existing scenarios (2026-05-20..2026-05-29).
+    """
     stats: dict = {
         "total_pnl": total_pnl,
         "closed_trades": closed,
@@ -42,7 +51,17 @@ def _write_trades(path: Path, total_pnl: float, unpaired: float | None,
     }
     if unpaired is not None:
         stats["unpaired_realized_pnl"] = unpaired
-    path.write_text(json.dumps({"stats": stats, "trades": []}))
+    if trades is None:
+        trades = []
+        if closed > 0:
+            trades = [{
+                "id": f"synth_{i}",
+                "status": "closed",
+                "entry_time": "2026-05-21 12:00:00+00:00",
+                "exit_time": "2026-05-28 12:00:00+00:00",
+                "realized_pnl": (total_pnl / closed) if closed else 0.0,
+            } for i in range(closed)]
+    path.write_text(json.dumps({"stats": stats, "trades": trades}))
 
 
 def test_within_threshold_exit_zero(tmp_path: Path, recon_mod, monkeypatch):
@@ -212,7 +231,12 @@ def test_open_positions_excluded_from_broker_realized(recon_mod):
          "legs": ["X1", "X2", "X3", "X4"]},
     ]
 
-    broker_realized, closed_count = recon_mod.compute_broker_realized(
+    # Stamp every fill with a timestamp so the window-extraction code path
+    # is also covered by this scenario.
+    for i, row in enumerate(fills):
+        row.setdefault("filled_at", f"2026-04-{1 + (i % 28):02d} 15:00:00+00:00")
+
+    broker_realized, closed_count, win_start, win_end = recon_mod.compute_broker_realized(
         {"trade_history": fills}
     )
 
@@ -220,6 +244,11 @@ def test_open_positions_excluded_from_broker_realized(recon_mod):
     assert broker_realized == 800.0
     # 3 closed leg-groups; the 2 open ones contribute $0
     assert closed_count == 3
+    # Window spans only the closed-group timestamps (open-group fills are
+    # excluded — even though we still appended their timestamps to their own
+    # group buckets, those groups never got selected as "closed").
+    assert win_start is not None and win_end is not None
+    assert win_start <= win_end
 
 
 def test_missing_unpaired_field_is_tolerated(tmp_path: Path, recon_mod, monkeypatch):
@@ -242,3 +271,133 @@ def test_missing_unpaired_field_is_tolerated(tmp_path: Path, recon_mod, monkeypa
     report = json.loads((reports / "reconciliation_2026-05-29.json").read_text())
     assert report["paired_realized_pnl"] == 0.0
     assert report["delta_dollars"] == 0.0
+
+
+def _mleg_fills(legs: list[str], open_price: float, close_price: float,
+                open_ts: str, close_ts: str, qty: int = 1) -> list[dict]:
+    return [
+        {"id": "open", "symbol": None, "side": "None", "qty": str(qty),
+         "price": f"{open_price:.2f}", "filled_at": open_ts,
+         "status": "OrderStatus.FILLED", "order_class": "OrderClass.MLEG",
+         "legs": legs},
+        {"id": "close", "symbol": None, "side": "None", "qty": str(qty),
+         "price": f"{close_price:.2f}", "filled_at": close_ts,
+         "status": "OrderStatus.FILLED", "order_class": "OrderClass.MLEG",
+         "legs": legs},
+    ]
+
+
+def test_paired_window_clip_excludes_out_of_window(tmp_path: Path, recon_mod,
+                                                    monkeypatch):
+    """Paired ledger has 5 closed trades: 2 outside broker window, 3 inside.
+    Only the 3 inside count toward delta. broker_realized is +$200, the 3 in
+    window paired trades sum to +$210 (delta -$10 < $150)."""
+    state = tmp_path / "system_state.json"
+    trades_path = tmp_path / "trades.json"
+    reports = tmp_path / "reports"
+
+    # Broker: one closed MLEG, +$3 credit -> -$1 debit = +$200, window
+    # 2026-05-20..2026-05-29. (Close-side price must be NEGATIVE so the
+    # MLEG signed_qty convention nets to zero.)
+    fills = _mleg_fills(
+        legs=["A", "B", "C", "D"],
+        open_price=3.0,
+        close_price=-1.0,
+        open_ts="2026-05-20 19:00:00+00:00",
+        close_ts="2026-05-29 19:00:00+00:00",
+    )
+    _write_state(state, fills)
+
+    # Paired: 3 inside (sum +$210), 2 outside (sum +$5000 — must be ignored).
+    paired_trades = [
+        {"id": "in1", "status": "closed", "entry_time": "2026-05-21T10:00:00+00:00",
+         "exit_time": "2026-05-22T10:00:00+00:00", "realized_pnl": 70.0},
+        {"id": "in2", "status": "closed", "entry_time": "2026-05-23T10:00:00+00:00",
+         "exit_time": "2026-05-24T10:00:00+00:00", "realized_pnl": 70.0},
+        {"id": "in3", "status": "closed", "entry_time": "2026-05-25T10:00:00+00:00",
+         "exit_time": "2026-05-26T10:00:00+00:00", "realized_pnl": 70.0},
+        {"id": "out_before", "status": "closed", "entry_time": "2026-01-10T10:00:00+00:00",
+         "exit_time": "2026-01-20T10:00:00+00:00", "realized_pnl": 2500.0},
+        {"id": "out_after", "status": "closed", "entry_time": "2026-06-10T10:00:00+00:00",
+         "exit_time": "2026-06-20T10:00:00+00:00", "realized_pnl": 2500.0},
+    ]
+    # stats.total_pnl is the FULL-history paired number (pre-clip). We must
+    # demonstrate the clip ignores it in favor of per-trade exit-time filter.
+    trades_path.write_text(json.dumps({
+        "stats": {"total_pnl": 5210.0, "closed_trades": 5,
+                  "unpaired_realized_pnl": 0.0, "unpaired_order_count": 0},
+        "trades": paired_trades,
+    }))
+
+    monkeypatch.delenv("SENTRY_DSN", raising=False)
+    code = recon_mod.main([
+        "--system-state", str(state),
+        "--trades", str(trades_path),
+        "--report-dir", str(reports),
+        "--date", "2026-05-29",
+    ])
+    assert code == 0  # delta = 200 - 210 = -10, within threshold
+
+    report = json.loads((reports / "reconciliation_2026-05-29.json").read_text())
+    assert report["broker_realized_pnl"] == 200.0
+    assert report["paired_realized_in_window"] == 210.0
+    assert report["paired_realized_outside_window"] == 5000.0
+    assert report["paired_trade_count_in_window"] == 3
+    assert report["paired_trade_count_outside_window"] == 2
+    assert report["delta_dollars"] == -10.0
+    assert report["alert_fired"] is False
+    assert report["window_clipped"] is True
+    assert report["window_start"] is not None
+    assert report["window_end"] is not None
+
+
+def test_paired_entirely_outside_window(tmp_path: Path, recon_mod, monkeypatch):
+    """All paired trades exit before broker window opens. paired_in_window=0,
+    delta = broker_realized alone. Broker +$500 > $150 -> alert fires."""
+    state = tmp_path / "system_state.json"
+    trades_path = tmp_path / "trades.json"
+    reports = tmp_path / "reports"
+
+    # Broker: +$500 net realized inside the window. Close price negative
+    # so MLEG net_qty hits zero (the IC is fully unwound).
+    fills = _mleg_fills(
+        legs=["W", "X", "Y", "Z"],
+        open_price=6.0,
+        close_price=-1.0,
+        open_ts="2026-05-20 18:00:00+00:00",
+        close_ts="2026-05-29 18:00:00+00:00",
+    )
+    _write_state(state, fills)
+
+    # Every paired trade exited BEFORE the broker window opened.
+    paired_trades = [
+        {"id": f"old{i}", "status": "closed",
+         "entry_time": "2026-01-05T10:00:00+00:00",
+         "exit_time": "2026-01-15T10:00:00+00:00",
+         "realized_pnl": 100.0}
+        for i in range(4)
+    ]
+    trades_path.write_text(json.dumps({
+        "stats": {"total_pnl": 400.0, "closed_trades": 4,
+                  "unpaired_realized_pnl": 0.0, "unpaired_order_count": 0},
+        "trades": paired_trades,
+    }))
+
+    monkeypatch.delenv("SENTRY_DSN", raising=False)
+    code = recon_mod.main([
+        "--system-state", str(state),
+        "--trades", str(trades_path),
+        "--report-dir", str(reports),
+        "--date", "2026-05-29",
+    ])
+    # broker $500, paired_in $0 -> delta $500 > $150 -> alert -> exit 2.
+    assert code == 2
+
+    report = json.loads((reports / "reconciliation_2026-05-29.json").read_text())
+    assert report["broker_realized_pnl"] == 500.0
+    assert report["paired_realized_in_window"] == 0.0
+    assert report["paired_trade_count_in_window"] == 0
+    assert report["paired_realized_outside_window"] == 400.0
+    assert report["paired_trade_count_outside_window"] == 4
+    assert report["delta_dollars"] == 500.0
+    assert report["alert_fired"] is True


### PR DESCRIPTION
## Summary

Supersedes #4078. Two-stage fix for the LL-354 reconciliation-noise problem.

**Stage 1 (commit 25f4637): closed-positions only.** Original `compute_broker_realized()` summed `signed_cash` across every FILLED row in `data/system_state.json::trade_history`, conflating open-position entry cash with realized P/L. Live smoke before: delta **-$52,370** (phantom alert every day).

**Stage 2 (commit cd20654): window-clip the paired ledger.** Even after closed-only, broker `trade_history` is a rolling ~60d Alpaca window (2026-03-11 -> 2026-05-11) while paired `trades.json` is full-history (2026-01-22 -> 2026-04-15). Diff'ing windowed-broker vs all-time-paired produced a permanent ~$7,722 baseline divergence -- same failure mode (alarm fatigue trains the operator to ignore), just smaller.

## Fix

### Stage 1 -- closed-positions only
- Group fills by **leg-key**: SIMPLE rows by OCC symbol; MLEG rows by sorted tuple of leg symbols
- Compute net signed quantity per group (SELL/credit positive, BUY/debit negative)
- Sum `signed_cash` only for groups where `net_qty == 0` (position fully closed)
- Open positions contribute **$0**

### Stage 2 -- window-clip paired
- `compute_broker_realized` additionally returns `(window_start, window_end)` = min/max `filled_at` across closed leg-groups
- `compute_paired_realized` accepts optional `(window_start, window_end)` and filters per-trade `trades[]` by `exit_time` (P/L is booked at exit, not entry)
- Returns in-window vs outside-window buckets so the divergence is *surfaced* not absorbed
- `delta = broker_realized - paired_realized_in_window` (apples-to-apples)
- Back-compat: `paired_realized_pnl` mirrors in-window; `paired_trade_count` mirrors in-window count

### Report schema (new fields)
```
window_start, window_end                          (ISO strings)
paired_realized_in_window                         (drives delta)
paired_realized_outside_window                    (informational)
paired_trade_count_in_window
paired_trade_count_outside_window
window_clipped                                    (bool; false on legacy path)
```

## Smoke Test (real data, 2026-05-29)

| Metric | v0 (buggy) | v1 (closed-only) | v2 (window-clipped) |
|---|---|---|---|
| `broker_realized` | -$59,829 | +$263 | +$263 |
| `paired_realized` (in window) | -$7,459 | -$7,459 | **-$3,798** |
| `paired_realized_outside_window` | n/a | n/a | -$3,661 |
| `delta` | **-$52,370** | **+$7,722** | **+$4,061** |
| Window | n/a | n/a | 2026-03-23 -> 2026-05-06 |
| Alert? | yes (phantom) | yes (window noise) | yes (real residual) |

The remaining +$4,061 is the *real* LL-354 signal we want surfaced -- it is no longer a windowing artifact. Per spec, the **$150 threshold is unchanged** -- whether to move it is informed by next session's data, not this PR.

## Tests

- `test_within_threshold_exit_zero` -- updated; synthetic paired trade placed inside the scenario's broker window
- `test_breach_threshold_exit_two_alert_fired` -- updated; same
- `test_open_positions_excluded_from_broker_realized` -- v1 invariant kept; now also asserts the window-extraction code path returns non-null bounds
- `test_missing_unpaired_field_is_tolerated` -- legacy path still works
- **NEW** `test_paired_window_clip_excludes_out_of_window` -- 5 paired trades, 2 outside window, 3 inside; only inside count toward delta
- **NEW** `test_paired_entirely_outside_window` -- in_window=$0, delta = broker_realized alone

```
$ pytest tests/unit/test_reconciliation.py -v
6 passed in 0.09s
```

## Constraints honored

- `.github/workflows/daily-reconciliation.yml` unchanged
- `$150` threshold unchanged (per spec)
- Karpathy: extended existing functions in place, did not refactor the file

## Test plan

- [x] `pytest tests/unit/test_reconciliation.py -v` -- 6/6 pass
- [x] `ruff check` -- clean
- [x] Live smoke -- delta now $4,061 (was -$52,370 -> $7,722 -> $4,061)
- [ ] CI green on this PR