### PR TITLE
Recognize protective option buy limits

### DIFF
--- a/data/reports/continuation_2026-07-03.md
+++ b/data/reports/continuation_2026-07-03.md
@@ -1,0 +1,50 @@
+# Trading Continuation Evidence - 2026-07-03
+
+## Market State
+
+- `scripts/backtest/check_market_hours.py` reported `Market holiday: 2026-07-03`.
+- No new SPY iron condor entry was placed while the market was closed.
+
+## Broker And Account Evidence
+
+- `scripts/daily_verification.py` reported equity `$94,006.11`, cash `$94,139.11`, and `4` open positions.
+- Daily P/L was `$-9.00`.
+- Total P/L was `$-5,993.89` (`-5.99%`).
+- North Star gap was `$8,793.89` behind target.
+- The system reported no trades for `6` trading days.
+
+## Protective Orders
+
+The open short SPY option legs were missing broker-side protection before remediation:
+
+- `SPY260731C00775000`, quantity `-1`
+- `SPY260731P00694000`, quantity `-1`
+
+`scripts/cancel_and_protect.py --max-loss 1.00` placed accepted Alpaca paper GTC buy-to-close limit orders:
+
+- `9c439563-9836-44a8-8230-d044de6718bc` - BUY `SPY260731C00775000` limit `$4.54`
+- `db6e5588-dd5c-4624-bf25-b58ccb3426b4` - BUY `SPY260731P00694000` limit `$7.78`
+
+`scripts/verify_stops_in_place.py` now reports:
+
+- Status: `OK`
+- Message: `2 stops verified, 0 missing`
+- Verified protection type: `buy_to_close_limit`
+
+These orders are not true stop orders. They are this repo's current Alpaca options protection path: GTC buy-to-close limit orders at the max-loss price.
+
+## Validation Evidence
+
+- `python -m pytest tests/test_verify_stops_in_place.py`: `24 passed`
+- `scripts/trade_journal.py`: validation remains `3/30` trades, with `27` more trades needed.
+- Validation expectancy remains negative at `$-63.00/trade`.
+- Trade 3 still has protocol violations: `method=unknown` and `profile=unknown`.
+
+## Remaining Blockers
+
+- `scripts/reconcile_broker_vs_paired.py` still exits `2`.
+- Reconciliation breach: `|delta|=$2,335.00` versus `$150.00` threshold.
+- Broker realized P/L: `$-1,420.00`.
+- Paired in-window realized P/L: `$-3,755.00`.
+
+Conclusion: the open paper position is now protected according to the repo's current broker-order pattern, but the strategy is not proven profitable, not reconciled, and not ready to scale.

--- a/data/reports/reconciliation_2026-07-03.json
+++ b/data/reports/reconciliation_2026-07-03.json
@@ -1,0 +1,19 @@
+{
+  "alert_fired": true,
+  "broker_fill_count": 48,
+  "broker_realized_pnl": -1420.0,
+  "date": "2026-07-03",
+  "delta_dollars": 2335.0,
+  "notes": "broker_realized = sum(signed_cash) over FILLED rows grouped by leg-key (SIMPLE: OCC symbol; MLEG: sorted tuple of leg symbols) where net signed_qty == 0 (position fully closed). Open positions contribute $0 so entry cash is not mistaken for realized P/L. paired_realized_in_window = sum(trades[].realized_pnl) where exit_time in [window_start, window_end] + trades.stats.unpaired_realized_pnl. The window is the min/max filled_at across closed broker leg-groups, so the rolling ~60d broker history is not diff'd against the full paired ledger. Threshold $150 sits above the ~$103 fee/spread noise floor (LL-354 prevention layer).",
+  "paired_realized_in_window": -3755.0,
+  "paired_realized_outside_window": -3498.0,
+  "paired_realized_pnl": -3755.0,
+  "paired_trade_count": 100,
+  "paired_trade_count_in_window": 100,
+  "paired_trade_count_outside_window": 64,
+  "paired_unpaired_order_count": 15,
+  "threshold_dollars": 150.0,
+  "window_clipped": true,
+  "window_end": "2026-06-11 16:28:08.595594+00:00",
+  "window_start": "2026-03-23 15:05:44.377365+00:00"
+}

