### PR TITLE
Replace failed IC entry system with evidence-gated put-credit validation

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -36,12 +36,12 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4
+        uses: github/codeql-action/init@7188fc363630916deb702c7fdcf4e481b751f97a # v4.37.1
         with:
           languages: ${{ matrix.language }}
           config-file: ./.github/codeql/codeql-config.yml
 
       - name: Perform CodeQL analysis
-        uses: github/codeql-action/analyze@7188fc363630916deb702c7fdcf4e481b751f97a # v4
+        uses: github/codeql-action/analyze@7188fc363630916deb702c7fdcf4e481b751f97a # v4.37.1
         with:
           category: "/language:${{ matrix.language }}"

--- a/.github/workflows/ic-simple.yml
+++ b/.github/workflows/ic-simple.yml
@@ -84,7 +84,9 @@ jobs:
           echo "run_put_credit=$RUN_PUT_CREDIT" >> $GITHUB_OUTPUT
           echo "Mode: $MODE, Dry run: $DRY, Put credit: $RUN_PUT_CREDIT"
 
-      - name: Manage residual IC positions (exit only — entries killed)
+      - name: Manage residual IC positions (broker-reconciled exits only)
+        id: residual_ic
+        continue-on-error: true
         if: steps.mode.outputs.mode != 'learn' && steps.mode.outputs.mode != 'status'
         env:
           ALPACA_PAPER_TRADING_API_KEY: ${{ secrets.ALPACA_PAPER_TRADING_API_KEY }}
@@ -94,16 +96,33 @@ jobs:
           CONTEXT_INDEX_MAX_AGE_MINUTES: "999999"
           PYTHONPATH: ${{ github.workspace }}
         run: |
-          # IC new entries are STRATEGY_KILLED. Always run exit management only
-          # so residual open IC legs still get stop/target/DTE handling.
-          FLAGS="--mode exit"
+          # Recover each open structure from its filled MLEG order. This remains
+          # correct when multiple ICs share strikes and broker quantities aggregate.
+          FLAGS=""
+          if [ "${{ steps.mode.outputs.dry_run }}" = "true" ]; then
+            FLAGS="--dry-run"
+          fi
+          python3 scripts/residual_ic_manager.py $FLAGS
+
+      - name: Manage put-credit exits
+        if: always() && steps.mode.outputs.mode != 'learn' && steps.mode.outputs.mode != 'status'
+        env:
+          ALPACA_PAPER_TRADING_API_KEY: ${{ secrets.ALPACA_PAPER_TRADING_API_KEY }}
+          ALPACA_PAPER_TRADING_API_SECRET: ${{ secrets.ALPACA_PAPER_TRADING_API_SECRET }}
+          PYTHONPATH: ${{ github.workspace }}
+        run: |
+          FLAGS="--manage-exits"
           if [ "${{ steps.mode.outputs.dry_run }}" = "true" ]; then
             FLAGS="$FLAGS --dry-run"
           fi
-          python3 scripts/ic_simple.py $FLAGS
+          # Every weekday slot evaluates fixed TP, stop, and DTE exits.
+          python3 scripts/spy_put_credit.py $FLAGS
 
       - name: Run spy_put_credit paper entry (successor strategy)
-        if: steps.mode.outputs.run_put_credit == 'true' && steps.mode.outputs.mode != 'learn'
+        if: >-
+          steps.residual_ic.outcome == 'success' &&
+          steps.mode.outputs.run_put_credit == 'true' &&
+          steps.mode.outputs.mode != 'learn'
         env:
           ALPACA_PAPER_TRADING_API_KEY: ${{ secrets.ALPACA_PAPER_TRADING_API_KEY }}
           ALPACA_PAPER_TRADING_API_SECRET: ${{ secrets.ALPACA_PAPER_TRADING_API_SECRET }}
@@ -142,7 +161,10 @@ jobs:
           python3 scripts/run_grpo_training.py || echo "GRPO training skipped"
 
       - name: Commit trade data
-        if: steps.mode.outputs.mode != 'status' && steps.mode.outputs.dry_run != 'true'
+        if: >-
+          always() &&
+          steps.mode.outputs.mode != 'status' &&
+          steps.mode.outputs.dry_run != 'true'
         run: |
           set -euo pipefail
           git config user.name "github-actions[bot]"
@@ -176,3 +198,9 @@ jobs:
             git pull --ff-only origin main
             git push origin HEAD:main
           fi
+
+      - name: Fail closed on unresolved residual IC inventory
+        if: always() && steps.residual_ic.outcome == 'failure'
+        run: |
+          echo "Residual IC reconciliation or exit submission failed; new entries stayed blocked."
+          exit 1

--- a/config/strategy_candidate_tournament.json
+++ b/config/strategy_candidate_tournament.json
@@ -1,0 +1,39 @@
+{
+  "incumbent_strategy_id": "ic_simple_spy_15_delta",
+  "active_paper_candidate_id": "spy_put_credit",
+  "promotion_thresholds": {
+    "min_closed_trades": 30,
+    "min_expectancy_per_trade": 1.0,
+    "min_profit_factor": 1.05,
+    "min_total_realized_pnl": 1.0,
+    "max_drawdown_pct": 10.0
+  },
+  "default_when_no_candidate_passes": "RETIRE_INCUMBENT_PAPER_VALIDATE_SUCCESSOR",
+  "candidates": [
+    {
+      "strategy_id": "spy_put_credit",
+      "hypothesis": "Replacing the failed four-leg SPY iron condor with one defined-risk bull put credit may retain the long-term equity-drift thesis while halving leg complexity and removing the losing call side.",
+      "rules": {
+        "universe": "SPY put options",
+        "entry": "Sell one 30-45 DTE SPY put at 0.15 target delta (0.10-0.22 band) and buy one put exactly $5 lower; live-delta provenance and at least $0.50 net credit are required.",
+        "exit": "Take profit at 25% of credit, stop when loss reaches 200% of entry credit, force exit by 7 DTE, and allow no discretionary exit before 24 hours.",
+        "risk": "One contract per structure, at most one new structure per day, at most two concurrent structures, paper only, and block whenever broker inventory and journals do not reconcile.",
+        "regime": "Validation hypothesis only; no edge or North Star contribution is claimed before the clean promotion gate passes."
+      },
+      "broker_requirements": {
+        "asset_class": "option",
+        "legs": 2,
+        "minimum_options_level": 3,
+        "requires_paper_trading": true
+      },
+      "evidence": {
+        "closed_trades": 0,
+        "expectancy_per_trade": 0.0,
+        "profit_factor": 0.0,
+        "total_realized_pnl": 0.0,
+        "max_drawdown_pct": null,
+        "ledger_clean": true
+      }
+    }
+  ]
+}

--- a/data/audit/clearstreet_active_capability_20260722.json
+++ b/data/audit/clearstreet_active_capability_20260722.json
@@ -19,10 +19,7 @@
     "single_leg_options": true,
     "multi_leg_options": false,
     "paper_trading_verified": false,
