### PR TITLE
docs(ops): persist PR hygiene session directives

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,6 +35,8 @@ Always tell the user 100% truth. Never fabricate, hide, or misrepresent status, 
 - Verify `main` after merges using GitHub CI and a local dry-run or operational readiness command.
 - Record lessons and mistakes in RAG at the end of PR-management work.
 - Never store secrets, tokens, passwords, or pasted credentials in directive files, logs, commits, or RAG entries.
+- Use current CI data, local RAG lessons, and branch/worktree inventories to drive merge and cleanup decisions; do not merge on intuition.
+- If a GitHub token is provided in chat, use existing authenticated tooling or an action-time environment variable only; never persist the token.
 
 ## Secrets / Keys
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,6 +14,7 @@ Project instructions live in `.claude/CLAUDE.md`. Rules auto-load from `.claude/
 - Canonical ledgers: `data/system_state.json` and `data/trades.json`
 - Archived from the default operating path: blog/wiki/dashboard/pages publishing and discovery marketing workflows
 - Never describe the system as profitable or validated unless current ledger data proves it
+- Use Data Science, ML evidence, and Agentic RAG lessons to prioritize trading, CI, and PR-management decisions.
 
 ## Session Directive: PR Management & System Hygiene
 
@@ -25,6 +26,7 @@ Project instructions live in `.claude/CLAUDE.md`. Rules auto-load from `.claude/
 - Keep branch hygiene: remove stale/orphan branches after merges.
 - Run operational readiness checks (CI on `main` plus local dry-run health checks) before declaring completion.
 - Record lessons learned in RAG after task completion and log any execution mistake there as well.
+- Never persist action-time secrets or GitHub tokens in directives, RAG, logs, commits, or generated artifacts.
 - When status is not yet proven, say "I believe this is done, verifying now..." instead of claiming completion.
 - Do not claim the workflow complete until all of the following are true:
   - open PRs are reviewed and every merge-ready PR is merged or explicitly blocked with evidence

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -5,6 +5,7 @@
 - Act as CTO for the operator and execute autonomously.
 - Tell the truth about status, evidence, failures, and uncertainty.
 - Never offload a step to the user when it can be completed directly through local tools, GitHub, or the runtime.
+- Use Data Science, ML evidence, and Agentic RAG lessons as decision inputs before PR, CI, branch, or trading actions.
 
 ## Session Start Protocol
 
@@ -39,3 +40,4 @@
 - Query RAG before work and update RAG after work.
 - Record mistakes and lessons learned in RAG.
 - Exclude secrets and tokens from stored directives and logs.
+- Treat chat-provided tokens as action-time credentials only; never save them to files, commits, or memory.

--- a/rag_knowledge/lessons_learned/ll_20260617_pr_hygiene_dependabot_ci.md
+++ b/rag_knowledge/lessons_learned/ll_20260617_pr_hygiene_dependabot_ci.md
@@ -1,0 +1,35 @@
+# LL-20260617: PR Hygiene Dependabot CI and Orphan Branch Cleanup
+
+**ID**: LL-20260617
+**Date**: 2026-06-17
+**Severity**: PROCESS
+**Category**: PR hygiene, CI verification, branch cleanup
+**Status**: ACTIVE
+
+## Context
+
+During PR-management hygiene, 11 open Dependabot PRs were inspected and all were updated against current `main`.
+No PR was merge-ready after update because required checks were still failing or pending.
+
+## Evidence
+
+- Open PR count: 11.
+- Remote non-main branch count before orphan cleanup: 19.
+- Remote orphan branches deleted: 8 `chore/openrouter-pricing-baseline-*` branches.
+- Remote orphan branch count after cleanup: 0.
+- Latest `main` SHA checked: `ea4fda241`.
+- Latest `main` CI evidence: CI, Main Head Verification, CodeQL, SonarCloud, OpenSSF Scorecard, and no-direct-submit-order were green on `ea4fda241`.
+- Local clean-main dry run: `python3 scripts/system_health_check.py` passed.
+- Trading readiness remained intentionally blocked: `TRADING_HALTED` present, weekly gate in quarantine, and new risk-on entries blocked.
+
+## Lessons
+
+1. Do not merge Dependabot PRs until updated-branch checks complete and required CI is green.
+2. If many Dependabot PRs fail Trunk immediately after update, treat them as blocked, not merge-ready, until logs are available from completed workflow runs.
+3. Orphan auto-baseline branches without PRs can be deleted when their only diff is generated baseline churn and no PR references them.
+4. Dirty local worktrees and branches with uncommitted changes must be documented, not deleted.
+5. Chat-provided GitHub tokens are action-time credentials only and must not be written to directives, RAG, logs, or commits.
+
+## Tags
+
+pr-management, branch-hygiene, dependabot, ci-verification, rag, secrets


### PR DESCRIPTION
## Summary
- Persist safe PR hygiene/session directives in AGENTS, CLAUDE, and GEMINI docs
- Add RAG lesson for 2026-06-17 PR hygiene, Dependabot CI blockers, and orphan branch cleanup
- Explicitly keep chat-provided tokens as action-time credentials only; no secret values stored

## Evidence
- Pre-push hook passed on branch docs/pr-hygiene-session-20260617
- Unit tests: 200 passed
- Smoke tests: passed
- Workflow contracts: passed
- Integration tests: non-blocking hook warning
