### PR TITLE
feat: Ralph+GSD put-credit edge OS (scorecard + continuous tick)

### DIFF
--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -1,17 +1,41 @@
 ---
-milestone: "v1.0"
-title: "Trade Velocity Acceleration"
+milestone: "v2.0-put-credit-edge"
+title: "Put Credit Edge Proof → Smart Ops"
 status: "active"
-created: "2026-03-23"
+created: "2026-07-23"
 ---
 
-# v1.0 — Trade Velocity Acceleration
+# v2.0 — Put Credit Edge Proof (Ralph + GSD)
 
-## Phase 1: Close Learning Loop (COMPLETE)
-- GRPO training script, wired into execution, CI retraining, RAG→IC, anti-churn guard
+**Honesty gate:** Never claim profitable until closed put-credit cohort hits kill criteria  
+(`n≥30`, expectancy>0, PF>1, total realized PnL>0). Live stays blocked until then.
 
-## Phase 2: Codebase Cleanup (IN PROGRESS)
-- Root cleanup, README simplification, dashboard rewrite, dead code removal
+## Phase 1: Cohort Truth Loop (IN PROGRESS)
 
-## Phase 3: Consensus Layer SEO
-- Schema markup, blog content, llms.txt, community presence
+- Put-credit cohort scorecard (family-isolated metrics)
+- Open inventory + manage-exits + residual IC ops on every tick
+- Ralph continuous tick script writing audit artifacts
+
+## Phase 2: Smart Entry Quality
+
+- Keep delta-band scan + min credit $0.50
+- Surface daily/concurrent limits in scorecard
+- Optional: credit/delta quality gates from realized losses only after n≥10
+
+## Phase 3: Exit Intelligence
+
+- PCS min 24h / TP 25% / stop 200% / 7 DTE (unchanged until evidence)
+- Residual IC profit_pct_of_max ops visibility
+- Stop refinement only after closed-cohort evidence (not vibes)
+
+## Phase 4: Edge Decision Gate
+
+- At n=30: EDGE_CANDIDATE vs NO_EDGE_KILL
+- Live scale plan only if EDGE_CANDIDATE
+- No IC revival by default
+
+## Phase 5: Learning Stack
+
+- Family-isolated ML/RAG (no IC metrics poisoning put-credit)
+- Trajectory feedback from closed PCS only
+- North Star progress from expectancy, not equity vibes

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -1,24 +1,36 @@
 ---
-milestone: "v1.0"
-current_phase: 2
+milestone: "v2.0-put-credit-edge"
+current_phase: 1
 status: "executing"
 ---
 
-# Project State
+# Project State — Put Credit Edge OS
 
-Last activity: 2026-03-23 - Hard reset: delete dead strategies, fix trading bugs
+Last activity: 2026-07-23 — GSD roadmap reset to put-credit validation; cohort scorecard + Ralph tick
 
 ### Current Phase
-Phase 2: Codebase Cleanup — dead strategies deleted, orphan detection added, trading halted for validation
 
-### Blockers/Concerns
-- TRADING_HALTED active — validating fixes before resuming
-- 6 orphan option legs to be closed at next market open
-- GRPO needs 30+ trades to override defaults (currently 11)
+Phase 1: Cohort Truth Loop
 
-### Quick Tasks Completed
+### Active strategy
 
-| # | Description | Date | Commit | Directory |
-|---|-------------|------|--------|-----------|
-| 1 | Implement consensus layer SEO: schema markup, 71K trade study blog post, llms.txt update | 2026-03-23 | 32a922cad | [1-implement-consensus-layer-seo-schema-mar](./quick/1-implement-consensus-layer-seo-schema-mar/) |
-| 2 | Hard reset: delete dead strategy files, enforce single IC execution path | 2026-03-23 | f1d8544a5 | [2-hard-reset-delete-dead-strategy-files-en](./quick/2-hard-reset-delete-dead-strategy-files-en/) |
+- Family: `spy_put_credit` only
+- Paper-only; live_blocked
+- Profile: 1-lot, max_daily=3, max_concurrent=2, min_credit=$0.50
+
+### Reality (do not inflate)
+
+- Closed put-credit cohort: **0** (all `trades.json` rows still iron_condor)
+- 1 open PCS holding (min 24h not met)
+- Residual ICs exit-only
+- Profitability: **unproven**
+
+### Blockers
+
+- Need closed put-credit sample n≥30 before edge judgment
+- Live capital blocked by design
+
+### Ralph loop
+
+- Tick: `scripts/ralph_gsd_profit_tick.sh`
+- State: `.claude/ralph/state.json`

