### PR TITLE
fix(put-credit): scan delta band so validation can enter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,7 @@ data/trading_halt.txt
 !data/system_state.json
 !data/trades.json
 !data/ic_entries.json
+!data/put_credit_entries.json
 !data/thumbgate_rules.json
 !data/strategy_params.json
 !data/ic_stats.json

--- a/data/put_credit_entries.json
+++ b/data/put_credit_entries.json
@@ -1,0 +1,29 @@
+{
+  "PCS_260828_4fc04e47a2da4fe9ab2814cdad69ab44": {
+    "strategy_family": "spy_put_credit",
+    "order_id": "4fc04e47-a2da-4fe9-ab28-14cdad69ab44",
+    "entry_time": "2026-07-23T15:37:11.214734+00:00",
+    "expiry": "2026-08-28",
+    "quantity": 1,
+    "credit": 0.53,
+    "limit_credit": 0.54,
+    "credit_source": "broker_fill",
+    "put_delta": 0.1843,
+    "selection_method": "live_delta_band_scan",
+    "strikes": {
+      "short_put": 696.0,
+      "long_put": 691.0
+    },
+    "signature": "SPY_2026-08-28_P691-696",
+    "validation_phase": true,
+    "profile_name": "spy-put-credit",
+    "status": "open",
+    "fill_confirmed": true,
+    "filled_avg_price": -0.53,
+    "filled_at": "2026-07-23T15:37:37.054945+00:00",
+    "legs": {
+      "short": "SPY260828P00696000",
+      "long": "SPY260828P00691000"
+    }
+  }
+}

--- a/scripts/build_rag_query_index.py
+++ b/scripts/build_rag_query_index.py
@@ -81,7 +81,9 @@ def _resolve_write_profile() -> str:
 def _resolve_output_targets(profile: str) -> tuple[list[Path], Path]:
     if profile == "repo":
         return REPO_OUTPUT_PATHS, REPO_LESSONS_PAGE_PATH
-    return LOCAL_OUTPUT_PATHS, LOCAL_LESSONS_PAGE_PATH
+    # Always refresh data/rag/lessons_query.json — mandatory trade gate reads this
+    # path for staleness. Local profile also writes artifacts for HTML browsing.
+    return LOCAL_OUTPUT_PATHS + REPO_OUTPUT_PATHS, LOCAL_LESSONS_PAGE_PATH
 
 
 def _extract_tags(text: str) -> list[str]:

--- a/scripts/spy_put_credit.py
+++ b/scripts/spy_put_credit.py
@@ -18,7 +18,7 @@ import logging
 import re
 import sys
 import time
-from datetime import date, datetime, timezone
+from datetime import date, datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any
 from zoneinfo import ZoneInfo
@@ -499,62 +499,145 @@ def manage_put_credit_exits(client, *, dry_run: bool = False) -> dict[str, Any]:
     return report
 
 
+def _friday_expiries(min_dte: int, max_dte: int, target_dte: int) -> list[str]:
+    """Candidate Friday expiries in [min_dte, max_dte], target first."""
+    today = datetime.now(timezone.utc).date()
+    fridays: list[tuple[int, str]] = []
+    # walk ~10 weeks forward
+    d = today
+    for _ in range(80):
+        d = d + timedelta(days=1)
+        if d.weekday() != 4:  # Friday
+            continue
+        dte = (d - today).days
+        if dte < min_dte:
+            continue
+        if dte > max_dte:
+            break
+        fridays.append((abs(dte - target_dte), d.isoformat()))
+    fridays.sort(key=lambda x: x[0])
+    return [exp for _, exp in fridays]
+
+
 def find_put_credit_opportunity(spy_price: float) -> dict | None:
-    """Select put vertical via live delta; ignore call side of IC selector."""
-    from src.markets.option_chain import select_strikes_by_delta
+    """Scan live put chain for $5-wide bull put credits in the policy delta band.
+
+    Unlike the IC dual-side selector (which often yields thin put-only credits at
+    exactly 15Δ), this searches the full put delta band and prefers candidates
+    that clear min_credit, then closest to target_delta, then higher credit.
+    """
+    from src.data.iv_data_provider import IVDataProvider
 
     profile = _load_profile()
