### PR TITLE
feat: put-credit regime gate + evidence logging (validation quality)

### DIFF
--- a/scripts/put_credit_cohort_scorecard.py
+++ b/scripts/put_credit_cohort_scorecard.py
@@ -96,6 +96,65 @@ def _is_closed(row: dict[str, Any]) -> bool:
     return False
 
 
+def _metrics_from_pnls(pnls: list[float]) -> dict[str, Any]:
+    n = len(pnls)
+    wins = [p for p in pnls if p > 0]
+    losses = [p for p in pnls if p < 0]
+    be = [p for p in pnls if p == 0]
+    gross_win = sum(wins)
+    gross_loss = abs(sum(losses))
+    total = sum(pnls)
+    expectancy = (total / n) if n else None
+    pf = (gross_win / gross_loss) if gross_loss > 0 else (None if n == 0 else float("inf"))
+    win_rate = (len(wins) / n * 100.0) if n else None
+    return {
+        "n": n,
+        "wins": len(wins),
+        "losses": len(losses),
+        "breakeven": len(be),
+        "win_rate_pct": round(win_rate, 2) if win_rate is not None else None,
+        "profit_factor": round(pf, 4) if isinstance(pf, float) and pf != float("inf") else pf,
+        "expectancy": round(expectancy, 4) if expectancy is not None else None,
+        "total_realized_pnl": round(total, 2) if n else 0.0,
+        "avg_win": round(sum(wins) / len(wins), 2) if wins else None,
+        "avg_loss": round(sum(losses) / len(losses), 2) if losses else None,
+    }
+
+
+def _rolling_windows(pnls: list[float], window: int = 20) -> dict[str, Any]:
+    """Stability check: last rolling window metrics (research backlog A2)."""
+    if not pnls:
+        return {
+            "window": window,
+            "sample_sufficient": False,
+            "last": None,
+            "note": "no closed put-credit pnls",
+        }
+    if len(pnls) < window:
+        m = _metrics_from_pnls(pnls)
+        return {
+            "window": window,
+            "sample_sufficient": False,
+            "last": m,
+            "note": f"need {window} closed trades for full rolling window (have {len(pnls)})",
+        }
+    last = _metrics_from_pnls(pnls[-window:])
+    # sign stability vs full sample
+    full = _metrics_from_pnls(pnls)
+    sign_flip = False
+    if full.get("expectancy") is not None and last.get("expectancy") is not None:
+        sign_flip = (full["expectancy"] > 0) != (last["expectancy"] > 0)
+    return {
+        "window": window,
+        "sample_sufficient": True,
+        "last": last,
+        "sign_flip_vs_full": sign_flip,
+        "note": (
+            "If sign_flip_vs_full at n>=30, treat edge as unstable (research kill heuristic)."
+        ),
+    }
+
+
 def summarize_closed(rows: list[dict[str, Any]]) -> dict[str, Any]:
     closed = [r for r in rows if _is_put_credit_trade(r) and _is_closed(r)]
     pnls: list[float] = []
@@ -111,16 +170,11 @@ def summarize_closed(rows: list[dict[str, Any]]) -> dict[str, Any]:
         if pnl is not None:
             pnls.append(pnl)
 