-    "documented_api_options_levels": [
-      1,
-      2
-    ]
+    "documented_api_options_levels": [1, 2]
   },
   "decision": {
     "current_role": "RESEARCH_ONLY",

--- a/data/audit/clearstreet_active_capability_20260722.json
+++ b/data/audit/clearstreet_active_capability_20260722.json
@@ -1,0 +1,40 @@
+{
+  "broker": "clearstreet_active",
+  "observed_at": "2026-07-22T16:31:00-04:00",
+  "source": "authenticated_web_readback_and_official_api_documentation",
+  "account": {
+    "authenticated_web_session": true,
+    "funded": false,
+    "equity_usd": 0.0,
+    "api_key_configured": false,
+    "options_level": 0,
+    "margin_type": "REG_T",
+    "margin_multiplier": "1x",
+    "omni_account_access_enabled": false
+  },
+  "api_capabilities": {
+    "base_url": "https://api.clearstreet.com",
+    "market_data": true,
+    "equities": true,
+    "single_leg_options": true,
+    "multi_leg_options": false,
+    "paper_trading_verified": false,
+    "documented_api_options_levels": [
+      1,
+      2
+    ]
+  },
+  "decision": {
+    "current_role": "RESEARCH_ONLY",
+    "may_replace_alpaca_execution": false,
+    "reason": "The current account is unfunded, has options level 0, has no API key, and Clear Street's retail API documentation currently limits option API execution to levels 1 and 2 rather than multi-leg spreads."
+  },
+  "official_sources": [
+    "https://docs.clearstreet.com/",
+    "https://docs.clearstreet.com/guides/trading/",
+    "https://docs.clearstreet.com/guides/instrument-data/",
+    "https://docs.clearstreet.com/guides/omni-ai/",
+    "https://docs.clearstreet.com/api/resources/v1/subresources/orders/methods/submit_orders/"
+  ],
+  "secret_material_recorded": false
+}

--- a/data/audit/open_inventory_latest.json
+++ b/data/audit/open_inventory_latest.json
@@ -1,0 +1,144 @@
+{
+  "clean": false,
+  "audited_at": "2026-07-22T21:04:14.937829+00:00",
+  "option_leg_count": 6,
+  "max_abs_qty": 2.0,
+  "expiries": [
+    "260821"
+  ],
+  "findings": [
+    {
+      "code": "LOT_SIZE_EXCEEDED",
+      "severity": "block",
+      "message": "Expiry 260821 has aggregated leg quantity not explained by distinct one-lot journal records",
+      "expiry_ymd": "260821",
+      "details": {
+        "offenders": [
+          {
+            "right": "C",
+            "strike": 776.0,
+            "actual_qty": -2.0,
+            "journal_qty": -1.0
+          },
+          {
+            "right": "C",
+            "strike": 781.0,
+            "actual_qty": 2.0,
+            "journal_qty": 1.0
+          }
+        ]
+      }
+    },
+    {
+      "code": "QTY_MISMATCH",
+      "severity": "block",
+      "message": "Expiry 260821: C776 qty=-2.0 does not match journaled qty=-1.0",
+      "expiry_ymd": "260821",
+      "details": {
+        "right": "C",
+        "strike": 776.0,
+        "actual_qty": -2.0,
+        "journal_qty": -1.0
+      }
+    },
+    {
+      "code": "QTY_MISMATCH",
+      "severity": "block",
+      "message": "Expiry 260821: C781 qty=2.0 does not match journaled qty=1.0",
+      "expiry_ymd": "260821",
+      "details": {
+        "right": "C",
+        "strike": 781.0,
+        "actual_qty": 2.0,
+        "journal_qty": 1.0
+      }
+    },
+    {
+      "code": "EXTRA_LEGS",
+      "severity": "block",
+      "message": "Expiry 260821: 2 open leg(s) not in journaled structure (orphan verticals or residual risk)",
+      "expiry_ymd": "260821",
+      "details": {
+        "extras": [
+          {
+            "right": "P",
+            "strike": 695.0,
+            "qty": 1.0
+          },
+          {
+            "right": "P",
+            "strike": 700.0,
+            "qty": -1.0
+          }
+        ]
+      }
+    },
+    {
+      "code": "SAME_EXPIRY_OVERSTACK",
+      "severity": "block",
+      "message": "Expiry 260821: short-leg units=4.0 exceed journaled units=2.0",
+      "expiry_ymd": "260821",
+      "details": {
+        "short_units": 4.0,
+        "leg_count": 6
+      }
+    }
+  ],
+  "legs": [
+    {
+      "symbol": "SPY260821C00776000",
+      "root": "SPY",
+      "expiry_ymd": "260821",
+      "right": "C",
+      "strike": 776.0,
+      "qty": -2.0
+    },
+    {
+      "symbol": "SPY260821C00781000",
+      "root": "SPY",
+      "expiry_ymd": "260821",
+      "right": "C",
+      "strike": 781.0,
+      "qty": 2.0
+    },
+    {
+      "symbol": "SPY260821P00695000",
+      "root": "SPY",
+      "expiry_ymd": "260821",
+      "right": "P",
+      "strike": 695.0,
+      "qty": 1.0
+    },
+    {
+      "symbol": "SPY260821P00700000",
+      "root": "SPY",
+      "expiry_ymd": "260821",
+      "right": "P",
+      "strike": 700.0,
+      "qty": -1.0
+    },
+    {
+      "symbol": "SPY260821P00703000",
+      "root": "SPY",
+      "expiry_ymd": "260821",
+      "right": "P",
+      "strike": 703.0,
+      "qty": 1.0
+    },
+    {
+      "symbol": "SPY260821P00708000",
+      "root": "SPY",
+      "expiry_ymd": "260821",
+      "right": "P",
+      "strike": 708.0,
+      "qty": -1.0
+    }
+  ],
+  "block_reasons": [
+    "Expiry 260821 has aggregated leg quantity not explained by distinct one-lot journal records",
+    "Expiry 260821: C776 qty=-2.0 does not match journaled qty=-1.0",
+    "Expiry 260821: C781 qty=2.0 does not match journaled qty=1.0",
+    "Expiry 260821: 2 open leg(s) not in journaled structure (orphan verticals or residual risk)",
+    "Expiry 260821: short-leg units=4.0 exceed journaled units=2.0"
+  ]
+}

--- a/data/audit/open_inventory_latest.json
+++ b/data/audit/open_inventory_latest.json
@@ -3,9 +3,7 @@
   "audited_at": "2026-07-22T21:04:14.937829+00:00",
   "option_leg_count": 6,
   "max_abs_qty": 2.0,
-  "expiries": [
-    "260821"
-  ],
+  "expiries": ["260821"],
   "findings": [
     {
       "code": "LOT_SIZE_EXCEEDED",

--- a/data/audit/residual_ic_latest.json
+++ b/data/audit/residual_ic_latest.json
@@ -1,0 +1,52 @@
+{
+  "audited_at": "2026-07-22T21:08:48.043378+00:00",
+  "dry_run": true,
+  "reconciled": 2,
+  "unresolved": {},
+  "checked": 2,
+  "holds": 2,
+  "would_exit": 0,
+  "submitted": 0,
+  "pending": 0,
+  "broken": 0,
+  "details": [
+    {
+      "entry_order_id": "12d3f881-7beb-46a0-b445-7185d0e5a9b9",
+      "expiry_yymmdd": "260821",
+      "credit": 1.11,
+      "symbols": [
+        "SPY260821P00703000",
+        "SPY260821P00708000",
+        "SPY260821C00776000",
+        "SPY260821C00781000"
+      ],
+      "should_exit": false,
+      "exit_reason": null,
+      "dte": 30,
+      "hold_hours": 29.468301375833335,
+      "current_debit": 1.09,
+      "pnl": 2.0,
+      "max_profit": 111.0,
+      "status": "hold"
+    },
+    {
+      "entry_order_id": "38126b75-50dd-49e5-932f-8939f332a0c2",
+      "expiry_yymmdd": "260821",
+      "credit": 1.12,
+      "symbols": [
+        "SPY260821P00695000",
+        "SPY260821P00700000",
+        "SPY260821C00776000",
+        "SPY260821C00781000"
+      ],
+      "should_exit": false,
+      "exit_reason": null,
+      "dte": 30,
+      "hold_hours": 125.54099451694445,
+      "current_debit": 0.99,
+      "pnl": 13.0,
+      "max_profit": 112.0,
+      "status": "hold"
+    }
+  ]
+}

--- a/scripts/enforce_promotion_gate.py
+++ b/scripts/enforce_promotion_gate.py
@@ -195,6 +195,22 @@ def calculate_stale_hours(system_state: dict[str, Any]) -> float | None:
     return age_hours
 
 
+def evaluate_staleness(
+    system_state: dict[str, Any], stale_threshold_hours: float
+) -> tuple[float | None, list[str]]:
+    """Fail closed when performance evidence is missing or stale."""
+
+    stale_hours = calculate_stale_hours(system_state)
+    if stale_hours is None:
+        return None, ["System-state timestamp is missing or invalid; freshness cannot be verified."]
+    if stale_hours >= stale_threshold_hours:
+        return stale_hours, [
+            f"System state is stale ({stale_hours:.1f}h >= {stale_threshold_hours:.1f}h); "
+            "refresh evidence before promotion."
+        ]
+    return stale_hours, []
+
+
 def build_json_result(
     status: str,
     deficits: list[str],
@@ -300,10 +316,9 @@ def main() -> None:
             sys.exit(0)
         raise
 
-    stale_hours = calculate_stale_hours(system_state)
-    stale_override = stale_hours is not None and stale_hours >= args.stale_threshold_hours
-
+    stale_hours, stale_deficits = evaluate_staleness(system_state, args.stale_threshold_hours)
     deficits = evaluate_gate(system_state, backtest_summary, args)
+    deficits.extend(stale_deficits)
 
     # Collect metrics for JSON output
     metrics = {
@@ -327,7 +342,7 @@ def main() -> None:
         "min_profitable_days": args.min_profitable_days,
     }
 
-    gate_passed = not deficits or override_flag or stale_override
+    gate_passed = not deficits or override_flag
     status = "passed" if gate_passed else "blocked"
 
     # JSON output mode
@@ -337,7 +352,7 @@ def main() -> None:
             deficits=deficits,
             metrics=metrics,
             thresholds=thresholds,
-            override_active=override_flag or stale_override,
+            override_active=override_flag,
             stale_hours=stale_hours,
         )
         json_str = json.dumps(json_result, indent=2)
@@ -349,12 +364,7 @@ def main() -> None:
             sys.exit(0 if gate_passed else 1)
 
     # Human-readable output
-    if stale_override and not args.json:
-        print(
-            f"⚠️  Skipping promotion gate: system_state.json is {stale_hours:.1f}h old (threshold {args.stale_threshold_hours}h)."
-        )
-
-    if deficits and not (override_flag or stale_override):
+    if deficits and not override_flag:
         print("❌ Promotion gate failed. Reasons:")
         for item in deficits:
             print(f"  - {item}")
@@ -365,11 +375,11 @@ def main() -> None:
         sys.exit(1)
 
     print("✅ Promotion gate satisfied. System may proceed to next stage.")
-    if override_flag or stale_override:
+    if override_flag:
         print("⚠️  Proceeding under manual override flag.")
 
     # Emit capital scaling plan if gate passed (without overrides) and enabled
-    if args.emit_scaling_plan and not deficits and not (override_flag or stale_override):
+    if args.emit_scaling_plan and not deficits and not override_flag:
         scaling_plan = calculate_scaling_recommendation(
             metrics=metrics,
             thresholds=thresholds,

--- a/scripts/residual_ic_manager.py
+++ b/scripts/residual_ic_manager.py
@@ -1,0 +1,379 @@
+#!/usr/bin/env python3
+"""Recover and manage residual ICs from broker-confirmed opening orders.
+
+The legacy manager grouped positions only by expiry and therefore skipped two
+valid one-lot iron condors when they shared a call vertical (six distinct OCC
+symbols, with the common call legs aggregated to quantity two).  This manager
+uses filled MLEG opening orders as the structure source of truth, allocates the
+current broker inventory back to each opening order, and evaluates each trade
+independently.
+
+It never opens a position.  A close is atomic MLEG-only; failure leaves the
+defined-risk structure intact for the next scheduled retry.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import sys
+from datetime import date, datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+from zoneinfo import ZoneInfo
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+AUDIT_PATH = ROOT / "data" / "audit" / "residual_ic_latest.json"
+EASTERN = ZoneInfo("America/New_York")
+logger = logging.getLogger("residual_ic_manager")
+
+
+def _text(value: Any) -> str:
+    return str(value or "").rsplit(".", 1)[-1].upper()
+
+
+def _number(value: Any, default: float = 0.0) -> float:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _timestamp(value: Any) -> datetime | None:
+    if isinstance(value, datetime):
+        parsed = value
+    else:
+        raw = str(value or "").strip()
+        if not raw:
+            return None
+        try:
+            parsed = datetime.fromisoformat(raw.replace("Z", "+00:00"))
+        except ValueError:
+            return None
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def _is_option(symbol: str) -> bool:
+    return len(symbol) > 10 and symbol.startswith("SPY") and symbol[-9:-8] in {"P", "C"}
+
+
+def _signed_order_leg_qty(parent: Any, leg: Any) -> float:
+    parent_qty = abs(_number(getattr(parent, "filled_qty", None) or getattr(parent, "qty", 1), 1))
+    leg_qty = abs(_number(getattr(leg, "filled_qty", None) or getattr(leg, "qty", 1), 1))
+    magnitude = parent_qty * leg_qty
+    return magnitude if _text(getattr(leg, "side", None)) == "BUY" else -magnitude
+
+
+def _is_filled_ic_open(order: Any) -> bool:
+    from src.utils.order_intent import parse_client_order_id
+
+    parsed = parse_client_order_id(str(getattr(order, "client_order_id", "") or ""))
+    legs = list(getattr(order, "legs", None) or [])
+    if not parsed or parsed["role"] != "OPEN" or parsed["intent"] != "IC":
+        return False
+    if "FILL" not in _text(getattr(order, "status", None)) or len(legs) != 4:
+        return False
+    symbols = [str(getattr(leg, "symbol", "") or "") for leg in legs]
+    return (
+        all(_is_option(symbol) for symbol in symbols)
+        and sum(symbol[-9:-8] == "P" for symbol in symbols) == 2
+        and sum(symbol[-9:-8] == "C" for symbol in symbols) == 2
+        and sum(_text(getattr(leg, "side", None)) == "BUY" for leg in legs) == 2
+        and sum(_text(getattr(leg, "side", None)) == "SELL" for leg in legs) == 2
+    )
+
+
+def recover_active_structures(
+    positions: list[Any], orders: list[Any]
+) -> tuple[list[dict[str, Any]], dict[str, float]]:
+    """Allocate current signed position quantities to recent filled IC opens."""
+
+    position_map = {
+        str(pos.symbol): pos
+        for pos in positions
+        if _is_option(str(getattr(pos, "symbol", "") or ""))
+        and abs(_number(getattr(pos, "qty", 0))) > 1e-9
+    }
+    available = {symbol: _number(pos.qty) for symbol, pos in position_map.items()}
+    candidates = [order for order in orders if _is_filled_ic_open(order)]
+    candidates.sort(
+        key=lambda order: (
+            _timestamp(getattr(order, "filled_at", None) or getattr(order, "created_at", None))
+            or datetime.min.replace(tzinfo=timezone.utc)
+        ),
+        reverse=True,
+    )
+
+    recovered: list[dict[str, Any]] = []
+    for order in candidates:
+        order_legs = list(getattr(order, "legs", None) or [])
+        needed: dict[str, float] = {}
+        for leg in order_legs:
+            symbol = str(leg.symbol)
+            needed[symbol] = needed.get(symbol, 0.0) + _signed_order_leg_qty(order, leg)
+
+        def enough(symbol: str, qty: float) -> bool:
+            have = available.get(symbol, 0.0)
+            return have * qty > 0 and abs(have) + 1e-9 >= abs(qty)
+
+        if not all(enough(symbol, qty) for symbol, qty in needed.items()):
+            continue
+
+        credit = 0.0
+        legs: list[dict[str, Any]] = []
+        for leg in order_legs:
+            symbol = str(leg.symbol)
+            signed_qty = _signed_order_leg_qty(order, leg)
+            available[symbol] -= signed_qty
+            entry_price = _number(getattr(leg, "filled_avg_price", None))
+            if signed_qty < 0:
+                credit += entry_price * abs(signed_qty)
+            else:
+                credit -= entry_price * abs(signed_qty)
+            pos = position_map[symbol]
+            legs.append(
+                {
+                    "symbol": symbol,
+                    "qty": signed_qty,
+                    "entry_price": entry_price,
+                    "current_price": _number(
+                        getattr(pos, "current_price", None),
+                        _number(getattr(pos, "avg_entry_price", None)),
+                    ),
+                }
+            )
+
+        if credit <= 0:
+            for symbol, qty in needed.items():
+                available[symbol] += qty
+            continue
+        sample_symbol = legs[0]["symbol"]
+        recovered.append(
+            {
+                "entry_order_id": str(order.id),
+                "client_order_id": str(getattr(order, "client_order_id", "") or ""),
+                "entry_time": (
+                    _timestamp(getattr(order, "filled_at", None))
+                    or _timestamp(getattr(order, "created_at", None))
+                ).isoformat(),
+                "expiry_yymmdd": sample_symbol[3:9],
+                "credit": round(credit, 4),
+                "quantity": abs(_number(getattr(order, "filled_qty", None) or 1, 1)),
+                "legs": legs,
+            }
+        )
+
+    unresolved = {symbol: qty for symbol, qty in available.items() if abs(qty) > 1e-9}
+    return recovered, unresolved
+
+
+def evaluate_residual_exit(
+    structure: dict[str, Any], *, now: datetime | None = None
+) -> dict[str, Any]:
+    """Apply canonical 50% profit, 100%-of-credit stop, and 7-DTE exit."""
+
+    from src.core.trading_constants import (
+        IC_PROFIT_TARGET_PCT,
+        IRON_CONDOR_EXIT_DTE,
+        IRON_CONDOR_MIN_HOLD_HOURS,
+        IRON_CONDOR_STOP_LOSS_MULTIPLIER,
+    )
+
+    current = now or datetime.now(timezone.utc)
+    if current.tzinfo is None:
+        current = current.replace(tzinfo=timezone.utc)
+    expiry_raw = str(structure["expiry_yymmdd"])
+    expiry = date(2000 + int(expiry_raw[:2]), int(expiry_raw[2:4]), int(expiry_raw[4:6]))
+    dte = (expiry - current.astimezone(EASTERN).date()).days
+    entered = _timestamp(structure.get("entry_time"))
+    hold_hours = (
+        (current.astimezone(timezone.utc) - entered).total_seconds() / 3600 if entered else None
+    )
+    credit = _number(structure.get("credit"))
+    current_debit = sum(
+        _number(leg.get("current_price")) * (1 if _number(leg.get("qty")) < 0 else -1)
+        for leg in structure.get("legs", [])
+    )
+    current_debit = max(0.0, current_debit)
+    quantity = max(1.0, abs(_number(structure.get("quantity"), 1)))
+    max_profit = credit * quantity * 100
+    pnl = (credit - current_debit) * quantity * 100
+
+    reason = None
+    if dte <= 1:
+        reason = "assignment_failsafe"
+    elif dte <= IRON_CONDOR_EXIT_DTE:
+        reason = "dte_exit"
+    elif hold_hours is not None and hold_hours >= IRON_CONDOR_MIN_HOLD_HOURS:
+        if pnl >= max_profit * IC_PROFIT_TARGET_PCT:
+            reason = "profit_target"
+        elif pnl <= -(max_profit * IRON_CONDOR_STOP_LOSS_MULTIPLIER):
+            reason = "stop_loss"
+
+    return {
+        "should_exit": reason is not None,
+        "exit_reason": reason,
+        "dte": dte,
+        "hold_hours": hold_hours,
+        "credit": round(credit, 4),
+        "current_debit": round(current_debit, 4),
+        "pnl": round(pnl, 2),
+        "max_profit": round(max_profit, 2),
+    }
+
+
+def _close_signature(structure: dict[str, Any]) -> tuple[tuple[str, str], ...]:
+    return tuple(
+        sorted(
+            (
+                str(leg["symbol"]),
+                "BUY" if _number(leg.get("qty")) < 0 else "SELL",
+            )
+            for leg in structure.get("legs", [])
+        )
+    )
+
+
+def _order_signature(order: Any) -> tuple[tuple[str, str], ...]:
+    return tuple(
+        sorted(
+            (str(getattr(leg, "symbol", "")), _text(getattr(leg, "side", None)))
+            for leg in list(getattr(order, "legs", None) or [])
+        )
+    )
+
+
+def _submit_close(client: Any, structure: dict[str, Any], decision: dict[str, Any]):
+    from alpaca.trading.enums import OrderClass, OrderSide, TimeInForce
+    from alpaca.trading.requests import LimitOrderRequest, OptionLegRequest
+    from src.safety.mandatory_trade_gate import safe_submit_order
+    from src.utils.order_intent import build_client_order_id
+
+    legs = [
+        OptionLegRequest(
+            symbol=str(leg["symbol"]),
+            side=OrderSide.BUY if _number(leg.get("qty")) < 0 else OrderSide.SELL,
+            ratio_qty=abs(int(_number(leg.get("qty"), 1))),
+        )
+        for leg in structure["legs"]
+    ]
+    put_strikes = [
+        int(str(leg["symbol"])[-8:]) / 1000
+        for leg in structure["legs"]
+        if str(leg["symbol"])[-9:-8] == "P"
+    ]
+    call_strikes = [
+        int(str(leg["symbol"])[-8:]) / 1000
+        for leg in structure["legs"]
+        if str(leg["symbol"])[-9:-8] == "C"
+    ]
+    max_width = max(max(put_strikes) - min(put_strikes), max(call_strikes) - min(call_strikes))
+    limit_debit = min(max_width, max(0.01, round(_number(decision["current_debit"]) + 0.10, 2)))
+    request = LimitOrderRequest(
+        qty=abs(int(_number(structure.get("quantity"), 1))),
+        order_class=OrderClass.MLEG,
+        legs=legs,
+        time_in_force=TimeInForce.DAY,
+        limit_price=limit_debit,
+        client_order_id=build_client_order_id("CLOSE", "IC"),
+    )
+    return safe_submit_order(client, request, strategy="iron_condor")
+
+
+def _get_orders(client: Any, *, open_only: bool = False) -> list[Any]:
+    from alpaca.trading.enums import QueryOrderStatus
+    from alpaca.trading.requests import GetOrdersRequest
+
+    kwargs: dict[str, Any] = {
+        "status": QueryOrderStatus.OPEN if open_only else QueryOrderStatus.ALL,
+        "nested": True,
+        "limit": 500,
+    }
+    if not open_only:
+        kwargs["after"] = datetime.now(timezone.utc) - timedelta(days=120)
+    return list(client.get_orders(filter=GetOrdersRequest(**kwargs)))
+
+
+def manage_residual_ics(client: Any, *, dry_run: bool = False) -> dict[str, Any]:
+    positions = list(client.get_all_positions())
+    option_positions = [pos for pos in positions if _is_option(str(getattr(pos, "symbol", "")))]
+    all_orders = _get_orders(client)
+    structures, unresolved = recover_active_structures(option_positions, all_orders)
+    pending_signatures = {_order_signature(order) for order in _get_orders(client, open_only=True)}
+    report: dict[str, Any] = {
+        "audited_at": datetime.now(timezone.utc).isoformat(),
+        "dry_run": dry_run,
+        "reconciled": len(structures),
+        "unresolved": unresolved,
+        "checked": 0,
+        "holds": 0,
+        "would_exit": 0,
+        "submitted": 0,
+        "pending": 0,
+        "broken": 1 if unresolved else 0,
+        "details": [],
+    }
+
+    for structure in structures:
+        report["checked"] += 1
+        decision = evaluate_residual_exit(structure)
+        detail = {
+            "entry_order_id": structure["entry_order_id"],
+            "expiry_yymmdd": structure["expiry_yymmdd"],
+            "credit": structure["credit"],
+            "symbols": [leg["symbol"] for leg in structure["legs"]],
+            **decision,
+        }
+        if not decision["should_exit"]:
+            report["holds"] += 1
+            detail["status"] = "hold"
+        elif _close_signature(structure) in pending_signatures:
+            report["pending"] += 1
+            detail["status"] = "exit_pending"
+        elif dry_run:
+            report["would_exit"] += 1
+            detail["status"] = "would_exit"
+        else:
+            try:
+                order = _submit_close(client, structure, decision)
+                report["submitted"] += 1
+                detail["status"] = "exit_submitted"
+                detail["exit_order_id"] = str(order.id)
+            except Exception as exc:  # noqa: BLE001
+                report["broken"] += 1
+                detail["status"] = "exit_submit_failed"
+                detail["error"] = str(exc)
+        report["details"].append(detail)
+
+    AUDIT_PATH.parent.mkdir(parents=True, exist_ok=True)
+    AUDIT_PATH.write_text(json.dumps(report, indent=2) + "\n", encoding="utf-8")
+    return report
+
+
+def _client():
+    from alpaca.trading.client import TradingClient
+    from src.utils.alpaca_client import get_alpaca_credentials
+
+    key, secret = get_alpaca_credentials()
+    if not key or not secret:
+        raise RuntimeError("Alpaca paper credentials missing")
+    return TradingClient(key, secret, paper=True)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Recover and manage residual broker ICs")
+    parser.add_argument("--dry-run", action="store_true", help="Evaluate without submitting closes")
+    args = parser.parse_args()
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
+    report = manage_residual_ics(_client(), dry_run=args.dry_run)
+    print(json.dumps(report, indent=2))
+    return 2 if report["broken"] else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/spy_put_credit.py
+++ b/scripts/spy_put_credit.py
@@ -254,8 +254,8 @@ def _confirm_entry_credit(client, entry: dict[str, Any], short_pos: Any, long_po
                 entry["fill_confirmed_at"] = datetime.now(timezone.utc).isoformat()
                 entry["status"] = "open"
                 return True
-        except Exception:
-            pass
+        except Exception as exc:
+            logger.warning("Could not confirm put-credit fill from order %s: %s", order_id, exc)
     short_entry = float(getattr(short_pos, "avg_entry_price", 0.0) or 0.0)
     long_entry = float(getattr(long_pos, "avg_entry_price", 0.0) or 0.0)
     derived = short_entry - long_entry

--- a/scripts/spy_put_credit.py
+++ b/scripts/spy_put_credit.py
@@ -15,10 +15,13 @@ from __future__ import annotations
 import argparse
 import json
 import logging
+import re
 import sys
 import time
-from datetime import datetime, timezone
+from datetime import date, datetime, timezone
 from pathlib import Path
+from typing import Any
+from zoneinfo import ZoneInfo
 
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT))
@@ -29,6 +32,8 @@ logger = logging.getLogger("spy_put_credit")
 ENTRIES_FILE = ROOT / "data" / "put_credit_entries.json"
 AUDIT_DIR = ROOT / "data" / "audit"
 SYSTEM_STATE = ROOT / "data" / "system_state.json"
+CLOSED_ENTRY_STATES = {"closed", "cancelled", "rejected"}
+EASTERN = ZoneInfo("America/New_York")
 
 
 def _load_profile():
@@ -83,6 +88,411 @@ def _get_paper_client():
     return TradingClient(key, secret, paper=True)
 
 
+def _load_entries() -> dict[str, dict[str, Any]]:
+    if not ENTRIES_FILE.exists():
+        return {}
+    payload = json.loads(ENTRIES_FILE.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"Expected object in {ENTRIES_FILE}")
+    return {str(key): value for key, value in payload.items() if isinstance(value, dict)}
+
+
+def _save_entries(entries: dict[str, dict[str, Any]]) -> None:
+    ENTRIES_FILE.parent.mkdir(parents=True, exist_ok=True)
+    ENTRIES_FILE.write_text(json.dumps(entries, indent=2) + "\n", encoding="utf-8")
+
+
+def _is_active_entry(entry: dict[str, Any]) -> bool:
+    return str(entry.get("status") or "open").strip().lower() not in CLOSED_ENTRY_STATES
+
+
+def _parse_timestamp(value: Any) -> datetime | None:
+    text = str(value or "").strip()
+    if not text:
+        return None
+    try:
+        parsed = datetime.fromisoformat(text.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def evaluate_entry_limits(
+    entries: dict[str, dict[str, Any]],
+    *,
+    candidate_signature: str | None = None,
+    now: datetime | None = None,
+) -> dict[str, Any]:
+    """Enforce one new structure/day, concurrency, and signature uniqueness."""
+
+    profile = _load_profile()
+    current = (now or datetime.now(timezone.utc)).astimezone(EASTERN)
+    active = {key: entry for key, entry in entries.items() if _is_active_entry(entry)}
+    today_count = 0
+    for entry in entries.values():
+        entry_dt = _parse_timestamp(entry.get("entry_time"))
+        if entry_dt and entry_dt.astimezone(EASTERN).date() == current.date():
+            today_count += 1
+
+    blockers: list[str] = []
+    if len(active) >= profile.max_concurrent_positions:
+        blockers.append(f"Concurrent put credits {len(active)}/{profile.max_concurrent_positions}.")
+    if today_count >= profile.max_daily_structures:
+        blockers.append(f"Daily put-credit limit {today_count}/{profile.max_daily_structures}.")
+    if candidate_signature and any(
+        str(entry.get("signature")) == candidate_signature for entry in active.values()
+    ):
+        blockers.append(f"Open put credit already uses signature {candidate_signature}.")
+
+    return {
+        "allowed": not blockers,
+        "blockers": blockers,
+        "active_count": len(active),
+        "today_count": today_count,
+        "max_concurrent": profile.max_concurrent_positions,
+        "max_daily": profile.max_daily_structures,
+    }
+
+
+def _expiry_yymmdd(entry: dict[str, Any]) -> str:
+    text = str(entry.get("expiry") or "").replace("-", "")
+    if len(text) == 8 and text.startswith("20"):
+        return text[2:]
+    if len(text) == 6 and text.isdigit():
+        return text
+    signature = str(entry.get("signature") or "")
+    match = re.search(r"SPY_(\d{4})-(\d{2})-(\d{2})_", signature)
+    return "".join(match.groups())[2:] if match else ""
+
+
+def _option_symbol(expiry_yymmdd: str, strike: float) -> str:
+    return f"SPY{expiry_yymmdd}P{int(float(strike) * 1000):08d}"
+
+
+def evaluate_put_credit_exit(
+    entry: dict[str, Any],
+    *,
+    short_price: float,
+    long_price: float,
+    now: datetime | None = None,
+) -> dict[str, Any]:
+    """Evaluate the fixed TP/SL/DTE lifecycle from current option marks."""
+
+    profile = _load_profile()
+    current = now or datetime.now(timezone.utc)
+    if current.tzinfo is None:
+        current = current.replace(tzinfo=timezone.utc)
+    expiry_yymmdd = _expiry_yymmdd(entry)
+    if not expiry_yymmdd:
+        raise ValueError("Put-credit journal entry has no parseable expiry")
+    expiry = date(2000 + int(expiry_yymmdd[:2]), int(expiry_yymmdd[2:4]), int(expiry_yymmdd[4:6]))
+    dte = (expiry - current.astimezone(EASTERN).date()).days
+    credit = float(entry.get("credit") or entry.get("limit_credit") or 0.0)
+    quantity = abs(int(float(entry.get("quantity") or 1)))
+    current_debit = max(0.0, float(short_price) - float(long_price))
+    pnl = (credit - current_debit) * 100 * quantity
+    max_profit = credit * 100 * quantity
+    entered = _parse_timestamp(entry.get("entry_time"))
+    hold_hours = (
+        (current.astimezone(timezone.utc) - entered).total_seconds() / 3600 if entered else None
+    )
+
+    reason = None
+    if dte <= 1:
+        reason = "assignment_failsafe"
+    elif dte <= profile.exit_dte:
+        reason = "dte_exit"
+    elif hold_hours is None:
+        reason = None
+    elif hold_hours >= profile.min_hold_hours:
+        if pnl >= max_profit * profile.take_profit_pct:
+            reason = "profit_target"
+        elif pnl <= -(max_profit * profile.stop_loss_pct):
+            reason = "stop_loss"
+
+    return {
+        "should_exit": reason is not None,
+        "exit_reason": reason,
+        "dte": dte,
+        "hold_hours": hold_hours,
+        "credit": credit,
+        "current_debit": current_debit,
+        "estimated_pnl": pnl,
+        "profit_target": max_profit * profile.take_profit_pct,
+        "stop_loss": -(max_profit * profile.stop_loss_pct),
+    }
+
+
+def _position_map(client) -> dict[str, Any]:
+    return {str(position.symbol): position for position in client.get_all_positions()}
+
+
+def _position_price(position: Any) -> float:
+    value = getattr(position, "current_price", None)
+    if value is None:
+        value = getattr(position, "avg_entry_price", 0.0)
+    return float(value or 0.0)
+
+
+def _position_qty(position: Any) -> float:
+    return float(getattr(position, "qty", 0.0) or 0.0)
+
+
+def _confirm_entry_credit(client, entry: dict[str, Any], short_pos: Any, long_pos: Any) -> bool:
+    if entry.get("credit_source") == "broker_fill":
+        return False
+    order_id = str(entry.get("order_id") or "")
+    if order_id:
+        try:
+            order = client.get_order_by_id(order_id)
+            fill = getattr(order, "filled_avg_price", None)
+            if fill not in (None, ""):
+                entry["credit"] = abs(float(fill))
+                entry["credit_source"] = "broker_fill"
+                entry["fill_confirmed_at"] = datetime.now(timezone.utc).isoformat()
+                entry["status"] = "open"
+                return True
+        except Exception:
+            pass
+    short_entry = float(getattr(short_pos, "avg_entry_price", 0.0) or 0.0)
+    long_entry = float(getattr(long_pos, "avg_entry_price", 0.0) or 0.0)
+    derived = short_entry - long_entry
+    if derived > 0:
+        entry["credit"] = derived
+        entry["credit_source"] = "broker_position_derived"
+        entry["fill_confirmed_at"] = datetime.now(timezone.utc).isoformat()
+        entry["status"] = "open"
+        return True
+    return False
+
+
+def _pending_exit_is_active(client, entry: dict[str, Any]) -> bool:
+    exit_order_id = str(entry.get("exit_order_id") or "")
+    if not exit_order_id:
+        return False
+    try:
+        order = client.get_order_by_id(exit_order_id)
+        status = str(getattr(order, "status", "") or "").upper()
+    except Exception:
+        return True
+    if "FILL" in status:
+        entry["status"] = "closed"
+        entry["exit_filled_at"] = datetime.now(timezone.utc).isoformat()
+        return True
+    if any(terminal in status for terminal in ("CANCEL", "REJECT", "EXPIRE")):
+        entry["status"] = "open"
+        entry.pop("exit_order_id", None)
+        return False
+    return True
+
+
+def _entry_order_status(client, entry: dict[str, Any]) -> str:
+    order_id = str(entry.get("order_id") or "")
+    if not order_id:
+        return "UNKNOWN"
+    try:
+        order = client.get_order_by_id(order_id)
+    except Exception:
+        return "UNKNOWN"
+    return str(getattr(order, "status", "") or "").upper()
+
+
+def _submit_orphan_close(client, position: Any):
+    from alpaca.trading.enums import OrderSide, TimeInForce
+    from alpaca.trading.requests import MarketOrderRequest
+    from src.safety.mandatory_trade_gate import safe_submit_order
+    from src.utils.order_intent import build_client_order_id
+
+    qty = _position_qty(position)
+    is_short = qty < 0
+    intent = "BPS" if is_short else "BPL"
+    leg_tag = "SP" if is_short else "LP"
+    return safe_submit_order(
+        client,
+        MarketOrderRequest(
+            symbol=str(position.symbol),
+            qty=abs(qty),
+            side=OrderSide.BUY if qty < 0 else OrderSide.SELL,
+            time_in_force=TimeInForce.DAY,
+            client_order_id=build_client_order_id("CLOSE", intent, leg_tag),
+        ),
+        strategy="spy_put_credit",
+    )
+
+
+def _submit_spread_close(client, entry: dict[str, Any], decision: dict[str, Any]):
+    from alpaca.trading.enums import OrderClass, OrderSide, TimeInForce
+    from alpaca.trading.requests import LimitOrderRequest, OptionLegRequest
+    from src.safety.mandatory_trade_gate import safe_submit_order
+    from src.utils.order_intent import build_client_order_id
+
+    expiry = _expiry_yymmdd(entry)
+    strikes = entry["strikes"]
+    legs = [
+        OptionLegRequest(
+            symbol=_option_symbol(expiry, float(strikes["short_put"])),
+            side=OrderSide.BUY,
+            ratio_qty=1,
+        ),
+        OptionLegRequest(
+            symbol=_option_symbol(expiry, float(strikes["long_put"])),
+            side=OrderSide.SELL,
+            ratio_qty=1,
+        ),
+    ]
+    profile = _load_profile()
+    limit_debit = min(
+        profile.wing_width,
+        round(float(decision["current_debit"]) + 0.05, 2),
+    )
+    return safe_submit_order(
+        client,
+        LimitOrderRequest(
+            qty=abs(int(float(entry.get("quantity") or 1))),
+            order_class=OrderClass.MLEG,
+            legs=legs,
+            time_in_force=TimeInForce.DAY,
+            limit_price=limit_debit,
+            client_order_id=build_client_order_id("CLOSE", "BPS"),
+        ),
+        strategy="spy_put_credit",
+    )
+
+
+def manage_put_credit_exits(client, *, dry_run: bool = False) -> dict[str, Any]:
+    """Manage every journaled PCS without duplicating pending close orders."""
+
+    entries = _load_entries()
+    positions = _position_map(client)
+    report: dict[str, Any] = {
+        "checked": 0,
+        "holds": 0,
+        "would_exit": 0,
+        "submitted": 0,
+        "pending": 0,
+        "broken": 0,
+        "details": [],
+    }
+    changed = False
+
+    for key, entry in entries.items():
+        if not _is_active_entry(entry):
+            continue
+        report["checked"] += 1
+        expiry = _expiry_yymmdd(entry)
+        strikes = entry.get("strikes") or {}
+        try:
+            short_symbol = _option_symbol(expiry, float(strikes["short_put"]))
+            long_symbol = _option_symbol(expiry, float(strikes["long_put"]))
+        except (KeyError, TypeError, ValueError):
+            report["broken"] += 1
+            report["details"].append({"key": key, "status": "invalid_journal"})
+            continue
+        short_pos = positions.get(short_symbol)
+        long_pos = positions.get(long_symbol)
+        if str(entry.get("status")) == "exit_pending" and _pending_exit_is_active(client, entry):
+            changed = True
+            report["pending"] += 1
+            report["details"].append({"key": key, "status": "exit_pending"})
+            continue
+        if short_pos is None or long_pos is None:
+            entry_status = _entry_order_status(client, entry)
+            if (
+                short_pos is None
+                and long_pos is None
+                and any(state in entry_status for state in ("NEW", "ACCEPT", "PENDING", "HELD"))
+            ):
+                entry["status"] = "entry_pending"
+                changed = True
+                report["pending"] += 1
+                report["details"].append({"key": key, "status": "entry_pending"})
+                continue
+            if (
+                short_pos is None
+                and long_pos is None
+                and any(state in entry_status for state in ("CANCEL", "REJECT", "EXPIRE"))
+            ):
+                entry["status"] = "rejected"
+                entry["entry_terminal_status"] = entry_status
+                changed = True
+                report["details"].append({"key": key, "status": "entry_rejected"})
+                continue
+            entry["status"] = "broken_structure"
+            entry["last_error"] = (
+                f"Expected legs absent: short_present={short_pos is not None}, "
+                f"long_present={long_pos is not None}"
+            )
+            changed = True
+            report["broken"] += 1
+            logger.error("%s: %s", key, entry["last_error"])
+            orphan = short_pos if short_pos is not None else long_pos
+            if orphan is not None:
+                if dry_run:
+                    report["would_exit"] += 1
+                    report["details"].append(
+                        {"key": key, "status": "would_close_orphan", "symbol": orphan.symbol}
+                    )
+                    continue
+                order = _submit_orphan_close(client, orphan)
+                entry["status"] = "exit_pending"
+                entry["exit_reason"] = "orphan_cleanup"
+                entry["exit_order_id"] = str(order.id)
+                entry["exit_submitted_at"] = datetime.now(timezone.utc).isoformat()
+                report["submitted"] += 1
+                report["details"].append(
+                    {
+                        "key": key,
+                        "status": "orphan_close_submitted",
+                        "symbol": orphan.symbol,
+                        "order_id": str(order.id),
+                    }
+                )
+                continue
+            report["details"].append({"key": key, "status": "broken_structure"})
+            continue
+        if _position_qty(short_pos) >= 0 or _position_qty(long_pos) <= 0:
+            report["broken"] += 1
+            report["details"].append({"key": key, "status": "wrong_leg_direction"})
+            continue
+        if _confirm_entry_credit(client, entry, short_pos, long_pos):
+            changed = True
+        decision = evaluate_put_credit_exit(
+            entry,
+            short_price=_position_price(short_pos),
+            long_price=_position_price(long_pos),
+        )
+        detail = {"key": key, **decision}
+        if not decision["should_exit"]:
+            report["holds"] += 1
+            detail["status"] = "hold"
+            report["details"].append(detail)
+            continue
+        if dry_run:
+            report["would_exit"] += 1
+            detail["status"] = "would_exit"
+            report["details"].append(detail)
+            continue
+
+        order = _submit_spread_close(client, entry, decision)
+        entry["status"] = "exit_pending"
+        entry["exit_reason"] = decision["exit_reason"]
+        entry["exit_order_id"] = str(order.id)
+        entry["exit_submitted_at"] = datetime.now(timezone.utc).isoformat()
+        entry["estimated_exit_debit"] = decision["current_debit"]
+        entry["estimated_exit_pnl"] = decision["estimated_pnl"]
+        changed = True
+        report["submitted"] += 1
+        detail["status"] = "exit_submitted"
+        detail["order_id"] = str(order.id)
+        report["details"].append(detail)
+
+    if changed:
+        _save_entries(entries)
+    return report
+
+
 def find_put_credit_opportunity(spy_price: float) -> dict | None:
     """Select put vertical via live delta; ignore call side of IC selector."""
     from src.markets.option_chain import select_strikes_by_delta
@@ -112,17 +522,13 @@ def find_put_credit_opportunity(spy_price: float) -> dict | None:
 
     put_wing = round(float(selection.short_put) - float(selection.long_put), 2)
     if put_wing != profile.wing_width:
-        logger.warning(
-            "Put wing $%s != required $%s — skip", put_wing, profile.wing_width
-        )
+        logger.warning("Put wing $%s != required $%s — skip", put_wing, profile.wing_width)
         return None
 
     # Put-side credit only (not full IC net credit)
     est_credit = round(float(selection.put_bid) - float(selection.long_put_ask), 2)
     if est_credit < profile.min_credit:
-        logger.warning(
-            "Put credit $%.2f < min $%.2f — skip", est_credit, profile.min_credit
-        )
+        logger.warning("Put credit $%.2f < min $%.2f — skip", est_credit, profile.min_credit)
         return None
 
     opp = {
@@ -151,7 +557,6 @@ def place_put_credit(client, opp: dict) -> str | None:
     """Submit 2-leg MLEG limit order for the bull put (paper client)."""
     from alpaca.trading.enums import OrderClass, OrderSide, TimeInForce
     from alpaca.trading.requests import LimitOrderRequest, OptionLegRequest
-
     from src.safety.mandatory_trade_gate import safe_submit_order
     from src.utils.order_intent import build_client_order_id
 
@@ -183,7 +588,7 @@ def place_put_credit(client, opp: dict) -> str | None:
                     legs=legs,
                     time_in_force=TimeInForce.DAY,
                     limit_price=round(-current, 2),
-                    client_order_id=build_client_order_id("OPEN", "PCS"),
+                    client_order_id=build_client_order_id("OPEN", "BPS"),
                 ),
                 strategy="spy_put_credit",
             )
@@ -214,34 +619,34 @@ def place_put_credit(client, opp: dict) -> str | None:
 
 
 def _record_entry(opp: dict, order_id: str) -> None:
-    entries: dict = {}
-    if ENTRIES_FILE.exists():
-        try:
-            entries = json.loads(ENTRIES_FILE.read_text(encoding="utf-8"))
-        except (OSError, ValueError):
-            entries = {}
+    entries = _load_entries()
     expiry_key = str(opp["expiry"]).replace("-", "")[2:]
-    key = f"PCS_{expiry_key}"
+    safe_order_id = re.sub(r"[^A-Za-z0-9]", "", str(order_id)) or "unknown"
+    key = f"PCS_{expiry_key}_{safe_order_id}"
+    if key in entries and entries[key].get("order_id") != order_id:
+        raise RuntimeError(f"Put-credit journal identity collision for {key}")
+    signature = f"SPY_{opp['expiry']}_P{int(opp['long_put'])}-{int(opp['short_put'])}"
     entries[key] = {
         "strategy_family": "spy_put_credit",
         "order_id": order_id,
         "entry_time": datetime.now(timezone.utc).isoformat(),
+        "expiry": opp["expiry"],
         "quantity": opp.get("quantity", 1),
         "credit": opp.get("est_credit"),
+        "limit_credit": opp.get("est_credit"),
+        "credit_source": "limit_estimate_unconfirmed",
         "put_delta": opp.get("put_delta"),
         "selection_method": opp.get("method"),
         "strikes": {
             "short_put": opp["short_put"],
             "long_put": opp["long_put"],
         },
-        "signature": (
-            f"SPY_{opp['expiry']}_P{int(opp['long_put'])}-{int(opp['short_put'])}"
-        ),
+        "signature": signature,
         "validation_phase": True,
         "profile_name": "spy-put-credit",
+        "status": "submitted_unconfirmed",
     }
-    ENTRIES_FILE.parent.mkdir(parents=True, exist_ok=True)
-    ENTRIES_FILE.write_text(json.dumps(entries, indent=2) + "\n", encoding="utf-8")
+    _save_entries(entries)
     logger.info("Recorded %s in %s", key, ENTRIES_FILE)
 
 
@@ -288,6 +693,11 @@ def main() -> int:
         help="Submit paper MLEG put credit via TradeGateway",
     )
     parser.add_argument("--status", action="store_true")
+    parser.add_argument(
+        "--manage-exits",
+        action="store_true",
+        help="Evaluate and submit paper exits for open put credits.",
+    )
     parser.add_argument("--live", action="store_true", help="Always rejected while live_blocked")
     args = parser.parse_args()
 
@@ -330,7 +740,23 @@ def main() -> int:
         )
         return 0
 
+    if args.manage_exits:
+        try:
+            client = _get_paper_client()
+        except Exception as exc:
+            logger.error("Paper client failed: %s", exc)
+            return 1
+        report = manage_put_credit_exits(client, dry_run=args.dry_run)
+        print(json.dumps(report, indent=2, default=str))
+        return 2 if report["broken"] else 0
+
     if not _inventory_ok():
+        return 2
+
+    limit_report = evaluate_entry_limits(_load_entries())
+    if not limit_report["allowed"]:
+        logger.error("PUT-CREDIT ENTRY LIMIT: %s", " | ".join(limit_report["blockers"]))
+        print(json.dumps(limit_report, indent=2))
         return 2
 
     try:
@@ -349,6 +775,13 @@ def main() -> int:
         logger.warning("No valid put-credit opportunity right now")
         print(json.dumps({"success": False, "reason": "no_opportunity", "plan_path": str(path)}))
         return 1
+
+    signature = f"SPY_{opp['expiry']}_P{int(opp['long_put'])}-{int(opp['short_put'])}"
+    limit_report = evaluate_entry_limits(_load_entries(), candidate_signature=signature)
+    if not limit_report["allowed"]:
+        logger.error("PUT-CREDIT ENTRY LIMIT: %s", " | ".join(limit_report["blockers"]))
+        print(json.dumps(limit_report, indent=2))
+        return 2
 
     logger.info(
         "Policy: 1-lot $%.0f-wide put credit | Δ=%.2f | credit=$%.2f | TP %.0f%% | SL %.0fx",
@@ -380,7 +813,23 @@ def main() -> int:
         logger.error("Paper client failed: %s", exc)
         return 1
 
-    order_id = place_put_credit(client, opp)
+    from src.safety.trade_lock import TradeLockTimeout, acquire_trade_lock
+
+    try:
+        with acquire_trade_lock(timeout=10):
+            if not _inventory_ok():
+                return 2
+            limit_report = evaluate_entry_limits(_load_entries(), candidate_signature=signature)
+            if not limit_report["allowed"]:
+                logger.error(
+                    "PUT-CREDIT ENTRY LIMIT after lock: %s",
+                    " | ".join(limit_report["blockers"]),
+                )
+                return 2
+            order_id = place_put_credit(client, opp)
+    except TradeLockTimeout as exc:
+        logger.warning("Put-credit entry lock unavailable: %s", exc)
+        return 2
     ok = order_id is not None
     print(
         json.dumps(

--- a/scripts/strategy_pivot_report.py
+++ b/scripts/strategy_pivot_report.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+"""Report whether the incumbent should trade and which broker can support a pivot."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+from src.safety.strategy_pivot import build_pivot_report
+
+DEFAULT_STATE = Path("data/system_state.json")
+DEFAULT_TRADES = Path("data/trades.json")
+DEFAULT_ENTRIES = Path("data/ic_entries.json")
+DEFAULT_TOURNAMENT = Path("config/strategy_candidate_tournament.json")
+DEFAULT_BROKER = Path("data/audit/clearstreet_active_capability_20260722.json")
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    with path.open("r", encoding="utf-8") as handle:
+        payload = json.load(handle)
+    if not isinstance(payload, dict):
+        raise ValueError(f"Expected JSON object in {path}")
+    return payload
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Evaluate strategy edge, ledger integrity, and broker compatibility."
+    )
+    parser.add_argument("--system-state", type=Path, default=DEFAULT_STATE)
+    parser.add_argument("--trades", type=Path, default=DEFAULT_TRADES)
+    parser.add_argument("--entries", type=Path, default=DEFAULT_ENTRIES)
+    parser.add_argument("--tournament", type=Path, default=DEFAULT_TOURNAMENT)
+    parser.add_argument("--broker", type=Path, default=DEFAULT_BROKER)
+    parser.add_argument("--json", action="store_true", help="Print the complete JSON report.")
+    return parser.parse_args()
+
+
+def _print_human(report: dict[str, Any]) -> None:
+    north_star = report["north_star"]
+    incumbent = report["incumbent"]
+    decision = incumbent["decision"]
+    audit = incumbent["ledger_audit"]
+    broker = report["broker"]
+
+    print("STRATEGY PIVOT GATE")
+    print(f"System action: {report['system_action']}")
+    print(f"Research action: {report['research_action']}")
+    print(f"North Star on course: {north_star['on_course']}")
+    print(
+        f"Paper equity: ${north_star['current_equity']:,.2f} "
+        f"({north_star['total_pl']:+,.2f}, drawdown {north_star['drawdown_pct']:.2f}%)"
+    )
+    print(f"Incumbent: {incumbent['strategy_id']} -> {decision['status']}")
+    print(f"May open new positions: {decision['may_open_new_positions']}")
+    print(f"May manage existing positions: {decision['may_manage_existing_positions']}")
+    print(f"Ledger clean: {audit['clean']}")
+    for reason in decision["reasons"]:
+        print(f"  - {reason}")
+    print(f"Clear Street role: {broker['current_role']}")
+    print()
+    print("Candidate tournament:")
+    for candidate in report["candidates"]:
+        candidate_decision = candidate["decision"]
+        broker_assessment = candidate["broker_assessment"]
+        print(
+            f"  - {candidate['strategy_id']}: {candidate_decision['status']}; "
+            f"Clear Street execution eligible={broker_assessment['execution_eligible']}"
+        )
+        for blocker in broker_assessment["blockers"]:
+            print(f"      broker blocker: {blocker}")
+
+
+def main() -> int:
+    args = parse_args()
+    report = build_pivot_report(
+        _load_json(args.system_state),
+        _load_json(args.trades),
+        _load_json(args.entries),
+        _load_json(args.tournament),
+        _load_json(args.broker),
+    )
+    if args.json:
+        print(json.dumps(report, indent=2, sort_keys=True))
+    else:
+        _print_human(report)
+    return 0 if report["north_star"]["on_course"] else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/risk/open_inventory_audit.py
+++ b/src/risk/open_inventory_audit.py
@@ -138,9 +138,40 @@ def _expected_structure_qty_map(entry: dict[str, Any]) -> dict[tuple[str, float]
     return mapping
 
 
+def _expected_put_credit_qty_map(entry: dict[str, Any]) -> dict[tuple[str, float], float]:
+    """Map (right, strike) -> signed qty from a journaled bull-put credit."""
+
+    strikes = entry.get("strikes") or {}
+    try:
+        qty = abs(float(entry.get("quantity") or 1))
+        short_put = float(strikes["short_put"])
+        long_put = float(strikes["long_put"])
+    except (KeyError, TypeError, ValueError):
+        return {}
+    if qty <= 0:
+        qty = 1.0
+    return {("P", short_put): -qty, ("P", long_put): qty}
+
+
+def _normalize_expiry_ymd(value: Any) -> str:
+    text = str(value or "").strip().replace("-", "")
+    if len(text) == 8 and text.startswith("20"):
+        return text[2:]
+    return text if len(text) == 6 and text.isdigit() else ""
+
+
+def _put_credit_expiry(key: str, entry: dict[str, Any]) -> str:
+    explicit = _normalize_expiry_ymd(entry.get("expiry"))
+    if explicit:
+        return explicit
+    match = re.match(r"^PCS_(\d{6})(?:_|$)", str(key))
+    return match.group(1) if match else ""
+
+
 def audit_open_inventory(
     positions: list[dict[str, Any]] | None,
     ic_entries: dict[str, Any] | None,
+    put_credit_entries: dict[str, Any] | None = None,
     *,
     max_contracts_per_trade: float = 1.0,
     max_concurrent_iron_condors: int = 2,
@@ -149,28 +180,10 @@ def audit_open_inventory(
     legs = normalize_positions(positions)
     findings: list[InventoryFinding] = []
     entries = ic_entries if isinstance(ic_entries, dict) else {}
+    pcs_entries = put_credit_entries if isinstance(put_credit_entries, dict) else {}
 
     max_abs = max((abs(leg.qty) for leg in legs), default=0.0)
     expiries = sorted({leg.expiry_ymd for leg in legs})
-
-    # Global lot-size rule: any open leg above 1-lot violates validation hygiene.
-    if max_abs > max_contracts_per_trade + 1e-9:
-        offenders = [
-            {"symbol": leg.symbol, "qty": leg.qty}
-            for leg in legs
-            if abs(leg.qty) > max_contracts_per_trade + 1e-9
-        ]
-        findings.append(
-            InventoryFinding(
-                code="LOT_SIZE_EXCEEDED",
-                severity="block",
-                message=(
-                    f"Open option leg qty exceeds max_contracts_per_trade="
-                    f"{max_contracts_per_trade} (max_abs_qty={max_abs})"
-                ),
-                details={"offenders": offenders, "max_abs_qty": max_abs},
-            )
-        )
 
     # Too many distinct expiries with structures can still be OK (max concurrent ICs),
     # but > max concurrent expiries is a block for new entries.
@@ -193,17 +206,25 @@ def audit_open_inventory(
 
     for expiry_ymd, exp_legs in sorted(by_expiry.items()):
         key = _ic_key(expiry_ymd)
+        journaled: list[tuple[str, dict[str, Any], str]] = []
         entry = entries.get(key)
-        if not isinstance(entry, dict):
-            # Legacy keys sometimes used IC_YYYYMMDD — try nothing else; CI already
-            # covers missing keys. Treat as block for new entries (exit loop blind).
+        if isinstance(entry, dict):
+            journaled.append((key, entry, "iron_condor"))
+        for pcs_key, pcs_entry in pcs_entries.items():
+            if (
+                isinstance(pcs_entry, dict)
+                and _put_credit_expiry(str(pcs_key), pcs_entry) == expiry_ymd
+            ):
+                journaled.append((str(pcs_key), pcs_entry, "spy_put_credit"))
+
+        if not journaled:
             findings.append(
                 InventoryFinding(
                     code="UNJOURNALED_EXPIRY",
                     severity="block",
                     message=(
-                        f"Open option expiry {expiry_ymd} has no {key} record in "
-                        "ic_entries.json — exit loop cannot evaluate stop/target"
+                        f"Open option expiry {expiry_ymd} has no IC or PCS journal record — "
+                        "exit managers cannot evaluate stop/target"
                     ),
                     expiry_ymd=expiry_ymd,
                     details={"leg_symbols": [leg.symbol for leg in exp_legs]},
@@ -211,7 +232,35 @@ def audit_open_inventory(
             )
             continue
 
-        expected = _expected_structure_qty_map(entry)
+        expected: dict[tuple[str, float], float] = {}
+        journal_keys: list[str] = []
+        for journal_key, journal_entry, family in journaled:
+            journal_keys.append(journal_key)
+            try:
+                entry_qty = abs(float(journal_entry.get("quantity") or 1))
+            except (TypeError, ValueError):
+                entry_qty = 1.0
+            if entry_qty > max_contracts_per_trade + 1e-9:
+                findings.append(
+                    InventoryFinding(
+                        code="LOT_SIZE_EXCEEDED",
+                        severity="block",
+                        message=(
+                            f"{journal_key} quantity={entry_qty} exceeds "
+                            f"max_contracts_per_trade={max_contracts_per_trade}"
+                        ),
+                        expiry_ymd=expiry_ymd,
+                        details={"journal_key": journal_key, "quantity": entry_qty},
+                    )
+                )
+            mapping = (
+                _expected_put_credit_qty_map(journal_entry)
+                if family == "spy_put_credit"
+                else _expected_structure_qty_map(journal_entry)
+            )
+            for leg_key, qty in mapping.items():
+                expected[leg_key] = expected.get(leg_key, 0.0) + qty
+
         actual: dict[tuple[str, float], float] = {}
         for leg in exp_legs:
             k = (leg.right, leg.strike)
@@ -222,12 +271,40 @@ def audit_open_inventory(
                 InventoryFinding(
                     code="JOURNAL_STRIKES_INCOMPLETE",
                     severity="block",
-                    message=f"{key} exists but strikes are incomplete",
+                    message=f"Expiry {expiry_ymd} journal records have incomplete strikes",
                     expiry_ymd=expiry_ymd,
-                    details={"entry_keys": sorted(entry.keys())},
+                    details={"journal_keys": journal_keys},
                 )
             )
             continue
+
+        # Aggregated broker quantities above one lot are valid only when the
+        # journal contains enough distinct one-lot structures to explain them.
+        lot_offenders = []
+        for leg_key, actual_qty in actual.items():
+            explained_qty = abs(expected.get(leg_key, 0.0))
+            if abs(actual_qty) > max(max_contracts_per_trade, explained_qty) + 1e-9:
+                lot_offenders.append(
+                    {
+                        "right": leg_key[0],
+                        "strike": leg_key[1],
+                        "actual_qty": actual_qty,
+                        "journal_qty": expected.get(leg_key, 0.0),
+                    }
+                )
+        if lot_offenders:
+            findings.append(
+                InventoryFinding(
+                    code="LOT_SIZE_EXCEEDED",
+                    severity="block",
+                    message=(
+                        f"Expiry {expiry_ymd} has aggregated leg quantity not explained "
+                        "by distinct one-lot journal records"
+                    ),
+                    expiry_ymd=expiry_ymd,
+                    details={"offenders": lot_offenders},
+                )
+            )
 
         # Qty / composition mismatch vs journaled 4-leg structure
         extras = []
@@ -241,7 +318,7 @@ def audit_open_inventory(
                         code="QTY_MISMATCH",
                         severity="block",
                         message=(
-                            f"{key}: {k[0]}{k[1]:g} qty={qty} does not match "
+                            f"Expiry {expiry_ymd}: {k[0]}{k[1]:g} qty={qty} does not match "
                             f"journaled qty={exp_qty}"
                         ),
                         expiry_ymd=expiry_ymd,
@@ -265,7 +342,7 @@ def audit_open_inventory(
                     code="EXTRA_LEGS",
                     severity="block",
                     message=(
-                        f"{key}: {len(extras)} open leg(s) not in journaled structure "
+                        f"Expiry {expiry_ymd}: {len(extras)} open leg(s) not in journaled structure "
                         f"(orphan verticals or residual risk)"
                     ),
                     expiry_ymd=expiry_ymd,
@@ -277,23 +354,24 @@ def audit_open_inventory(
                 InventoryFinding(
                     code="MISSING_LEGS",
                     severity="block",
-                    message=f"{key}: journaled legs missing from broker book",
+                    message=f"Expiry {expiry_ymd}: journaled legs missing from broker book",
                     expiry_ymd=expiry_ymd,
                     details={"missing": missing},
                 )
             )
 
-        # Same-expiry multi-structure signal: more than 4 legs or extra shorts
+        # Same-expiry overstack is based on journaled structure quantity, not
+        # symbol count; valid PCS/IC structures may share an expiry.
         short_units = sum(abs(leg.qty) for leg in exp_legs if leg.qty < 0)
-        if short_units > max_contracts_per_trade * 2 + 1e-9:
-            # One IC has 2 short legs (put+call) * qty
+        expected_short_units = sum(abs(qty) for qty in expected.values() if qty < 0)
+        if short_units > expected_short_units + 1e-9:
             findings.append(
                 InventoryFinding(
                     code="SAME_EXPIRY_OVERSTACK",
                     severity="block",
                     message=(
                         f"Expiry {expiry_ymd}: short-leg units={short_units} exceed "
-                        f"one 1-lot iron condor (expected <= {max_contracts_per_trade * 2})"
+                        f"journaled units={expected_short_units}"
                     ),
                     expiry_ymd=expiry_ymd,
                     details={"short_units": short_units, "leg_count": len(exp_legs)},
@@ -345,9 +423,17 @@ def audit_from_files(
         if isinstance(raw, dict):
             entries = raw
 
+    put_credit_entries: dict[str, Any] = {}
+    put_credit_path = root / "data" / "put_credit_entries.json"
+    if put_credit_path.exists():
+        raw = json.loads(put_credit_path.read_text(encoding="utf-8"))
+        if isinstance(raw, dict):
+            put_credit_entries = raw
+
     return audit_open_inventory(
         positions,
         entries,
+        put_credit_entries,
         max_contracts_per_trade=max_contracts_per_trade,
         max_concurrent_iron_condors=max_concurrent_iron_condors,
     )

--- a/src/risk/trade_gateway.py
+++ b/src/risk/trade_gateway.py
@@ -892,12 +892,9 @@ class TradeGateway:
                 ),
                 0.0,
             )
-            is_reducing = (
-                existing_qty != 0.0
-                and (
-                    (request.side.lower() == "buy" and existing_qty < 0)
-                    or (request.side.lower() == "sell" and existing_qty > 0)
-                )
+            is_reducing = existing_qty != 0.0 and (
+                (request.side.lower() == "buy" and existing_qty < 0)
+                or (request.side.lower() == "sell" and existing_qty > 0)
             )
             if not is_reducing:
                 try:
@@ -909,9 +906,16 @@ class TradeGateway:
                         raw_entries = json.loads(entries_path.read_text(encoding="utf-8"))
                         if isinstance(raw_entries, dict):
                             ic_entries = raw_entries
+                    put_credit_entries: dict[str, Any] = {}
+                    pcs_path = Path("data/put_credit_entries.json")
+                    if pcs_path.exists():
+                        raw_pcs = json.loads(pcs_path.read_text(encoding="utf-8"))
+                        if isinstance(raw_pcs, dict):
+                            put_credit_entries = raw_pcs
                     inventory = audit_open_inventory(
                         positions,
                         ic_entries,
+                        put_credit_entries,
                         max_contracts_per_trade=float(self.MAX_CONTRACTS_PER_TRADE),
                         max_concurrent_iron_condors=int(self.MAX_CONCURRENT_ICS),
                     )

--- a/src/safety/mandatory_trade_gate.py
+++ b/src/safety/mandatory_trade_gate.py
@@ -120,7 +120,12 @@ _POLICY_METADATA_PATH = (
 _DEFAULT_POLICY_MAX_AGE_DAYS = 7
 _DEFAULT_POLICY_MIN_TRADE_COUNT = 30
 _VALIDATION_ENTRY_MAX_QTY = 1
-_VALIDATION_STRATEGIES = {"iron_condor", "ic_simple", "options_income"}
+_VALIDATION_STRATEGIES = {
+    "iron_condor",
+    "ic_simple",
+    "options_income",
+    "spy_put_credit",
+}
 
 
 def _load_north_star_weekly_gate() -> dict[str, Any]:

--- a/src/safety/milestone_controller.py
+++ b/src/safety/milestone_controller.py
@@ -104,6 +104,9 @@ def resolve_strategy_family(strategy: str) -> str:
     options_tokens = (
         "iron_condor",
         "credit_spread",
+        "spy_put_credit",
+        "put_credit",
+        "bull_put",
         "put_spread",
         "call_spread",
         "vertical_spread",

--- a/src/safety/strategy_pivot.py
+++ b/src/safety/strategy_pivot.py
@@ -1,0 +1,454 @@
+"""Evidence-first strategy retirement and broker compatibility decisions.
+
+The trading system must distinguish three questions that were previously
+conflated:
+
+* Does the strategy have a measured edge?
+* Is the trade ledger trustworthy enough to measure that edge?
+* Can the selected broker execute the strategy as designed?
+
+This module is intentionally read-only.  It produces a fail-closed decision
+that callers can use before opening new risk while allowing existing position
+management to continue.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import asdict, dataclass
+from typing import Any
+
+OPTION_SYMBOL = re.compile(r"^(?P<root>[A-Z]+)(?P<expiry>\d{6})[CP]\d{8}$")
+
+
+@dataclass(frozen=True)
+class ValidationThresholds:
+    """Minimum evidence required before a candidate may open paper risk."""
+
+    min_closed_trades: int = 30
+    min_expectancy_per_trade: float = 1.0
+    min_profit_factor: float = 1.05
+    min_total_realized_pnl: float = 1.0
+    max_drawdown_pct: float = 10.0
+
+
+DEFAULT_VALIDATION_THRESHOLDS = ValidationThresholds()
+
+
+@dataclass(frozen=True)
+class StrategyEvidence:
+    """Comparable performance evidence for one exact rule set."""
+
+    closed_trades: int
+    expectancy_per_trade: float
+    profit_factor: float
+    total_realized_pnl: float
+    max_drawdown_pct: float | None = None
+
+
+@dataclass(frozen=True)
+class LedgerAudit:
+    """Structural checks that must pass before performance is trusted."""
+
+    clean: bool
+    issues: tuple[str, ...]
+    raw_trade_rows: int
+    reported_closed_trades: int
+    unpaired_order_count: int
+    attribution_clean: bool = True
+    open_inventory_clean: bool = True
+
+
+@dataclass(frozen=True)
+class StrategyDecision:
+    """Decision for the incumbent or a candidate strategy."""
+
+    status: str
+    may_open_new_positions: bool
+    may_manage_existing_positions: bool
+    reasons: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class BrokerSnapshot:
+    """Observed account state plus documented API capabilities."""
+
+    broker: str
+    observed_at: str
+    authenticated_web_session: bool
+    funded: bool
+    equity_usd: float
+    api_key_configured: bool
+    options_level: int
+    supports_market_data: bool
+    supports_equities: bool
+    supports_single_leg_options: bool
+    supports_multi_leg_options: bool
+    paper_trading_verified: bool
+
+    @classmethod
+    def from_payload(cls, payload: dict[str, Any]) -> BrokerSnapshot:
+        account = payload.get("account", {})
+        capabilities = payload.get("api_capabilities", {})
+        return cls(
+            broker=str(payload.get("broker", "unknown")),
+            observed_at=str(payload.get("observed_at", "unknown")),
+            authenticated_web_session=bool(account.get("authenticated_web_session", False)),
+            funded=bool(account.get("funded", False)),
+            equity_usd=float(account.get("equity_usd", 0.0) or 0.0),
+            api_key_configured=bool(account.get("api_key_configured", False)),
+            options_level=int(account.get("options_level", 0) or 0),
+            supports_market_data=bool(capabilities.get("market_data", False)),
+            supports_equities=bool(capabilities.get("equities", False)),
+            supports_single_leg_options=bool(capabilities.get("single_leg_options", False)),
+            supports_multi_leg_options=bool(capabilities.get("multi_leg_options", False)),
+            paper_trading_verified=bool(capabilities.get("paper_trading_verified", False)),
+        )
+
+
+@dataclass(frozen=True)
+class BrokerAssessment:
+    """Whether a broker is useful for research and eligible for execution."""
+
+    research_eligible: bool
+    execution_eligible: bool
+    blockers: tuple[str, ...]
+
+
+def _as_float(value: Any, default: float = 0.0) -> float:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _as_int(value: Any, default: int = 0) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def audit_strategy_ledger(
+    system_state: dict[str, Any],
+    trades_data: dict[str, Any],
+    ic_entries: dict[str, Any],
+    *,
+    symbol_root: str = "SPY",
+) -> LedgerAudit:
+    """Detect unpaired fills and open structures missing unique journal rows."""
+
+    stats = trades_data.get("stats", {}) if isinstance(trades_data, dict) else {}
+    raw_trades = trades_data.get("trades", []) if isinstance(trades_data, dict) else []
+    raw_count = len(raw_trades) if isinstance(raw_trades, list) else 0
+    reported_closed = _as_int(stats.get("closed_trades"), raw_count)
+    unpaired_count = _as_int(stats.get("unpaired_order_count"), 0)
+    issues: list[str] = []
+    attribution_clean = True
+    open_inventory_clean = True
+
+    if unpaired_count > 0:
+        attribution_clean = False
+        issues.append(
+            f"Trade ledger contains {unpaired_count} unpaired orders; cohort attribution is not clean."
+        )
+
+    if reported_closed != raw_count + unpaired_count:
+        attribution_clean = False
+        issues.append(
+            "Reported closed-trade count does not reconcile to raw rows plus unpaired orders "
+            f"({reported_closed} != {raw_count} + {unpaired_count})."
+        )
+
+    positions = system_state.get("performance", {}).get("open_positions", [])
+    option_legs_by_expiry: dict[str, int] = {}
+    if isinstance(positions, list):
+        for position in positions:
+            if not isinstance(position, dict):
+                continue
+            match = OPTION_SYMBOL.match(str(position.get("symbol", "")))
+            if not match or match.group("root") != symbol_root:
+                continue
+            quantity = abs(_as_float(position.get("quantity"), 0.0))
+            option_legs_by_expiry[match.group("expiry")] = option_legs_by_expiry.get(
+                match.group("expiry"), 0
+            ) + int(round(quantity))
+
+    entry_keys = list(ic_entries) if isinstance(ic_entries, dict) else []
+    for expiry, leg_contracts in sorted(option_legs_by_expiry.items()):
+        if leg_contracts % 4:
+            open_inventory_clean = False
+            issues.append(
+                f"Open {symbol_root} {expiry} exposure has {leg_contracts} leg-contracts, "
+                "which cannot be partitioned into four-leg iron condors."
+            )
+            continue
+        open_structures = leg_contracts // 4
+        matching_entries = sum(1 for key in entry_keys if str(key).endswith(expiry))
+        if matching_entries < open_structures:
+            open_inventory_clean = False
+            issues.append(
+                f"Open {symbol_root} {expiry} exposure represents {open_structures} structures "
+                f"but the journal has {matching_entries} expiry-keyed record(s); an entry was "
+                "overwritten or never recorded."
+            )
+
+    return LedgerAudit(
+        clean=not issues,
+        issues=tuple(issues),
+        raw_trade_rows=raw_count,
+        reported_closed_trades=reported_closed,
+        unpaired_order_count=unpaired_count,
+        attribution_clean=attribution_clean,
+        open_inventory_clean=open_inventory_clean,
+    )
+
+
+def incumbent_evidence(
+    system_state: dict[str, Any], trades_data: dict[str, Any]
+) -> StrategyEvidence:
+    """Read the canonical lifetime ledger, falling back to trades.json stats."""
+
+    weekly_gate = system_state.get("north_star_weekly_gate", {})
+    ledger = weekly_gate.get("lifetime_ledger", {}) if isinstance(weekly_gate, dict) else {}
+    if not isinstance(ledger, dict) or not ledger:
+        ledger = trades_data.get("stats", {}) if isinstance(trades_data, dict) else {}
+
+    drawdown = system_state.get("paper_account", {}).get("total_pl_pct")
+    return StrategyEvidence(
+        closed_trades=_as_int(ledger.get("closed_trades"), 0),
+        expectancy_per_trade=_as_float(
+            ledger.get("expectancy_per_trade", ledger.get("expectancy")), 0.0
+        ),
+        profit_factor=_as_float(ledger.get("profit_factor"), 0.0),
+        total_realized_pnl=_as_float(
+            ledger.get("total_realized_pnl", ledger.get("total_pnl")), 0.0
+        ),
+        max_drawdown_pct=abs(_as_float(drawdown)) if drawdown is not None else None,
+    )
+
+
+def evaluate_strategy(
+    evidence: StrategyEvidence,
+    ledger_audit: LedgerAudit,
+    thresholds: ValidationThresholds = DEFAULT_VALIDATION_THRESHOLDS,
+) -> StrategyDecision:
+    """Fail closed when the edge is negative, incomplete, or untrustworthy."""
+
+    reasons = list(ledger_audit.issues)
+    enough_trades = evidence.closed_trades >= thresholds.min_closed_trades
+    failed_edge = enough_trades and (
+        evidence.expectancy_per_trade < thresholds.min_expectancy_per_trade
+        or evidence.profit_factor < thresholds.min_profit_factor
+        or evidence.total_realized_pnl < thresholds.min_total_realized_pnl
+    )
+
+    if failed_edge:
+        reasons.append(
+            "Measured lifetime edge failed the retirement floor: "
+            f"{evidence.closed_trades} closes, expectancy ${evidence.expectancy_per_trade:.2f}, "
+            f"profit factor {evidence.profit_factor:.2f}, realized P/L "
+            f"${evidence.total_realized_pnl:.2f}."
+        )
+        return StrategyDecision(
+            status="RETIRE_NEW_ENTRIES",
+            may_open_new_positions=False,
+            may_manage_existing_positions=True,
+            reasons=tuple(reasons),
+        )
+
+    if not ledger_audit.clean:
+        reasons.append("Performance cannot be promoted until the ledger is reconciled.")
+        return StrategyDecision(
+            status="BLOCKED_DATA_INTEGRITY",
+            may_open_new_positions=False,
+            may_manage_existing_positions=True,
+            reasons=tuple(reasons),
+        )
+
+    if not enough_trades:
+        reasons.append(
+            f"Only {evidence.closed_trades}/{thresholds.min_closed_trades} clean paper trades exist."
+        )
+        return StrategyDecision(
+            status="PAPER_VALIDATION_ONLY",
+            may_open_new_positions=True,
+            may_manage_existing_positions=True,
+            reasons=tuple(reasons),
+        )
+
+    if evidence.max_drawdown_pct is not None and (
+        evidence.max_drawdown_pct > thresholds.max_drawdown_pct
+    ):
+        reasons.append(
+            f"Drawdown {evidence.max_drawdown_pct:.2f}% exceeds {thresholds.max_drawdown_pct:.2f}%."
+        )
+        return StrategyDecision(
+            status="REJECT_DRAWDOWN",
+            may_open_new_positions=False,
+            may_manage_existing_positions=True,
+            reasons=tuple(reasons),
+        )
+
+    reasons.append("All clean-sample promotion thresholds passed.")
+    return StrategyDecision(
+        status="PAPER_VALIDATED",
+        may_open_new_positions=True,
+        may_manage_existing_positions=True,
+        reasons=tuple(reasons),
+    )
+
+
+def assess_broker(snapshot: BrokerSnapshot, requirements: dict[str, Any]) -> BrokerAssessment:
+    """Check documented broker capability separately from strategy evidence."""
+
+    blockers: list[str] = []
+    asset_class = str(requirements.get("asset_class", "equity")).lower()
+    legs = max(1, _as_int(requirements.get("legs"), 1))
+    minimum_options_level = _as_int(requirements.get("minimum_options_level"), 0)
+    requires_paper = bool(requirements.get("requires_paper_trading", True))
+
+    if not snapshot.api_key_configured:
+        blockers.append("No broker API key is configured.")
+    if not snapshot.funded:
+        blockers.append("The account is unfunded.")
+    if requires_paper and not snapshot.paper_trading_verified:
+        blockers.append("Paper-trading API support has not been verified.")
+
+    if asset_class == "equity":
+        if not snapshot.supports_equities:
+            blockers.append("The API does not support equity execution.")
+    elif asset_class == "option":
+        if snapshot.options_level < minimum_options_level:
+            blockers.append(
+                f"Account options level {snapshot.options_level} is below required level "
+                f"{minimum_options_level}."
+            )
+        if legs == 1 and not snapshot.supports_single_leg_options:
+            blockers.append("The API does not support single-leg option execution.")
+        if legs > 1 and not snapshot.supports_multi_leg_options:
+            blockers.append("The API does not support atomic multi-leg option execution.")
+    else:
+        blockers.append(f"Unknown asset class: {asset_class}.")
+
+    research_eligible = bool(snapshot.authenticated_web_session and snapshot.supports_market_data)
+    return BrokerAssessment(
+        research_eligible=research_eligible,
+        execution_eligible=not blockers,
+        blockers=tuple(blockers),
+    )
+
+
+def build_pivot_report(
+    system_state: dict[str, Any],
+    trades_data: dict[str, Any],
+    ic_entries: dict[str, Any],
+    tournament: dict[str, Any],
+    broker_payload: dict[str, Any],
+) -> dict[str, Any]:
+    """Build the auditable North Star and strategy-tournament decision."""
+
+    thresholds = ValidationThresholds(**tournament.get("promotion_thresholds", {}))
+    audit = audit_strategy_ledger(system_state, trades_data, ic_entries)
+    evidence = incumbent_evidence(system_state, trades_data)
+    incumbent = evaluate_strategy(evidence, audit, thresholds)
+    broker = BrokerSnapshot.from_payload(broker_payload)
+
+    candidates: list[dict[str, Any]] = []
+    any_validated_candidate = False
+    for candidate in tournament.get("candidates", []):
+        candidate_evidence_payload = candidate.get("evidence", {})
+        candidate_evidence = StrategyEvidence(
+            closed_trades=_as_int(candidate_evidence_payload.get("closed_trades"), 0),
+            expectancy_per_trade=_as_float(
+                candidate_evidence_payload.get("expectancy_per_trade"), 0.0
+            ),
+            profit_factor=_as_float(candidate_evidence_payload.get("profit_factor"), 0.0),
+            total_realized_pnl=_as_float(candidate_evidence_payload.get("total_realized_pnl"), 0.0),
+            max_drawdown_pct=(
+                _as_float(candidate_evidence_payload.get("max_drawdown_pct"))
+                if candidate_evidence_payload.get("max_drawdown_pct") is not None
+                else None
+            ),
+        )
+        candidate_audit = LedgerAudit(
+            clean=bool(candidate_evidence_payload.get("ledger_clean", True)),
+            issues=tuple(candidate_evidence_payload.get("ledger_issues", [])),
+            raw_trade_rows=candidate_evidence.closed_trades,
+            reported_closed_trades=candidate_evidence.closed_trades,
+            unpaired_order_count=0,
+            attribution_clean=bool(candidate_evidence_payload.get("ledger_clean", True)),
+            open_inventory_clean=True,
+        )
+        decision = evaluate_strategy(candidate_evidence, candidate_audit, thresholds)
+        broker_assessment = assess_broker(broker, candidate.get("broker_requirements", {}))
+        any_validated_candidate = any_validated_candidate or (decision.status == "PAPER_VALIDATED")
+        candidates.append(
+            {
+                "strategy_id": candidate.get("strategy_id"),
+                "active_paper_candidate": (
+                    candidate.get("strategy_id") == tournament.get("active_paper_candidate_id")
+                ),
+                "hypothesis": candidate.get("hypothesis"),
+                "rules": candidate.get("rules", {}),
+                "evidence": asdict(candidate_evidence),
+                "decision": asdict(decision),
+                "broker_assessment": asdict(broker_assessment),
+            }
+        )
+
+    paper_account = system_state.get("paper_account", {})
+    starting_balance = _as_float(paper_account.get("starting_balance"), 100_000.0)
+    equity = _as_float(paper_account.get("equity", paper_account.get("current_equity")), 0.0)
+    total_pl = _as_float(paper_account.get("total_pl"), equity - starting_balance)
+    on_course = bool(incumbent.status == "PAPER_VALIDATED" and total_pl > 0 and audit.clean)
+
+    active_paper_candidate = next(
+        (candidate for candidate in candidates if candidate["active_paper_candidate"]), None
+    )
+    if not audit.open_inventory_clean:
+        system_action = "RECONCILE_INVENTORY_MANAGE_EXITS_ONLY"
+        research_action = "PAPER_VALIDATE_SUCCESSOR_AFTER_INVENTORY_CLEAN"
+    elif any_validated_candidate:
+        system_action = "PAPER_TRADE_VALIDATED_CANDIDATE"
+        research_action = "CONTINUE_CONTROLLED_PAPER_VALIDATION"
+    elif active_paper_candidate and (
+        active_paper_candidate["decision"]["status"] == "PAPER_VALIDATION_ONLY"
+    ):
+        system_action = "RETIRE_INCUMBENT_PAPER_VALIDATE_SUCCESSOR"
+        research_action = "RUN_ACTIVE_SUCCESSOR_PAPER_COHORT"
+    else:
+        system_action = "EXIT_ONLY_STAY_FLAT"
+        research_action = "SELECT_AND_SPECIFY_PAPER_CANDIDATE"
+    return {
+        "system_action": system_action,
+        "research_action": research_action,
+        "north_star": {
+            "on_course": on_course,
+            "starting_balance": starting_balance,
+            "current_equity": equity,
+            "total_pl": total_pl,
+            "drawdown_pct": abs(_as_float(paper_account.get("total_pl_pct"), 0.0)),
+            "reason": (
+                "No clean, validated positive-expectancy strategy is currently available."
+                if not on_course
+                else "Incumbent has clean positive evidence and positive paper P/L."
+            ),
+        },
+        "incumbent": {
+            "strategy_id": tournament.get("incumbent_strategy_id", "ic_simple"),
+            "evidence": asdict(evidence),
+            "ledger_audit": asdict(audit),
+            "decision": asdict(incumbent),
+        },
+        "broker": {
+            "snapshot": asdict(broker),
+            "current_role": "RESEARCH_ONLY",
+            "reason": (
+                "Authenticated market research is available, but account and API execution "
+                "requirements are not satisfied."
+            ),
+        },
+        "promotion_thresholds": asdict(thresholds),
+        "candidates": candidates,
+    }

--- a/tests/test_active_strategy.py
+++ b/tests/test_active_strategy.py
@@ -3,7 +3,10 @@
 from __future__ import annotations
 
 import json
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -28,9 +31,7 @@ def test_kill_state_defaults_ic_dead(tmp_path: Path, monkeypatch):
     }
     (runtime / "strategy_kill_switch.json").write_text(json.dumps(kill), encoding="utf-8")
     monkeypatch.setattr("src.core.active_strategy.RUNTIME_DIR", runtime)
-    monkeypatch.setattr(
-        "src.core.active_strategy.KILL_FILE", runtime / "strategy_kill_switch.json"
-    )
+    monkeypatch.setattr("src.core.active_strategy.KILL_FILE", runtime / "strategy_kill_switch.json")
     monkeypatch.setattr(
         "src.core.active_strategy.HYPOTHESIS_FILE",
         runtime / "strategy_validation_hypothesis.json",
@@ -62,9 +63,7 @@ def test_assert_entry_allowed_blocks_ic(tmp_path: Path, monkeypatch):
         encoding="utf-8",
     )
     monkeypatch.setattr("src.core.active_strategy.RUNTIME_DIR", runtime)
-    monkeypatch.setattr(
-        "src.core.active_strategy.KILL_FILE", runtime / "strategy_kill_switch.json"
-    )
+    monkeypatch.setattr("src.core.active_strategy.KILL_FILE", runtime / "strategy_kill_switch.json")
     monkeypatch.setattr(
         "src.core.active_strategy.HYPOTHESIS_FILE",
         runtime / "missing.json",
@@ -136,3 +135,250 @@ def test_repo_kill_switch_file_present():
         (root / "data" / "runtime" / "edge_rehabilitation_plan.json").read_text(encoding="utf-8")
     )
     assert rehab.get("status") == "killed"
+
+
+def _put_credit_opp() -> dict:
+    return {
+        "expiry": "2026-08-21",
+        "short_put": 700.0,
+        "long_put": 695.0,
+        "est_credit": 1.0,
+        "put_delta": 0.15,
+        "method": "live_delta",
+        "quantity": 1,
+    }
+
+
+def test_put_credit_journal_uses_unique_order_identity(tmp_path, monkeypatch):
+    from scripts import spy_put_credit as pcs
+
+    entries_path = tmp_path / "put_credit_entries.json"
+    monkeypatch.setattr(pcs, "ENTRIES_FILE", entries_path)
+
+    pcs._record_entry(_put_credit_opp(), "order-1")
+    pcs._record_entry(_put_credit_opp(), "order-2")
+
+    entries = json.loads(entries_path.read_text(encoding="utf-8"))
+    assert set(entries) == {"PCS_260821_order1", "PCS_260821_order2"}
+    assert entries["PCS_260821_order1"]["credit_source"] == "limit_estimate_unconfirmed"
+    assert entries["PCS_260821_order2"]["expiry"] == "2026-08-21"
+
+
+def test_put_credit_entry_builds_supported_bull_put_order_id(tmp_path, monkeypatch):
+    from scripts import spy_put_credit as pcs
+    from src.utils.order_intent import parse_client_order_id
+
+    captured = {}
+
+    def fake_submit(client, request, strategy=None):
+        captured["request"] = request
+        captured["strategy"] = strategy
+        return SimpleNamespace(id="order-1", status="FILLED")
+
+    monkeypatch.setattr(pcs, "ENTRIES_FILE", tmp_path / "put_credit_entries.json")
+    monkeypatch.setattr(pcs.time, "sleep", lambda _: None)
+    monkeypatch.setattr("src.safety.mandatory_trade_gate.safe_submit_order", fake_submit)
+    client = MagicMock()
+    client.get_order_by_id.return_value = SimpleNamespace(status="FILLED")
+
+    order_id = pcs.place_put_credit(client, _put_credit_opp())
+
+    assert order_id == "order-1"
+    assert captured["strategy"] == "spy_put_credit"
+    assert float(captured["request"].limit_price) == -0.95
+    parsed = parse_client_order_id(captured["request"].client_order_id)
+    assert parsed is not None
+    assert parsed["role"] == "OPEN"
+    assert parsed["intent"] == "BPS"
+
+
+def test_put_credit_resolves_to_options_income_milestone_family():
+    from src.safety.milestone_controller import resolve_strategy_family
+
+    assert resolve_strategy_family("spy_put_credit") == "options_income"
+
+
+def test_put_credit_entry_limits_enforce_daily_concurrent_and_signature():
+    from scripts import spy_put_credit as pcs
+
+    now = datetime(2026, 7, 22, 16, 0, tzinfo=timezone.utc)
+    entries = {
+        "PCS_1": {
+            "status": "open",
+            "entry_time": now.isoformat(),
+            "signature": "same",
+        }
+    }
+
+    report = pcs.evaluate_entry_limits(entries, candidate_signature="same", now=now)
+
+    assert report["allowed"] is False
+    assert report["today_count"] == 1
+    assert any("Daily" in blocker for blocker in report["blockers"])
+    assert any("signature" in blocker for blocker in report["blockers"])
+
+    entries["PCS_2"] = {
+        "status": "open",
+        "entry_time": (now - timedelta(days=1)).isoformat(),
+        "signature": "different",
+    }
+    report = pcs.evaluate_entry_limits(entries, now=now)
+    assert report["active_count"] == 2
+    assert any("Concurrent" in blocker for blocker in report["blockers"])
+
+
+def test_put_credit_exit_rules_cover_profit_stop_hold_and_dte():
+    from scripts import spy_put_credit as pcs
+
+    now = datetime(2026, 7, 22, 16, 0, tzinfo=timezone.utc)
+    entry = {
+        "expiry": "2026-08-21",
+        "entry_time": (now - timedelta(days=2)).isoformat(),
+        "credit": 1.0,
+        "quantity": 1,
+    }
+
+    profit = pcs.evaluate_put_credit_exit(entry, short_price=0.60, long_price=0.10, now=now)
+    assert profit["should_exit"] is True
+    assert profit["exit_reason"] == "profit_target"
+
+    stop = pcs.evaluate_put_credit_exit(entry, short_price=3.40, long_price=0.10, now=now)
+    assert stop["should_exit"] is True
+    assert stop["exit_reason"] == "stop_loss"
+
+    young_entry = {**entry, "entry_time": (now - timedelta(hours=2)).isoformat()}
+    young = pcs.evaluate_put_credit_exit(young_entry, short_price=0.60, long_price=0.10, now=now)
+    assert young["should_exit"] is False
+
+    dte_entry = {**entry, "expiry": "2026-07-29"}
+    dte = pcs.evaluate_put_credit_exit(dte_entry, short_price=1.0, long_price=0.20, now=now)
+    assert dte["exit_reason"] == "dte_exit"
+
+
+def test_put_credit_exit_manager_dry_run_never_submits(tmp_path, monkeypatch):
+    from scripts import spy_put_credit as pcs
+
+    now = datetime.now(timezone.utc)
+    entries_path = tmp_path / "put_credit_entries.json"
+    entries_path.write_text(
+        json.dumps(
+            {
+                "PCS_260821_order1": {
+                    "status": "open",
+                    "expiry": "2026-08-21",
+                    "entry_time": (now - timedelta(days=2)).isoformat(),
+                    "credit": 1.0,
+                    "credit_source": "broker_fill",
+                    "quantity": 1,
+                    "strikes": {"short_put": 700.0, "long_put": 695.0},
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(pcs, "ENTRIES_FILE", entries_path)
+    client = MagicMock()
+    client.get_all_positions.return_value = [
+        SimpleNamespace(
+            symbol="SPY260821P00700000",
+            qty="-1",
+            current_price="0.60",
+            avg_entry_price="1.20",
+        ),
+        SimpleNamespace(
+            symbol="SPY260821P00695000",
+            qty="1",
+            current_price="0.10",
+            avg_entry_price="0.20",
+        ),
+    ]
+    monkeypatch.setattr(
+        pcs,
+        "_submit_spread_close",
+        MagicMock(side_effect=AssertionError("dry run submitted an order")),
+    )
+
+    report = pcs.manage_put_credit_exits(client, dry_run=True)
+
+    assert report["would_exit"] == 1
+    assert report["submitted"] == 0
+
+
+def test_put_credit_exit_manager_distinguishes_pending_entry_from_broken(tmp_path, monkeypatch):
+    from scripts import spy_put_credit as pcs
+
+    entries_path = tmp_path / "put_credit_entries.json"
+    entries_path.write_text(
+        json.dumps(
+            {
+                "PCS_260821_order1": {
+                    "status": "submitted_unconfirmed",
+                    "order_id": "order-1",
+                    "expiry": "2026-08-21",
+                    "entry_time": datetime.now(timezone.utc).isoformat(),
+                    "credit": 1.0,
+                    "quantity": 1,
+                    "strikes": {"short_put": 700.0, "long_put": 695.0},
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(pcs, "ENTRIES_FILE", entries_path)
+    client = MagicMock()
+    client.get_all_positions.return_value = []
+    client.get_order_by_id.return_value = SimpleNamespace(status="NEW")
+
+    report = pcs.manage_put_credit_exits(client, dry_run=False)
+
+    assert report["pending"] == 1
+    assert report["broken"] == 0
+    saved = json.loads(entries_path.read_text(encoding="utf-8"))
+    assert saved["PCS_260821_order1"]["status"] == "entry_pending"
+
+
+def test_put_credit_exit_manager_dry_run_flags_orphan_cleanup(tmp_path, monkeypatch):
+    from scripts import spy_put_credit as pcs
+
+    entries_path = tmp_path / "put_credit_entries.json"
+    entries_path.write_text(
+        json.dumps(
+            {
+                "PCS_260821_order1": {
+                    "status": "open",
+                    "order_id": "order-1",
+                    "expiry": "2026-08-21",
+                    "entry_time": datetime.now(timezone.utc).isoformat(),
+                    "credit": 1.0,
+                    "quantity": 1,
+                    "strikes": {"short_put": 700.0, "long_put": 695.0},
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(pcs, "ENTRIES_FILE", entries_path)
+    client = MagicMock()
+    client.get_all_positions.return_value = [
+        SimpleNamespace(
+            symbol="SPY260821P00700000",
+            qty="-1",
+            current_price="1.00",
+            avg_entry_price="1.20",
+        )
+    ]
+    client.get_order_by_id.return_value = SimpleNamespace(status="FILLED")
+
+    report = pcs.manage_put_credit_exits(client, dry_run=True)
+
+    assert report["broken"] == 1
+    assert report["would_exit"] == 1
+    assert report["details"][0]["status"] == "would_close_orphan"
+
+
+def test_schedule_manages_put_credit_exits_every_weekday_slot():
+    workflow = (
+        Path(__file__).resolve().parents[1] / ".github" / "workflows" / "ic-simple.yml"
+    ).read_text(encoding="utf-8")
+    assert "Manage put-credit exits" in workflow
+    assert "--manage-exits" in workflow

--- a/tests/test_mandatory_trade_gate.py
+++ b/tests/test_mandatory_trade_gate.py
@@ -298,9 +298,7 @@ class TestValidateTradeMandatory:
         assert "rebuild in progress" in result.reason.lower()
         assert any("trading_halt: BLOCKED" in check for check in result.checks_performed)
 
-    def test_ml_halt_allows_controlled_paper_validation_reset(
-        self, monkeypatch, tmp_path
-    ):
+    def test_ml_halt_allows_controlled_paper_validation_reset(self, monkeypatch, tmp_path):
         """Validation reset can collect new one-lot paper evidence despite legacy ML halt."""
         import json
 
@@ -349,14 +347,27 @@ class TestValidateTradeMandatory:
 
         assert result.approved is True
         assert any(
-            "ML_HALT_BYPASSED_VALIDATION_RESET" in check
-            for check in result.checks_performed
+            "ML_HALT_BYPASSED_VALIDATION_RESET" in check for check in result.checks_performed
         )
         assert any("legacy ML halt bypassed" in warning for warning in result.rag_warnings)
 
-    def test_ml_halt_still_blocks_live_or_scaling_entries(
-        self, monkeypatch, tmp_path
-    ):
+    def test_successor_put_credit_is_an_allowed_controlled_paper_family(self, monkeypatch):
+        import src.safety.mandatory_trade_gate as gate_mod
+
+        monkeypatch.setattr(gate_mod, "_weekly_gate_allows_validation_entries", lambda: True)
+
+        allowed = gate_mod._is_controlled_paper_validation_context(
+            strategy="spy_put_credit",
+            context={
+                "paper_trading": True,
+                "controlled_paper_validation_entry": True,
+                "validation_entry_quantity": 1,
+            },
+        )
+
+        assert allowed is True
+
+    def test_ml_halt_still_blocks_live_or_scaling_entries(self, monkeypatch, tmp_path):
         """Validation reset must not become a live/scaling bypass."""
         import json
 
@@ -405,9 +416,7 @@ class TestValidateTradeMandatory:
         assert "ml gate blocked" in result.reason.lower()
         assert any("trading_halt: BLOCKED" in check for check in result.checks_performed)
 
-    def test_validation_reset_does_not_bypass_manual_halt(
-        self, monkeypatch, tmp_path
-    ):
+    def test_validation_reset_does_not_bypass_manual_halt(self, monkeypatch, tmp_path):
         """Only the legacy ML win-rate sentinel is bypassable."""
         import json
 

--- a/tests/test_open_inventory_audit.py
+++ b/tests/test_open_inventory_audit.py
@@ -73,7 +73,9 @@ def test_detects_two_lot_call_and_extra_put_vertical():
     assert "LOT_SIZE_EXCEEDED" in codes
     assert "EXTRA_LEGS" in codes or "QTY_MISMATCH" in codes
     assert "SAME_EXPIRY_OVERSTACK" in codes
-    assert any("776" in r or "lot" in r.lower() or "extra" in r.lower() for r in result.block_reasons())
+    assert any(
+        "776" in r or "lot" in r.lower() or "extra" in r.lower() for r in result.block_reasons()
+    )
 
 
 def test_unjournaled_expiry_blocks():
@@ -81,6 +83,50 @@ def test_unjournaled_expiry_blocks():
     result = audit_open_inventory(positions, {})
     assert result.clean is False
     assert any(f.code == "UNJOURNALED_EXPIRY" for f in result.findings)
+
+
+def test_clean_put_credit_is_explained_by_pcs_journal():
+    positions = [
+        {"symbol": "SPY260821P00700000", "qty": -1},
+        {"symbol": "SPY260821P00695000", "qty": 1},
+    ]
+    pcs_entries = {
+        "PCS_260821_order1": {
+            "expiry": "2026-08-21",
+            "quantity": 1,
+            "strikes": {"short_put": 700.0, "long_put": 695.0},
+        }
+    }
+
+    result = audit_open_inventory(positions, {}, pcs_entries)
+
+    assert result.clean is True
+    assert result.block_reasons() == []
+
+
+def test_two_distinct_one_lot_put_credits_may_share_expiry():
+    positions = [
+        {"symbol": "SPY260821P00700000", "qty": -1},
+        {"symbol": "SPY260821P00695000", "qty": 1},
+        {"symbol": "SPY260821P00690000", "qty": -1},
+        {"symbol": "SPY260821P00685000", "qty": 1},
+    ]
+    pcs_entries = {
+        "PCS_260821_order1": {
+            "expiry": "2026-08-21",
+            "quantity": 1,
+            "strikes": {"short_put": 700.0, "long_put": 695.0},
+        },
+        "PCS_260821_order2": {
+            "expiry": "2026-08-21",
+            "quantity": 1,
+            "strikes": {"short_put": 690.0, "long_put": 685.0},
+        },
+    }
+
+    result = audit_open_inventory(positions, {}, pcs_entries)
+
+    assert result.clean is True
 
 
 def test_audit_from_files_on_repo_fixture(tmp_path: Path):

--- a/tests/test_promotion_gate.py
+++ b/tests/test_promotion_gate.py
@@ -2,7 +2,7 @@ import json
 from argparse import Namespace
 from pathlib import Path
 
-from scripts.enforce_promotion_gate import evaluate_gate
+from scripts.enforce_promotion_gate import evaluate_gate, evaluate_staleness
 
 FIXTURES = Path("tests/fixtures")
 
@@ -36,3 +36,18 @@ def test_promotion_gate_flags_low_win_rate():
     summary = load_fixture("backtest_summary_sample.json")
     deficits = evaluate_gate(state, summary, base_args())
     assert any("Win rate" in item for item in deficits)
+
+
+def test_promotion_gate_fails_closed_when_timestamp_is_missing():
+    stale_hours, deficits = evaluate_staleness({}, 48.0)
+
+    assert stale_hours is None
+    assert any("freshness cannot be verified" in item for item in deficits)
+
+
+def test_promotion_gate_fails_closed_when_state_is_stale():
+    state = {"meta": {"last_updated": "2020-01-01T00:00:00Z"}}
+    stale_hours, deficits = evaluate_staleness(state, 48.0)
+
+    assert stale_hours is not None and stale_hours > 48.0
+    assert any("refresh evidence before promotion" in item for item in deficits)

--- a/tests/test_residual_ic_manager.py
+++ b/tests/test_residual_ic_manager.py
@@ -1,0 +1,116 @@
+from datetime import datetime, timezone
+from types import SimpleNamespace
+
+from scripts.residual_ic_manager import (
+    _close_signature,
+    _order_signature,
+    evaluate_residual_exit,
+    recover_active_structures,
+)
+
+
+def _leg(symbol, side, fill):
+    return SimpleNamespace(
+        symbol=symbol,
+        side=side,
+        qty="1",
+        filled_qty="1",
+        filled_avg_price=str(fill),
+    )
+
+
+def _open(order_id, when, put_long, put_short, credit_parts):
+    lp, sp, sc, lc = credit_parts
+    return SimpleNamespace(
+        id=order_id,
+        client_order_id=f"IC-OPEN-IC--{int(when.timestamp() * 1_000_000_000)}",
+        status="FILLED",
+        qty="1",
+        filled_qty="1",
+        created_at=when,
+        filled_at=when,
+        legs=[
+            _leg(f"SPY260821P{int(put_long * 1000):08d}", "BUY", lp),
+            _leg(f"SPY260821P{int(put_short * 1000):08d}", "SELL", sp),
+            _leg("SPY260821C00776000", "SELL", sc),
+            _leg("SPY260821C00781000", "BUY", lc),
+        ],
+    )
+
+
+def _position(symbol, qty, current):
+    return SimpleNamespace(symbol=symbol, qty=str(qty), current_price=str(current))
+
+
+def test_recovers_two_same_expiry_structures_with_shared_call_vertical():
+    older = datetime(2026, 7, 17, 15, 36, tzinfo=timezone.utc)
+    newer = datetime(2026, 7, 21, 15, 40, tzinfo=timezone.utc)
+    orders = [
+        _open("38126b7550dd49e5939f", older, 695, 700, (3.40, 3.80, 2.04, 1.32)),
+        _open("12d3f8817beb46a0b445", newer, 703, 708, (2.96, 3.37, 1.85, 1.15)),
+    ]
+    positions = [
+        _position("SPY260821P00695000", 1, 2.0),
+        _position("SPY260821P00700000", -1, 2.3),
+        _position("SPY260821P00703000", 1, 2.5),
+        _position("SPY260821P00708000", -1, 2.9),
+        _position("SPY260821C00776000", -2, 1.2),
+        _position("SPY260821C00781000", 2, 0.7),
+    ]
+
+    recovered, unresolved = recover_active_structures(positions, orders)
+
+    assert len(recovered) == 2
+    assert unresolved == {}
+    assert sorted(item["credit"] for item in recovered) == [1.11, 1.12]
+
+
+def test_recovery_reports_unexplained_live_leg():
+    positions = [_position("SPY260821P00695000", 1, 2.0)]
+    recovered, unresolved = recover_active_structures(positions, [])
+    assert recovered == []
+    assert unresolved == {"SPY260821P00695000": 1.0}
+
+
+def test_exit_rules_respect_hold_and_trigger_profit_after_24h():
+    structure = {
+        "expiry_yymmdd": "260821",
+        "entry_time": "2026-07-21T15:40:00+00:00",
+        "credit": 1.0,
+        "quantity": 1,
+        "legs": [
+            {"qty": -1, "current_price": 0.7},
+            {"qty": 1, "current_price": 0.2},
+            {"qty": -1, "current_price": 0.4},
+            {"qty": 1, "current_price": 0.1},
+        ],
+    }
+    held = evaluate_residual_exit(structure, now=datetime(2026, 7, 21, 20, 0, tzinfo=timezone.utc))
+    profit = evaluate_residual_exit(
+        structure, now=datetime(2026, 7, 22, 20, 0, tzinfo=timezone.utc)
+    )
+    assert held["should_exit"] is False
+    assert profit["should_exit"] is False  # $20 P/L is below the $50 target
+
+    structure["legs"][0]["current_price"] = 0.3
+    profit = evaluate_residual_exit(
+        structure, now=datetime(2026, 7, 22, 20, 0, tzinfo=timezone.utc)
+    )
+    assert profit["should_exit"] is True
+    assert profit["exit_reason"] == "profit_target"
+
+
+def test_pending_close_signature_matches_structure():
+    structure = {
+        "legs": [
+            {"symbol": "SPY260821P00703000", "qty": 1},
+            {"symbol": "SPY260821P00708000", "qty": -1},
+        ]
+    }
+    order = SimpleNamespace(
+        legs=[
+            SimpleNamespace(symbol="SPY260821P00708000", side="BUY"),
+            SimpleNamespace(symbol="SPY260821P00703000", side="SELL"),
+        ]
+    )
+    assert _close_signature(structure) == _order_signature(order)

--- a/tests/test_strategy_pivot.py
+++ b/tests/test_strategy_pivot.py
@@ -1,0 +1,178 @@
+"""Tests for the evidence-first strategy pivot gate."""
+
+from __future__ import annotations
+
+from src.safety.strategy_pivot import (
+    BrokerSnapshot,
+    StrategyEvidence,
+    ValidationThresholds,
+    assess_broker,
+    audit_strategy_ledger,
+    build_pivot_report,
+    evaluate_strategy,
+)
+
+
+def _state() -> dict:
+    return {
+        "paper_account": {
+            "starting_balance": 100_000.0,
+            "equity": 94_062.0,
+            "total_pl": -5_938.0,
+            "total_pl_pct": -5.938,
+        },
+        "performance": {
+            "open_positions": [
+                {"symbol": "SPY260821C00776000", "quantity": -2},
+                {"symbol": "SPY260821C00781000", "quantity": 2},
+                {"symbol": "SPY260821P00695000", "quantity": 1},
+                {"symbol": "SPY260821P00700000", "quantity": -1},
+                {"symbol": "SPY260821P00703000", "quantity": 1},
+                {"symbol": "SPY260821P00708000", "quantity": -1},
+            ]
+        },
+        "north_star_weekly_gate": {
+            "lifetime_ledger": {
+                "closed_trades": 174,
+                "expectancy_per_trade": -31.977,
+                "profit_factor": 0.70,
+                "total_realized_pnl": -5_564.0,
+            }
+        },
+    }
+
+
+def _trades() -> dict:
+    return {
+        "stats": {
+            "closed_trades": 174,
+            "unpaired_order_count": 15,
+        },
+        "trades": [{} for _ in range(159)],
+    }
+
+
+def _broker() -> dict:
+    return {
+        "broker": "clearstreet_active",
+        "observed_at": "2026-07-22T16:31:00-04:00",
+        "account": {
+            "authenticated_web_session": True,
+            "funded": False,
+            "equity_usd": 0,
+            "api_key_configured": False,
+            "options_level": 0,
+        },
+        "api_capabilities": {
+            "market_data": True,
+            "equities": True,
+            "single_leg_options": True,
+            "multi_leg_options": False,
+            "paper_trading_verified": False,
+        },
+    }
+
+
+def test_ledger_audit_detects_unpaired_and_overwritten_same_expiry_entry() -> None:
+    audit = audit_strategy_ledger(
+        _state(),
+        _trades(),
+        {"IC_260821": {"order_id": "second-entry-overwrote-first"}},
+    )
+
+    assert not audit.clean
+    assert audit.unpaired_order_count == 15
+    assert any("unpaired orders" in issue for issue in audit.issues)
+    assert any("represents 2 structures" in issue for issue in audit.issues)
+
+
+def test_negative_mature_incumbent_is_retired_but_exits_remain_allowed() -> None:
+    audit = audit_strategy_ledger(_state(), _trades(), {"IC_260821": {}})
+    decision = evaluate_strategy(
+        StrategyEvidence(
+            closed_trades=174,
+            expectancy_per_trade=-31.98,
+            profit_factor=0.70,
+            total_realized_pnl=-5_564,
+            max_drawdown_pct=5.94,
+        ),
+        audit,
+    )
+
+    assert decision.status == "RETIRE_NEW_ENTRIES"
+    assert not decision.may_open_new_positions
+    assert decision.may_manage_existing_positions
+
+
+def test_clean_candidate_needs_30_trades_and_positive_edge() -> None:
+    clean_audit = audit_strategy_ledger(
+        {"performance": {"open_positions": []}},
+        {"stats": {"closed_trades": 30, "unpaired_order_count": 0}, "trades": [{}] * 30},
+        {},
+    )
+    decision = evaluate_strategy(
+        StrategyEvidence(
+            closed_trades=30,
+            expectancy_per_trade=12.0,
+            profit_factor=1.25,
+            total_realized_pnl=360.0,
+            max_drawdown_pct=4.0,
+        ),
+        clean_audit,
+        ValidationThresholds(),
+    )
+
+    assert decision.status == "PAPER_VALIDATED"
+    assert decision.may_open_new_positions
+
+
+def test_clearstreet_is_research_only_and_cannot_execute_iron_condor() -> None:
+    snapshot = BrokerSnapshot.from_payload(_broker())
+    assessment = assess_broker(
+        snapshot,
+        {
+            "asset_class": "option",
+            "legs": 4,
+            "minimum_options_level": 3,
+            "requires_paper_trading": True,
+        },
+    )
+
+    assert assessment.research_eligible
+    assert not assessment.execution_eligible
+    assert "No broker API key is configured." in assessment.blockers
+    assert "The API does not support atomic multi-leg option execution." in assessment.blockers
+
+
+def test_report_stays_exit_only_until_a_candidate_passes() -> None:
+    tournament = {
+        "incumbent_strategy_id": "ic_simple",
+        "promotion_thresholds": {},
+        "candidates": [
+            {
+                "strategy_id": "spy_long_trend",
+                "hypothesis": "test",
+                "rules": {},
+                "broker_requirements": {
+                    "asset_class": "equity",
+                    "legs": 1,
+                    "requires_paper_trading": True,
+                },
+                "evidence": {
+                    "closed_trades": 0,
+                    "expectancy_per_trade": 0,
+                    "profit_factor": 0,
+                    "total_realized_pnl": 0,
+                    "ledger_clean": True,
+                },
+            }
+        ],
+    }
+
+    report = build_pivot_report(_state(), _trades(), {"IC_260821": {}}, tournament, _broker())
+
+    assert report["system_action"] == "RECONCILE_INVENTORY_MANAGE_EXITS_ONLY"
+    assert not report["north_star"]["on_course"]
+    assert report["incumbent"]["decision"]["status"] == "RETIRE_NEW_ENTRIES"
+    assert report["candidates"][0]["decision"]["status"] == "PAPER_VALIDATION_ONLY"
+    assert report["broker"]["current_role"] == "RESEARCH_ONLY"

--- a/tests/unit/test_ic_simple.py
+++ b/tests/unit/test_ic_simple.py
@@ -757,6 +757,9 @@ class TestE2EPipeline:
                 "src.utils.regime_detector.RegimeDetector.detect_live_regime_with_prediction",
                 return_value=_Snapshot(),
             ),
+            # This legacy pipeline test exercises credit construction directly;
+            # production remains killed by separate active-strategy tests.
+            patch("src.core.active_strategy.entry_block_message", return_value=None),
             patch.object(Path, "read_text", _patched_read),
             patch("scripts.ic_simple._fomc_blackout_reason", return_value=None),
         ):
@@ -849,6 +852,8 @@ class TestE2EPipeline:
                 "src.utils.regime_detector.RegimeDetector.detect_live_regime_with_prediction",
                 return_value=_Snapshot(),
             ),
+            # Isolate the same-expiry gate even though production IC entry is killed.
+            patch("src.core.active_strategy.entry_block_message", return_value=None),
             patch.object(Path, "read_text", _patched_read),
             patch("scripts.ic_simple._fomc_blackout_reason", return_value=None),
         ):


### PR DESCRIPTION
## What changed

- Makes the negative lifetime ledger an explicit retirement gate for IC Simple and blocks stale evidence from auto-promoting a strategy.
- Keeps the successor `spy_put_credit` paper-only with unique trade IDs, one-entry-per-day and two-position caps, fixed profit/stop/DTE exits, and broker/journal reconciliation.
- Reconstructs the two live August ICs from broker-confirmed MLEG fills so shared call strikes no longer cause the exit manager to skip them.
- Treats Clear Street as research-only until account/API/multi-leg requirements are satisfied.
- Updates scheduled automation so residual ICs and successor exits are managed independently and failures keep new entries blocked.

## Why

The incumbent lifetime ledger is negative: 174 closes, profit factor 0.70, expectancy -$31.98/trade, and realized P/L -$5,564. The expiry-keyed IC journal also overwrote one of two same-expiry structures, making the legacy manager skip both positions.

## Impact

No live capital is enabled and no broker migration is performed. Existing paper positions remain exit-managed. The successor cannot claim edge or scale until at least 30 clean paper closes clear the positive-expectancy promotion gate.

## Validation

- `97 passed` focused successor, inventory, promotion, mandatory-gate, and trade-gateway tests after rebase
- `124 passed` broader suite including legacy IC guardian tests
- Authenticated Alpaca dry run: 2 residual ICs reconciled, 0 unresolved legs, both HOLD, 0 orders submitted
- Strategy pivot report exits non-zero as designed while North Star is off course