### PR TITLE
test: harden put-credit band scan

### DIFF
--- a/scripts/spy_put_credit.py
+++ b/scripts/spy_put_credit.py
@@ -519,6 +519,67 @@ def _friday_expiries(min_dte: int, max_dte: int, target_dte: int) -> list[str]:
     return [exp for _, exp in fridays]
 
 
+def _as_float(value: Any) -> float | None:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _scan_put_credit_candidates(
+    expiry: str,
+    options: list[dict[str, Any]],
+    profile: Any,
+) -> tuple[list[dict[str, Any]], dict[str, Any] | None]:
+    """Return policy-qualified candidates and the best sub-minimum candidate."""
+    puts: dict[float, dict[str, Any]] = {}
+    for option in options:
+        if option.get("type") != "put" or option.get("expiration") != expiry:
+            continue
+        strike = _as_float(option.get("strike"))
+        if strike is not None:
+            puts[strike] = option
+
+    candidates: list[dict[str, Any]] = []
+    best_sub_min: dict[str, Any] | None = None
+    for short_strike, short in puts.items():
+        delta = _as_float(short.get("delta"))
+        short_bid = _as_float(short.get("bid"))
+        if delta is None or short_bid is None or short_bid < 0.05:
+            continue
+
+        put_delta = abs(delta)
+        if not (profile.delta_band_min <= put_delta <= profile.delta_band_max):
+            continue
+
+        long_strike = round(short_strike - float(profile.wing_width), 2)
+        long_option = puts.get(long_strike)
+        long_ask = _as_float(long_option.get("ask")) if long_option else None
+        if long_ask is None or long_ask <= 0:
+            continue
+
+        est_credit = round(short_bid - long_ask, 2)
+        if est_credit <= 0:
+            continue
+        row = {
+            "expiry": expiry,
+            "short_put": short_strike,
+            "long_put": long_strike,
+            "put_wing": float(profile.wing_width),
+            "est_credit": est_credit,
+            "put_delta": put_delta,
+            "method": "live_delta_band_scan",
+            "quantity": profile.max_contracts_per_trade,
+            "spy_price": None,
+            "delta_distance": abs(put_delta - float(profile.short_delta)),
+        }
+        if est_credit >= profile.min_credit:
+            candidates.append(row)
+        elif best_sub_min is None or est_credit > best_sub_min["est_credit"]:
+            best_sub_min = row
+    return candidates, best_sub_min
+
+
 def find_put_credit_opportunity(spy_price: float) -> dict | None:
     """Scan live put chain for $5-wide bull put credits in the policy delta band.
 
@@ -530,86 +591,38 @@ def find_put_credit_opportunity(spy_price: float) -> dict | None:
 
     profile = _load_profile()
     provider = IVDataProvider()
-    wing = float(profile.wing_width)
     band_lo = float(profile.delta_band_min)
     band_hi = float(profile.delta_band_max)
-    target_delta = float(profile.short_delta)
     min_credit = float(profile.min_credit)
 
     candidates: list[dict] = []
     best_sub_min: dict | None = None
+    try:
+        # IVDataProvider currently fetches the complete Alpaca chain before
+        # filtering. Fetch once, then partition locally instead of repeating the
+        # same network request for every expiry and delta slice.
+        options = provider.get_options_chain_with_greeks(
+            symbol=profile.underlying,
+            min_open_interest=0,
+        )
+    except Exception as exc:
+        logger.warning("Chain fetch failed: %s", exc)
+        return None
 
     for expiry in _friday_expiries(profile.min_dte, profile.max_dte, profile.target_dte):
-        try:
-            # Short candidates inside delta band; long wings are outside band.
-            shorts = provider.get_options_chain_with_greeks(
-                symbol=profile.underlying,
-                expiration=expiry,
-                min_delta=band_lo,
-                max_delta=band_hi,
-                min_open_interest=0,
-            )
-            all_puts = provider.get_options_chain_with_greeks(
-                symbol=profile.underlying,
-                expiration=expiry,
-                min_open_interest=0,
-            )
-        except Exception as exc:
-            logger.warning("Chain fetch failed for %s: %s", expiry, exc)
-            continue
-
-        puts_short = [
-            o
-            for o in shorts
-            if o.get("type") == "put"
-            and o.get("bid", 0) and float(o.get("bid") or 0) >= 0.05
-            and o.get("delta") is not None
-        ]
-        puts_all = {float(o["strike"]): o for o in all_puts if o.get("type") == "put"}
-        if not puts_short or not puts_all:
-            continue
-
-        for short in puts_short:
-            put_delta = abs(float(short["delta"]))
-            if not (band_lo <= put_delta <= band_hi):
-                continue
-            short_strike = float(short["strike"])
-            long_strike = round(short_strike - wing, 2)
-            # snap long to nearest available strike <= target wing
-            long_candidates = [s for s in puts_all if s <= long_strike + 1e-9]
-            if not long_candidates:
-                continue
-            long_strike = max(long_candidates)
-            put_wing = round(short_strike - long_strike, 2)
-            # require exact wing width for controlled experiment ($5)
-            if abs(put_wing - wing) > 1e-6:
-                continue
-            long_opt = puts_all.get(long_strike)
-            if not long_opt:
-                continue
-            long_ask = float(long_opt.get("ask") or 0.0)
-            short_bid = float(short.get("bid") or 0.0)
-            if long_ask <= 0 or short_bid <= 0:
-                continue
-            est_credit = round(short_bid - long_ask, 2)
-            if est_credit <= 0:
-                continue
-            row = {
-                "expiry": expiry,
-                "short_put": short_strike,
-                "long_put": long_strike,
-                "put_wing": put_wing,
-                "est_credit": est_credit,
-                "put_delta": put_delta,
-                "method": "live_delta_band_scan",
-                "quantity": profile.max_contracts_per_trade,
-                "spy_price": spy_price,
-                "delta_distance": abs(put_delta - target_delta),
-            }
-            if est_credit >= min_credit:
-                candidates.append(row)
-            elif best_sub_min is None or est_credit > best_sub_min["est_credit"]:
-                best_sub_min = row
+        expiry_candidates, expiry_sub_min = _scan_put_credit_candidates(
+            expiry,
+            options,
+            profile,
+        )
+        for row in expiry_candidates:
+            row["spy_price"] = spy_price
+        candidates.extend(expiry_candidates)
+        if expiry_sub_min and (
+            best_sub_min is None or expiry_sub_min["est_credit"] > best_sub_min["est_credit"]
+        ):
+            expiry_sub_min["spy_price"] = spy_price
+            best_sub_min = expiry_sub_min
 
     if not candidates:
         if best_sub_min:

--- a/tests/test_active_strategy.py
+++ b/tests/test_active_strategy.py
@@ -123,49 +123,140 @@ def test_put_credit_inventory_gate_fails_closed_on_unexplained_leg(monkeypatch):
     assert pcs._inventory_ok(object()) is False
 
 
-def test_find_put_credit_uses_put_side_only(monkeypatch):
+def test_find_put_credit_scans_chain_once_and_uses_put_side_only(monkeypatch):
     import sys
     import types
 
     from scripts import spy_put_credit as pcs
 
-    expiry = "2026-08-21"
-    # Band-scan uses IVDataProvider put chain only (no call side).
-    short = {
-        "type": "put",
-        "strike": 700.0,
-        "delta": -0.15,
-        "bid": 1.20,
-        "ask": 1.25,
-    }
-    long = {
-        "type": "put",
-        "strike": 695.0,
-        "delta": -0.10,
-        "bid": 0.35,
-        "ask": 0.40,
-    }
-
-    class FakeProvider:
-        def get_options_chain_with_greeks(self, **kwargs):
-            # First call is delta-band filtered shorts; second is full put book.
-            if kwargs.get("min_delta") is not None:
-                return [short]
-            return [short, long]
+    expiry = "2026-08-28"
+    chain = [
+        {
+            "expiration": expiry,
+            "type": "put",
+            "strike": 700.0,
+            "bid": 1.20,
+            "ask": 1.25,
+            "delta": -0.15,
+        },
+        {
+            "expiration": expiry,
+            "type": "put",
+            "strike": 695.0,
+            "bid": 0.35,
+            "ask": 0.40,
+            "delta": -0.12,
+        },
+        {
+            "expiration": expiry,
+            "type": "call",
+            "strike": 800.0,
+            "bid": 3.00,
+            "ask": 3.10,
+            "delta": 0.15,
+        },
+    ]
+    provider = MagicMock()
+    provider.get_options_chain_with_greeks.return_value = chain
 
     # Inject a stub module so the late import inside find_put_credit_opportunity
     # does not pull real pandas/alpaca deps in unit tests.
     stub = types.ModuleType("src.data.iv_data_provider")
-    stub.IVDataProvider = FakeProvider
+    stub.IVDataProvider = lambda: provider
     monkeypatch.setitem(sys.modules, "src.data.iv_data_provider", stub)
-    monkeypatch.setattr(pcs, "_friday_expiries", lambda *a, **k: [expiry])
+    monkeypatch.setattr(pcs, "_friday_expiries", lambda *_: [expiry])
     opp = pcs.find_put_credit_opportunity(747.0)
+
     assert opp is not None
     assert opp["short_put"] == 700.0
     assert opp["long_put"] == 695.0
     assert opp["est_credit"] == 0.80
     assert opp["method"] == "live_delta_band_scan"
     assert "short_call" not in opp
+    provider.get_options_chain_with_greeks.assert_called_once_with(
+        symbol="SPY",
+        min_open_interest=0,
+    )
+
+
+def test_find_put_credit_prefers_target_delta_over_higher_credit(monkeypatch):
+    from scripts import spy_put_credit as pcs
+
+    expiry = "2026-08-28"
+    chain = [
+        {
+            "expiration": expiry,
+            "type": "put",
+            "strike": 700.0,
+            "bid": 1.10,
+            "ask": 1.20,
+            "delta": -0.15,
+        },
+        {
+            "expiration": expiry,
+            "type": "put",
+            "strike": 695.0,
+            "bid": 0.40,
+            "ask": 0.50,
+            "delta": -0.12,
+        },
+        {
+            "expiration": expiry,
+            "type": "put",
+            "strike": 690.0,
+            "bid": 1.50,
+            "ask": 1.60,
+            "delta": -0.19,
+        },
+        {
+            "expiration": expiry,
+            "type": "put",
+            "strike": 685.0,
+            "bid": 0.25,
+            "ask": 0.30,
+            "delta": -0.16,
+        },
+    ]
+    provider = MagicMock()
+    provider.get_options_chain_with_greeks.return_value = chain
+    monkeypatch.setattr("src.data.iv_data_provider.IVDataProvider", lambda: provider)
+    monkeypatch.setattr(pcs, "_friday_expiries", lambda *_: [expiry])
+
+    opp = pcs.find_put_credit_opportunity(747.0)
+
+    assert opp is not None
+    assert opp["short_put"] == 700.0
+    assert opp["put_delta"] == 0.15
+    assert opp["est_credit"] == 0.60
+
+
+def test_find_put_credit_keeps_minimum_credit_fail_closed(monkeypatch):
+    from scripts import spy_put_credit as pcs
+
+    expiry = "2026-08-28"
+    provider = MagicMock()
+    provider.get_options_chain_with_greeks.return_value = [
+        {
+            "expiration": expiry,
+            "type": "put",
+            "strike": 700.0,
+            "bid": 0.80,
+            "ask": 0.85,
+            "delta": -0.15,
+        },
+        {
+            "expiration": expiry,
+            "type": "put",
+            "strike": 695.0,
+            "bid": 0.40,
+            "ask": 0.45,
+            "delta": -0.12,
+        },
+    ]
+    monkeypatch.setattr("src.data.iv_data_provider.IVDataProvider", lambda: provider)
+    monkeypatch.setattr(pcs, "_friday_expiries", lambda *_: [expiry])
+
+    assert pcs.find_put_credit_opportunity(747.0) is None
 
 
 def test_repo_kill_switch_file_present():
@@ -548,9 +639,7 @@ def test_put_credit_parsing_and_credit_confirmation_failure_paths(tmp_path, monk
     assert pcs._parse_timestamp("not-a-timestamp") is None
     assert pcs._parse_timestamp("2026-07-22T12:00:00").tzinfo == timezone.utc
     assert pcs._expiry_yymmdd({"expiry": "260821"}) == "260821"
-    assert (
-        pcs._expiry_yymmdd({"signature": "SPY_2026-08-21_P695-700"}) == "260821"
-    )
+    assert pcs._expiry_yymmdd({"signature": "SPY_2026-08-21_P695-700"}) == "260821"
     assert pcs._expiry_yymmdd({}) == ""
 
     with pytest.raises(ValueError, match="no parseable expiry"):
@@ -637,9 +726,7 @@ def test_put_credit_main_manage_exit_reports_broken(monkeypatch, capsys):
     _patch_put_credit_cli_basics(pcs, monkeypatch)
     monkeypatch.setattr("sys.argv", ["spy_put_credit.py", "--manage-exits", "--dry-run"])
     monkeypatch.setattr(pcs, "_get_paper_client", lambda: object())
-    monkeypatch.setattr(
-        pcs, "manage_put_credit_exits", lambda client, dry_run: {"broken": 1}
-    )
+    monkeypatch.setattr(pcs, "manage_put_credit_exits", lambda client, dry_run: {"broken": 1})
     assert pcs.main() == 2
     assert '"broken": 1' in capsys.readouterr().out
 
@@ -672,9 +759,7 @@ def test_put_credit_main_blocks_duplicate_after_selection(tmp_path, monkeypatch,
     monkeypatch.setattr(pcs, "find_put_credit_opportunity", lambda _: _put_credit_opp())
     allowed = {"allowed": True, "blockers": []}
     blocked = {"allowed": False, "blockers": ["duplicate signature"]}
-    monkeypatch.setattr(
-        pcs, "evaluate_entry_limits", MagicMock(side_effect=[allowed, blocked])
-    )
+    monkeypatch.setattr(pcs, "evaluate_entry_limits", MagicMock(side_effect=[allowed, blocked]))
 
     assert pcs.main() == 2
     assert "duplicate signature" in capsys.readouterr().out

--- a/tests/test_staleness_guard.py
+++ b/tests/test_staleness_guard.py
@@ -219,6 +219,15 @@ class TestGetStalenessWarning:
 
 
 class TestContextFreshness:
+    def test_local_rag_build_refreshes_trade_gate_index(self):
+        from scripts import build_rag_query_index as builder
+
+        output_paths, page_path = builder._resolve_output_targets("local")
+
+        assert builder.LOCAL_OUTPUT_PATHS[0] in output_paths
+        assert builder.REPO_OUTPUT_PATHS[0] in output_paths
+        assert page_path == builder.LOCAL_LESSONS_PAGE_PATH
+
     def test_resolve_rag_query_index_path_prefers_local_profile(self, tmp_path, monkeypatch):
         repo_path = tmp_path / "repo_lessons_query.json"
         local_path = tmp_path / "local_lessons_query.json"


### PR DESCRIPTION
## What changed

- Replaced repeated full-chain requests with one Alpaca chain fetch per scan and local expiry partitioning.
- Extracted pure candidate selection that enforces the existing 10–22 delta band, exact $5 width, one-lot quantity, and $0.50 minimum credit.
- Updated the stale selector test and added coverage for target-delta preference, minimum-credit fail-closed behavior, and local RAG output refreshing the mandatory gate index.

## Why

The parent PR #4263 successfully found and filled one paper spread, but its existing selector test fails because it still mocks the removed IC-style selector. The initial implementation also fetched the same full option chain twice for each candidate expiry. A live fill is not a substitute for deterministic regression coverage.

## Impact

Future scans make one market-data request instead of repeated full-chain requests. Trading thresholds and the already-filled paper position are unchanged.

## Verification

- 120 focused active-strategy, staleness, TradeGateway, and workflow tests passed.
- Ruff and format checks passed.
- `git diff --check` passed.
- No broker orders submitted by this patch.