### PR TITLE
docs: CLAUDE + CTO status after IC kill / put-credit pivot

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -17,8 +17,15 @@ Source of truth: `src/core/trading_constants.py`
 
 ## Dual-Track Mandate
 
-1. **The Lab (Paper Account `PA3C5AG0CECQ`)**: ~$100,000. Strategy formulation + GRPO self-training. Up to 2 concurrent SPY Iron Condors (8 legs max).
-2. **The Field (Live Account `979807421`)**: $0 equity (started $20, lost 100%). Inactive — no capital deployed.
+1. **The Lab (Paper Account `PA3C5AG0CECQ`)**: ~$100,000. Active validation: **`spy_put_credit`** (1-lot SPY bull put, max 2 concurrent). Iron condor / `ic_simple` **new entries KILLED** (see `data/runtime/strategy_kill_switch.json`). Residual IC legs: exit-only via guardian/`ic_simple.py --mode exit`.
+2. **The Field (Live Account `979807421`)**: $0 equity (started $20, lost 100%). Inactive — no capital deployed. Live blocked until put-credit kill criteria clear (n≥30, expectancy>0, PF>1).
+
+## Active Strategy (post IC kill, 2026-07-22)
+
+- Primary entry: `scripts/spy_put_credit.py` (paper only)
+- Kill switch: `src/core/active_strategy.py` + `data/runtime/strategy_kill_switch.json`
+- Inventory must be clean before new risk: `scripts/audit_open_inventory.py`
+- Do **not** claim put credit is profitable until cohort evidence exists
 
 ## AI-Native Strategy (GRPO)
 
@@ -36,7 +43,10 @@ printf 'thumbs down' | python3 scripts/capture_hook_feedback.py
 python scripts/sync_alpaca_state.py          # refresh broker snapshot
 python scripts/sync_closed_positions.py      # refresh paired trade ledger
 python scripts/system_health_check.py        # verify protected systems before trading
-python src/orchestration/daggr_workflow.py   # run full trading session
+.venv/bin/python scripts/spy_put_credit.py --status   # active strategy status
+.venv/bin/python scripts/spy_put_credit.py --dry-run  # plan put credit (no order)
+.venv/bin/python scripts/audit_open_inventory.py      # inventory hygiene (exit 2 if unclean)
+.venv/bin/python scripts/ic_simple.py --mode exit     # residual IC exit only
 ```
 
 ## Simplification Mandate

--- a/data/runtime/cto_operating_status.json
+++ b/data/runtime/cto_operating_status.json
@@ -1,0 +1,41 @@
+{
+  "as_of": "2026-07-22T20:45:00Z",
+  "role": "CTO autonomous under CEO delegation",
+  "north_star": {
+    "target_monthly_after_tax": 6000,
+    "on_track": false,
+    "reason": "No proven edge. Paper equity ~$94.1k. Live $0. Income progress 0%."
+  },
+  "strategy": {
+    "ic_simple": "KILLED",
+    "active": "spy_put_credit",
+    "paper_only": true,
+    "live_blocked": true,
+    "merged_prs": ["#4247", "#4248"],
+    "closed_as_superseded": ["#4246"]
+  },
+  "ledger": {
+    "paper_equity": 94062.0,
+    "closed_trades": 174,
+    "win_rate_pct": 17.24,
+    "profit_factor": 0.7,
+    "expectancy": -31.98,
+    "total_realized_pnl": -5564.0
+  },
+  "open_risk": {
+    "option_legs": 6,
+    "expiry": "2026-08-21",
+    "inventory_clean": false,
+    "unrealized_approx": 15.0,
+    "issue": "Journaled 1-lot IC_260821 but broker has 2-lot call vertical + orphan put 695/700",
+    "action": "Exit-manage residual via ic_simple --mode exit / guardian only; no freehand close; block new put-credit until clean"
+  },
+  "next_actions": [
+    "Keep IC entry paths killed",
+    "Manage residual Aug-21 inventory via exit workflow",
+    "When inventory clean, collect spy_put_credit paper cohort n->30",
+    "Do not scale or go live without kill-criteria pass",
+    "Do not migrate to Clear Street until paper edge proven"
+  ],
+  "truth": "System is operationally redirected off IC. Not yet a profitable trading machine."
+}


### PR DESCRIPTION
## Summary
Align agent directives with merged strategy kill (#4247) and ops rewire (#4248):

- Dual-track: Lab = \`spy_put_credit\` paper; IC entry killed
- Commands: put-credit status/dry-run, inventory audit, IC exit-only
- \`data/runtime/cto_operating_status.json\` — truthful snapshot for next session

## Evidence
- Main: #4247 + #4248 merged
- Open inventory unclean (blocks new put-credit entries correctly)