### PR TITLE
fix: IC Simple entry path trades 5-wide wings (second config source)

### DIFF
--- a/data/strategy_params.json
+++ b/data/strategy_params.json
@@ -1,10 +1,10 @@
 {
-  "version": 1,
-  "updated_at": "2026-03-30T20:30:00Z",
-  "updated_by": "seed",
+  "version": 2,
+  "updated_at": "2026-07-02T18:00:00Z",
+  "updated_by": "validation_cohort_1",
   "params": {
     "target_delta": 0.15,
-    "wing_width": 10,
+    "wing_width": 5,
     "target_dte": 30,
     "min_dte": 30,
     "max_dte": 45,
@@ -16,5 +16,5 @@
   },
   "adjustments": [],
   "confidence": 0.0,
-  "note": "Seed values from CLAUDE.md trading rules. ML pipeline will adjust params when confidence > 0.7 and trade_count >= 10."
+  "note": "Validation cohort 1 params. Change from seed: wing_width 10->5 (rehab plan loss cluster ten_wide_wings; hypothesis rejects 10-wide wings). profit_target and stop_loss unchanged \u2014 pinned canonical constants; the 25%/200% redesign is PENDING_CEO_APPROVAL in data/runtime/proposals/validation_hypothesis_200pct_stop.json."
 }

--- a/scripts/ic_simple.py
+++ b/scripts/ic_simple.py
@@ -33,7 +33,7 @@ def _load_strategy_params() -> dict:
     """Load strategy params from ML-writable config. Falls back to defaults."""
     defaults = {
         "target_delta": 0.15,
-        "wing_width": 10,
+        "wing_width": 5,  # validation hypothesis: no 10-wide wings
         "target_dte": 30,
         "min_dte": 30,  # CLAUDE.md mandate: 30 DTE minimum
         "max_dte": 45,

--- a/tests/test_validation_hypothesis_compliance.py
+++ b/tests/test_validation_hypothesis_compliance.py
@@ -83,3 +83,21 @@ def test_hypothesis_unblocks_quarantined_entries(hypothesis: dict) -> None:
         "hypothesis does not cover the rehab plan's top loss clusters; "
         "north_star_guard will quarantine ALL new validation entries"
     )
+
+
+def test_ic_simple_strategy_params_honor_hypothesis(hypothesis: dict) -> None:
+    """scripts/ic_simple.py reads data/strategy_params.json (ML-writable), a
+    second config source that bypasses trading_profiles. The 2026-07-02 dry
+    run proved it can propose 10-wide entries after the profile was fixed —
+    guard both sources."""
+    if not hypothesis.get("enabled"):
+        pytest.skip("validation hypothesis disabled")
+
+    params_path = HYPOTHESIS_PATH.parents[1] / "strategy_params.json"
+    params = json.loads(params_path.read_text())["params"]
+
+    assert params["wing_width"] < 10, "ten_wide_wings loss cluster repeated"
+    assert params["stop_loss"] == 1.0, "pinned canonical constant"
+    assert params["profit_target"] == 0.50, "fixed exit plan per hypothesis"
+    assert params["max_ic"] <= 2
+    assert params["exit_dte"] >= 7

--- a/tests/unit/test_ic_simple.py
+++ b/tests/unit/test_ic_simple.py
@@ -230,10 +230,11 @@ class TestFindOpportunity:
 
     def _mock_selection(self, net_credit_val, method="live_delta", put_delta=0.15, call_delta=0.15):
         sel = StrikeSelection(
+            # 5-wide wings per validation hypothesis (WING_WIDTH contract)
             short_put=620.0,
-            long_put=610.0,
+            long_put=615.0,
             short_call=680.0,
-            long_call=690.0,
+            long_call=685.0,
             put_delta=put_delta,
             call_delta=call_delta,
             method=method,


### PR DESCRIPTION
Follow-up to #4171. The post-merge dry-run entry (run 28609782056) proved the quarantine gate is lifted but the proposed IC was still $10-wide: `scripts/ic_simple.py` builds entries from `data/strategy_params.json` (ML-writable seed, wing_width=10), not from `trading_profiles`.

**Fix:** params file + fallback default → 5-wide. `profit_target`/`stop_loss` untouched (pinned canonical constants).
**Prevention:** the hypothesis-compliance CI test now also validates `strategy_params.json`, so neither config source can drift back to 10-wide (or non-canonical exits) while validation is enabled.
**Tests:** 27/27 `tests/unit/test_ic_simple.py`, 5/5 compliance guard; fixtures updated to 5-wide (the wing contract correctly rejects 10-wide now).

Must merge before tomorrow's 15:00 UTC scheduled entry, or the first unquarantined trade fires 10-wide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H5b6AuafsfzPVBjTX1NQ46