-    selection = select_strikes_by_delta(
-        underlying_price=spy_price,
-        wing_width=profile.wing_width,
-        target_delta=profile.short_delta,
-        target_dte=profile.target_dte,
-        min_dte=profile.min_dte,
-        max_dte=profile.max_dte,
-    )
-    if selection.method != "live_delta":
-        logger.warning("Strike method %r is not live_delta — skip", selection.method)
+    provider = IVDataProvider()
+    wing = float(profile.wing_width)
+    band_lo = float(profile.delta_band_min)
+    band_hi = float(profile.delta_band_max)
+    target_delta = float(profile.short_delta)
+    min_credit = float(profile.min_credit)
+
+    candidates: list[dict] = []
+    best_sub_min: dict | None = None
+
+    for expiry in _friday_expiries(profile.min_dte, profile.max_dte, profile.target_dte):
+        try:
+            # Short candidates inside delta band; long wings are outside band.
+            shorts = provider.get_options_chain_with_greeks(
+                symbol=profile.underlying,
+                expiration=expiry,
+                min_delta=band_lo,
+                max_delta=band_hi,
+                min_open_interest=0,
+            )
+            all_puts = provider.get_options_chain_with_greeks(
+                symbol=profile.underlying,
+                expiration=expiry,
+                min_open_interest=0,
+            )
+        except Exception as exc:
+            logger.warning("Chain fetch failed for %s: %s", expiry, exc)
+            continue
+
+        puts_short = [
+            o
+            for o in shorts
+            if o.get("type") == "put"
+            and o.get("bid", 0) and float(o.get("bid") or 0) >= 0.05
+            and o.get("delta") is not None
+        ]
+        puts_all = {float(o["strike"]): o for o in all_puts if o.get("type") == "put"}
+        if not puts_short or not puts_all:
+            continue
+
+        for short in puts_short:
+            put_delta = abs(float(short["delta"]))
+            if not (band_lo <= put_delta <= band_hi):
+                continue
+            short_strike = float(short["strike"])
+            long_strike = round(short_strike - wing, 2)
+            # snap long to nearest available strike <= target wing
+            long_candidates = [s for s in puts_all if s <= long_strike + 1e-9]
+            if not long_candidates:
+                continue
+            long_strike = max(long_candidates)
+            put_wing = round(short_strike - long_strike, 2)
+            # require exact wing width for controlled experiment ($5)
+            if abs(put_wing - wing) > 1e-6:
+                continue
+            long_opt = puts_all.get(long_strike)
+            if not long_opt:
+                continue
+            long_ask = float(long_opt.get("ask") or 0.0)
+            short_bid = float(short.get("bid") or 0.0)
+            if long_ask <= 0 or short_bid <= 0:
+                continue
+            est_credit = round(short_bid - long_ask, 2)
+            if est_credit <= 0:
+                continue
+            row = {
+                "expiry": expiry,
+                "short_put": short_strike,
+                "long_put": long_strike,
+                "put_wing": put_wing,
+                "est_credit": est_credit,
+                "put_delta": put_delta,
+                "method": "live_delta_band_scan",
+                "quantity": profile.max_contracts_per_trade,
+                "spy_price": spy_price,
+                "delta_distance": abs(put_delta - target_delta),
+            }
+            if est_credit >= min_credit:
+                candidates.append(row)
+            elif best_sub_min is None or est_credit > best_sub_min["est_credit"]:
+                best_sub_min = row
+
+    if not candidates:
+        if best_sub_min:
+            logger.warning(
+                "Best put credit in band $%.2f < min $%.2f (short=%.0f Δ=%.3f exp=%s) — skip",
+                best_sub_min["est_credit"],
+                min_credit,
+                best_sub_min["short_put"],
+                best_sub_min["put_delta"],
+                best_sub_min["expiry"],
+            )
+        else:
+            logger.warning("No put verticals found in delta band %.2f-%.2f", band_lo, band_hi)
         return None
 
-    put_delta = abs(float(selection.put_delta or 0.0))
-    if not (profile.delta_band_min <= put_delta <= profile.delta_band_max):
-        logger.warning(
-            "Put delta %.3f outside band %.2f-%.2f — skip",
-            put_delta,
-            profile.delta_band_min,
-            profile.delta_band_max,
-        )
-        return None
-
-    put_wing = round(float(selection.short_put) - float(selection.long_put), 2)
-    if put_wing != profile.wing_width:
-        logger.warning("Put wing $%s != required $%s — skip", put_wing, profile.wing_width)
-        return None
-
-    # Put-side credit only (not full IC net credit)
-    est_credit = round(float(selection.put_bid) - float(selection.long_put_ask), 2)
-    if est_credit < profile.min_credit:
-        logger.warning("Put credit $%.2f < min $%.2f — skip", est_credit, profile.min_credit)
-        return None
-
-    opp = {
-        "expiry": selection.expiry,
-        "short_put": float(selection.short_put),
-        "long_put": float(selection.long_put),
-        "put_wing": put_wing,
-        "est_credit": est_credit,
-        "put_delta": put_delta,
-        "method": selection.method,
-        "quantity": profile.max_contracts_per_trade,
-        "spy_price": spy_price,
-    }
+    # Prefer closer to target delta, then higher credit, then nearer target DTE already ordered
+    candidates.sort(key=lambda r: (r["delta_distance"], -r["est_credit"]))
+    opp = candidates[0]
+    opp.pop("delta_distance", None)
     logger.info(
-        "Opportunity: SPY put credit short=%.0f long=%.0f credit=$%.2f delta=%.3f exp=%s",
+        "Opportunity: SPY put credit short=%.0f long=%.0f credit=$%.2f delta=%.3f exp=%s "
+        "(scanned %d band-qualified)",
         opp["short_put"],
         opp["long_put"],
         opp["est_credit"],
         opp["put_delta"],
         opp["expiry"],
+        len(candidates),
     )
     return opp
 

