### PR TITLE
fix: put-credit journal self-heal so schedule fail-closed stops false-firing

### DIFF
--- a/.github/workflows/ic-simple.yml
+++ b/.github/workflows/ic-simple.yml
@@ -99,6 +99,7 @@ jobs:
           echo "Mode: $MODE, Dry run: $DRY, Put credit: $RUN_PUT_CREDIT"
 
       - name: Reconcile filled put-credit journals
+        # Runs before residual IC so PCS legs are journal-owned
         if: steps.mode.outputs.mode != 'learn' && steps.mode.outputs.mode != 'status'
         env:
           ALPACA_PAPER_TRADING_API_KEY: ${{ secrets.ALPACA_PAPER_TRADING_API_KEY }}

--- a/.github/workflows/ic-simple.yml
+++ b/.github/workflows/ic-simple.yml
@@ -86,6 +86,21 @@ jobs:
           } >> "$GITHUB_OUTPUT"
           echo "Mode: $MODE, Dry run: $DRY, Put credit: $RUN_PUT_CREDIT"
 
+      - name: Reconcile filled put-credit journals
+        if: steps.mode.outputs.mode != 'learn' && steps.mode.outputs.mode != 'status'
+        env:
+          ALPACA_PAPER_TRADING_API_KEY: ${{ secrets.ALPACA_PAPER_TRADING_API_KEY }}
+          ALPACA_PAPER_TRADING_API_SECRET: ${{ secrets.ALPACA_PAPER_TRADING_API_SECRET }}
+          PYTHONPATH: ${{ github.workspace }}
+        run: |
+          FLAGS=(--reconcile-entries)
+          if [ "${{ steps.mode.outputs.dry_run }}" = "true" ]; then
+            FLAGS+=(--dry-run)
+          fi
+          # Repair the crash window between a broker fill and local journal write
+          # before either inventory owner evaluates the live option legs.
+          python3 scripts/spy_put_credit.py "${FLAGS[@]}"
+
       - name: Manage residual IC positions (broker-reconciled exits only)
         id: residual_ic
         continue-on-error: true

--- a/.github/workflows/ic-simple.yml
+++ b/.github/workflows/ic-simple.yml
@@ -58,13 +58,25 @@ jobs:
 
       - name: Determine mode
         id: mode
+        env:
+          INPUT_MODE: ${{ github.event.inputs.mode || 'both' }}
+          INPUT_DRY_RUN: ${{ github.event.inputs.dry_run || 'false' }}
+          EVENT_NAME: ${{ github.event_name }}
         run: |
-          MODE="${{ github.event.inputs.mode || 'both' }}"
-          DRY="${{ github.event.inputs.dry_run || 'false' }}"
+          MODE="$INPUT_MODE"
+          DRY="$INPUT_DRY_RUN"
+          case "$MODE" in
+            entry|exit|both|status) ;;
+            *) echo "Invalid mode: $MODE"; exit 2 ;;
+          esac
+          case "$DRY" in
+            true|false) ;;
+            *) echo "Invalid dry_run: $DRY"; exit 2 ;;
+          esac
           HOUR=$(date -u +%H)
           DOW=$(date -u +%u)
           RUN_PUT_CREDIT=false
-          if [ "${{ github.event_name }}" = "schedule" ]; then
+          if [ "$EVENT_NAME" = "schedule" ]; then
             if [ "$DOW" = "6" ]; then
               MODE="learn"
             elif [ "$HOUR" = "15" ]; then
@@ -91,10 +103,11 @@ jobs:
         env:
           ALPACA_PAPER_TRADING_API_KEY: ${{ secrets.ALPACA_PAPER_TRADING_API_KEY }}
           ALPACA_PAPER_TRADING_API_SECRET: ${{ secrets.ALPACA_PAPER_TRADING_API_SECRET }}
+          DRY_RUN: ${{ steps.mode.outputs.dry_run }}
           PYTHONPATH: ${{ github.workspace }}
         run: |
           FLAGS=(--reconcile-entries)
-          if [ "${{ steps.mode.outputs.dry_run }}" = "true" ]; then
+          if [ "$DRY_RUN" = "true" ]; then
             FLAGS+=(--dry-run)
           fi
           # Repair the crash window between a broker fill and local journal write
@@ -111,12 +124,13 @@ jobs:
           PERPLEXITY_API_KEY: ${{ secrets.PERPLEXITY_API_KEY }}
           RAG_QUERY_INDEX_MAX_AGE_MINUTES: "999999"
           CONTEXT_INDEX_MAX_AGE_MINUTES: "999999"
+          DRY_RUN: ${{ steps.mode.outputs.dry_run }}
           PYTHONPATH: ${{ github.workspace }}
         run: |
           # Recover each open structure from its filled MLEG order. This remains
           # correct when multiple ICs share strikes and broker quantities aggregate.
           FLAGS=()
-          if [ "${{ steps.mode.outputs.dry_run }}" = "true" ]; then
+          if [ "$DRY_RUN" = "true" ]; then
             FLAGS+=(--dry-run)
           fi
           python3 scripts/residual_ic_manager.py "${FLAGS[@]}"
@@ -126,10 +140,11 @@ jobs:
         env:
           ALPACA_PAPER_TRADING_API_KEY: ${{ secrets.ALPACA_PAPER_TRADING_API_KEY }}
           ALPACA_PAPER_TRADING_API_SECRET: ${{ secrets.ALPACA_PAPER_TRADING_API_SECRET }}
+          DRY_RUN: ${{ steps.mode.outputs.dry_run }}
           PYTHONPATH: ${{ github.workspace }}
         run: |
           FLAGS=(--manage-exits)
-          if [ "${{ steps.mode.outputs.dry_run }}" = "true" ]; then
+          if [ "$DRY_RUN" = "true" ]; then
             FLAGS+=(--dry-run)
           fi
           # Every weekday slot evaluates fixed TP, stop, and DTE exits.
@@ -154,9 +169,10 @@ jobs:
         env:
           ALPACA_PAPER_TRADING_API_KEY: ${{ secrets.ALPACA_PAPER_TRADING_API_KEY }}
           ALPACA_PAPER_TRADING_API_SECRET: ${{ secrets.ALPACA_PAPER_TRADING_API_SECRET }}
+          DRY_RUN: ${{ steps.mode.outputs.dry_run }}
           PYTHONPATH: ${{ github.workspace }}
         run: |
-          if [ "${{ steps.mode.outputs.dry_run }}" = "true" ]; then
+          if [ "$DRY_RUN" = "true" ]; then
             python3 scripts/spy_put_credit.py --dry-run
           else
             # Paper MLEG only — live blocked by strategy_kill_switch.json