-    n = len(pnls)
-    wins = [p for p in pnls if p > 0]
-    losses = [p for p in pnls if p < 0]
-    be = [p for p in pnls if p == 0]
-    gross_win = sum(wins)
-    gross_loss = abs(sum(losses))
-    total = sum(pnls)
-    expectancy = (total / n) if n else None
-    pf = (gross_win / gross_loss) if gross_loss > 0 else (None if n == 0 else float("inf"))
-    win_rate = (len(wins) / n * 100.0) if n else None
+    base = _metrics_from_pnls(pnls)
+    n = base["n"]
+    expectancy = base["expectancy"]
+    pf = base["profit_factor"]
+    total = base["total_realized_pnl"]
 
     kill = {
         "n_target": KILL_N,
@@ -131,6 +185,11 @@ def summarize_closed(rows: list[dict[str, Any]]) -> dict[str, Any]:
         else None,
         "profit_factor_gt_1": (pf is not None and pf > KILL_MIN_PF) if n >= KILL_N else None,
         "total_pnl_gt_0": (total > 0) if n >= KILL_N else None,
+        "research_note": (
+            "n=30 is an interim floor; Parallel research recommends ~100 trades and "
+            "multi-regime coverage before desk-grade confidence. Live still blocked "
+            "until EDGE_CANDIDATE; do not deposit capital on interim n alone."
+        ),
     }
     if n >= KILL_N:
         kill["pass_all"] = bool(
@@ -143,16 +202,17 @@ def summarize_closed(rows: list[dict[str, Any]]) -> dict[str, Any]:
 
     return {
         "closed_n": n,
-        "wins": len(wins),
-        "losses": len(losses),
-        "breakeven": len(be),
-        "win_rate_pct": round(win_rate, 2) if win_rate is not None else None,
-        "profit_factor": round(pf, 4) if isinstance(pf, float) and pf != float("inf") else pf,
-        "expectancy": round(expectancy, 4) if expectancy is not None else None,
-        "total_realized_pnl": round(total, 2) if n else 0.0,
-        "avg_win": round(sum(wins) / len(wins), 2) if wins else None,
-        "avg_loss": round(sum(losses) / len(losses), 2) if losses else None,
+        "wins": base["wins"],
+        "losses": base["losses"],
+        "breakeven": base["breakeven"],
+        "win_rate_pct": base["win_rate_pct"],
+        "profit_factor": base["profit_factor"],
+        "expectancy": base["expectancy"],
+        "total_realized_pnl": base["total_realized_pnl"],
+        "avg_win": base["avg_win"],
+        "avg_loss": base["avg_loss"],
         "kill_criteria": kill,
+        "rolling_20": _rolling_windows(pnls, 20),
     }
 
 
@@ -166,6 +226,7 @@ def summarize_open(entries: dict[str, Any] | None) -> dict[str, Any]:
         status = str(entry.get("status") or "open").lower()
         if status in {"closed", "exited", "cancelled", "canceled"}:
             continue
+        regime = entry.get("regime") if isinstance(entry.get("regime"), dict) else {}
         open_rows.append(
             {
                 "key": key,
@@ -174,6 +235,13 @@ def summarize_open(entries: dict[str, Any] | None) -> dict[str, Any]:
                 "quantity": entry.get("quantity"),
                 "entry_time": entry.get("entry_time") or entry.get("filled_at"),
                 "signature": entry.get("signature"),
+                "regime": {
+                    "vix": regime.get("vix"),
+                    "iv_rank_proxy": regime.get("iv_rank_proxy"),
+                    "spy_above_200dma": regime.get("spy_above_200dma"),
+                }
+                if regime
+                else None,
             }
         )
     return {"open_n": len(open_rows), "entries": open_rows}
@@ -228,10 +296,19 @@ def build_scorecard(
             "claim_profitable": False
             if closed["closed_n"] < KILL_N
             else bool(closed["kill_criteria"].get("pass_all")),
+            "live_deposit_ready": False,
             "note": (
-                "Do not claim profitability until kill_criteria.verdict is EDGE_CANDIDATE "
-                f"(n>={KILL_N}, expectancy>0, PF>1, total PnL>0)."
+                "Do not claim profitability or deposit real capital until kill_criteria.verdict "
+                f"is EDGE_CANDIDATE (n>={KILL_N}, expectancy>0, PF>1, total PnL>0). "
+                "Process upgrades (regime gate, logging) improve validation quality only — "
+                "they do not create edge."
             ),
+        },
+        "process_upgrades": {
+            "regime_gate": "IVR>=30 and VIX<=30 hard; SPY 200-DMA soft-flag",
+            "entry_regime_logging": True,
+            "exit_counterfactuals_tp50_dte21": True,
+            "rolling_20_metrics": True,
         },
     }
 

