### PR TITLE
fix: block new entries on unclean open inventory

### DIFF
--- a/.claude/rules/open-inventory-hygiene.md
+++ b/.claude/rules/open-inventory-hygiene.md
@@ -1,0 +1,19 @@
+# Open Inventory Hygiene (2026-07-22)
+
+## Problem
+SPY 2026-08-21 was journaled as a 1-lot IC (`IC_260821` P703-708/C776-781) but the
+broker book had a 2-lot call vertical plus an orphan put vertical on the same expiry.
+Validation could still open more risk on top of garbage, and exit/stop mapping failed.
+
+## Prevention
+1. `src/risk/open_inventory_audit.py` — structure audit (lot size, journal match, extras).
+2. `scripts/audit_open_inventory.py` — CLI; exit 2 when unclean.
+3. `TradeGateway` rejects new risk with `UNCLEAN_INVENTORY` until book matches journal.
+4. Buy-to-close / sell-to-close of existing legs remain allowed so guardian can clean.
+
+## Operator
+```bash
+.venv/bin/python scripts/audit_open_inventory.py
+```
+Do not open new validation ICs while this returns unclean.
+Do not freehand-close outside the guardian workflow.

--- a/scripts/audit_open_inventory.py
+++ b/scripts/audit_open_inventory.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+"""Audit open option inventory vs ic_entries + 1-lot validation rules.
+
+Exit codes:
+  0 — clean (or no option positions)
+  2 — unclean inventory (block new entries)
+  1 — script/IO error
+
+Usage:
+  python scripts/audit_open_inventory.py
+  python scripts/audit_open_inventory.py --json-out data/audit/open_inventory_latest.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+
+def _bootstrap() -> Path:
+    root = Path(__file__).resolve().parents[1]
+    root_s = str(root)
+    if root_s not in sys.path:
+        sys.path.insert(0, root_s)
+    return root
+
+
+def main() -> int:
+    root = _bootstrap()
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo-root", default=str(root))
+    parser.add_argument(
+        "--json-out",
+        default="data/audit/open_inventory_latest.json",
+        help="Write full audit JSON here",
+    )
+    args = parser.parse_args()
+
+    try:
+        from src.core.trading_constants import (
+            MAX_CONCURRENT_IRON_CONDORS,
+            MAX_CONTRACTS_PER_TRADE,
+        )
+    except Exception:
+        MAX_CONTRACTS_PER_TRADE = 1
+        MAX_CONCURRENT_IRON_CONDORS = 2
+
+    from src.risk.open_inventory_audit import audit_from_files, write_audit_report
+
+    result = audit_from_files(
+        args.repo_root,
+        max_contracts_per_trade=float(MAX_CONTRACTS_PER_TRADE),
+        max_concurrent_iron_condors=int(MAX_CONCURRENT_IRON_CONDORS),
+    )
+    out_path = Path(args.repo_root) / args.json_out
+    write_audit_report(result, out_path)
+
+    print(json.dumps(result.to_dict(), indent=2))
+    print(f"json_out={out_path}")
+    print(f"clean={result.clean} findings={len(result.findings)}")
+
+    if not result.clean:
+        print("UNCLEAN_INVENTORY: block new validation entries until book matches journal")
+        for reason in result.block_reasons():
+            print(f"  - {reason}")
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/iron_condor_trader.py
+++ b/scripts/iron_condor_trader.py
@@ -1266,6 +1266,54 @@ def main():
                 )
                 return {"success": False, "reason": halt_state.reason}
 
+        # Open-inventory hygiene before any new risk (1-lot / journal match).
+        # Dirty books (e.g. SPY 2026-08-21 2-lot call + orphan put) must not get
+        # additional structures stacked on top during validation_reset.
+        try:
+            from src.core.trading_constants import (
+                MAX_CONCURRENT_IRON_CONDORS,
+                MAX_CONTRACTS_PER_TRADE,
+            )
+            from src.risk.open_inventory_audit import (
+                audit_from_files,
+                write_audit_report,
+            )
+
+            inventory = audit_from_files(
+                PROJECT_ROOT,
+                max_contracts_per_trade=float(MAX_CONTRACTS_PER_TRADE),
+                max_concurrent_iron_condors=int(MAX_CONCURRENT_IRON_CONDORS),
+            )
+            report_path = PROJECT_ROOT / "data" / "audit" / "open_inventory_latest.json"
+            write_audit_report(inventory, report_path)
+            if not inventory.clean:
+                reason = (
+                    "UNCLEAN_INVENTORY: "
+                    + "; ".join(inventory.block_reasons()[:3])
+                )
+                logger.error("🛑 %s", reason)
+                logger.error("   Audit report: %s", report_path)
+                telemetry.update_ticker_decision(
+                    ticker,
+                    gate=0,
+                    status="REJECT",
+                    rejection_reason=reason,
+                    indicators={
+                        "inventory_clean": False,
+                        "findings": [f.code for f in inventory.findings],
+                    },
+                )
+                return {"success": False, "reason": reason}
+            logger.info(
+                "✅ Open inventory clean (legs=%s expiries=%s)",
+                inventory.option_leg_count,
+                inventory.expiries,
+            )
+        except Exception as inv_err:
+            logger.error("⚠️ Inventory audit error (fail closed): %s", inv_err)
+            if not args.force:
+                return {"success": False, "reason": f"Inventory audit error: {inv_err}"}
+
         # ExecutionAgent enforces VIX gate, DTE gate, and daily throttle.
         # Thursday-only gate was removed 2026-05-20 (Bonferroni adj_p=0.190).
         try:
@@ -1300,6 +1348,20 @@ def main():
 
             logger.info("✅ High-Alpha Validation PASSED.")
 
+        except ModuleNotFoundError as alpha_err:
+            # Common when operators run system python instead of .venv (alpaca-py).
+            venv_py = PROJECT_ROOT / ".venv" / "bin" / "python"
+            logger.error(f"⚠️ High-Alpha Gate Error: {alpha_err}")
+            logger.error(
+                "   Missing dependency in %s. Prefer: %s scripts/iron_condor_trader.py --dry-run",
+                sys.executable,
+                venv_py if venv_py.exists() else ".venv/bin/python",
+            )
+            if not args.force:
+                return {
+                    "success": False,
+                    "reason": f"Safety Agent Error: {alpha_err}",
+                }
         except Exception as alpha_err:
             logger.error(f"⚠️ High-Alpha Gate Error: {alpha_err}")
             if not args.force:

--- a/src/risk/open_inventory_audit.py
+++ b/src/risk/open_inventory_audit.py
@@ -1,0 +1,363 @@
+"""Open option inventory audit for iron-condor validation hygiene.
+
+Detects the failure mode we hit on SPY 2026-08-21:
+
+* journaled 1-lot IC (P703-708 / C776-781)
+* broker book showed 2-lot call vertical + an extra put vertical on the same expiry
+
+Without this check, validation entries stack on dirty inventory, the exit loop
+cannot map legs cleanly to credits, and the controlled-experiment 1-lot rule is
+silently violated after fill.
+
+Pure functions. No broker closes. Callers decide whether to block new entries.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+OPTION_OCC = re.compile(r"^([A-Z]+)(\d{6})([CP])(\d{8})$")
+
+
+@dataclass(frozen=True)
+class ParsedLeg:
+    symbol: str
+    root: str
+    expiry_ymd: str  # YYMMDD
+    right: str  # C or P
+    strike: float
+    qty: float
+
+
+@dataclass
+class InventoryFinding:
+    code: str
+    severity: str  # "block" | "warn"
+    message: str
+    expiry_ymd: str | None = None
+    details: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class InventoryAuditResult:
+    clean: bool
+    findings: list[InventoryFinding] = field(default_factory=list)
+    legs: list[ParsedLeg] = field(default_factory=list)
+    expiries: list[str] = field(default_factory=list)
+    max_abs_qty: float = 0.0
+    option_leg_count: int = 0
+    audited_at: str = ""
+
+    def block_reasons(self) -> list[str]:
+        return [f.message for f in self.findings if f.severity == "block"]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "clean": self.clean,
+            "audited_at": self.audited_at,
+            "option_leg_count": self.option_leg_count,
+            "max_abs_qty": self.max_abs_qty,
+            "expiries": list(self.expiries),
+            "findings": [asdict(f) for f in self.findings],
+            "legs": [asdict(leg) for leg in self.legs],
+            "block_reasons": self.block_reasons(),
+        }
+
+
+def parse_option_leg(symbol: str, qty: float) -> ParsedLeg | None:
+    match = OPTION_OCC.match(str(symbol).strip().upper())
+    if not match:
+        return None
+    root, ymd, right, strike_raw = match.groups()
+    return ParsedLeg(
+        symbol=str(symbol).strip().upper(),
+        root=root,
+        expiry_ymd=ymd,
+        right=right,
+        strike=int(strike_raw) / 1000.0,
+        qty=float(qty),
+    )
+
+
+def _qty_from_position(row: dict[str, Any]) -> float:
+    for key in ("qty", "quantity", "qty_available"):
+        if row.get(key) is not None:
+            try:
+                return float(row[key])
+            except (TypeError, ValueError):
+                continue
+    return 0.0
+
+
+def normalize_positions(positions: list[dict[str, Any]] | None) -> list[ParsedLeg]:
+    legs: list[ParsedLeg] = []
+    for row in positions or []:
+        if not isinstance(row, dict):
+            continue
+        symbol = row.get("symbol")
+        if not symbol:
+            continue
+        parsed = parse_option_leg(str(symbol), _qty_from_position(row))
+        if parsed is not None and abs(parsed.qty) > 1e-9:
+            legs.append(parsed)
+    return legs
+
+
+def _ic_key(expiry_ymd: str) -> str:
+    return f"IC_{expiry_ymd}"
+
+
+def _expected_structure_qty_map(entry: dict[str, Any]) -> dict[tuple[str, float], float]:
+    """Map (right, strike) -> signed qty from a journaled IC entry."""
+    strikes = entry.get("strikes") or {}
+    try:
+        qty = abs(float(entry.get("quantity") or 1))
+    except (TypeError, ValueError):
+        qty = 1.0
+    if qty <= 0:
+        qty = 1.0
+
+    mapping: dict[tuple[str, float], float] = {}
+    try:
+        short_put = float(strikes["short_put"])
+        long_put = float(strikes["long_put"])
+        short_call = float(strikes["short_call"])
+        long_call = float(strikes["long_call"])
+    except (KeyError, TypeError, ValueError):
+        return mapping
+
+    mapping[("P", short_put)] = -qty
+    mapping[("P", long_put)] = qty
+    mapping[("C", short_call)] = -qty
+    mapping[("C", long_call)] = qty
+    return mapping
+
+
+def audit_open_inventory(
+    positions: list[dict[str, Any]] | None,
+    ic_entries: dict[str, Any] | None,
+    *,
+    max_contracts_per_trade: float = 1.0,
+    max_concurrent_iron_condors: int = 2,
+) -> InventoryAuditResult:
+    """Audit open option legs against controlled-experiment + journal records."""
+    legs = normalize_positions(positions)
+    findings: list[InventoryFinding] = []
+    entries = ic_entries if isinstance(ic_entries, dict) else {}
+
+    max_abs = max((abs(leg.qty) for leg in legs), default=0.0)
+    expiries = sorted({leg.expiry_ymd for leg in legs})
+
+    # Global lot-size rule: any open leg above 1-lot violates validation hygiene.
+    if max_abs > max_contracts_per_trade + 1e-9:
+        offenders = [
+            {"symbol": leg.symbol, "qty": leg.qty}
+            for leg in legs
+            if abs(leg.qty) > max_contracts_per_trade + 1e-9
+        ]
+        findings.append(
+            InventoryFinding(
+                code="LOT_SIZE_EXCEEDED",
+                severity="block",
+                message=(
+                    f"Open option leg qty exceeds max_contracts_per_trade="
+                    f"{max_contracts_per_trade} (max_abs_qty={max_abs})"
+                ),
+                details={"offenders": offenders, "max_abs_qty": max_abs},
+            )
+        )
+
+    # Too many distinct expiries with structures can still be OK (max concurrent ICs),
+    # but > max concurrent expiries is a block for new entries.
+    if len(expiries) > max_concurrent_iron_condors:
+        findings.append(
+            InventoryFinding(
+                code="TOO_MANY_EXPIRIES",
+                severity="block",
+                message=(
+                    f"{len(expiries)} open option expiries exceed "
+                    f"max_concurrent_iron_condors={max_concurrent_iron_condors}"
+                ),
+                details={"expiries": expiries},
+            )
+        )
+
+    by_expiry: dict[str, list[ParsedLeg]] = {}
+    for leg in legs:
+        by_expiry.setdefault(leg.expiry_ymd, []).append(leg)
+
+    for expiry_ymd, exp_legs in sorted(by_expiry.items()):
+        key = _ic_key(expiry_ymd)
+        entry = entries.get(key)
+        if not isinstance(entry, dict):
+            # Legacy keys sometimes used IC_YYYYMMDD — try nothing else; CI already
+            # covers missing keys. Treat as block for new entries (exit loop blind).
+            findings.append(
+                InventoryFinding(
+                    code="UNJOURNALED_EXPIRY",
+                    severity="block",
+                    message=(
+                        f"Open option expiry {expiry_ymd} has no {key} record in "
+                        "ic_entries.json — exit loop cannot evaluate stop/target"
+                    ),
+                    expiry_ymd=expiry_ymd,
+                    details={"leg_symbols": [leg.symbol for leg in exp_legs]},
+                )
+            )
+            continue
+
+        expected = _expected_structure_qty_map(entry)
+        actual: dict[tuple[str, float], float] = {}
+        for leg in exp_legs:
+            k = (leg.right, leg.strike)
+            actual[k] = actual.get(k, 0.0) + leg.qty
+
+        if not expected:
+            findings.append(
+                InventoryFinding(
+                    code="JOURNAL_STRIKES_INCOMPLETE",
+                    severity="block",
+                    message=f"{key} exists but strikes are incomplete",
+                    expiry_ymd=expiry_ymd,
+                    details={"entry_keys": sorted(entry.keys())},
+                )
+            )
+            continue
+
+        # Qty / composition mismatch vs journaled 4-leg structure
+        extras = []
+        for k, qty in actual.items():
+            exp_qty = expected.get(k)
+            if exp_qty is None:
+                extras.append({"right": k[0], "strike": k[1], "qty": qty})
+            elif abs(qty - exp_qty) > 1e-9:
+                findings.append(
+                    InventoryFinding(
+                        code="QTY_MISMATCH",
+                        severity="block",
+                        message=(
+                            f"{key}: {k[0]}{k[1]:g} qty={qty} does not match "
+                            f"journaled qty={exp_qty}"
+                        ),
+                        expiry_ymd=expiry_ymd,
+                        details={
+                            "right": k[0],
+                            "strike": k[1],
+                            "actual_qty": qty,
+                            "journal_qty": exp_qty,
+                        },
+                    )
+                )
+
+        missing = []
+        for k, exp_qty in expected.items():
+            if k not in actual:
+                missing.append({"right": k[0], "strike": k[1], "journal_qty": exp_qty})
+
+        if extras:
+            findings.append(
+                InventoryFinding(
+                    code="EXTRA_LEGS",
+                    severity="block",
+                    message=(
+                        f"{key}: {len(extras)} open leg(s) not in journaled structure "
+                        f"(orphan verticals or residual risk)"
+                    ),
+                    expiry_ymd=expiry_ymd,
+                    details={"extras": extras},
+                )
+            )
+        if missing:
+            findings.append(
+                InventoryFinding(
+                    code="MISSING_LEGS",
+                    severity="block",
+                    message=f"{key}: journaled legs missing from broker book",
+                    expiry_ymd=expiry_ymd,
+                    details={"missing": missing},
+                )
+            )
+
+        # Same-expiry multi-structure signal: more than 4 legs or extra shorts
+        short_units = sum(abs(leg.qty) for leg in exp_legs if leg.qty < 0)
+        if short_units > max_contracts_per_trade * 2 + 1e-9:
+            # One IC has 2 short legs (put+call) * qty
+            findings.append(
+                InventoryFinding(
+                    code="SAME_EXPIRY_OVERSTACK",
+                    severity="block",
+                    message=(
+                        f"Expiry {expiry_ymd}: short-leg units={short_units} exceed "
+                        f"one 1-lot iron condor (expected <= {max_contracts_per_trade * 2})"
+                    ),
+                    expiry_ymd=expiry_ymd,
+                    details={"short_units": short_units, "leg_count": len(exp_legs)},
+                )
+            )
+
+    clean = not any(f.severity == "block" for f in findings)
+    return InventoryAuditResult(
+        clean=clean,
+        findings=findings,
+        legs=legs,
+        expiries=expiries,
+        max_abs_qty=max_abs,
+        option_leg_count=len(legs),
+        audited_at=datetime.now(timezone.utc).isoformat(),
+    )
+
+
+def audit_from_files(
+    repo_root: Path | str,
+    *,
+    max_contracts_per_trade: float = 1.0,
+    max_concurrent_iron_condors: int = 2,
+) -> InventoryAuditResult:
+    root = Path(repo_root)
+    state_path = root / "data" / "system_state.json"
+    entries_path = root / "data" / "ic_entries.json"
+
+    positions: list[dict[str, Any]] = []
+    if state_path.exists():
+        state = json.loads(state_path.read_text(encoding="utf-8"))
+        positions = list(state.get("positions") or [])
+        if not positions:
+            # Some syncs only populate performance.open_positions
+            open_pos = (state.get("performance") or {}).get("open_positions") or []
+            for row in open_pos:
+                if not isinstance(row, dict):
+                    continue
+                positions.append(
+                    {
+                        "symbol": row.get("symbol"),
+                        "qty": row.get("quantity", row.get("qty")),
+                    }
+                )
+
+    entries: dict[str, Any] = {}
+    if entries_path.exists():
+        raw = json.loads(entries_path.read_text(encoding="utf-8"))
+        if isinstance(raw, dict):
+            entries = raw
+
+    return audit_open_inventory(
+        positions,
+        entries,
+        max_contracts_per_trade=max_contracts_per_trade,
+        max_concurrent_iron_condors=max_concurrent_iron_condors,
+    )
+
+
+def write_audit_report(
+    result: InventoryAuditResult,
+    path: Path | str,
+) -> Path:
+    out = Path(path)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(json.dumps(result.to_dict(), indent=2) + "\n", encoding="utf-8")
+    return out

