### PR TITLE
Fix closed-position sync repo imports

### DIFF
--- a/scripts/sync_closed_positions.py
+++ b/scripts/sync_closed_positions.py
@@ -22,6 +22,8 @@ logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(
 logger = logging.getLogger(__name__)
 
 PROJECT_ROOT = Path(__file__).parent.parent
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
 DATA_DIR = PROJECT_ROOT / "data"
 SYSTEM_STATE_FILE = DATA_DIR / "system_state.json"
 TRADES_FILE = DATA_DIR / "trades.json"


### PR DESCRIPTION
## Summary\n- add repo root to sys.path for scripts/sync_closed_positions.py\n- preserve broker trade-history sync when invoked as python3 scripts/sync_closed_positions.py in CI\n\n## Verification\n- python3 scripts/sync_closed_positions.py --help\n- python3 -m pytest tests/unit/test_sync_closed_positions.py -q\n- python3 -m ruff check scripts/sync_closed_positions.py tests/unit/test_sync_closed_positions.py