--- a/scripts/spy_put_credit.py
+++ b/scripts/spy_put_credit.py
@@ -212,7 +212,7 @@ def evaluate_put_credit_exit(
         elif pnl <= -(max_profit * profile.stop_loss_pct):
             reason = "stop_loss"
 
-    return {
+    result = {
         "should_exit": reason is not None,
         "exit_reason": reason,
         "dte": dte,
@@ -223,6 +223,13 @@ def evaluate_put_credit_exit(
         "profit_target": max_profit * profile.take_profit_pct,
         "stop_loss": -(max_profit * profile.stop_loss_pct),
     }
+    try:
+        from src.risk.put_credit_regime import attach_counterfactuals
+
+        result = attach_counterfactuals(result, credit=credit, quantity=quantity, dte=dte)
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("counterfactual attach skipped: %s", exc)
+    return result
 
 
 def _position_map(client) -> dict[str, Any]:
@@ -983,6 +990,17 @@ def _record_entry(opp: dict, order_id: str) -> None:
     if key in entries and entries[key].get("order_id") != order_id:
         raise RuntimeError(f"Put-credit journal identity collision for {key}")
     signature = f"SPY_{opp['expiry']}_P{int(opp['long_put'])}-{int(opp['short_put'])}"
+    regime = opp.get("regime") if isinstance(opp.get("regime"), dict) else None
+    if regime is None:
+        try:
+            from src.risk.put_credit_regime import capture_regime_snapshot
+
+            regime = capture_regime_snapshot(
+                float(opp["spy_price"]) if opp.get("spy_price") is not None else None
+            ).as_dict()
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("Regime snapshot at journal failed: %s", exc)
+            regime = {"error": str(exc)}
     entries[key] = {
         "strategy_family": "spy_put_credit",
         "order_id": order_id,
@@ -1002,6 +1020,7 @@ def _record_entry(opp: dict, order_id: str) -> None:
         "validation_phase": True,
         "profile_name": "spy-put-credit",
         "status": "submitted_unconfirmed",
+        "regime": regime,
     }
     _save_entries(entries)
     logger.info("Recorded %s in %s", key, ENTRIES_FILE)
@@ -1077,6 +1096,16 @@ def main() -> int:
         "--reconcile-entries",
         action="store_true",
         help="Recover missing PCS journals from filled paper BPS orders.",
+    )
+    parser.add_argument(
+        "--ignore-regime-gate",
+        action="store_true",
+        help="Bypass IVR/VIX regime entry gate (paper debug only; still paper-only).",
+    )
+    parser.add_argument(
+        "--regime-status",
+        action="store_true",
+        help="Print current regime snapshot and gate decision only.",
     )
     parser.add_argument("--live", action="store_true", help="Always rejected while live_blocked")
     args = parser.parse_args()
@@ -1158,6 +1187,18 @@ def main() -> int:
         print(json.dumps(report, indent=2, default=str))
         return 2 if report["broken"] else 0
 
+    if args.regime_status:
+        try:
+            price = float(get_underlying_price("SPY"))
+        except Exception:
+            price = None
+        from src.risk.put_credit_regime import capture_regime_snapshot, evaluate_regime_gate
+
+        snap = capture_regime_snapshot(price)
+        gate = evaluate_regime_gate(snap)
+        print(json.dumps(gate, indent=2, default=str))
+        return 0 if gate["allowed"] else 2
+
     if not _inventory_ok():
         return 2
 
@@ -1173,10 +1214,51 @@ def main() -> int:
         logger.error("Cannot get SPY price: %s", exc)
         return 1
 
+    # Research-backed regime gate (IVR / VIX) before scanning or submitting.
+    from src.risk.put_credit_regime import capture_regime_snapshot, evaluate_regime_gate
+
+    regime_snap = capture_regime_snapshot(spy_price)
+    regime_gate = evaluate_regime_gate(regime_snap)
+    if not regime_gate["allowed"] and not args.ignore_regime_gate:
+        logger.error(
+            "PUT-CREDIT REGIME GATE BLOCKED: %s",
+            " | ".join(regime_gate["blockers"]),
+        )
+        print(
+            json.dumps(
+                {
+                    "success": False,
+                    "reason": "regime_gate_blocked",
+                    "regime": regime_gate,
+                },
+                indent=2,
+                default=str,
+            )
+        )
+        return 2
+    if regime_gate.get("soft_flags"):
+        logger.warning("Regime soft flags: %s", " | ".join(regime_gate["soft_flags"]))
+    if args.ignore_regime_gate and not regime_gate["allowed"]:
+        logger.warning(
+            "Ignoring regime gate blockers (debug): %s",
+            " | ".join(regime_gate["blockers"]),
+        )
+
     opp = find_put_credit_opportunity(spy_price)
+    if isinstance(opp, dict):
+        opp["spy_price"] = spy_price
+        opp["regime"] = regime_snap.as_dict()
+        opp["regime_gate"] = {
+            "allowed": regime_gate["allowed"],
+            "blockers": regime_gate["blockers"],
+            "soft_flags": regime_gate["soft_flags"],
+            "thresholds": regime_gate["thresholds"],
+        }
     dry = not args.execute_paper
     plan = plan_structure(dry_run=dry, opp=opp)
     plan["spy_price"] = spy_price
+    plan["regime"] = regime_snap.as_dict()
+    plan["regime_gate"] = regime_gate
     path = write_plan(plan)
 
     if opp is None:
@@ -1192,19 +1274,28 @@ def main() -> int:
         return 2
 
     logger.info(
-        "Policy: 1-lot $%.0f-wide put credit | Δ=%.2f | credit=$%.2f | TP %.0f%% | SL %.0fx",
+        "Policy: 1-lot $%.0f-wide put credit | Δ=%.2f | credit=$%.2f | TP %.0f%% | SL %.0fx | "
+        "IVR=%s VIX=%s",
         plan["wing_width"],
         opp["put_delta"],
         opp["est_credit"],
         plan["take_profit_pct"] * 100,
         plan["stop_loss_pct"],
+        regime_snap.iv_rank_proxy,
+        regime_snap.vix,
     )
 
     if dry:
         logger.info("DRY RUN — no order (pass --execute-paper for paper MLEG)")
         print(
             json.dumps(
-                {"success": True, "dry_run": True, "opportunity": opp, "plan_path": str(path)},
+                {
+                    "success": True,
+                    "dry_run": True,
+                    "opportunity": opp,
+                    "regime": regime_gate,
+                    "plan_path": str(path),
+                },
                 indent=2,
                 default=str,
             )
@@ -1227,6 +1318,16 @@ def main() -> int:
         with acquire_trade_lock(timeout=10):
             if not _inventory_ok(client):
                 return 2
+            # Re-check regime under lock (stale window)
+            regime_snap2 = capture_regime_snapshot(spy_price)
+            regime_gate2 = evaluate_regime_gate(regime_snap2)
+            if not regime_gate2["allowed"] and not args.ignore_regime_gate:
+                logger.error(
+                    "PUT-CREDIT REGIME GATE BLOCKED after lock: %s",
+                    " | ".join(regime_gate2["blockers"]),
+                )
+                return 2
+            opp["regime"] = regime_snap2.as_dict()
             limit_report = evaluate_entry_limits(_load_entries(), candidate_signature=signature)
             if not limit_report["allowed"]:
                 logger.error(

--- a/src/risk/put_credit_regime.py
+++ b/src/risk/put_credit_regime.py
@@ -60,7 +60,6 @@ def _spy_sma_200(spy_price: float | None) -> tuple[float | None, bool | None, st
         from alpaca.data.historical import StockHistoricalDataClient
         from alpaca.data.requests import StockBarsRequest
         from alpaca.data.timeframe import TimeFrame
-
         from src.utils.alpaca_client import get_alpaca_credentials
 
         key, secret = get_alpaca_credentials()

--- a/src/risk/put_credit_regime.py
+++ b/src/risk/put_credit_regime.py
@@ -1,0 +1,248 @@
+"""Regime snapshot and entry gate for spy_put_credit paper validation.
+
+Research-backed minimal filter (Parallel deep research 2026-07-24):
+- Prefer short premium when IV rank proxy is elevated (IVR >= 30)
+- Hard veto when VIX is extreme (VIX > 30)
+- Optional trend soft-flag: SPY vs 200-day SMA (logged; hard only if enabled)
+
+Does NOT claim edge. Live remains blocked by kill switch until cohort gates pass.
+Missing market data fails closed for *new entries* (fail open for pure logging).
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from dataclasses import asdict, dataclass
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# Research defaults — keep knobs explicit for audit.
+MIN_IV_RANK = float(os.environ.get("PUT_CREDIT_MIN_IVR", "30"))
+MAX_VIX = float(os.environ.get("PUT_CREDIT_MAX_VIX", "30"))
+REQUIRE_ABOVE_200DMA = os.environ.get("PUT_CREDIT_REQUIRE_200DMA", "0").lower() in {
+    "1",
+    "true",
+    "yes",
+}
+# When true, missing IVR/VIX blocks entries. Default true for reliability.
+FAIL_CLOSED_ON_MISSING = os.environ.get("PUT_CREDIT_REGIME_FAIL_CLOSED", "1").lower() in {
+    "1",
+    "true",
+    "yes",
+}
+
+
+@dataclass(frozen=True)
+class RegimeSnapshot:
+    """Point-in-time regime fields recorded on each put-credit entry."""
+
+    captured_at: str
+    spy_price: float | None
+    vix: float | None
+    iv_rank_proxy: float | None
+    iv_rank_method: str
+    spy_sma_200: float | None
+    spy_above_200dma: bool | None
+    source_errors: tuple[str, ...] = ()
+
+    def as_dict(self) -> dict[str, Any]:
+        payload = asdict(self)
+        payload["source_errors"] = list(self.source_errors)
+        return payload
+
+
+def _spy_sma_200(spy_price: float | None) -> tuple[float | None, bool | None, str | None]:
+    """Return (sma200, above, error)."""
+    try:
+        from alpaca.data.historical import StockHistoricalDataClient
+        from alpaca.data.requests import StockBarsRequest
+        from alpaca.data.timeframe import TimeFrame
+
+        from src.utils.alpaca_client import get_alpaca_credentials
+
+        key, secret = get_alpaca_credentials()
+        if not key:
+            return None, None, "no_alpaca_credentials"
+        client = StockHistoricalDataClient(key, secret)
+        end = datetime.now(timezone.utc)
+        start = end - timedelta(days=400)
+        req = StockBarsRequest(
+            symbol_or_symbols=["SPY"],
+            timeframe=TimeFrame.Day,
+            start=start,
+            end=end,
+        )
+        bars = client.get_stock_bars(req)
+        rows = bars.data.get("SPY") if hasattr(bars, "data") else None
+        if not rows or len(rows) < 200:
+            return None, None, f"insufficient_spy_bars:{0 if not rows else len(rows)}"
+        closes = [float(b.close) for b in rows if getattr(b, "close", None) is not None]
+        if len(closes) < 200:
+            return None, None, f"insufficient_spy_closes:{len(closes)}"
+        sma = sum(closes[-200:]) / 200.0
+        price = float(spy_price) if spy_price is not None else closes[-1]
+        return round(sma, 4), bool(price >= sma), None
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("SPY 200-DMA fetch failed: %s", exc)
+        return None, None, f"spy_sma_error:{exc}"
+
+
+def capture_regime_snapshot(spy_price: float | None = None) -> RegimeSnapshot:
+    """Best-effort regime snapshot. Never raises — returns partial fields + errors."""
+
+    errors: list[str] = []
+    vix: float | None = None
+    ivr: float | None = None
+    ivr_method = "none"
+
+    try:
+        from src.options.vix_monitor import VIXMonitor
+
+        monitor = VIXMonitor()
+        vix = float(monitor.get_current_vix())
+    except Exception as exc:  # noqa: BLE001
+        errors.append(f"vix:{exc}")
+        logger.warning("Regime snapshot: VIX unavailable: %s", exc)
+
+    try:
+        from src.markets.iv_rank import current_iv_rank_proxy
+
+        ivr = current_iv_rank_proxy("SPY")
+        if ivr is not None:
+            ivr_method = "vixy_percentile_proxy"
+        else:
+            errors.append("iv_rank_proxy_none")
+    except Exception as exc:  # noqa: BLE001
+        errors.append(f"iv_rank:{exc}")
+        logger.warning("Regime snapshot: IV rank proxy unavailable: %s", exc)
+
+    # Prefer VIX percentile as IVR when proxy missing but VIX monitor works
+    if ivr is None:
+        try:
+            from src.options.vix_monitor import VIXMonitor
+
+            pct = float(VIXMonitor().get_vix_percentile(252))
+            ivr = pct
+            ivr_method = "vix_percentile_252"
+        except Exception as exc:  # noqa: BLE001
+            errors.append(f"vix_percentile:{exc}")
+
+    sma, above, sma_err = _spy_sma_200(spy_price)
+    if sma_err:
+        errors.append(sma_err)
+
+    return RegimeSnapshot(
+        captured_at=datetime.now(timezone.utc).isoformat(),
+        spy_price=float(spy_price) if spy_price is not None else None,
+        vix=round(vix, 4) if vix is not None else None,
+        iv_rank_proxy=round(ivr, 2) if ivr is not None else None,
+        iv_rank_method=ivr_method,
+        spy_sma_200=sma,
+        spy_above_200dma=above,
+        source_errors=tuple(errors),
+    )
+
+
+def evaluate_regime_gate(
+    snapshot: RegimeSnapshot | dict[str, Any],
+    *,
+    min_iv_rank: float = MIN_IV_RANK,
+    max_vix: float = MAX_VIX,
+    require_above_200dma: bool = REQUIRE_ABOVE_200DMA,
+    fail_closed_on_missing: bool = FAIL_CLOSED_ON_MISSING,
+) -> dict[str, Any]:
+    """Return {allowed, blockers, soft_flags, snapshot}.
+
+    Hard blockers (default):
+    - VIX > max_vix
+    - IV rank proxy < min_iv_rank
+    - missing VIX or IVR when fail_closed_on_missing
+    Soft flags (never block unless require_above_200dma):
+    - SPY below 200-DMA
+    """
+
+    if isinstance(snapshot, RegimeSnapshot):
+        snap = snapshot.as_dict()
+    else:
+        snap = dict(snapshot)
+
+    blockers: list[str] = []
+    soft: list[str] = []
+
+    vix = snap.get("vix")
+    ivr = snap.get("iv_rank_proxy")
+    above = snap.get("spy_above_200dma")
+
+    if vix is None:
+        msg = "VIX unavailable for regime gate"
+        if fail_closed_on_missing:
+            blockers.append(msg)
+        else:
+            soft.append(msg)
+    elif float(vix) > float(max_vix):
+        blockers.append(f"VIX {float(vix):.2f} > max {float(max_vix):.2f} (hard veto)")
+
+    if ivr is None:
+        msg = "IV rank proxy unavailable for regime gate"
+        if fail_closed_on_missing:
+            blockers.append(msg)
+        else:
+            soft.append(msg)
+    elif float(ivr) < float(min_iv_rank):
+        blockers.append(
+            f"IV rank proxy {float(ivr):.1f} < min {float(min_iv_rank):.1f} (short-premium filter)"
+        )
+
+    if above is False:
+        msg = "SPY below 200-day SMA (trend soft-flag)"
+        if require_above_200dma:
+            blockers.append(msg)
+        else:
+            soft.append(msg)
+    elif above is None:
+        soft.append("SPY 200-DMA unavailable")
+
+    return {
+        "allowed": not blockers,
+        "blockers": blockers,
+        "soft_flags": soft,
+        "thresholds": {
+            "min_iv_rank": min_iv_rank,
+            "max_vix": max_vix,
+            "require_above_200dma": require_above_200dma,
+            "fail_closed_on_missing": fail_closed_on_missing,
+        },
+        "snapshot": snap,
+    }
+
+
+def attach_counterfactuals(
+    exit_eval: dict[str, Any],
+    *,
+    credit: float,
+    quantity: int = 1,
+    dte: int | None = None,
+) -> dict[str, Any]:
+    """Add public-rule counterfactuals (50% TP, 21 DTE) without changing live exits."""
+
+    qty = abs(int(quantity or 1))
+    max_profit = float(credit) * 100.0 * qty
+    pnl = float(exit_eval.get("estimated_pnl") or 0.0)
+    out = dict(exit_eval)
+    out["counterfactuals"] = {
+        "tp_25_target": round(max_profit * 0.25, 2),
+        "tp_50_target": round(max_profit * 0.50, 2),
+        "would_hit_tp_25_now": pnl >= max_profit * 0.25,
+        "would_hit_tp_50_now": pnl >= max_profit * 0.50,
+        "public_exit_dte": 21,
+        "dte_now": dte,
+        "would_trigger_public_21dte_exit": (dte is not None and dte <= 21),
+        "note": (
+            "Counterfactuals only — system still exits at profile TP 25% / exit_dte=7. "
+            "Used to compare our rules to public 50%/21-DTE research without re-running history."
+        ),
+    }
+    return out

--- a/tests/test_put_credit_regime.py
+++ b/tests/test_put_credit_regime.py
@@ -1,0 +1,96 @@
+"""Tests for put-credit regime gate and counterfactuals."""
+
+from __future__ import annotations
+
+from src.risk.put_credit_regime import (
+    RegimeSnapshot,
+    attach_counterfactuals,
+    evaluate_regime_gate,
+)
+
+
+def _snap(**kwargs) -> RegimeSnapshot:
+    base = dict(
+        captured_at="2026-07-24T00:00:00+00:00",
+        spy_price=740.0,
+        vix=18.0,
+        iv_rank_proxy=45.0,
+        iv_rank_method="test",
+        spy_sma_200=700.0,
+        spy_above_200dma=True,
+        source_errors=(),
+    )
+    base.update(kwargs)
+    return RegimeSnapshot(**base)
+
+
+def test_regime_allows_healthy_short_premium():
+    gate = evaluate_regime_gate(_snap())
+    assert gate["allowed"] is True
+    assert gate["blockers"] == []
+
+
+def test_regime_blocks_high_vix():
+    gate = evaluate_regime_gate(_snap(vix=35.0))
+    assert gate["allowed"] is False
+    assert any("VIX" in b for b in gate["blockers"])
+
+
+def test_regime_blocks_low_ivr():
+    gate = evaluate_regime_gate(_snap(iv_rank_proxy=10.0))
+    assert gate["allowed"] is False
+    assert any("IV rank" in b for b in gate["blockers"])
+
+
+def test_regime_missing_vix_fail_closed():
+    gate = evaluate_regime_gate(_snap(vix=None), fail_closed_on_missing=True)
+    assert gate["allowed"] is False
+    assert any("VIX unavailable" in b for b in gate["blockers"])
+
+
+def test_regime_missing_vix_fail_open():
+    gate = evaluate_regime_gate(_snap(vix=None), fail_closed_on_missing=False)
+    assert gate["allowed"] is True
+    assert any("VIX unavailable" in f for f in gate["soft_flags"])
+
+
+def test_trend_soft_flag_by_default():
+    gate = evaluate_regime_gate(_snap(spy_above_200dma=False), require_above_200dma=False)
+    assert gate["allowed"] is True
+    assert any("200-day" in f for f in gate["soft_flags"])
+
+
+def test_trend_hard_when_required():
+    gate = evaluate_regime_gate(_snap(spy_above_200dma=False), require_above_200dma=True)
+    assert gate["allowed"] is False
+
+
+def test_counterfactuals_tp50_and_21dte():
+    base = {
+        "should_exit": False,
+        "exit_reason": None,
+        "estimated_pnl": 20.0,
+        "credit": 0.80,
+    }
+    out = attach_counterfactuals(base, credit=0.80, quantity=1, dte=15)
+    cf = out["counterfactuals"]
+    assert cf["tp_50_target"] == 40.0
+    assert cf["would_hit_tp_25_now"] is True  # 20 >= 20
+    assert cf["would_hit_tp_50_now"] is False  # 20 < 40
+    assert cf["would_trigger_public_21dte_exit"] is True  # dte 15 <= 21
+
+
+def test_exit_eval_includes_counterfactuals():
+    from scripts.spy_put_credit import evaluate_put_credit_exit
+
+    entry = {
+        "expiry": "2026-08-28",
+        "credit": 1.0,
+        "quantity": 1,
+        "entry_time": "2026-07-01T15:00:00+00:00",
+        "signature": "SPY_2026-08-28_P690-695",
+    }
+    # short - long = debit; credit 1.0, debit 0.5 → pnl 50, max profit 100 → 50% TP
+    detail = evaluate_put_credit_exit(entry, short_price=1.0, long_price=0.5)
+    assert "counterfactuals" in detail
+    assert detail["counterfactuals"]["would_hit_tp_50_now"] is True


### PR DESCRIPTION
## Summary
Process upgrades from Parallel deep research so put-credit validation is more rigorous **without claiming profitability**.

1. **Regime entry gate** — IV rank proxy ≥30 and VIX ≤30 (hard); SPY 200-DMA soft-flag
2. **Entry logging** — regime fields on every PCS journal row
3. **Exit counterfactuals** — log would-hit 50% TP / 21 DTE vs our 25% / 7 DTE
4. **Cohort scorecard** — rolling 20-trade metrics; `live_deposit_ready: false` until EDGE_CANDIDATE

## Honesty
These changes **do not make the system profitable**. Closed put-credit n is still 0. Live stays blocked. Deposit real money only after kill criteria pass.

## Test plan
- [x] `pytest tests/test_put_credit_regime.py -q` (9 passed)
- [x] `spy_put_credit.py --regime-status` smoke (VIX/IVR live)
- [ ] CI green