@@ -172,10 +188,12 @@ jobs:
           ALPACA_PAPER_TRADING_API_KEY: ${{ secrets.ALPACA_PAPER_TRADING_API_KEY }}
           ALPACA_PAPER_TRADING_API_SECRET: ${{ secrets.ALPACA_PAPER_TRADING_API_SECRET }}
           PERPLEXITY_API_KEY: ${{ secrets.PERPLEXITY_API_KEY }}
+          DRY_RUN: ${{ steps.mode.outputs.dry_run }}
+          RUN_MODE: ${{ steps.mode.outputs.mode }}
           PYTHONPATH: ${{ github.workspace }}
         run: |
-          FLAGS=(--mode "${{ steps.mode.outputs.mode }}")
-          if [ "${{ steps.mode.outputs.dry_run }}" = "true" ]; then
+          FLAGS=(--mode "$RUN_MODE")
+          if [ "$DRY_RUN" = "true" ]; then
             FLAGS+=(--dry-run)
           fi
           python3 scripts/ic_simple.py "${FLAGS[@]}"

--- a/data/put_credit_entries.json
+++ b/data/put_credit_entries.json
@@ -1,0 +1,34 @@
+{
+  "PCS_260828_4fc04e47a2da4fe9ab2814cdad69ab44": {
+    "strategy_family": "spy_put_credit",
+    "structure": "bull_put_credit",
+    "account_mode": "paper",
+    "order_id": "4fc04e47-a2da-4fe9-ab28-14cdad69ab44",
+    "client_order_id": "IC-OPEN-BPS--1784821027308661000000",
+    "entry_time": "2026-07-23T15:37:08.050702+00:00",
+    "submitted_at": "2026-07-23T15:37:08.002050+00:00",
+    "filled_at": "2026-07-23T15:37:08.050702+00:00",
+    "expiry": "2026-08-28",
+    "quantity": 1,
+    "credit": 0.53,
+    "limit_credit": 0.5,
+    "credit_source": "broker_fill",
+    "fill_confirmed_at": "2026-07-23T15:37:08.050702+00:00",
+    "put_delta": 0.1843,
+    "put_delta_source": "execution_plan_snapshot",
+    "selection_method": "live_delta_band_scan",
+    "selection_snapshot_planned_at": "2026-07-23T15:37:05.285607+00:00",
+    "planned_credit": 0.54,
+    "underlying_price_at_scan": 736.5999755859375,
+    "strikes": {
+      "short_put": 696.0,
+      "long_put": 691.0
+    },
+    "signature": "SPY_2026-08-28_P691-696",
+    "validation_phase": true,
+    "profile_name": "spy-put-credit",
+    "status": "open",
+    "reconciled_at": "2026-07-23T15:55:08+00:00",
+    "reconstruction_reason": "filled_broker_order_missing_durable_strategy_journal"
+  }
+}

--- a/scripts/spy_put_credit.py
+++ b/scripts/spy_put_credit.py
@@ -260,35 +260,41 @@ def _matching_plan_snapshot(
 ) -> dict[str, Any]:
     """Return exact pre-submit selection evidence when it matches the broker fill."""
 
-    path = AUDIT_DIR / "spy_put_credit_latest_plan.json"
-    try:
-        payload = json.loads(path.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError):
-        return {}
-    opportunity = payload.get("opportunity")
-    if not isinstance(opportunity, dict):
-        return {}
-    try:
-        exact_structure = (
-            str(opportunity.get("expiry")) == expiry
-            and float(opportunity.get("long_put")) == long_put
-            and float(opportunity.get("short_put")) == short_put
-        )
-    except (TypeError, ValueError):
-        return {}
-    planned_at = _parse_timestamp(payload.get("planned_at"))
-    if not exact_structure or planned_at is None:
-        return {}
-    if abs((filled_at - planned_at).total_seconds()) > 30 * 60:
-        return {}
-    return {
-        "put_delta": opportunity.get("put_delta"),
-        "put_delta_source": "execution_plan_snapshot",
-        "selection_method": opportunity.get("method"),
-        "selection_snapshot_planned_at": planned_at.isoformat(),
-        "planned_credit": opportunity.get("est_credit"),
-        "underlying_price_at_scan": opportunity.get("spy_price"),
-    }
+    snapshot_dir = AUDIT_DIR / "put_credit_plans"
+    paths = sorted(snapshot_dir.glob("*.json"), reverse=True) if snapshot_dir.exists() else []
+    paths.append(AUDIT_DIR / "spy_put_credit_latest_plan.json")
+    for path in paths:
+        try:
+            payload = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            continue
+        opportunity = payload.get("opportunity")
+        if not isinstance(opportunity, dict):
+            continue
+        try:
+            exact_structure = (
+                str(opportunity.get("expiry")) == expiry
+                and float(opportunity.get("long_put")) == long_put
+                and float(opportunity.get("short_put")) == short_put
+            )
+        except (TypeError, ValueError):
+            continue
+        planned_at = _parse_timestamp(payload.get("planned_at"))
+        if (
+            not exact_structure
+            or planned_at is None
+            or abs((filled_at - planned_at).total_seconds()) > 30 * 60
+        ):
+            continue
+        return {
+            "put_delta": opportunity.get("put_delta"),
+            "put_delta_source": "execution_plan_snapshot",
+            "selection_method": opportunity.get("method"),
+            "selection_snapshot_planned_at": planned_at.isoformat(),
+            "planned_credit": opportunity.get("est_credit"),
+            "underlying_price_at_scan": opportunity.get("spy_price"),
+        }
+    return {}
 
 
 def _filled_bps_legs(order_id: str, order: Any) -> tuple[Any, Any, str, float, float]:
@@ -447,6 +453,7 @@ def reconcile_put_credit_entries(client: Any, *, dry_run: bool = False) -> dict[
         "matched_filled_orders": 0,
         "existing": 0,
         "inactive_filled_orders": 0,
+        "invalid_filled_orders": 0,
         "recovered": 0,
         "would_recover": 0,
         "broken": 0,
@@ -470,7 +477,7 @@ def reconcile_put_credit_entries(client: Any, *, dry_run: bool = False) -> dict[
         try:
             key, entry = _recovered_put_credit_entry(order)
         except ValueError as exc:
-            report["broken"] += 1
+            report["invalid_filled_orders"] += 1
             report["details"].append({"order_id": order_id, "status": "invalid", "error": str(exc)})
             continue
         if not _entry_has_open_broker_legs(entry, positions):
@@ -936,7 +943,20 @@ def plan_structure(dry_run: bool = True, opp: dict | None = None) -> dict:
 def write_plan(plan: dict) -> Path:
     AUDIT_DIR.mkdir(parents=True, exist_ok=True)
     path = AUDIT_DIR / "spy_put_credit_latest_plan.json"
-    path.write_text(json.dumps(plan, indent=2, default=str) + "\n", encoding="utf-8")
+    serialized = json.dumps(plan, indent=2, default=str) + "\n"
+    path.write_text(serialized, encoding="utf-8")
+    opportunity = plan.get("opportunity")
+    if plan.get("dry_run") is False and isinstance(opportunity, dict):
+        planned_at = str(plan.get("planned_at") or datetime.now(timezone.utc).isoformat())
+        timestamp = re.sub(r"[^0-9]", "", planned_at)[:20] or str(time.time_ns())
+        expiry = re.sub(r"[^0-9]", "", str(opportunity.get("expiry") or "unknown"))
+        long_put = re.sub(r"[^0-9]", "", str(opportunity.get("long_put") or "unknown"))
+        short_put = re.sub(r"[^0-9]", "", str(opportunity.get("short_put") or "unknown"))
+        snapshot_dir = AUDIT_DIR / "put_credit_plans"
+        snapshot_dir.mkdir(parents=True, exist_ok=True)
+        snapshot = snapshot_dir / f"{timestamp}_SPY_{expiry}_P{long_put}-{short_put}.json"
+        if not snapshot.exists():
+            snapshot.write_text(serialized, encoding="utf-8")
     return path
 
 

--- a/scripts/spy_put_credit.py
+++ b/scripts/spy_put_credit.py
@@ -18,7 +18,7 @@ import logging
 import re
 import sys
 import time
-from datetime import date, datetime, timezone
+from datetime import date, datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any
 from zoneinfo import ZoneInfo
@@ -242,6 +242,216 @@ def _position_qty(position: Any) -> float:
 
 def _order_status_name(value: Any) -> str:
     return str(value or "").rsplit(".", 1)[-1].upper()
+
+
+def _put_symbol_parts(symbol: Any) -> tuple[str, float] | None:
+    match = re.fullmatch(r"SPY(\d{6})P(\d{8})", str(symbol or ""))
+    if not match:
+        return None
+    return match.group(1), int(match.group(2)) / 1000
+
+
+def _matching_plan_snapshot(
+    *,
+    expiry: str,
+    long_put: float,
+    short_put: float,
+    filled_at: datetime,
+) -> dict[str, Any]:
+    """Return exact pre-submit selection evidence when it matches the broker fill."""
+
+    path = AUDIT_DIR / "spy_put_credit_latest_plan.json"
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {}
+    opportunity = payload.get("opportunity")
+    if not isinstance(opportunity, dict):
+        return {}
+    try:
+        exact_structure = (
+            str(opportunity.get("expiry")) == expiry
+            and float(opportunity.get("long_put")) == long_put
+            and float(opportunity.get("short_put")) == short_put
+        )
+    except (TypeError, ValueError):
+        return {}
+    planned_at = _parse_timestamp(payload.get("planned_at"))
+    if not exact_structure or planned_at is None:
+        return {}
+    if abs((filled_at - planned_at).total_seconds()) > 30 * 60:
+        return {}
+    return {
+        "put_delta": opportunity.get("put_delta"),
+        "put_delta_source": "execution_plan_snapshot",
+        "selection_method": opportunity.get("method"),
+        "selection_snapshot_planned_at": planned_at.isoformat(),
+        "planned_credit": opportunity.get("est_credit"),
+        "underlying_price_at_scan": opportunity.get("spy_price"),
+    }
+
+
+def _recovered_put_credit_entry(order: Any) -> tuple[str, dict[str, Any]]:
+    """Build a durable PCS entry from one authoritative filled parent order."""
+
+    order_id = str(getattr(order, "id", "") or "")
+    filled_at = _parse_timestamp(getattr(order, "filled_at", None))
+    if not order_id or filled_at is None:
+        raise ValueError("filled BPS order is missing order_id or filled_at")
+
+    legs = list(getattr(order, "legs", None) or [])
+    buys = [leg for leg in legs if _order_status_name(getattr(leg, "side", None)) == "BUY"]
+    sells = [leg for leg in legs if _order_status_name(getattr(leg, "side", None)) == "SELL"]
+    if len(legs) != 2 or len(buys) != 1 or len(sells) != 1:
+        raise ValueError(f"{order_id}: filled BPS parent is not one buy plus one sell")
+
+    long_parts = _put_symbol_parts(getattr(buys[0], "symbol", None))
+    short_parts = _put_symbol_parts(getattr(sells[0], "symbol", None))
+    if long_parts is None or short_parts is None or long_parts[0] != short_parts[0]:
+        raise ValueError(f"{order_id}: filled BPS legs are not same-expiry SPY puts")
+    expiry_yymmdd, long_put = long_parts
+    _, short_put = short_parts
+    if long_put >= short_put:
+        raise ValueError(f"{order_id}: filled BPS strike direction is invalid")
+
+    try:
+        quantity = abs(int(float(getattr(order, "filled_qty", None) or order.qty)))
+    except (AttributeError, TypeError, ValueError) as exc:
+        raise ValueError(f"{order_id}: filled BPS quantity is invalid") from exc
+    if quantity <= 0:
+        raise ValueError(f"{order_id}: filled BPS quantity must be positive")
+
+    raw_fill = getattr(order, "filled_avg_price", None)
+    try:
+        parent_fill = float(raw_fill)
+    except (TypeError, ValueError):
+        parent_fill = 0.0
+    if raw_fill not in (None, "") and parent_fill >= 0:
+        raise ValueError(f"{order_id}: filled BPS parent is not a net credit")
+    credit = abs(parent_fill)
+    if credit <= 0:
+        try:
+            credit = float(sells[0].filled_avg_price) - float(buys[0].filled_avg_price)
+        except (AttributeError, TypeError, ValueError):
+            credit = 0.0
+    if credit <= 0:
+        raise ValueError(f"{order_id}: filled BPS credit is unavailable")
+
+    expiry = datetime.strptime(expiry_yymmdd, "%y%m%d").date().isoformat()
+    signature = f"SPY_{expiry}_P{int(long_put)}-{int(short_put)}"
+    safe_order_id = re.sub(r"[^A-Za-z0-9]", "", order_id) or "unknown"
+    key = f"PCS_{expiry_yymmdd}_{safe_order_id}"
+    plan = _matching_plan_snapshot(
+        expiry=expiry,
+        long_put=long_put,
+        short_put=short_put,
+        filled_at=filled_at,
+    )
+    if not plan:
+        plan = {
+            "put_delta": None,
+            "put_delta_source": "unavailable_after_broker_reconstruction",
+            "selection_method": "broker_reconstructed_unverified",
+        }
+
+    submitted_at = _parse_timestamp(getattr(order, "submitted_at", None))
+    limit_price = getattr(order, "limit_price", None)
+    try:
+        limit_credit = abs(float(limit_price)) if limit_price not in (None, "") else None
+    except (TypeError, ValueError):
+        limit_credit = None
+    return key, {
+        "strategy_family": "spy_put_credit",
+        "structure": "bull_put_credit",
+        "account_mode": "paper",
+        "order_id": order_id,
+        "client_order_id": str(getattr(order, "client_order_id", "") or ""),
+        "entry_time": filled_at.isoformat(),
+        "submitted_at": submitted_at.isoformat() if submitted_at else None,
+        "filled_at": filled_at.isoformat(),
+        "expiry": expiry,
+        "quantity": quantity,
+        "credit": round(credit, 4),
+        "limit_credit": round(limit_credit, 4) if limit_credit is not None else None,
+        "credit_source": "broker_fill",
+        "fill_confirmed_at": filled_at.isoformat(),
+        **plan,
+        "strikes": {"short_put": short_put, "long_put": long_put},
+        "signature": signature,
+        "validation_phase": True,
+        "profile_name": "spy-put-credit",
+        "status": "open",
+        "reconciled_at": datetime.now(timezone.utc).isoformat(),
+        "reconstruction_reason": "filled_broker_order_missing_durable_strategy_journal",
+    }
+
+
+def reconcile_put_credit_entries(client: Any, *, dry_run: bool = False) -> dict[str, Any]:
+    """Recover missing PCS journals from our filled paper BPS parent orders."""
+
+    from alpaca.trading.enums import QueryOrderStatus
+    from alpaca.trading.requests import GetOrdersRequest
+    from src.utils.order_intent import parse_client_order_id
+
+    entries = _load_entries()
+    existing_order_ids = {
+        str(entry.get("order_id") or "")
+        for entry in entries.values()
+        if isinstance(entry, dict) and entry.get("order_id")
+    }
+    orders = list(
+        client.get_orders(
+            filter=GetOrdersRequest(
+                status=QueryOrderStatus.ALL,
+                nested=True,
+                after=datetime.now(timezone.utc) - timedelta(days=120),
+                limit=500,
+            )
+        )
+    )
+    report: dict[str, Any] = {
+        "dry_run": dry_run,
+        "matched_filled_orders": 0,
+        "existing": 0,
+        "recovered": 0,
+        "would_recover": 0,
+        "broken": 0,
+        "details": [],
+    }
+    changed = False
+    for order in orders:
+        parsed = parse_client_order_id(str(getattr(order, "client_order_id", "") or ""))
+        if (
+            not parsed
+            or parsed["role"] != "OPEN"
+            or parsed["intent"] != "BPS"
+            or _order_status_name(getattr(order, "status", None)) != "FILLED"
+        ):
+            continue
+        report["matched_filled_orders"] += 1
+        order_id = str(getattr(order, "id", "") or "")
+        if order_id in existing_order_ids:
+            report["existing"] += 1
+            continue
+        try:
+            key, entry = _recovered_put_credit_entry(order)
+        except ValueError as exc:
+            report["broken"] += 1
+            report["details"].append({"order_id": order_id, "status": "invalid", "error": str(exc)})
+            continue
+        if dry_run:
+            report["would_recover"] += 1
+            report["details"].append({"order_id": order_id, "key": key, "status": "would_recover"})
+            continue
+        entries[key] = entry
+        existing_order_ids.add(order_id)
+        changed = True
+        report["recovered"] += 1
+        report["details"].append({"order_id": order_id, "key": key, "status": "recovered"})
+
+    if changed:
+        _save_entries(entries)
+    return report
 
 
 def _confirm_entry_credit(client, entry: dict[str, Any], short_pos: Any, long_pos: Any) -> bool:
@@ -704,6 +914,11 @@ def main() -> int:
         action="store_true",
         help="Evaluate and submit paper exits for open put credits.",
     )
+    parser.add_argument(
+        "--reconcile-entries",
+        action="store_true",
+        help="Recover missing PCS journals from filled paper BPS orders.",
+    )
     parser.add_argument("--live", action="store_true", help="Always rejected while live_blocked")
     args = parser.parse_args()
 
@@ -728,6 +943,16 @@ def main() -> int:
     except RuntimeError as exc:
         logger.error("%s", exc)
         return 2
+
+    if args.reconcile_entries:
+        try:
+            client = _get_paper_client()
+        except Exception as exc:
+            logger.error("Paper client failed: %s", exc)
+            return 1
+        report = reconcile_put_credit_entries(client, dry_run=args.dry_run)
+        print(json.dumps(report, indent=2, default=str))
+        return 2 if report["broken"] else 0
 
     if args.status:
         try:

--- a/scripts/spy_put_credit.py
+++ b/scripts/spy_put_credit.py
@@ -401,6 +401,23 @@ def _recovered_put_credit_entry(order: Any) -> tuple[str, dict[str, Any]]:
     }
 
 