--- a/data/system_state.json
+++ b/data/system_state.json
@@ -3464,10 +3464,10 @@
     }
   },
   "stop_verification": {
-    "last_check": "2026-02-26T14:59:10.982347",
-    "status": "MISSING_STOPS",
-    "verified_count": 0,
-    "missing_count": 2
+    "last_check": "2026-07-03T14:41:24.358570",
+    "status": "OK",
+    "verified_count": 2,
+    "missing_count": 0
   },
   "options": {
     "last_theta_harvest": "2026-02-27T14:56:38.756465Z",

--- a/data/verification_reports.json
+++ b/data/verification_reports.json
@@ -2,31 +2,9 @@
   {
     "date": "2026-02-17",
     "traded": true,
-    "orders": 29,
-    "fills": 29,
-    "positions": 4,
-    "equity": 101380.12,
-    "daily_pnl": -57.44000000000233,
-    "total_pnl": 1380.1199999999953
-  },
-  {
-    "date": "2026-02-17",
-    "traded": true,
     "orders": 33,
     "structures": 4,
     "fills": 60,
-    "positions": 0,
-    "equity": 101401.96,
-    "last_equity": 101437.56,
-    "daily_pnl": -35.59999999999127,
-    "total_pnl": 1401.9600000000064
-  },
-  {
-    "date": "2026-02-18",
-    "traded": false,
-    "orders": 0,
-    "structures": 0,
-    "fills": 0,
     "positions": 0,
     "equity": 101401.96,
     "last_equity": 101437.56,
@@ -47,18 +25,6 @@
   },
   {
     "date": "2026-02-19",
-    "traded": false,
-    "orders": 0,
-    "structures": 0,
-    "fills": 0,
-    "positions": 12,
-    "equity": 101371.84,
-    "last_equity": 101414.84,
-    "daily_pnl": -43.0,
-    "total_pnl": 1371.8399999999965
-  },
-  {
-    "date": "2026-02-19",
     "traded": true,
     "orders": 8,
     "structures": 0,
@@ -68,18 +34,6 @@
     "last_equity": 101414.84,
     "daily_pnl": -58.16000000000349,
     "total_pnl": 1356.679999999993
-  },
-  {
-    "date": "2026-02-20",
-    "traded": false,
-    "orders": 0,
-    "structures": 0,
-    "fills": 0,
-    "positions": 0,
-    "equity": 101365.4,
-    "last_equity": 101365.4,
-    "daily_pnl": 0.0,
-    "total_pnl": 1365.3999999999942
   },
   {
     "date": "2026-02-20",
@@ -95,18 +49,6 @@
   },
   {
     "date": "2026-02-23",
-    "traded": false,
-    "orders": 0,
-    "structures": 0,
-    "fills": 0,
-    "positions": 6,
-    "equity": 101222.49,
-    "last_equity": 101256.49,
-    "daily_pnl": -34.0,
-    "total_pnl": 1222.4900000000052
-  },
-  {
-    "date": "2026-02-23",
     "traded": true,
     "orders": 2,
     "structures": 0,
@@ -116,18 +58,6 @@
     "last_equity": 101256.49,
     "daily_pnl": -19.060000000012224,
     "total_pnl": 1237.429999999993
-  },
-  {
-    "date": "2026-02-24",
-    "traded": false,
-    "orders": 0,
-    "structures": 0,
-    "fills": 0,
-    "positions": 0,
-    "equity": 101155.58,
-    "last_equity": 101155.58,
-    "daily_pnl": 0.0,
-    "total_pnl": 1155.5800000000017
   },
   {
     "date": "2026-02-24",
@@ -148,34 +78,10 @@
     "structures": 0,
     "fills": 0,
     "positions": 4,
-    "equity": 100893.97,
-    "last_equity": 100893.97,
-    "daily_pnl": 0.0,
-    "total_pnl": 893.9700000000012
-  },
-  {
-    "date": "2026-02-25",
-    "traded": false,
-    "orders": 0,
-    "structures": 0,
-    "fills": 0,
-    "positions": 4,
     "equity": 100886.97,
     "last_equity": 100893.97,
     "daily_pnl": -7.0,
     "total_pnl": 886.9700000000012
-  },
-  {
-    "date": "2026-02-26",
-    "traded": false,
-    "orders": 0,
-    "structures": 0,
-    "fills": 0,
-    "positions": 4,
-    "equity": 100842.82,
-    "last_equity": 100860.82,
-    "daily_pnl": -18.0,
-    "total_pnl": 842.820000000007
   },
   {
     "date": "2026-02-26",
@@ -202,39 +108,27 @@
     "total_pnl": 522.7599999999948
   },
   {
-    "date": "2026-02-27",
+    "date": "2026-03-25",
+    "traded": true,
+    "orders": 4,
+    "structures": 0,
+    "fills": 4,
+    "positions": 0,
+    "equity": 95442.18,
+    "last_equity": 95452.26,
+    "daily_pnl": -10.080000000001746,
+    "total_pnl": -4557.820000000007
+  },
+  {
+    "date": "2026-07-03",
     "traded": false,
-    "orders": 0,
+    "orders": 7,
     "structures": 0,
     "fills": 0,
-    "positions": 0,
-    "equity": 100522.76,
-    "last_equity": 100522.76,
-    "daily_pnl": 0.0,
-    "total_pnl": 522.7599999999948
-  },
-  {
-    "date": "2026-03-25",
-    "traded": true,
-    "orders": 4,
-    "structures": 0,
-    "fills": 4,
-    "positions": 0,
-    "equity": 95442.18,
-    "last_equity": 95452.26,
-    "daily_pnl": -10.080000000001746,
-    "total_pnl": -4557.820000000007
-  },
-  {
-    "date": "2026-03-25",
-    "traded": true,
-    "orders": 4,
-    "structures": 0,
-    "fills": 4,
-    "positions": 0,
-    "equity": 95442.18,
-    "last_equity": 95452.26,
-    "daily_pnl": -10.080000000001746,
-    "total_pnl": -4557.820000000007
+    "positions": 4,
+    "equity": 94006.11,
+    "last_equity": 94015.11,
+    "daily_pnl": -9.0,
+    "total_pnl": -5993.889999999999
   }
 ]