--- a/scripts/put_credit_cohort_scorecard.py
+++ b/scripts/put_credit_cohort_scorecard.py
@@ -1,0 +1,270 @@
+#!/usr/bin/env python3
+"""Put-credit validation cohort scorecard (edge truth, not marketing).
+
+Outputs kill-criteria progress for the active spy_put_credit family only.
+Never invents profitability: n=0 closed → insufficient sample.
+
+Usage:
+  .venv/bin/python scripts/put_credit_cohort_scorecard.py
+  .venv/bin/python scripts/put_credit_cohort_scorecard.py --json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+DEFAULT_TRADES = ROOT / "data" / "trades.json"
+DEFAULT_ENTRIES = ROOT / "data" / "put_credit_entries.json"
+DEFAULT_KILL = ROOT / "data" / "runtime" / "strategy_kill_switch.json"
+DEFAULT_OUT = ROOT / "data" / "audit" / "put_credit_cohort_latest.json"
+
+KILL_N = 30
+KILL_MIN_EXPECTANCY = 0.0
+KILL_MIN_PF = 1.0
+
+
+def _load_json(path: Path) -> Any:
+    if not path.is_file():
+        return None
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+
+
+def _as_float(value: Any) -> float | None:
+    try:
+        if value is None or value == "":
+            return None
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _trade_rows(trades_payload: Any) -> list[dict[str, Any]]:
+    if isinstance(trades_payload, list):
+        return [t for t in trades_payload if isinstance(t, dict)]
+    if not isinstance(trades_payload, dict):
+        return []
+    for key in ("trades", "closed_trades", "paired", "trade_history"):
+        rows = trades_payload.get(key)
+        if isinstance(rows, list):
+            return [t for t in rows if isinstance(t, dict)]
+    # flat dict of id -> trade
+    vals = [v for v in trades_payload.values() if isinstance(v, dict)]
+    if vals and any("realized_pnl" in v or "strategy" in v for v in vals[:5]):
+        return vals
+    return []
+
+
+def _is_put_credit_trade(row: dict[str, Any]) -> bool:
+    blob = " ".join(
+        str(row.get(k) or "")
+        for k in ("strategy", "strategy_family", "structure", "type", "signature", "id")
+    ).lower()
+    if "iron_condor" in blob and "put_credit" not in blob and "bull_put" not in blob:
+        return False
+    return any(
+        token in blob
+        for token in (
+            "spy_put_credit",
+            "put_credit",
+            "bull_put",
+            "bull put",
+            "pcs_",
+        )
+    )
+
+
+def _is_closed(row: dict[str, Any]) -> bool:
+    status = str(row.get("status") or "").lower()
+    if status in {"closed", "filled_closed", "done"}:
+        return True
+    if row.get("exit_time") or row.get("exit_date"):
+        return True
+    if _as_float(row.get("realized_pnl")) is not None and status != "open":
+        return status != "open"
+    return False
+
+
+def summarize_closed(rows: list[dict[str, Any]]) -> dict[str, Any]:
+    closed = [r for r in rows if _is_put_credit_trade(r) and _is_closed(r)]
+    pnls: list[float] = []
+    for r in closed:
+        pnl = _as_float(r.get("realized_pnl"))
+        if pnl is None:
+            # reconstruct from entry/exit cash when present
+            entry = _as_float(r.get("entry_net_cash")) or _as_float(r.get("entry_credit"))
+            exit_ = _as_float(r.get("exit_net_cash"))
+            if entry is not None and exit_ is not None:
+                # credit entry positive cash in, exit is buy-to-close negative
+                pnl = entry + exit_
+        if pnl is not None:
+            pnls.append(pnl)
+
+    n = len(pnls)
+    wins = [p for p in pnls if p > 0]
+    losses = [p for p in pnls if p < 0]
+    be = [p for p in pnls if p == 0]
+    gross_win = sum(wins)
+    gross_loss = abs(sum(losses))
+    total = sum(pnls)
+    expectancy = (total / n) if n else None
+    pf = (gross_win / gross_loss) if gross_loss > 0 else (None if n == 0 else float("inf"))
+    win_rate = (len(wins) / n * 100.0) if n else None
+
+    kill = {
+        "n_target": KILL_N,
+        "n_closed": n,
+        "sample_sufficient": n >= KILL_N,
+        "expectancy_gt_0": (expectancy is not None and expectancy > KILL_MIN_EXPECTANCY)
+        if n >= KILL_N
+        else None,
+        "profit_factor_gt_1": (pf is not None and pf > KILL_MIN_PF) if n >= KILL_N else None,
+        "total_pnl_gt_0": (total > 0) if n >= KILL_N else None,
+    }
+    if n >= KILL_N:
+        kill["pass_all"] = bool(
+            kill["expectancy_gt_0"] and kill["profit_factor_gt_1"] and kill["total_pnl_gt_0"]
+        )
+        kill["verdict"] = "EDGE_CANDIDATE" if kill["pass_all"] else "NO_EDGE_KILL"
+    else:
+        kill["pass_all"] = None
+        kill["verdict"] = "INSUFFICIENT_SAMPLE"
+
+    return {
+        "closed_n": n,
+        "wins": len(wins),
+        "losses": len(losses),
+        "breakeven": len(be),
+        "win_rate_pct": round(win_rate, 2) if win_rate is not None else None,
+        "profit_factor": round(pf, 4) if isinstance(pf, float) and pf != float("inf") else pf,
+        "expectancy": round(expectancy, 4) if expectancy is not None else None,
+        "total_realized_pnl": round(total, 2) if n else 0.0,
+        "avg_win": round(sum(wins) / len(wins), 2) if wins else None,
+        "avg_loss": round(sum(losses) / len(losses), 2) if losses else None,
+        "kill_criteria": kill,
+    }
+
+
+def summarize_open(entries: dict[str, Any] | None) -> dict[str, Any]:
+    if not isinstance(entries, dict):
+        return {"open_n": 0, "entries": []}
+    open_rows = []
+    for key, entry in entries.items():
+        if not isinstance(entry, dict):
+            continue
+        status = str(entry.get("status") or "open").lower()
+        if status in {"closed", "exited", "cancelled", "canceled"}:
+            continue
+        open_rows.append(
+            {
+                "key": key,
+                "expiry": entry.get("expiry"),
+                "credit": entry.get("credit"),
+                "quantity": entry.get("quantity"),
+                "entry_time": entry.get("entry_time") or entry.get("filled_at"),
+                "signature": entry.get("signature"),
+            }
+        )
+    return {"open_n": len(open_rows), "entries": open_rows}
+
+
+def build_scorecard(
+    *,
+    trades_path: Path = DEFAULT_TRADES,
+    entries_path: Path = DEFAULT_ENTRIES,
+    kill_path: Path = DEFAULT_KILL,
+) -> dict[str, Any]:
+    trades = _load_json(trades_path)
+    entries = _load_json(entries_path)
+    kill_switch = _load_json(kill_path) or {}
+    closed = summarize_closed(_trade_rows(trades))
+    open_ = summarize_open(entries if isinstance(entries, dict) else {})
+
+    try:
+        from src.core.trading_profiles import get_put_credit_profile
+
+        profile = get_put_credit_profile()
+        profile_view = {
+            "name": profile.name,
+            "max_daily_structures": profile.max_daily_structures,
+            "max_concurrent_positions": profile.max_concurrent_positions,
+            "max_contracts_per_trade": profile.max_contracts_per_trade,
+            "min_credit": profile.min_credit,
+            "take_profit_pct": profile.take_profit_pct,
+            "stop_loss_pct": profile.stop_loss_pct,
+            "min_hold_hours": profile.min_hold_hours,
+        }
+    except Exception as exc:  # noqa: BLE001
+        profile_view = {"error": str(exc)}
+
+    progress = {
+        "closed_toward_n30": closed["closed_n"],
+        "remaining_to_gate": max(0, KILL_N - closed["closed_n"]),
+        "pct_to_gate": round(min(100.0, closed["closed_n"] / KILL_N * 100.0), 1),
+    }
+
+    return {
+        "schema_version": "put-credit-cohort-scorecard/1",
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "active_family": kill_switch.get("active_family"),
+        "paper_only": kill_switch.get("paper_only"),
+        "live_blocked": kill_switch.get("live_blocked"),
+        "profile": profile_view,
+        "open": open_,
+        "closed": closed,
+        "progress": progress,
+        "honesty": {
+            "claim_profitable": False
+            if closed["closed_n"] < KILL_N
+            else bool(closed["kill_criteria"].get("pass_all")),
+            "note": (
+                "Do not claim profitability until kill_criteria.verdict is EDGE_CANDIDATE "
+                f"(n>={KILL_N}, expectancy>0, PF>1, total PnL>0)."
+            ),
+        },
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--json", action="store_true", help="Print JSON only")
+    parser.add_argument("--out", type=Path, default=DEFAULT_OUT)
+    args = parser.parse_args()
+
+    card = build_scorecard()
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    args.out.write_text(json.dumps(card, indent=2) + "\n", encoding="utf-8")
+
+    if args.json:
+        print(json.dumps(card, indent=2))
+        return 0
+
+    closed = card["closed"]
+    kill = closed["kill_criteria"]
+    print("=== PUT CREDIT COHORT SCORECARD ===")
+    print(f"active_family: {card.get('active_family')} paper_only={card.get('paper_only')}")
+    print(f"open: {card['open']['open_n']}  closed: {closed['closed_n']}/{KILL_N}")
+    print(f"progress_to_gate: {card['progress']['pct_to_gate']}%")
+    print(
+        f"win_rate: {closed['win_rate_pct']}  PF: {closed['profit_factor']}  "
+        f"expectancy: {closed['expectancy']}  total_pnl: {closed['total_realized_pnl']}"
+    )
+    print(f"kill_verdict: {kill['verdict']}")
+    print(f"honesty: {card['honesty']['note']}")
+    print(f"json_out={args.out}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ralph_gsd_profit_tick.py
+++ b/scripts/ralph_gsd_profit_tick.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+"""One Ralph+GSD profit tick: inventory, manage dry-runs, cohort scorecard.
+
+Paper-only. Never submits live risk. Never claims profitability.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess  # nosec B404 — fixed local scripts only
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+
+def _run(args: list[str]) -> dict:
+    proc = subprocess.run(  # nosec B603 — argv is fixed repo scripts, not shell
+        args,
+        cwd=str(ROOT),
+        capture_output=True,
+        text=True,
+        timeout=180,
+        shell=False,
+    )
+    return {
+        "cmd": args,
+        "rc": proc.returncode,
+        "stdout_tail": (proc.stdout or "")[-4000:],
+        "stderr_tail": (proc.stderr or "")[-1500:],
+    }
+
+
+def main() -> int:
+    py = ROOT / ".venv" / "bin" / "python"
+    python = str(py if py.is_file() else Path(sys.executable))
+    ts = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H%M%SZ")
+    out_dir = ROOT / "data" / "audit" / "ralph_ticks"
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    steps = {
+        "inventory": _run([python, "scripts/audit_open_inventory.py"]),
+        "put_credit_manage_dry": _run(
+            [python, "scripts/spy_put_credit.py", "--manage-exits", "--dry-run"]
+        ),
+        "residual_ic_dry": _run([python, "scripts/residual_ic_manager.py", "--dry-run"]),
+        "cohort": _run([python, "scripts/put_credit_cohort_scorecard.py", "--json"]),
+    }
+
+    cohort = {}
+    raw = steps["cohort"]["stdout_tail"]
+    try:
+        # scorecard prints pure JSON with --json
+        cohort = json.loads(raw[raw.find("{") : raw.rfind("}") + 1])
+    except Exception:
+        cohort = {"parse_error": True, "raw_tail": raw[-500:]}
+
+    report = {
+        "schema_version": "ralph-gsd-profit-tick/1",
+        "ts": ts,
+        "rcs": {k: v["rc"] for k, v in steps.items()},
+        "inventory_ok": steps["inventory"]["rc"] in (0, 2),  # 2 = unclean still ran
+        "inventory_clean": steps["inventory"]["rc"] == 0,
+        "cohort": {
+            "closed_n": (cohort.get("closed") or {}).get("closed_n"),
+            "open_n": (cohort.get("open") or {}).get("open_n"),
+            "kill_verdict": ((cohort.get("closed") or {}).get("kill_criteria") or {}).get(
+                "verdict"
+            ),
+            "progress_pct": (cohort.get("progress") or {}).get("pct_to_gate"),
+            "claim_profitable": (cohort.get("honesty") or {}).get("claim_profitable"),
+        },
+        "honesty": "paper validation only; live_blocked; no profitability claim",
+    }
+    report_path = out_dir / f"tick_{ts}.json"
+    report_path.write_text(json.dumps(report, indent=2) + "\n", encoding="utf-8")
+
+    # Detail dumps for debugging
+    (out_dir / f"tick_{ts}_inventory.txt").write_text(
+        steps["inventory"]["stdout_tail"], encoding="utf-8"
+    )
+    (out_dir / f"tick_{ts}_cohort.json").write_text(
+        json.dumps(cohort, indent=2) + "\n", encoding="utf-8"
+    )
+
+    ralph_state = ROOT / ".claude" / "ralph" / "state.json"
+    ralph_state.parent.mkdir(parents=True, exist_ok=True)
+    prev = {}
+    if ralph_state.is_file():
+        try:
+            prev = json.loads(ralph_state.read_text(encoding="utf-8"))
+        except json.JSONDecodeError:
+            prev = {}
+    prev.update(
+        {
+            "active": True,
+            "framework": "ralph+gsd",
+            "goal": "put_credit_edge_proof_n30",
+            "iteration": int(prev.get("iteration") or 0) + 1,
+            "max_iterations": int(prev.get("max_iterations") or 10_000),
+            "last_tick_at": datetime.now(timezone.utc).isoformat(),
+            "last_tick_report": str(report_path),
+            "claim_profitable": False,
+            "status": "running",
+            "completion_promise": "EDGE_GATE_READY_OR_KILLED",
+        }
+    )
+    ralph_state.write_text(json.dumps(prev, indent=2) + "\n", encoding="utf-8")
+
+    print(json.dumps(report, indent=2))
+    print(f"report={report_path}")
+    print(f"ralph_iteration={prev['iteration']}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ralph_gsd_profit_tick.sh
+++ b/scripts/ralph_gsd_profit_tick.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+# Wrapper for Ralph+GSD profit tick (LaunchAgent / cron friendly).
+set -euo pipefail
+ROOT="$(cd "$(dirname "${0}")/.." && pwd)"
+cd "${ROOT}"
+if [[ -x "${ROOT}/.venv/bin/python" ]]; then
+	exec "${ROOT}/.venv/bin/python" "${ROOT}/scripts/ralph_gsd_profit_tick.py"
+fi
+exec python3 "${ROOT}/scripts/ralph_gsd_profit_tick.py"

--- a/scripts/spy_put_credit.py
+++ b/scripts/spy_put_credit.py
@@ -1064,6 +1064,11 @@ def main() -> int:
     )
     parser.add_argument("--status", action="store_true")
     parser.add_argument(
+        "--cohort",
+        action="store_true",
+        help="Print put-credit validation cohort scorecard (edge truth)",
+    )
+    parser.add_argument(
         "--manage-exits",
         action="store_true",
         help="Evaluate and submit paper exits for open put credits.",
@@ -1108,6 +1113,13 @@ def main() -> int:
         print(json.dumps(report, indent=2, default=str))
         return 2 if report["broken"] else 0
 
+    if args.cohort:
+        from scripts.put_credit_cohort_scorecard import build_scorecard
+
+        card = build_scorecard()
+        print(json.dumps(card, indent=2, default=str))
+        return 0
+
     if args.status:
         try:
             price = get_underlying_price("SPY")
@@ -1116,9 +1128,20 @@ def main() -> int:
         plan = plan_structure(dry_run=True)
         plan["spy_price"] = price
         path = write_plan(plan)
+        try:
+            from scripts.put_credit_cohort_scorecard import build_scorecard
+
+            cohort = build_scorecard()
+        except Exception as exc:  # noqa: BLE001
+            cohort = {"error": str(exc)}
         print(
             json.dumps(
-                {"kill_state": state.__dict__, "plan": plan, "plan_path": str(path)},
+                {
+                    "kill_state": state.__dict__,
+                    "plan": plan,
+                    "plan_path": str(path),
+                    "cohort": cohort,
+                },
                 indent=2,
                 default=str,
             )

--- a/tests/test_put_credit_cohort_scorecard.py
+++ b/tests/test_put_credit_cohort_scorecard.py
@@ -1,0 +1,51 @@
+"""Unit tests for put-credit cohort scorecard (edge honesty)."""
+
+from __future__ import annotations
+
+from scripts.put_credit_cohort_scorecard import summarize_closed, summarize_open
+
+
+def test_summarize_closed_insufficient_sample():
+    rows = [
+        {
+            "strategy": "spy_put_credit",
+            "status": "closed",
+            "realized_pnl": 10.0,
+        }
+    ]
+    out = summarize_closed(rows)
+    assert out["closed_n"] == 1
+    assert out["wins"] == 1
+    assert out["kill_criteria"]["verdict"] == "INSUFFICIENT_SAMPLE"
+    assert out["kill_criteria"]["sample_sufficient"] is False
+
+
+def test_summarize_closed_ignores_iron_condor():
+    rows = [
+        {"strategy": "iron_condor", "status": "closed", "realized_pnl": -50.0},
+        {"strategy": "spy_put_credit", "status": "closed", "realized_pnl": 12.0},
+    ]
+    out = summarize_closed(rows)
+    assert out["closed_n"] == 1
+    assert out["total_realized_pnl"] == 12.0
+
+
+def test_summarize_closed_edge_candidate_at_n30():
+    wins = [{"strategy": "spy_put_credit", "status": "closed", "realized_pnl": 20.0}] * 20
+    losses = [{"strategy": "spy_put_credit", "status": "closed", "realized_pnl": -10.0}] * 10
+    out = summarize_closed(wins + losses)
+    assert out["closed_n"] == 30
+    assert out["kill_criteria"]["sample_sufficient"] is True
+    assert out["expectancy"] is not None and out["expectancy"] > 0
+    assert out["profit_factor"] is not None and out["profit_factor"] > 1
+    assert out["kill_criteria"]["verdict"] == "EDGE_CANDIDATE"
+
+
+def test_summarize_open_skips_closed():
+    entries = {
+        "PCS_open": {"status": "open", "expiry": "2026-08-28", "credit": 0.5},
+        "PCS_done": {"status": "closed", "expiry": "2026-08-21", "credit": 0.4},
+    }
+    out = summarize_open(entries)
+    assert out["open_n"] == 1
+    assert out["entries"][0]["key"] == "PCS_open"


### PR DESCRIPTION
Ralph+GSD continuous put-credit edge OS: cohort scorecard, hourly tick, GSD roadmap. Paper only. No profitability claims until n>=30 EDGE_CANDIDATE.