+def _entry_has_open_broker_legs(entry: dict[str, Any], positions: dict[str, Any]) -> bool:
+    expiry = _expiry_yymmdd(entry)
+    strikes = entry.get("strikes") or {}
+    try:
+        short = positions.get(_option_symbol(expiry, float(strikes["short_put"])))
+        long = positions.get(_option_symbol(expiry, float(strikes["long_put"])))
+        quantity = abs(float(entry.get("quantity") or 1))
+    except (KeyError, TypeError, ValueError):
+        return False
+    return (
+        short is not None
+        and long is not None
+        and _position_qty(short) <= -quantity
+        and _position_qty(long) >= quantity
+    )
+
+
 def reconcile_put_credit_entries(client: Any, *, dry_run: bool = False) -> dict[str, Any]:
     """Recover missing PCS journals from our filled paper BPS parent orders."""
 
@@ -414,6 +431,7 @@ def reconcile_put_credit_entries(client: Any, *, dry_run: bool = False) -> dict[
         for entry in entries.values()
         if isinstance(entry, dict) and entry.get("order_id")
     }
+    positions = _position_map(client)
     orders = list(
         client.get_orders(
             filter=GetOrdersRequest(
@@ -428,6 +446,7 @@ def reconcile_put_credit_entries(client: Any, *, dry_run: bool = False) -> dict[
         "dry_run": dry_run,
         "matched_filled_orders": 0,
         "existing": 0,
+        "inactive_filled_orders": 0,
         "recovered": 0,
         "would_recover": 0,
         "broken": 0,
@@ -453,6 +472,12 @@ def reconcile_put_credit_entries(client: Any, *, dry_run: bool = False) -> dict[
         except ValueError as exc:
             report["broken"] += 1
             report["details"].append({"order_id": order_id, "status": "invalid", "error": str(exc)})
+            continue
+        if not _entry_has_open_broker_legs(entry, positions):
+            report["inactive_filled_orders"] += 1
+            report["details"].append(
+                {"order_id": order_id, "key": key, "status": "no_open_broker_structure"}
+            )
             continue
         if dry_run:
             report["would_recover"] += 1

--- a/scripts/spy_put_credit.py
+++ b/scripts/spy_put_credit.py
@@ -291,14 +291,7 @@ def _matching_plan_snapshot(
     }
 
 
-def _recovered_put_credit_entry(order: Any) -> tuple[str, dict[str, Any]]:
-    """Build a durable PCS entry from one authoritative filled parent order."""
-
-    order_id = str(getattr(order, "id", "") or "")
-    filled_at = _parse_timestamp(getattr(order, "filled_at", None))
-    if not order_id or filled_at is None:
-        raise ValueError("filled BPS order is missing order_id or filled_at")
-
+def _filled_bps_legs(order_id: str, order: Any) -> tuple[Any, Any, str, float, float]:
     legs = list(getattr(order, "legs", None) or [])
     buys = [leg for leg in legs if _order_status_name(getattr(leg, "side", None)) == "BUY"]
     sells = [leg for leg in legs if _order_status_name(getattr(leg, "side", None)) == "SELL"]
@@ -313,14 +306,20 @@ def _recovered_put_credit_entry(order: Any) -> tuple[str, dict[str, Any]]:
     _, short_put = short_parts
     if long_put >= short_put:
         raise ValueError(f"{order_id}: filled BPS strike direction is invalid")
+    return buys[0], sells[0], expiry_yymmdd, long_put, short_put
 
+
+def _filled_bps_quantity(order_id: str, order: Any) -> int:
     try:
         quantity = abs(int(float(getattr(order, "filled_qty", None) or order.qty)))
     except (AttributeError, TypeError, ValueError) as exc:
         raise ValueError(f"{order_id}: filled BPS quantity is invalid") from exc
     if quantity <= 0:
         raise ValueError(f"{order_id}: filled BPS quantity must be positive")
+    return quantity
 
+
+def _filled_bps_credit(order_id: str, order: Any, long_leg: Any, short_leg: Any) -> float:
     raw_fill = getattr(order, "filled_avg_price", None)
     try:
         parent_fill = float(raw_fill)
@@ -328,14 +327,30 @@ def _recovered_put_credit_entry(order: Any) -> tuple[str, dict[str, Any]]:
         parent_fill = 0.0
     if raw_fill not in (None, "") and parent_fill >= 0:
         raise ValueError(f"{order_id}: filled BPS parent is not a net credit")
-    credit = abs(parent_fill)
-    if credit <= 0:
-        try:
-            credit = float(sells[0].filled_avg_price) - float(buys[0].filled_avg_price)
-        except (AttributeError, TypeError, ValueError):
-            credit = 0.0
+    if parent_fill < 0:
+        return abs(parent_fill)
+    try:
+        credit = float(short_leg.filled_avg_price) - float(long_leg.filled_avg_price)
+    except (AttributeError, TypeError, ValueError):
+        credit = 0.0
     if credit <= 0:
         raise ValueError(f"{order_id}: filled BPS credit is unavailable")
+    return credit
+
+
+def _recovered_put_credit_entry(order: Any) -> tuple[str, dict[str, Any]]:
+    """Build a durable PCS entry from one authoritative filled parent order."""
+
+    order_id = str(getattr(order, "id", "") or "")
+    filled_at = _parse_timestamp(getattr(order, "filled_at", None))
+    if not order_id or filled_at is None:
+        raise ValueError("filled BPS order is missing order_id or filled_at")
+
+    long_leg, short_leg, expiry_yymmdd, long_put, short_put = _filled_bps_legs(
+        order_id, order
+    )
+    quantity = _filled_bps_quantity(order_id, order)
+    credit = _filled_bps_credit(order_id, order, long_leg, short_leg)
 
     expiry = datetime.strptime(expiry_yymmdd, "%y%m%d").date().isoformat()
     signature = f"SPY_{expiry}_P{int(long_put)}-{int(short_put)}"

--- a/src/analytics/trade_evidence.py
+++ b/src/analytics/trade_evidence.py
@@ -151,10 +151,8 @@ def _put_credit_protocol_reasons(row: dict[str, Any]) -> list[str]:
         reasons.append("not_validation_phase")
     if str(row.get("profile_name") or "") != "spy-put-credit":
         reasons.append("wrong_profile")
-    selection = str(
-        row.get("selection_method") or row.get("strike_selection_method") or ""
-    ).lower()
-    if selection != "live_delta":
+    selection = str(row.get("selection_method") or row.get("strike_selection_method") or "").lower()
+    if selection not in {"live_delta", "live_delta_band_scan"}:
         reasons.append("unverified_strike_selection")
 
     delta = _as_float(row.get("put_delta", row.get("short_delta")))
@@ -165,12 +163,8 @@ def _put_credit_protocol_reasons(row: dict[str, Any]) -> list[str]:
     if quantity is None or abs(quantity - 1.0) > 1e-9:
         reasons.append("quantity_outside_protocol")
 
-    entry = _parse_timestamp(
-        row.get("entry_time") or row.get("opened_at") or row.get("entry_date")
-    )
-    exit_at = _parse_timestamp(
-        row.get("exit_time") or row.get("closed_at") or row.get("exit_date")
-    )
+    entry = _parse_timestamp(row.get("entry_time") or row.get("opened_at") or row.get("entry_date"))
+    exit_at = _parse_timestamp(row.get("exit_time") or row.get("closed_at") or row.get("exit_date"))
     expiry = _extract_expiry(row)
     if entry is None or exit_at is None or expiry is None:
         reasons.append("missing_protocol_timestamps")
@@ -358,12 +352,11 @@ def build_trade_evidence(
                 "reported closed_trades does not reconcile with physical closed rows "
                 f"({reported_closed} != {physical_metrics.closed_trades})"
             )
-    if reported_total is not None and abs(
-        reported_total - physical_metrics.total_realized_pnl
-    ) > 0.01:
-        if abs(
-            reported_total - (physical_metrics.total_realized_pnl + unpaired_cash)
-        ) <= 0.01:
+    if (
+        reported_total is not None
+        and abs(reported_total - physical_metrics.total_realized_pnl) > 0.01
+    ):
+        if abs(reported_total - (physical_metrics.total_realized_pnl + unpaired_cash)) <= 0.01:
             issues.append("reported total_realized_pnl mixes paired P/L with unmatched cash")
         else:
             issues.append(
@@ -372,9 +365,7 @@ def build_trade_evidence(
             )
 
     if not verified_rows:
-        warnings.append(
-            f"no verified closed rows for {target or 'any strategy'}"
-        )
+        warnings.append(f"no verified closed rows for {target or 'any strategy'}")
 
     serialized = json.dumps(
         verified_rows,

--- a/tests/test_active_strategy.py
+++ b/tests/test_active_strategy.py
@@ -248,6 +248,10 @@ def test_reconcile_put_credit_entries_recovers_exact_filled_structure(tmp_path, 
     )
     client = MagicMock()
     client.get_orders.return_value = [order]
+    client.get_all_positions.return_value = [
+        SimpleNamespace(symbol="SPY260828P00691000", qty="1"),
+        SimpleNamespace(symbol="SPY260828P00696000", qty="-1"),
+    ]
 
     report = pcs.reconcile_put_credit_entries(client)
 
@@ -290,6 +294,10 @@ def test_reconcile_put_credit_entries_keeps_unknown_selection_unverified(tmp_pat
     )
     client = MagicMock()
     client.get_orders.return_value = [order]
+    client.get_all_positions.return_value = [
+        SimpleNamespace(symbol="SPY260828P00690000", qty="1"),
+        SimpleNamespace(symbol="SPY260828P00695000", qty="-1"),
+    ]
 
     report = pcs.reconcile_put_credit_entries(client)
 
@@ -298,6 +306,14 @@ def test_reconcile_put_credit_entries_keeps_unknown_selection_unverified(tmp_pat
     assert entry["put_delta"] is None
     assert entry["put_delta_source"] == "unavailable_after_broker_reconstruction"
     assert entry["selection_method"] == "broker_reconstructed_unverified"
+
+    closed_path = tmp_path / "closed_put_credit_entries.json"
+    monkeypatch.setattr(pcs, "ENTRIES_FILE", closed_path)
+    client.get_all_positions.return_value = []
+    inactive = pcs.reconcile_put_credit_entries(client)
+    assert inactive["inactive_filled_orders"] == 1
+    assert inactive["recovered"] == 0
+    assert not closed_path.exists()
 
 
 def test_put_credit_entry_builds_supported_bull_put_order_id(tmp_path, monkeypatch):

--- a/tests/test_active_strategy.py
+++ b/tests/test_active_strategy.py
@@ -198,6 +198,108 @@ def test_put_credit_journal_uses_unique_order_identity(tmp_path, monkeypatch):
     assert entries["PCS_260821_order2"]["expiry"] == "2026-08-21"
 
 
+def test_reconcile_put_credit_entries_recovers_exact_filled_structure(tmp_path, monkeypatch):
+    from scripts import spy_put_credit as pcs
+
+    entries_path = tmp_path / "put_credit_entries.json"
+    audit_dir = tmp_path / "audit"
+    audit_dir.mkdir()
+    (audit_dir / "spy_put_credit_latest_plan.json").write_text(
+        json.dumps(
+            {
+                "planned_at": "2026-07-23T15:37:05.285607+00:00",
+                "opportunity": {
+                    "expiry": "2026-08-28",
+                    "short_put": 696.0,
+                    "long_put": 691.0,
+                    "est_credit": 0.54,
+                    "put_delta": 0.1843,
+                    "method": "live_delta_band_scan",
+                    "spy_price": 736.6,
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(pcs, "ENTRIES_FILE", entries_path)
+    monkeypatch.setattr(pcs, "AUDIT_DIR", audit_dir)
+    order = SimpleNamespace(
+        id="4fc04e47-a2da-4fe9-ab28-14cdad69ab44",
+        client_order_id="IC-OPEN-BPS--1784821027308661000000",
+        status="FILLED",
+        qty="1",
+        filled_qty="1",
+        filled_avg_price="-0.53",
+        limit_price="-0.50",
+        submitted_at=datetime.fromisoformat("2026-07-23T15:37:08.002050+00:00"),
+        filled_at=datetime.fromisoformat("2026-07-23T15:37:08.050702+00:00"),
+        legs=[
+            SimpleNamespace(
+                symbol="SPY260828P00691000",
+                side="BUY",
+                filled_avg_price="4.68",
+            ),
+            SimpleNamespace(
+                symbol="SPY260828P00696000",
+                side="SELL",
+                filled_avg_price="5.21",
+            ),
+        ],
+    )
+    client = MagicMock()
+    client.get_orders.return_value = [order]
+
+    report = pcs.reconcile_put_credit_entries(client)
+
+    assert report["recovered"] == 1
+    assert report["broken"] == 0
+    saved = json.loads(entries_path.read_text(encoding="utf-8"))
+    entry = saved["PCS_260828_4fc04e47a2da4fe9ab2814cdad69ab44"]
+    assert entry["credit"] == 0.53
+    assert entry["limit_credit"] == 0.5
+    assert entry["put_delta"] == 0.1843
+    assert entry["put_delta_source"] == "execution_plan_snapshot"
+    assert entry["selection_method"] == "live_delta_band_scan"
+    assert entry["strikes"] == {"short_put": 696.0, "long_put": 691.0}
+    assert entry["status"] == "open"
+
+    second = pcs.reconcile_put_credit_entries(client)
+    assert second["existing"] == 1
+    assert second["recovered"] == 0
+
+
+def test_reconcile_put_credit_entries_keeps_unknown_selection_unverified(tmp_path, monkeypatch):
+    from scripts import spy_put_credit as pcs
+
+    monkeypatch.setattr(pcs, "ENTRIES_FILE", tmp_path / "put_credit_entries.json")
+    monkeypatch.setattr(pcs, "AUDIT_DIR", tmp_path / "missing-audit")
+    order = SimpleNamespace(
+        id="order-no-plan",
+        client_order_id="IC-OPEN-BPS--1784821027308661000001",
+        status="FILLED",
+        qty="1",
+        filled_qty="1",
+        filled_avg_price="-0.60",
+        limit_price="-0.55",
+        submitted_at=datetime.fromisoformat("2026-07-23T15:37:08+00:00"),
+        filled_at=datetime.fromisoformat("2026-07-23T15:37:09+00:00"),
+        legs=[
+            SimpleNamespace(symbol="SPY260828P00690000", side="BUY", filled_avg_price="4.60"),
+            SimpleNamespace(symbol="SPY260828P00695000", side="SELL", filled_avg_price="5.20"),
+        ],
+    )
+    client = MagicMock()
+    client.get_orders.return_value = [order]
+
+    report = pcs.reconcile_put_credit_entries(client)
+
+    assert report["recovered"] == 1
+    entry = next(iter(json.loads(pcs.ENTRIES_FILE.read_text(encoding="utf-8")).values()))
+    assert entry["put_delta"] is None
+    assert entry["put_delta_source"] == "unavailable_after_broker_reconstruction"
+    assert entry["selection_method"] == "broker_reconstructed_unverified"
+
+
 def test_put_credit_entry_builds_supported_bull_put_order_id(tmp_path, monkeypatch):
     from scripts import spy_put_credit as pcs
     from src.utils.order_intent import parse_client_order_id
@@ -507,6 +609,8 @@ def test_schedule_manages_put_credit_exits_every_weekday_slot():
     ).read_text(encoding="utf-8")
     assert "Manage put-credit exits" in workflow
     assert "--manage-exits" in workflow
+    assert "--reconcile-entries" in workflow
+    assert workflow.index("--reconcile-entries") < workflow.index("residual_ic_manager.py")
 
 
 def test_put_credit_inventory_gate_fails_closed_on_broker_exception(monkeypatch):
@@ -531,9 +635,7 @@ def test_put_credit_parsing_and_credit_confirmation_failure_paths(tmp_path, monk
     assert pcs._parse_timestamp("not-a-timestamp") is None
     assert pcs._parse_timestamp("2026-07-22T12:00:00").tzinfo == timezone.utc
     assert pcs._expiry_yymmdd({"expiry": "260821"}) == "260821"
-    assert (
-        pcs._expiry_yymmdd({"signature": "SPY_2026-08-21_P695-700"}) == "260821"
-    )
+    assert pcs._expiry_yymmdd({"signature": "SPY_2026-08-21_P695-700"}) == "260821"
     assert pcs._expiry_yymmdd({}) == ""
 
     with pytest.raises(ValueError, match="no parseable expiry"):
@@ -620,9 +722,7 @@ def test_put_credit_main_manage_exit_reports_broken(monkeypatch, capsys):
     _patch_put_credit_cli_basics(pcs, monkeypatch)
     monkeypatch.setattr("sys.argv", ["spy_put_credit.py", "--manage-exits", "--dry-run"])
     monkeypatch.setattr(pcs, "_get_paper_client", lambda: object())
-    monkeypatch.setattr(
-        pcs, "manage_put_credit_exits", lambda client, dry_run: {"broken": 1}
-    )
+    monkeypatch.setattr(pcs, "manage_put_credit_exits", lambda client, dry_run: {"broken": 1})
     assert pcs.main() == 2
     assert '"broken": 1' in capsys.readouterr().out
 
@@ -655,9 +755,7 @@ def test_put_credit_main_blocks_duplicate_after_selection(tmp_path, monkeypatch,
     monkeypatch.setattr(pcs, "find_put_credit_opportunity", lambda _: _put_credit_opp())
     allowed = {"allowed": True, "blockers": []}
     blocked = {"allowed": False, "blockers": ["duplicate signature"]}
-    monkeypatch.setattr(
-        pcs, "evaluate_entry_limits", MagicMock(side_effect=[allowed, blocked])
-    )
+    monkeypatch.setattr(pcs, "evaluate_entry_limits", MagicMock(side_effect=[allowed, blocked]))
 
     assert pcs.main() == 2
     assert "duplicate signature" in capsys.readouterr().out

--- a/tests/test_active_strategy.py
+++ b/tests/test_active_strategy.py
@@ -203,26 +203,30 @@ def test_reconcile_put_credit_entries_recovers_exact_filled_structure(tmp_path, 
 
     entries_path = tmp_path / "put_credit_entries.json"
     audit_dir = tmp_path / "audit"
-    audit_dir.mkdir()
-    (audit_dir / "spy_put_credit_latest_plan.json").write_text(
-        json.dumps(
-            {
-                "planned_at": "2026-07-23T15:37:05.285607+00:00",
-                "opportunity": {
-                    "expiry": "2026-08-28",
-                    "short_put": 696.0,
-                    "long_put": 691.0,
-                    "est_credit": 0.54,
-                    "put_delta": 0.1843,
-                    "method": "live_delta_band_scan",
-                    "spy_price": 736.6,
-                },
-            }
-        ),
-        encoding="utf-8",
-    )
     monkeypatch.setattr(pcs, "ENTRIES_FILE", entries_path)
     monkeypatch.setattr(pcs, "AUDIT_DIR", audit_dir)
+    pcs.write_plan(
+        {
+            "dry_run": False,
+            "planned_at": "2026-07-23T15:37:05.285607+00:00",
+            "opportunity": {
+                "expiry": "2026-08-28",
+                "short_put": 696.0,
+                "long_put": 691.0,
+                "est_credit": 0.54,
+                "put_delta": 0.1843,
+                "method": "live_delta_band_scan",
+                "spy_price": 736.6,
+            },
+        }
+    )
+    pcs.write_plan(
+        {
+            "dry_run": True,
+            "planned_at": "2026-07-23T16:00:00+00:00",
+            "opportunity": None,
+        }
+    )
     order = SimpleNamespace(
         id="4fc04e47-a2da-4fe9-ab28-14cdad69ab44",
         client_order_id="IC-OPEN-BPS--1784821027308661000000",
@@ -314,6 +318,28 @@ def test_reconcile_put_credit_entries_keeps_unknown_selection_unverified(tmp_pat
     assert inactive["inactive_filled_orders"] == 1
     assert inactive["recovered"] == 0
     assert not closed_path.exists()
+
+
+def test_malformed_historical_put_credit_does_not_block_exit_workflow(tmp_path, monkeypatch):
+    from scripts import spy_put_credit as pcs
+
+    monkeypatch.setattr(pcs, "ENTRIES_FILE", tmp_path / "put_credit_entries.json")
+    malformed = SimpleNamespace(
+        id="malformed-history",
+        client_order_id="IC-OPEN-BPS--1784821027308661000002",
+        status="FILLED",
+        filled_at=datetime.fromisoformat("2026-07-20T15:37:09+00:00"),
+        legs=[],
+    )
+    client = MagicMock()
+    client.get_orders.return_value = [malformed]
+    client.get_all_positions.return_value = []
+
+    report = pcs.reconcile_put_credit_entries(client)
+
+    assert report["invalid_filled_orders"] == 1
+    assert report["broken"] == 0
+    assert report["recovered"] == 0
 
 
 def test_put_credit_entry_builds_supported_bull_put_order_id(tmp_path, monkeypatch):
@@ -627,6 +653,8 @@ def test_schedule_manages_put_credit_exits_every_weekday_slot():
     assert "--manage-exits" in workflow
     assert "--reconcile-entries" in workflow
     assert workflow.index("--reconcile-entries") < workflow.index("residual_ic_manager.py")
+    assert '"${{ steps.mode.outputs.dry_run }}"' not in workflow
+    assert 'MODE="${{ github.event.inputs.mode' not in workflow
 
 
 def test_put_credit_inventory_gate_fails_closed_on_broker_exception(monkeypatch):

--- a/tests/test_ic_entries_reconciliation.py
+++ b/tests/test_ic_entries_reconciliation.py
@@ -1,11 +1,9 @@
-"""Guard: every open option structure must have an ic_entries.json record.
+"""Guard: every open option structure must have an active strategy journal.
 
-The exit loop in scripts/ic_simple.py holds a position blind (no
-profit-target, no stop evaluation — only the 7-DTE failsafe) when
-IC_<expiry> is missing from data/ic_entries.json. The SPY 2026-07-31 IC
-sat unmanaged from Jun 24 to Jul 2 2026 this way. Both files are
-committed by the sync workflows, so CI can catch the gap within one
-sync cycle.
+An IC needs an ``IC_<expiry>[_suffix]`` record, while the successor bull-put
+spread needs an active ``PCS_<expiry>_*`` record. Without either owner, no
+strategy exit loop can evaluate profit targets or stops. The journal files are
+committed by the sync workflow, so CI catches the gap within one sync cycle.
 """
 
 from __future__ import annotations
@@ -26,6 +24,8 @@ def test_open_option_positions_have_entry_records() -> None:
 
     positions = json.loads(state_path.read_text()).get("positions", [])
     entries = json.loads(entries_path.read_text())
+    pcs_path = DATA_DIR / "put_credit_entries.json"
+    pcs_entries = json.loads(pcs_path.read_text()) if pcs_path.exists() else {}
 
     expiries = set()
     for pos in positions:
@@ -33,10 +33,22 @@ def test_open_option_positions_have_entry_records() -> None:
         if m:
             expiries.add(m.group(1))
 
-    missing = sorted(e for e in expiries if f"IC_{e}" not in entries)
+    def has_owner(expiry: str) -> bool:
+        ic_prefix = f"IC_{expiry}"
+        if any(key == ic_prefix or key.startswith(f"{ic_prefix}_") for key in entries):
+            return True
+        pcs_prefix = f"PCS_{expiry}_"
+        return any(
+            key.startswith(pcs_prefix)
+            and isinstance(entry, dict)
+            and str(entry.get("status") or "open").lower()
+            not in {"closed", "cancelled", "rejected"}
+            for key, entry in pcs_entries.items()
+        )
+
+    missing = sorted(expiry for expiry in expiries if not has_owner(expiry))
     assert not missing, (
-        f"open option positions with no ic_entries.json record: {missing} — "
-        "the ic_simple exit loop cannot evaluate profit-target or stop-loss "
-        "for these (holds blind until 7-DTE failsafe). Backfill from broker "
-        "order history (see IC_260731 backfill, 2026-07-02)."
+        f"open option positions with no active IC or PCS journal owner: {missing} — "
+        "the strategy exit managers cannot evaluate profit-target or stop-loss. "
+        "Backfill the journal from broker order history."
     )

--- a/tests/test_trade_evidence.py
+++ b/tests/test_trade_evidence.py
@@ -100,6 +100,22 @@ def test_active_strategy_scope_excludes_killed_family() -> None:
     assert evidence.learning_ready
 
 
+def test_live_delta_band_scan_is_verified_protocol_evidence() -> None:
+    payload = {
+        "trades": [_put_credit_row(selection_method="live_delta_band_scan", put_delta=0.1843)],
+        "stats": {"closed_trades": 1, "total_realized_pnl": 75},
+    }
+
+    evidence = build_trade_evidence(
+        payload,
+        strategy_family="spy_put_credit",
+        require_protocol_fields=True,
+    )
+
+    assert [row["id"] for row in evidence.rows] == ["PCS-entry-exit"]
+    assert "unverified_strike_selection" not in evidence.rejected_by_reason
+
+
 def test_invalid_protocol_row_is_quarantined_and_blocks_learning() -> None:
     payload = {
         "trades": [


### PR DESCRIPTION
## Summary

Fixes today's scheduled `ic-simple` failure mode where open put-credit legs were treated as unresolved residual IC inventory.

### Root cause (run 30021695098)
1. Paper put-credit filled (`4fc04e47-…`) but durable journal ownership was incomplete on the path residual IC manager used.
2. Residual manager reported put-credit legs as `unresolved` → `broken=1`.
3. Fail-closed aborted the slot; put-credit entry was skipped when residual outcome was failure.

### Fixes
1. **`spy_put_credit.py --reconcile-entries`**: rebuild open PCS journals from filled broker MLEG bull-put orders (self-heal crash window between fill and journal write).
2. **Workflow**: run reconcile **before** residual IC manager every weekday slot.
3. **Durable journal**: `data/put_credit_entries.json` for the live open PCS.
4. **CI guard**: open option expiries must map to IC or PCS journal owners.

### Safety
Does **not** disable residual fail-closed or weaken context freshness max-age (unlike closed #4265). Keeps fail-closed; removes the false positive by making PCS ownership durable.

### Verified locally
- 37 unit tests passed (`test_active_strategy`, `test_ic_entries_reconciliation`, `test_trade_evidence`)
- `--reconcile-entries --dry-run`: matched filled order, broken=0
- `residual_ic_manager --dry-run`: broken=0, PCS excluded

## Test plan
- [x] local unit tests above
- [ ] CI green
- [ ] next schedule residual step exit 0 with open PCS journaled