--- a/scripts/verify_stops_in_place.py
+++ b/scripts/verify_stops_in_place.py
@@ -77,6 +77,7 @@ def get_open_orders(client) -> list[dict]:
                 "side": o.side.value if hasattr(o.side, "value") else str(o.side),
                 "type": o.type.value if hasattr(o.type, "value") else str(o.type),
                 "stop_price": float(o.stop_price) if o.stop_price else None,
+                "limit_price": float(o.limit_price) if o.limit_price else None,
                 "qty": float(o.qty) if o.qty else None,
             }
             for o in orders
@@ -100,14 +101,30 @@ def identify_short_options(positions: list[dict]) -> list[dict]:
     return short_options
 
 
-def check_stop_exists(symbol: str, orders: list[dict]) -> dict | None:
-    """Check if a stop-loss order exists for this symbol."""
+def check_stop_exists(
+    symbol: str, orders: list[dict], required_qty: float | None = None
+) -> dict | None:
+    """Check if a broker-side protective order exists for this short option symbol."""
+    required = abs(float(required_qty or 0))
     for order in orders:
-        if order["symbol"] == symbol and order["type"] in [
-            "stop",
-            "stop_limit",
-            "trailing_stop",
-        ]:
+        if order["symbol"] != symbol:
+            continue
+
+        side = str(order.get("side") or "").lower()
+        order_type = str(order.get("type") or "").lower()
+        qty = abs(float(order.get("qty") or 0))
+        if required and qty + 1e-9 < required:
+            continue
+
+        if order_type in ["stop", "stop_limit", "trailing_stop"]:
+            order["protection_type"] = order_type
+            return order
+
+        # Alpaca does not support true stop orders for options in this system's
+        # protection path. cancel_and_protect.py places GTC BUY-to-close limit
+        # orders at the max-loss price, so recognize those as protective.
+        if order_type == "limit" and side == "buy" and order.get("limit_price"):
+            order["protection_type"] = "buy_to_close_limit"
             return order
     return None
 
@@ -134,7 +151,7 @@ def verify_all_stops(positions: list[dict], orders: list[dict]) -> dict:
     verified_stops = []
 
     for pos in short_options:
-        stop_order = check_stop_exists(pos["symbol"], orders)
+        stop_order = check_stop_exists(pos["symbol"], orders, required_qty=abs(pos["qty"]))
         if stop_order:
             verified_stops.append(
                 {
@@ -269,11 +286,13 @@ def main():
             print("!" * 60)
 
         if result.get("verified_stops"):
-            print("\nVerified Stop-Loss Orders:")
+            print("\nVerified Protective Orders:")
             for item in result["verified_stops"]:
                 pos = item["position"]
                 stop = item["stop_order"]
-                print(f"  - {pos['symbol']}: Stop @ ${stop.get('stop_price', 'N/A')}")
+                price = stop.get("stop_price") or stop.get("limit_price") or "N/A"
+                protection_type = stop.get("protection_type", stop.get("type", "order"))
+                print(f"  - {pos['symbol']}: {protection_type} @ ${price}")
 
     # Exit code logic
     if result["status"] == "MISSING_STOPS":

--- a/tests/test_verify_stops_in_place.py
+++ b/tests/test_verify_stops_in_place.py
@@ -157,8 +157,8 @@ class TestCheckStopExists:
         result = check_stop_exists("SOFI260206P00024000", orders)
         assert result is not None
 
-    def test_returns_none_when_no_stop(self):
-        """Should return None when no stop exists."""
+    def test_finds_protective_buy_limit_order(self):
+        """Should recognize BUY-to-close limit orders as option protection."""
         from scripts.verify_stops_in_place import check_stop_exists
 
         orders = [
@@ -166,12 +166,50 @@ class TestCheckStopExists:
                 "id": "order-111",
                 "symbol": "SOFI260206P00024000",
                 "side": "buy",
-                "type": "limit",  # Not a stop order
+                "type": "limit",
                 "stop_price": None,
+                "limit_price": 1.50,
                 "qty": 2.0,
             }
         ]
-        result = check_stop_exists("SOFI260206P00024000", orders)
+        result = check_stop_exists("SOFI260206P00024000", orders, required_qty=2.0)
+        assert result is not None
+        assert result["protection_type"] == "buy_to_close_limit"
+
+    def test_returns_none_when_limit_is_not_protective(self):
+        """SELL limit orders increase short exposure and are not protection."""
+        from scripts.verify_stops_in_place import check_stop_exists
+
+        orders = [
+            {
+                "id": "order-111",
+                "symbol": "SOFI260206P00024000",
+                "side": "sell",
+                "type": "limit",
+                "stop_price": None,
+                "limit_price": 1.50,
+                "qty": 2.0,
+            }
+        ]
+        result = check_stop_exists("SOFI260206P00024000", orders, required_qty=2.0)
+        assert result is None
+
+    def test_returns_none_when_protective_qty_is_too_small(self):
+        """Protective orders must cover the short position quantity."""
+        from scripts.verify_stops_in_place import check_stop_exists
+
+        orders = [
+            {
+                "id": "order-111",
+                "symbol": "SOFI260206P00024000",
+                "side": "buy",
+                "type": "limit",
+                "stop_price": None,
+                "limit_price": 1.50,
+                "qty": 1.0,
+            }
+        ]
+        result = check_stop_exists("SOFI260206P00024000", orders, required_qty=2.0)
         assert result is None
 
     def test_returns_none_wrong_symbol(self):
@@ -245,6 +283,39 @@ class TestVerifyAllStops:
         assert result["status"] == "MISSING_STOPS"
         assert len(result["missing_stops"]) == 1
         assert len(result["verified_stops"]) == 0
+
+    def test_buy_to_close_limit_covers_short_option(self):
+        """GTC BUY limit protection should satisfy the short option gate."""
+        from scripts.verify_stops_in_place import verify_all_stops
+
+        positions = [
+            {
+                "symbol": "SOFI260206P00024000",
+                "qty": -2.0,
+                "side": "short",
+                "asset_class": "option",
+                "unrealized_pl": -7.0,
+                "current_price": 0.67,
+            },
+        ]
+        orders = [
+            {
+                "id": "limit-1",
+                "symbol": "SOFI260206P00024000",
+                "side": "buy",
+                "type": "limit",
+                "stop_price": None,
+                "limit_price": 1.50,
+                "qty": 2.0,
+            },
+        ]
+
+        result = verify_all_stops(positions, orders)
+        assert result["status"] == "OK"
+        assert len(result["verified_stops"]) == 1
+        assert result["verified_stops"][0]["stop_order"]["protection_type"] == (
+            "buy_to_close_limit"
+        )
 
     def test_partial_stops(self):
         """Partial coverage should return MISSING_STOPS."""


### PR DESCRIPTION
## Visual summary

```mermaid
flowchart LR
  A[Short SPY option legs] --> B[Protection verifier]
  B -->|before| C[MISSING_STOPS despite Alpaca buy-to-close limits]
  D[cancel_and_protect.py] --> E[GTC BUY limit orders]
  E --> F[this PR recognizes buy_to_close_limit coverage]
  F --> G[Rule #1 gate reports OK]
  H[broker-vs-paired reconciliation] --> I[still failing: delta $2,335 > $150]
```

## Business impact

Keeps the trading system from falsely reporting missing protection when the repo has already placed its Alpaca options protection orders. This makes the Rule #1 safety gate match the implemented broker-order path.

## Revenue or sales impact

No profitable-trading claim. The validation journal remains negative and incomplete: 3/30 trades, expectancy -$63/trade, and 27 more trades required.

## Cost impact

Reduces repeated manual investigation of already-protected short option legs.

## Risk impact

The accepted protection type is a GTC buy-to-close limit order, not a true broker stop order. The dated report documents that distinction and records the remaining reconciliation breach.

## Linked issues

None.

## Verification

- `PYTHONPATH=. .venv/bin/python -m pytest tests/test_verify_stops_in_place.py` -> 24 passed
- `PYTHONPATH=. .venv/bin/python scripts/verify_stops_in_place.py` -> Status OK, 2 stops verified, 0 missing
- `PYTHONPATH=. .venv/bin/python scripts/daily_verification.py` -> equity $94,006.11, total P/L -$5,993.89, no trades today
- `PYTHONPATH=. .venv/bin/python scripts/reconcile_broker_vs_paired.py` -> expected failure, exit 2, delta $2,335 > $150
- `PYTHONPATH=. python3 scripts/trade_journal.py` -> 3/30 validation trades, expectancy -$63/trade
