### PR TITLE
fix(ci): isolate trade gateway halt state in tests

### DIFF
--- a/src/risk/trade_gateway.py
+++ b/src/risk/trade_gateway.py
@@ -680,6 +680,7 @@ class TradeGateway:
         return False, ""
 
     DECISION_LOG_PATH = Path("data/gateway_decisions.jsonl")
+    TRADING_HALTED_FILE = Path("data/TRADING_HALTED")
 
     def evaluate(self, request: TradeRequest) -> GatewayDecision:
         """
@@ -799,7 +800,7 @@ class TradeGateway:
 
         if is_position_opening:
             # Check 1: TRADING_HALTED flag file
-            halt_file = Path("data/TRADING_HALTED")
+            halt_file = self.TRADING_HALTED_FILE
             if halt_file.exists():
                 halt_reason = halt_file.read_text().strip() or "Manual trading halt"
                 logger.error(f"🚨 CIRCUIT BREAKER: Trading halted - {halt_reason}")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -30,8 +30,7 @@ def disable_circuit_breaker_for_tests(monkeypatch, tmp_path):
 
     fake_halt = tmp_path / "TRADING_HALTED"
 
-    # Patch every module that has its own TRADING_HALTED_FILE constant.
-    # Grep'd from src/: only crisis_monitor.py defines one at module scope.
+    # Patch every module/class that owns a TRADING_HALTED_FILE path.
     # Use raising=False so absence of the attribute (e.g. import-time errors
     # in minimal CI) never breaks the whole test session.
     try:
@@ -39,6 +38,18 @@ def disable_circuit_breaker_for_tests(monkeypatch, tmp_path):
 
         monkeypatch.setattr(
             _crisis_monitor, "TRADING_HALTED_FILE", fake_halt, raising=False
+        )
+    except (ImportError, ModuleNotFoundError):
+        pass
+
+    try:
+        import src.risk.trade_gateway as _trade_gateway
+
+        monkeypatch.setattr(
+            _trade_gateway.TradeGateway,
+            "TRADING_HALTED_FILE",
+            fake_halt,
+            raising=False,
         )
     except (ImportError, ModuleNotFoundError):
         pass

--- a/tests/test_ml_feedback_loop.py
+++ b/tests/test_ml_feedback_loop.py
@@ -242,7 +242,13 @@ def test_gate_blocks_insufficient_trades():
 
 def test_gate_allows_good_performance():
     """Enough trades with positive expectancy and profit factor should allow."""
-    stats = {"closed_trades": 50, "win_rate_pct": 75.0, "avg_win": 100, "avg_loss": 80}
+    stats = {
+        "closed_trades": 50,
+        "win_rate_pct": 75.0,
+        "avg_win": 100,
+        "avg_loss": 80,
+        "total_realized_pnl": 1775.0,
+    }
     gate = check_trading_gate(stats)
     assert gate["should_trade"]
     assert gate["expectancy_per_trade"] > 0
@@ -272,7 +278,13 @@ def test_gate_blocks_breakeven_profit_factor():
 
 def test_gate_calculates_expectancy():
     """Expectancy = (win_rate * avg_win) - (loss_rate * avg_loss)."""
-    stats = {"closed_trades": 100, "win_rate_pct": 80.0, "avg_win": 100, "avg_loss": 200}
+    stats = {
+        "closed_trades": 100,
+        "win_rate_pct": 80.0,
+        "avg_win": 100,
+        "avg_loss": 200,
+        "total_realized_pnl": 4000.0,
+    }
     gate = check_trading_gate(stats)
     # Expected: 0.8 * 100 - 0.2 * 200 = 80 - 40 = 40
     assert gate["expectancy_per_trade"] == 40.0


### PR DESCRIPTION
## Summary
- make TradeGateway halt sentinel path injectable while preserving the production default data/TRADING_HALTED
- patch pytest's global halt-isolation fixture to redirect TradeGateway to a per-test temp halt file
- update synthetic ML gate fixtures with realized P/L so they match broker-truth expectancy calculations

## Verification
- pytest tests/test_trade_gateway.py tests/test_rule_one_validator.py tests/test_ml_feedback_loop.py -q: 66 passed
- python3 tests/test_workflow_contracts.py: passed
- pre-push hook: 200 unit tests passed, smoke passed, workflow contracts passed; quick integration issues non-blocking

## Notes
- This fixes latest main CI failure on ad491165 where checked-in data/TRADING_HALTED short-circuited gateway tests before downstream rejection reasons were evaluated.