--- a/tests/test_active_strategy.py
+++ b/tests/test_active_strategy.py
@@ -124,6 +124,9 @@ def test_put_credit_inventory_gate_fails_closed_on_unexplained_leg(monkeypatch):
 
 
 def test_find_put_credit_uses_put_side_only(monkeypatch):
+    import sys
+    import types
+
     from scripts import spy_put_credit as pcs
 
     expiry = "2026-08-21"
@@ -150,11 +153,12 @@ def test_find_put_credit_uses_put_side_only(monkeypatch):
                 return [short]
             return [short, long]
 
+    # Inject a stub module so the late import inside find_put_credit_opportunity
+    # does not pull real pandas/alpaca deps in unit tests.
+    stub = types.ModuleType("src.data.iv_data_provider")
+    stub.IVDataProvider = FakeProvider
+    monkeypatch.setitem(sys.modules, "src.data.iv_data_provider", stub)
     monkeypatch.setattr(pcs, "_friday_expiries", lambda *a, **k: [expiry])
-    monkeypatch.setattr(
-        "src.data.iv_data_provider.IVDataProvider",
-        FakeProvider,
-    )
     opp = pcs.find_put_credit_opportunity(747.0)
     assert opp is not None
     assert opp["short_put"] == 700.0

--- a/tests/test_active_strategy.py
+++ b/tests/test_active_strategy.py
@@ -126,28 +126,41 @@ def test_put_credit_inventory_gate_fails_closed_on_unexplained_leg(monkeypatch):
 def test_find_put_credit_uses_put_side_only(monkeypatch):
     from scripts import spy_put_credit as pcs
 
-    class Sel:
-        method = "live_delta"
-        put_delta = 0.15
-        short_put = 700.0
-        long_put = 695.0
-        put_bid = 1.20
-        long_put_ask = 0.40
-        expiry = "2026-08-21"
+    expiry = "2026-08-21"
+    # Band-scan uses IVDataProvider put chain only (no call side).
+    short = {
+        "type": "put",
+        "strike": 700.0,
+        "delta": -0.15,
+        "bid": 1.20,
+        "ask": 1.25,
+    }
+    long = {
+        "type": "put",
+        "strike": 695.0,
+        "delta": -0.10,
+        "bid": 0.35,
+        "ask": 0.40,
+    }
 
+    class FakeProvider:
+        def get_options_chain_with_greeks(self, **kwargs):
+            # First call is delta-band filtered shorts; second is full put book.
+            if kwargs.get("min_delta") is not None:
+                return [short]
+            return [short, long]
+
+    monkeypatch.setattr(pcs, "_friday_expiries", lambda *a, **k: [expiry])
     monkeypatch.setattr(
-        "src.markets.option_chain.select_strikes_by_delta",
-        lambda **kwargs: Sel(),
+        "src.data.iv_data_provider.IVDataProvider",
+        FakeProvider,
     )
-    # ensure import path inside function sees the patch
-    import src.markets.option_chain as oc
-
-    monkeypatch.setattr(oc, "select_strikes_by_delta", lambda **kwargs: Sel())
     opp = pcs.find_put_credit_opportunity(747.0)
     assert opp is not None
     assert opp["short_put"] == 700.0
     assert opp["long_put"] == 695.0
     assert opp["est_credit"] == 0.80
+    assert opp["method"] == "live_delta_band_scan"
     assert "short_call" not in opp
 
 

--- a/tests/test_ic_entries_reconciliation.py
+++ b/tests/test_ic_entries_reconciliation.py
@@ -1,11 +1,9 @@
-"""Guard: every open option structure must have an ic_entries.json record.
+"""Guard: every open option structure must have a journal record.
 
