### PR TITLE
fix: backfill IC_260731 entry record — open position had no stop/profit management

### DIFF
--- a/data/ic_entries.json
+++ b/data/ic_entries.json
@@ -94,5 +94,19 @@
       "long_call": 735.0
     },
     "fill_confirmed": true
+  },
+  "IC_260731": {
+    "credit": 2.05,
+    "date": "2026-06-24T15:52:54.718598+00:00",
+    "entry_time": "2026-06-24T15:52:54.718598+00:00",
+    "order_id": "8f3615f3-6ff1-4a58-a316-b4c7b63059d9",
+    "signature": "SPY_2026-07-31_P684-694_C775-785",
+    "strikes": {
+      "short_put": 694.0,
+      "long_put": 684.0,
+      "short_call": 775.0,
+      "long_call": 785.0
+    },
+    "backfilled": "2026-07-02: reconstructed from Alpaca fill 8f3615f3 (sell P694 @3.89, buy P684 @3.07, sell C775 @2.27, buy C785 @1.04 = $2.05 net credit). Entry record was never written (order placed outside ic_simple entry path), which made the exit loop hold the position blind \u2014 no profit-target or stop evaluation."
   }
 }

--- a/tests/test_ic_entries_reconciliation.py
+++ b/tests/test_ic_entries_reconciliation.py
@@ -1,0 +1,42 @@
+"""Guard: every open option structure must have an ic_entries.json record.
+
+The exit loop in scripts/ic_simple.py holds a position blind (no
+profit-target, no stop evaluation — only the 7-DTE failsafe) when
+IC_<expiry> is missing from data/ic_entries.json. The SPY 2026-07-31 IC
+sat unmanaged from Jun 24 to Jul 2 2026 this way. Both files are
+committed by the sync workflows, so CI can catch the gap within one
+sync cycle.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+DATA_DIR = Path(__file__).resolve().parents[1] / "data"
+OPTION_SYMBOL = re.compile(r"^SPY(\d{6})[CP]\d{8}$")
+
+
+def test_open_option_positions_have_entry_records() -> None:
+    state_path = DATA_DIR / "system_state.json"
+    entries_path = DATA_DIR / "ic_entries.json"
+    if not state_path.exists() or not entries_path.exists():
+        return
+
+    positions = json.loads(state_path.read_text()).get("positions", [])
+    entries = json.loads(entries_path.read_text())
+
+    expiries = set()
+    for pos in positions:
+        m = OPTION_SYMBOL.match(str(pos.get("symbol", "")))
+        if m:
+            expiries.add(m.group(1))
+
+    missing = sorted(e for e in expiries if f"IC_{e}" not in entries)
+    assert not missing, (
+        f"open option positions with no ic_entries.json record: {missing} — "
+        "the ic_simple exit loop cannot evaluate profit-target or stop-loss "
+        "for these (holds blind until 7-DTE failsafe). Backfill from broker "
+        "order history (see IC_260731 backfill, 2026-07-02)."
+    )


### PR DESCRIPTION
The open SPY Jul-31 IC has been held **blind** since June 24: no `IC_260731` record in `data/ic_entries.json` means the ic_simple exit loop skips it before the P/L calculation — **no profit-target exit and no stop-loss evaluation**, only the 7-DTE failsafe (Jul 24). Every exit run since entry logged `IC 260731: no entry_date recorded. Hold (safety default)`.

**Broker truth (Alpaca paper):** MLEG order `8f3615f3`, filled 2026-06-24 15:52:54 UTC — sell P694 @3.89, buy P684 @3.07, sell C775 @2.27, buy C785 @1.04 → net credit **$2.05**. Position is currently ~+$72 (≈35% of max profit), so the 50% profit target may trigger soon after this lands.

**Fix:** backfill the entry record from broker order history.
**Prevention:** new CI test reconciles open option positions in `system_state.json` against `ic_entries.json` — a blind position now fails CI within one sync cycle.

Note: the June 24 entry predates today's quarantine fix and was placed outside the ic_simple entry path (which is also why the record is missing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H5b6AuafsfzPVBjTX1NQ46