--- a/src/risk/trade_gateway.py
+++ b/src/risk/trade_gateway.py
@@ -116,6 +116,10 @@ class RejectionReason(Enum):
         f"Per-trade contracts exceed MAX_CONTRACTS_PER_TRADE={_MAX_CONTRACTS_PER_TRADE} "
         f"(controlled-experiment.md: 1-lot only)"
     )
+    UNCLEAN_INVENTORY = (
+        "Open option inventory is unclean (lot/orphan/journal mismatch) — "
+        "reconcile broker book before new entries"
+    )
     BEHAVIORAL_GUARD_BLOCKED = "Behavioral guard blocked trade (FOMO/cooling/blacklist)"
 
 
@@ -864,6 +868,83 @@ class TradeGateway:
                             "lot_size_cap": self.MAX_CONTRACTS_PER_TRADE,
                             "requested_quantity": requested_qty,
                             "rule": "controlled-experiment.md: 1-lot only",
+                        },
+                    )
+
+            # Check 2c: Open inventory must match journaled 1-lot ICs before any
+            # new risk is added. SPY 2026-08-21 had journal qty=1 but broker showed
+            # 2-lot calls + an orphan put vertical — validation would keep stacking
+            # on garbage without this gate.
+            #
+            # Closing / reducing existing legs is ALWAYS allowed so the guardian
+            # can clean a dirty book (buy-to-close short, sell-to-close long).
+            def _pos_qty(row: dict[str, Any]) -> float:
+                try:
+                    return float(row.get("qty", row.get("quantity", 0)) or 0)
+                except (TypeError, ValueError):
+                    return 0.0
+
+            existing_qty = next(
+                (
+                    _pos_qty(p)
+                    for p in positions
+                    if p.get("symbol") == request.symbol and abs(_pos_qty(p)) > 1e-9
+                ),
+                0.0,
+            )
+            is_reducing = (
+                existing_qty != 0.0
+                and (
+                    (request.side.lower() == "buy" and existing_qty < 0)
+                    or (request.side.lower() == "sell" and existing_qty > 0)
+                )
+            )
+            if not is_reducing:
+                try:
+                    from src.risk.open_inventory_audit import audit_open_inventory
+
+                    ic_entries: dict[str, Any] = {}
+                    entries_path = Path("data/ic_entries.json")
+                    if entries_path.exists():
+                        raw_entries = json.loads(entries_path.read_text(encoding="utf-8"))
+                        if isinstance(raw_entries, dict):
+                            ic_entries = raw_entries
+                    inventory = audit_open_inventory(
+                        positions,
+                        ic_entries,
+                        max_contracts_per_trade=float(self.MAX_CONTRACTS_PER_TRADE),
+                        max_concurrent_iron_condors=int(self.MAX_CONCURRENT_ICS),
+                    )
+                    if not inventory.clean:
+                        logger.error(
+                            "🚨 UNCLEAN INVENTORY: %s",
+                            "; ".join(inventory.block_reasons()[:3]),
+                        )
+                        return GatewayDecision(
+                            approved=False,
+                            request=request,
+                            rejection_reasons=[RejectionReason.UNCLEAN_INVENTORY],
+                            risk_score=1.0,
+                            metadata={
+                                "circuit_breaker": "UNCLEAN_INVENTORY",
+                                "block_reasons": inventory.block_reasons(),
+                                "findings": [f.code for f in inventory.findings],
+                                "action": (
+                                    "Reconcile broker book to ic_entries (1-lot IC only) "
+                                    "via guardian/orphan path before new entries"
+                                ),
+                            },
+                        )
+                except Exception as inv_exc:  # noqa: BLE001 — fail closed on audit errors
+                    logger.error("🚨 Inventory audit failed closed: %s", inv_exc)
+                    return GatewayDecision(
+                        approved=False,
+                        request=request,
+                        rejection_reasons=[RejectionReason.UNCLEAN_INVENTORY],
+                        risk_score=1.0,
+                        metadata={
+                            "circuit_breaker": "UNCLEAN_INVENTORY",
+                            "error": str(inv_exc),
                         },
                     )
 