-The exit loop in scripts/ic_simple.py holds a position blind (no
-profit-target, no stop evaluation — only the 7-DTE failsafe) when
-IC_<expiry> is missing from data/ic_entries.json. The SPY 2026-07-31 IC
-sat unmanaged from Jun 24 to Jul 2 2026 this way. Both files are
-committed by the sync workflows, so CI can catch the gap within one
-sync cycle.
+IC residual legs need `data/ic_entries.json` (IC_<YYMMDD> or IC_<YYMMDD>_*).
+Put-credit legs need `data/put_credit_entries.json` (open PCS with matching
+expiry). Residual IC manager and put-credit exit manager both fail closed
+without that mapping.
 """
 
 from __future__ import annotations
@@ -16,16 +14,53 @@ from pathlib import Path
 
 DATA_DIR = Path(__file__).resolve().parents[1] / "data"
 OPTION_SYMBOL = re.compile(r"^SPY(\d{6})[CP]\d{8}$")
+INACTIVE = {"closed", "cancelled", "rejected"}
+
+
+def _pcs_expiries(pcs: dict) -> set[str]:
+    out: set[str] = set()
+    for key, entry in pcs.items():
+        if not isinstance(entry, dict):
+            continue
+        if str(entry.get("status") or "open").strip().lower() in INACTIVE:
+            continue
+        exp = str(entry.get("expiry") or "")
+        # expiry may be YYYY-MM-DD
+        if len(exp) >= 10 and exp[4] == "-":
+            y, m, d = exp[:10].split("-")
+            out.add(f"{y[2:]}{m}{d}")
+            continue
+        # key like PCS_260828_...
+        m = re.search(r"(\d{6})", key)
+        if m:
+            out.add(m.group(1))
+    return out
+
+
+def _ic_expiries(entries: dict) -> set[str]:
+    out: set[str] = set()
+    for key in entries:
+        if not str(key).startswith("IC_"):
+            continue
+        # IC_260821 or IC_260821_2
+        m = re.match(r"IC_(\d{6})", str(key))
+        if m:
+            out.add(m.group(1))
+    return out
 
 
 def test_open_option_positions_have_entry_records() -> None:
     state_path = DATA_DIR / "system_state.json"
     entries_path = DATA_DIR / "ic_entries.json"
+    pcs_path = DATA_DIR / "put_credit_entries.json"
     if not state_path.exists() or not entries_path.exists():
         return
 
     positions = json.loads(state_path.read_text()).get("positions", [])
     entries = json.loads(entries_path.read_text())
+    pcs = json.loads(pcs_path.read_text()) if pcs_path.exists() else {}
+
+    covered = _ic_expiries(entries) | _pcs_expiries(pcs if isinstance(pcs, dict) else {})
 
     expiries = set()
     for pos in positions:
@@ -33,10 +68,9 @@ def test_open_option_positions_have_entry_records() -> None:
         if m:
             expiries.add(m.group(1))
 
-    missing = sorted(e for e in expiries if f"IC_{e}" not in entries)
+    missing = sorted(e for e in expiries if e not in covered)
     assert not missing, (
-        f"open option positions with no ic_entries.json record: {missing} — "
-        "the ic_simple exit loop cannot evaluate profit-target or stop-loss "
-        "for these (holds blind until 7-DTE failsafe). Backfill from broker "
-        "order history (see IC_260731 backfill, 2026-07-02)."
+        f"open option positions with no IC or put-credit journal record: {missing} — "
+        "exit managers cannot evaluate profit-target/stop without a journal map. "
+        "Backfill ic_entries.json (IC_*) or put_credit_entries.json (PCS)."
     )


### PR DESCRIPTION
## Summary

Unblocks SPY put-credit paper entries when exact 15Δ IC-style selection yields put credits below the $0.50 floor.

### Change
`find_put_credit_opportunity` now scans Fridays in the policy DTE range and puts in the **0.10–0.22** delta band for exact **$5** wings, requiring **min_credit ≥ $0.50**, preferring closest to 0.15Δ.

### Evidence (live paper, 2026-07-23)
- Before: put credit ~$0.31–$0.37 → skip
- After scan: filled paper MLEG `4fc04e47-a2da-4fe9-ab28-14cdad69ab44` SPY 2026-08-28 **P696/P691**, credit **$0.53**, 1-lot

Still paper-only validation. Does not claim edge or live profitability.

## Test plan
- [x] dry-run finds band-qualified opp
- [x] execute-paper fill on Alpaca paper
- [ ] CI green