--- a/tests/test_open_inventory_audit.py
+++ b/tests/test_open_inventory_audit.py
@@ -1,0 +1,119 @@
+"""Tests for open option inventory hygiene audit."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from src.risk.open_inventory_audit import (
+    audit_from_files,
+    audit_open_inventory,
+    parse_option_leg,
+)
+
+
+def test_parse_option_leg():
+    leg = parse_option_leg("SPY260821C00776000", -2)
+    assert leg is not None
+    assert leg.expiry_ymd == "260821"
+    assert leg.right == "C"
+    assert leg.strike == 776.0
+    assert leg.qty == -2.0
+
+
+def test_clean_one_lot_ic():
+    positions = [
+        {"symbol": "SPY260821C00776000", "qty": -1},
+        {"symbol": "SPY260821C00781000", "qty": 1},
+        {"symbol": "SPY260821P00703000", "qty": 1},
+        {"symbol": "SPY260821P00708000", "qty": -1},
+    ]
+    entries = {
+        "IC_260821": {
+            "quantity": 1,
+            "strikes": {
+                "short_put": 708.0,
+                "long_put": 703.0,
+                "short_call": 776.0,
+                "long_call": 781.0,
+            },
+        }
+    }
+    result = audit_open_inventory(positions, entries)
+    assert result.clean is True
+    assert result.option_leg_count == 4
+    assert result.block_reasons() == []
+
+
+def test_detects_two_lot_call_and_extra_put_vertical():
+    """Reproduce SPY 2026-08-21 dirty book from live ledger."""
+    positions = [
+        {"symbol": "SPY260821C00776000", "qty": -2},
+        {"symbol": "SPY260821C00781000", "qty": 2},
+        {"symbol": "SPY260821P00695000", "qty": 1},
+        {"symbol": "SPY260821P00700000", "qty": -1},
+        {"symbol": "SPY260821P00703000", "qty": 1},
+        {"symbol": "SPY260821P00708000", "qty": -1},
+    ]
+    entries = {
+        "IC_260821": {
+            "quantity": 1,
+            "signature": "SPY_2026-08-21_P703-708_C776-781",
+            "strikes": {
+                "short_put": 708.0,
+                "long_put": 703.0,
+                "short_call": 776.0,
+                "long_call": 781.0,
+            },
+        }
+    }
+    result = audit_open_inventory(positions, entries)
+    assert result.clean is False
+    codes = {f.code for f in result.findings}
+    assert "LOT_SIZE_EXCEEDED" in codes
+    assert "EXTRA_LEGS" in codes or "QTY_MISMATCH" in codes
+    assert "SAME_EXPIRY_OVERSTACK" in codes
+    assert any("776" in r or "lot" in r.lower() or "extra" in r.lower() for r in result.block_reasons())
+
+
+def test_unjournaled_expiry_blocks():
+    positions = [{"symbol": "SPY260821P00708000", "qty": -1}]
+    result = audit_open_inventory(positions, {})
+    assert result.clean is False
+    assert any(f.code == "UNJOURNALED_EXPIRY" for f in result.findings)
+
+
+def test_audit_from_files_on_repo_fixture(tmp_path: Path):
+    data = tmp_path / "data"
+    data.mkdir()
+    (data / "system_state.json").write_text(
+        json.dumps(
+            {
+                "positions": [
+                    {"symbol": "SPY260821C00776000", "qty": -1},
+                    {"symbol": "SPY260821C00781000", "qty": 1},
+                    {"symbol": "SPY260821P00703000", "qty": 1},
+                    {"symbol": "SPY260821P00708000", "qty": -1},
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    (data / "ic_entries.json").write_text(
+        json.dumps(
+            {
+                "IC_260821": {
+                    "quantity": 1,
+                    "strikes": {
+                        "short_put": 708.0,
+                        "long_put": 703.0,
+                        "short_call": 776.0,
+                        "long_call": 781.0,
+                    },
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    result = audit_from_files(tmp_path)
+    assert result.clean is True

--- a/tests/test_trade_gateway.py
+++ b/tests/test_trade_gateway.py
@@ -10,6 +10,7 @@ Tests key gateway functionality:
 These tests ensure the gateway properly rejects risky trades.
 """
 
+import json
 from datetime import datetime as real_datetime
 from unittest.mock import MagicMock, patch
 
@@ -589,6 +590,75 @@ class TestTradeGatewayLotSizeCap:
         )
         decision = gateway.evaluate(request)
         assert RejectionReason.LOT_SIZE_EXCEEDED not in decision.rejection_reasons
+
+
+class TestTradeGatewayUncleanInventory:
+    """Block new risk when broker book does not match journaled 1-lot IC."""
+
+    def _make_gateway(self, positions=None):
+        gw = TradeGateway(executor=None, paper=True)
+        gw.executor = MockExecutor(account_equity=100_000, positions=positions or [])
+        return gw
+
+    def test_new_entry_blocked_on_dirty_open_book(self, tmp_path, monkeypatch):
+        dirty = [
+            {"symbol": "SPY260821C00776000", "qty": -2, "unrealized_pl": 0},
+            {"symbol": "SPY260821C00781000", "qty": 2, "unrealized_pl": 0},
+            {"symbol": "SPY260821P00703000", "qty": 1, "unrealized_pl": 0},
+            {"symbol": "SPY260821P00708000", "qty": -1, "unrealized_pl": 0},
+            {"symbol": "SPY260821P00695000", "qty": 1, "unrealized_pl": 0},
+            {"symbol": "SPY260821P00700000", "qty": -1, "unrealized_pl": 0},
+        ]
+        gateway = self._make_gateway(positions=dirty)
+        entries = {
+            "IC_260821": {
+                "quantity": 1,
+                "strikes": {
+                    "short_put": 708.0,
+                    "long_put": 703.0,
+                    "short_call": 776.0,
+                    "long_call": 781.0,
+                },
+            }
+        }
+        entries_path = tmp_path / "ic_entries.json"
+        entries_path.write_text(json.dumps(entries), encoding="utf-8")
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / "data").mkdir()
+        (tmp_path / "data" / "ic_entries.json").write_text(json.dumps(entries), encoding="utf-8")
+
+        request = TradeRequest(
+            symbol="SPY",
+            side="sell",
+            quantity=1,
+            source="test",
+            is_option=True,
+            strategy_type="iron_condor",
+        )
+        decision = gateway.evaluate(request)
+        assert not decision.approved
+        assert RejectionReason.UNCLEAN_INVENTORY in decision.rejection_reasons
+
+    def test_buy_to_close_allowed_when_inventory_dirty(self, tmp_path, monkeypatch):
+        symbol = "SPY260821C00776000"
+        dirty = [
+            {"symbol": symbol, "qty": -2, "unrealized_pl": 0},
+            {"symbol": "SPY260821C00781000", "qty": 2, "unrealized_pl": 0},
+        ]
+        gateway = self._make_gateway(positions=dirty)
+        (tmp_path / "data").mkdir()
+        (tmp_path / "data" / "ic_entries.json").write_text("{}", encoding="utf-8")
+        monkeypatch.chdir(tmp_path)
+
+        request = TradeRequest(
+            symbol=symbol,
+            side="buy",  # buy-to-close excess short
+            quantity=1,
+            source="test",
+            is_option=True,
+        )
+        decision = gateway.evaluate(request)
+        assert RejectionReason.UNCLEAN_INVENTORY not in decision.rejection_reasons
 
 
 class TestTradeGatewayDecisionTelemetry:


### PR DESCRIPTION
## Summary
- Adds `open_inventory_audit` that compares broker option legs to `ic_entries.json` (lot size, extras, qty mismatch, overstack).
- `TradeGateway` rejects **new** risk with `UNCLEAN_INVENTORY` when the book is dirty; buy/sell-to-close still allowed so guardian can clean.
- `iron_condor_trader` fails closed on unclean inventory before high-alpha; clearer error if system Python lacks `alpaca`.
- CLI: `python scripts/audit_open_inventory.py` (exit 2 when unclean).
- Live book currently unclean: SPY 2026-08-21 journaled 1-lot IC but shows 2-lot calls + orphan put vertical.

## Why
Without this, validation can stack on garbage inventory and the 1-lot experiment is meaningless.

## Test plan
- [x] `pytest tests/test_open_inventory_audit.py tests/test_trade_gateway.py::TestTradeGatewayLotSizeCap tests/test_trade_gateway.py::TestTradeGatewayUncleanInventory -q`
- [x] `ruff check` on touched files
- [x] `scripts/audit_open_inventory.py` reports unclean on current ledger

## Out of scope
- No position closes (boundary policy).
- Clear Street broker migration (not helpful until edge is proven on paper).