### PR TITLE
fix: Greptile P1s — daily cap broker max, RAG lessons-only, regime fail-closed, counterfactuals

### DIFF
--- a/scripts/put_credit_cohort_scorecard.py
+++ b/scripts/put_credit_cohort_scorecard.py
@@ -155,8 +155,19 @@ def _rolling_windows(pnls: list[float], window: int = 20) -> dict[str, Any]:
     }
 
 
+def _close_sort_key(row: dict[str, Any]) -> str:
+    """ISO-ish close timestamp for chronological rolling windows (Greptile #4280 P2)."""
+    for key in ("exit_time", "exit_date", "closed_at", "filled_at", "entry_time"):
+        val = row.get(key)
+        if val:
+            return str(val)
+    return ""
+
+
 def summarize_closed(rows: list[dict[str, Any]]) -> dict[str, Any]:
     closed = [r for r in rows if _is_put_credit_trade(r) and _is_closed(r)]
+    # Sort by close time so rolling_20 is last-N by time, not JSON iteration order.
+    closed = sorted(closed, key=_close_sort_key)
     pnls: list[float] = []
     for r in closed:
         pnl = _as_float(r.get("realized_pnl"))
@@ -242,6 +253,9 @@ def summarize_open(entries: dict[str, Any] | None) -> dict[str, Any]:
                 }
                 if regime
                 else None,
+                "last_counterfactuals": entry.get("last_counterfactuals"),
+                "last_counterfactuals_at": entry.get("last_counterfactuals_at"),
+                "last_mark": entry.get("last_mark"),
             }
         )
     return {"open_n": len(open_rows), "entries": open_rows}

--- a/scripts/spy_put_credit.py
+++ b/scripts/spy_put_credit.py
@@ -730,6 +730,18 @@ def manage_put_credit_exits(client, *, dry_run: bool = False) -> dict[str, Any]:
             short_price=_position_price(short_pos),
             long_price=_position_price(long_pos),
         )
+        # Greptile #4280 P1: persist counterfactuals on the journal so cohort
+        # analysis can compare 25% TP / 7-DTE vs public 50% / 21-DTE later.
+        if isinstance(decision.get("counterfactuals"), dict):
+            entry["last_counterfactuals"] = decision["counterfactuals"]
+            entry["last_counterfactuals_at"] = datetime.now(timezone.utc).isoformat()
+            entry["last_mark"] = {
+                "current_debit": decision.get("current_debit"),
+                "estimated_pnl": decision.get("estimated_pnl"),
+                "dte": decision.get("dte"),
+                "hold_hours": decision.get("hold_hours"),
+            }
+            changed = True
         detail = {"key": key, **decision}
         if not decision["should_exit"]:
             report["holds"] += 1
@@ -749,6 +761,8 @@ def manage_put_credit_exits(client, *, dry_run: bool = False) -> dict[str, Any]:
         entry["exit_submitted_at"] = datetime.now(timezone.utc).isoformat()
         entry["estimated_exit_debit"] = decision["current_debit"]
         entry["estimated_exit_pnl"] = decision["estimated_pnl"]
+        if isinstance(decision.get("counterfactuals"), dict):
+            entry["exit_counterfactuals"] = decision["counterfactuals"]
         _save_entries(entries)
         changed = True
         report["submitted"] += 1

--- a/src/options/vix_monitor.py
+++ b/src/options/vix_monitor.py
@@ -175,15 +175,20 @@ class VIXMonitor:
             logger.error(f"Failed to fetch VIX: {e}")
             raise RuntimeError(f"Unable to fetch VIX data: {e}")
 
-    def get_vix_percentile(self, lookback_days: int = 252) -> float:
+    def get_vix_percentile(
+        self, lookback_days: int = 252, *, default: float | None = 50.0
+    ) -> float | None:
         """
         Calculate VIX percentile over historical period.
 
         Args:
             lookback_days: Number of trading days to look back (default: 252 = 1 year)
+            default: Value when history/errors prevent a real percentile.
+                Pass ``default=None`` for fail-closed callers (put-credit regime gate).
+                Legacy callers keep the historical median placeholder (50.0).
 
         Returns:
-            VIX percentile (0-100)
+            VIX percentile (0-100), or ``default`` when unavailable.
         """
         try:
             current_vix = self.get_current_vix()
@@ -197,7 +202,7 @@ class VIXMonitor:
 
             if hist.empty or len(hist) < 30:
                 logger.warning(f"Insufficient VIX history: {len(hist)} days")
-                return 50.0  # Default to median
+                return default
 
             # Calculate percentile
             historical_closes = hist["Close"].values
@@ -212,7 +217,7 @@ class VIXMonitor:
 
         except Exception as e:
             logger.error(f"Failed to calculate VIX percentile: {e}")
-            return 50.0  # Default to median on error
+            return default
 
     def get_vix_term_structure(self) -> dict[str, float]:
         """

--- a/src/risk/put_credit_regime.py
+++ b/src/risk/put_credit_regime.py
@@ -118,14 +118,19 @@ def capture_regime_snapshot(spy_price: float | None = None) -> RegimeSnapshot:
         errors.append(f"iv_rank:{exc}")
         logger.warning("Regime snapshot: IV rank proxy unavailable: %s", exc)
 
-    # Prefer VIX percentile as IVR when proxy missing but VIX monitor works
+    # Prefer VIX percentile as IVR when proxy missing but VIX monitor works.
+    # Greptile #4280 P1: never accept the legacy median placeholder (50.0) as a
+    # real IVR — pass default=None so missing history fails closed at the gate.
     if ivr is None:
         try:
             from src.options.vix_monitor import VIXMonitor
 
-            pct = float(VIXMonitor().get_vix_percentile(252))
-            ivr = pct
-            ivr_method = "vix_percentile_252"
+            pct = VIXMonitor().get_vix_percentile(252, default=None)
+            if pct is None:
+                errors.append("vix_percentile_unavailable")
+            else:
+                ivr = float(pct)
+                ivr_method = "vix_percentile_252"
         except Exception as exc:  # noqa: BLE001
             errors.append(f"vix_percentile:{exc}")
 

--- a/src/safety/mandatory_trade_gate.py
+++ b/src/safety/mandatory_trade_gate.py
@@ -444,12 +444,36 @@ def _count_put_credit_structures_today() -> int:
     return n
 
 
+def _et_session_start_utc_iso() -> str:
+    """UTC ISO timestamp for America/New_York midnight today (not UTC midnight)."""
+    from zoneinfo import ZoneInfo
+
+    et = ZoneInfo("America/New_York")
+    now_et = datetime.now(et)
+    start_et = now_et.replace(hour=0, minute=0, second=0, microsecond=0)
+    return start_et.astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _is_put_credit_entry_order(order: Any) -> bool:
+    """True only for put-credit *entry* fills (not same-day closes).
+
+    Greptile #4285: counting CLOSE BPS 2-leg fills inflated the daily cap.
+    Our path tags entries as OPEN+BPS via build_client_order_id.
+    """
+    client_id = str(getattr(order, "client_order_id", "") or "").upper()
+    if not client_id:
+        return False
+    if "CLOSE" in client_id:
+        return False
+    # Entry path only — OPEN + BPS (bull put spread)
+    return "OPEN" in client_id and "BPS" in client_id
+
+
 def _count_put_credit_structures_today_from_broker() -> int:
-    """Broker-side put-credit structure count for today (ET).
+    """Broker-side put-credit *entry* count for today (ET session).
 
     Greptile #4278 P1: journal-only counters undercount when a fill lands but the
     process dies before durable journal write. Use max(journal, broker).
-    Counts filled 2-leg multi-leg orders (bull put) and client_order_ids with BPS.
     """
     if os.environ.get("PYTEST_CURRENT_TEST") or "pytest" in sys.modules:
         return 0
@@ -469,26 +493,19 @@ def _count_put_credit_structures_today_from_broker() -> int:
         from alpaca.trading.requests import GetOrdersRequest
 
         client = TradingClient(api_key, api_secret, paper=is_paper)
-        today_str = _today_et_str()
+        # Greptile #4285: ET date + Z was wrong (UTC midnight). Use ET session start.
+        after_utc = _et_session_start_utc_iso()
         orders = client.get_orders(
             GetOrdersRequest(
                 status=QueryOrderStatus.FILLED,
-                after=f"{today_str}T00:00:00Z",
+                after=after_utc,
                 limit=100,
             )
         )
-        n = 0
-        for order in orders or []:
-            legs = getattr(order, "legs", None) or []
-            client_id = str(getattr(order, "client_order_id", "") or "").upper()
-            # 2-leg multi-leg = put credit vertical; BPS client id = our put-credit path
-            if len(legs) == 2 or "BPS" in client_id or "PUT_CREDIT" in client_id:
-                # Exclude pure single-leg orphan closes (1 leg, no BPS)
-                if len(legs) == 1 and "BPS" not in client_id:
-                    continue
-                n += 1
+        n = sum(1 for order in (orders or []) if _is_put_credit_entry_order(order))
         logger.info(
-            "Broker put-credit structure count today: %s (from %s filled orders)",
+            "Broker put-credit ENTRY count today (after=%s): %s (from %s filled orders)",
+            after_utc,
             n,
             len(orders or []),
         )
@@ -1975,6 +1992,13 @@ def safe_submit_order(client, order_request, strategy: str | None = None):
             # Never log fake ModelSelector/Juror "AGREE" during cold validation.
             # =================================================================
             ml_ready, ml_meta = _active_strategy_ml_ready()
+            # Opt-in only: secondary juror is not wired. Never invent AGREE.
+            # Greptile #4285: do not call juror (and soft-bypass outages) until enabled.
+            juror_enabled = os.environ.get("MULTI_MODEL_JUROR_ENABLED", "").lower() in {
+                "1",
+                "true",
+                "yes",
+            }
             if not ml_ready:
                 logger.info(
                     "ML consensus deferred (no edge sample): family=%s n=%s learning_ready=%s detail=%s",
@@ -1989,6 +2013,20 @@ def safe_submit_order(client, order_request, strategy: str | None = None):
                     attributes={
                         "status": "DEFERRED_NO_EDGE",
                         "family": str(ml_meta.get("family") or ""),
+                        "n": int(ml_meta.get("n") or 0),
+                    },
+                )
+            elif not juror_enabled:
+                logger.info(
+                    "ML sample ready (n=%s) but MULTI_MODEL_JUROR_ENABLED unset; "
+                    "consensus deferred (no fake AGREE, no outage bypass)",
+                    ml_meta.get("n"),
+                )
+                gateway.capture_span(
+                    "juror_consensus",
+                    trace_id,
+                    attributes={
+                        "status": "DEFERRED_JUROR_NOT_CONFIGURED",
                         "n": int(ml_meta.get("n") or 0),
                     },
                 )
@@ -2008,31 +2046,11 @@ def safe_submit_order(client, order_request, strategy: str | None = None):
                     )
                 except ImportError:
                     raise ValueError(
-                        "MULTI-MODEL CONSENSUS REQUIRED (learning_ready) but MultiModelJuror unavailable"
+                        "MULTI-MODEL CONSENSUS REQUIRED (learning_ready + enabled) "
+                        "but MultiModelJuror unavailable"
                     ) from None
-                except RuntimeError as e:
-                    # Greptile #4281 P1: JUROR_UNAVAILABLE must not permanently hard-block
-                    # every open after edge is proven. Never claim AGREE; allow without
-                    # multi-model consensus until a real secondary provider is wired.
-                    if "JUROR_UNAVAILABLE" in str(e):
-                        logger.warning(
-                            "Juror unavailable after ml_ready (n=%s); opening without "
-                            "multi-model consensus claim (no fake AGREE): %s",
-                            ml_meta.get("n"),
-                            e,
-                        )
-                        gateway.capture_span(
-                            "juror_consensus",
-                            trace_id,
-                            attributes={
-                                "status": "UNAVAILABLE_NO_FAKE_AGREE",
-                                "n": int(ml_meta.get("n") or 0),
-                            },
-                        )
-                    else:
-                        logger.error(f"CONSENSUS ERROR: {e}")
-                        raise ValueError(f"CRITICAL: Consensus check failed: {e}") from e
                 except Exception as e:
+                    # Fail closed when juror is explicitly enabled.
                     logger.error(f"CONSENSUS ERROR: {e}")
                     raise ValueError(f"CRITICAL: Consensus check failed: {e}") from e
 

--- a/src/safety/mandatory_trade_gate.py
+++ b/src/safety/mandatory_trade_gate.py
@@ -444,6 +444,60 @@ def _count_put_credit_structures_today() -> int:
     return n
 
 
+def _count_put_credit_structures_today_from_broker() -> int:
+    """Broker-side put-credit structure count for today (ET).
+
+    Greptile #4278 P1: journal-only counters undercount when a fill lands but the
+    process dies before durable journal write. Use max(journal, broker).
+    Counts filled 2-leg multi-leg orders (bull put) and client_order_ids with BPS.
+    """
+    if os.environ.get("PYTEST_CURRENT_TEST") or "pytest" in sys.modules:
+        return 0
+
+    try:
+        from src.utils.alpaca_client import get_alpaca_credentials
+
+        credentials = get_alpaca_credentials()
+        api_key, api_secret = credentials[0], credentials[1]
+        inferred_paper = _infer_paper_from_credentials(credentials)
+        is_paper = True if inferred_paper is None else inferred_paper
+        if not api_key or not api_secret:
+            raise ValueError("No Alpaca credentials")
+
+        from alpaca.trading.client import TradingClient
+        from alpaca.trading.enums import QueryOrderStatus
+        from alpaca.trading.requests import GetOrdersRequest
+
+        client = TradingClient(api_key, api_secret, paper=is_paper)
+        today_str = _today_et_str()
+        orders = client.get_orders(
+            GetOrdersRequest(
+                status=QueryOrderStatus.FILLED,
+                after=f"{today_str}T00:00:00Z",
+                limit=100,
+            )
+        )
+        n = 0
+        for order in orders or []:
+            legs = getattr(order, "legs", None) or []
+            client_id = str(getattr(order, "client_order_id", "") or "").upper()
+            # 2-leg multi-leg = put credit vertical; BPS client id = our put-credit path
+            if len(legs) == 2 or "BPS" in client_id or "PUT_CREDIT" in client_id:
+                # Exclude pure single-leg orphan closes (1 leg, no BPS)
+                if len(legs) == 1 and "BPS" not in client_id:
+                    continue
+                n += 1
+        logger.info(
+            "Broker put-credit structure count today: %s (from %s filled orders)",
+            n,
+            len(orders or []),
+        )
+        return n
+    except Exception as exc:
+        logger.warning("Broker put-credit structure count failed: %s", exc)
+        return 0
+
+
 def _count_structures_today_from_alpaca() -> int:
     """Count today's IC entries from Alpaca order history (works in CI and local).
 
@@ -512,9 +566,15 @@ def _count_structures_today_from_alpaca() -> int:
 
 
 def _structures_today_for_gate() -> int:
-    """Structure count for the active family (put-credit vs residual IC noise)."""
+    """Structure count for the active family (put-credit vs residual IC noise).
+
+    Put-credit: max(journal, broker) so a fill-before-journal crash cannot
+    undercount past max_daily_structures (Greptile #4278 P1).
+    """
     if _active_strategy_family() == "spy_put_credit":
-        return _count_put_credit_structures_today()
+        journal_n = _count_put_credit_structures_today()
+        broker_n = _count_put_credit_structures_today_from_broker()
+        return max(int(journal_n or 0), int(broker_n or 0))
     return _count_structures_today_from_alpaca()
 
 
@@ -1950,6 +2010,28 @@ def safe_submit_order(client, order_request, strategy: str | None = None):
                     raise ValueError(
                         "MULTI-MODEL CONSENSUS REQUIRED (learning_ready) but MultiModelJuror unavailable"
                     ) from None
+                except RuntimeError as e:
+                    # Greptile #4281 P1: JUROR_UNAVAILABLE must not permanently hard-block
+                    # every open after edge is proven. Never claim AGREE; allow without
+                    # multi-model consensus until a real secondary provider is wired.
+                    if "JUROR_UNAVAILABLE" in str(e):
+                        logger.warning(
+                            "Juror unavailable after ml_ready (n=%s); opening without "
+                            "multi-model consensus claim (no fake AGREE): %s",
+                            ml_meta.get("n"),
+                            e,
+                        )
+                        gateway.capture_span(
+                            "juror_consensus",
+                            trace_id,
+                            attributes={
+                                "status": "UNAVAILABLE_NO_FAKE_AGREE",
+                                "n": int(ml_meta.get("n") or 0),
+                            },
+                        )
+                    else:
+                        logger.error(f"CONSENSUS ERROR: {e}")
+                        raise ValueError(f"CRITICAL: Consensus check failed: {e}") from e
                 except Exception as e:
                     logger.error(f"CONSENSUS ERROR: {e}")
                     raise ValueError(f"CRITICAL: Consensus check failed: {e}") from e
@@ -1992,18 +2074,13 @@ def safe_submit_order(client, order_request, strategy: str | None = None):
                         "(0 lessons retrieved; rebuild indexes or fix LessonsSearch)"
                     )
 
-                # Protocol baseline is a first-class source (not a substitute for lessons).
-                # Lessons remain mandatory above; baseline makes protocol keywords auditable.
-                audit_context = [
-                    "Protocol source: Rule #1 don't lose money; mandatory stop-loss; "
-                    "check VIX; 15-delta shorts; 50% profit or 25% validation TP; "
-                    "7 DTE exit; 1-lot credit defined-risk only."
-                ] + retrieved_context
-
+                # Greptile #4281 P1: do NOT inject synthetic protocol baseline into
+                # retrieved_context — that made any nonempty lesson score groundedness
+                # 1.0. Score against *actual lessons only*; protocol lives in reasoning.
                 score = evaluator.evaluate(
                     proposal=proposal,
                     reasoning=protocol_reasoning,
-                    retrieved_context=audit_context,
+                    retrieved_context=retrieved_context,
                 )
 
                 if score.is_hallucination_risk:

--- a/tests/test_mandatory_trade_gate.py
+++ b/tests/test_mandatory_trade_gate.py
@@ -737,6 +737,29 @@ class TestPutCreditDailyStructureGate:
         monkeypatch.setattr(gate_mod, "_count_put_credit_structures_today_from_broker", lambda: 0)
         assert gate_mod._structures_today_for_gate() == 2
 
+    def test_broker_entry_classifier_ignores_closes(self):
+        """Greptile #4285: same-day CLOSE BPS must not inflate daily entry count."""
+        import src.safety.mandatory_trade_gate as gate_mod
+        from types import SimpleNamespace
+
+        open_o = SimpleNamespace(client_order_id="OPEN_BPS_abc", legs=[1, 2])
+        close_o = SimpleNamespace(client_order_id="CLOSE_BPS_abc", legs=[1, 2])
+        orphan = SimpleNamespace(client_order_id="CLOSE_BPL_x", legs=[1])
+        assert gate_mod._is_put_credit_entry_order(open_o) is True
+        assert gate_mod._is_put_credit_entry_order(close_o) is False
+        assert gate_mod._is_put_credit_entry_order(orphan) is False
+
+    def test_et_session_start_is_utc_iso(self):
+        import src.safety.mandatory_trade_gate as gate_mod
+
+        s = gate_mod._et_session_start_utc_iso()
+        assert s.endswith("Z")
+        assert "T" in s
+        # Must be parseable as UTC
+        from datetime import datetime
+
+        datetime.strptime(s, "%Y-%m-%dT%H:%M:%SZ")
+
 
 class TestMlConsensusAndHardReasoning:
     """Hard RAG groundedness + no ML theater until learning_ready n>=30."""

--- a/tests/test_mandatory_trade_gate.py
+++ b/tests/test_mandatory_trade_gate.py
@@ -724,6 +724,19 @@ class TestPutCreditDailyStructureGate:
         assert ok is False
         assert "3/3" in reason
 
+    def test_structures_today_uses_max_of_journal_and_broker(self, monkeypatch):
+        """Greptile #4278: fill-before-journal must not undercount past max_daily."""
+        import src.safety.mandatory_trade_gate as gate_mod
+
+        monkeypatch.setattr(gate_mod, "_active_strategy_family", lambda: "spy_put_credit")
+        monkeypatch.setattr(gate_mod, "_count_put_credit_structures_today", lambda: 1)
+        monkeypatch.setattr(gate_mod, "_count_put_credit_structures_today_from_broker", lambda: 3)
+        assert gate_mod._structures_today_for_gate() == 3
+
+        monkeypatch.setattr(gate_mod, "_count_put_credit_structures_today", lambda: 2)
+        monkeypatch.setattr(gate_mod, "_count_put_credit_structures_today_from_broker", lambda: 0)
+        assert gate_mod._structures_today_for_gate() == 2
+
 
 class TestMlConsensusAndHardReasoning:
     """Hard RAG groundedness + no ML theater until learning_ready n>=30."""

--- a/tests/test_put_credit_cohort_scorecard_order.py
+++ b/tests/test_put_credit_cohort_scorecard_order.py
@@ -1,0 +1,23 @@
+"""Greptile #4280 P2: rolling window must be time-ordered."""
+
+from scripts.put_credit_cohort_scorecard import summarize_closed
+
+
+def test_rolling_uses_chronological_last_n_not_json_order():
+    # Deliberately reverse chronological in list order
+    rows = [
+        {
+            "strategy": "spy_put_credit",
+            "status": "closed",
+            "exit_time": f"2026-06-{i:02d}T15:00:00+00:00",
+            "realized_pnl": float(i),
+        }
+        for i in range(1, 25)
+    ]
+    rows = list(reversed(rows))  # newest first in input
+    out = summarize_closed(rows)
+    assert out["closed_n"] == 24
+    rolling = out["rolling_20"]["last"]
+    assert rolling is not None
+    # last 20 by time are exits 5..24 with pnls 5..24; sum = (5+24)*20/2 = 290
+    assert rolling["total_realized_pnl"] == 290.0

--- a/tests/test_put_credit_regime.py
+++ b/tests/test_put_credit_regime.py
@@ -48,6 +48,13 @@ def test_regime_missing_vix_fail_closed():
     assert any("VIX unavailable" in b for b in gate["blockers"])
 
 
+def test_regime_missing_ivr_fail_closed():
+    """Greptile #4280: unavailable IVR must block, not invent IVR=50."""
+    gate = evaluate_regime_gate(_snap(iv_rank_proxy=None), fail_closed_on_missing=True)
+    assert gate["allowed"] is False
+    assert any("IV rank" in b for b in gate["blockers"])
+
+
 def test_regime_missing_vix_fail_open():
     gate = evaluate_regime_gate(_snap(vix=None), fail_closed_on_missing=False)
     assert gate["allowed"] is True

--- a/tests/test_reasoning_evaluator.py
+++ b/tests/test_reasoning_evaluator.py
@@ -51,3 +51,20 @@ def test_evaluator_signal_contradiction():
 
     assert score.is_hallucination_risk is True
     assert score.signal_relevance == 0.0  # Contradiction between SELL side and 'reject' reasoning
+
+
+def test_put_credit_unrelated_lesson_does_not_auto_pass():
+    """Greptile #4281: unrelated lesson must not inherit synthetic protocol keywords."""
+    evaluator = ReasoningEvaluator(threshold=0.7)
+    proposal = {"strategy": "spy_put_credit"}
+    reasoning = (
+        "Phil Town Rule #1: don't lose money. SPY-only 1-lot $5-wide bull put credit. "
+        "Target ~15-delta short put, stop-loss at 200% of credit, exit by 7 DTE."
+    )
+    # Unrelated lesson — no protocol keywords
+    context = ["Remember to rotate API keys every 90 days for security hygiene."]
+
+    score = evaluator.evaluate(proposal, reasoning, context)
+
+    assert score.is_hallucination_risk is True
+    assert score.groundedness < 0.7

--- a/tests/test_validator_coverage.py
+++ b/tests/test_validator_coverage.py
@@ -545,16 +545,44 @@ class TestSafeSubmitOrder:
 
         mock_client.submit_order.assert_not_called()
 
+    @staticmethod
+    def _protocol_grounded_lessons():
+        """Lesson text that satisfies IC groundedness keywords without synthetic baseline.
+
+        Use a plain object (not MagicMock): MagicMock invents truthy .snippet attrs
+        that become garbage context and score groundedness 0.
+        """
+        from types import SimpleNamespace
+
+        return [
+            SimpleNamespace(
+                snippet=None,
+                content=(
+                    "Rule #1 don't lose money. Use stop-loss, check VIX, "
+                    "15-delta shorts, 50% profit target or 7 dte exit."
+                ),
+                prevention=None,
+                title=None,
+            )
+        ]
+
+    @patch("src.rag.lessons_search.LessonsSearch")
     @patch("src.safety.mandatory_trade_gate._get_positions_qty_map", return_value={})
     @patch("src.safety.mandatory_trade_gate._estimate_opening_max_loss")
     @patch("src.safety.mandatory_trade_gate.validate_trade_mandatory")
     @patch("src.safety.mandatory_trade_gate._infer_is_closing_order", return_value=False)
     def test_allows_credit_oriented_iron_condor_entry(
-        self, _mock_is_closing, mock_gate, mock_estimate_opening_max_loss, _mock_qty_map
+        self,
+        _mock_is_closing,
+        mock_gate,
+        mock_estimate_opening_max_loss,
+        _mock_qty_map,
+        mock_lessons,
     ):
         """Proper short iron condors should still pass through safe_submit_order."""
         mock_gate.return_value = MagicMock(approved=True, reason="")
         mock_estimate_opening_max_loss.return_value = (100.0, 35, "SPY")
+        mock_lessons.return_value.search.return_value = self._protocol_grounded_lessons()
 
         mock_client = MagicMock(spec=["get_account", "submit_order"])
         mock_client.get_account.return_value = MagicMock(equity="10000")
@@ -574,11 +602,12 @@ class TestSafeSubmitOrder:
         safe_submit_order(mock_client, mock_request, strategy="iron_condor")
         mock_client.submit_order.assert_called_once_with(mock_request)
 
+    @patch("src.rag.lessons_search.LessonsSearch")
     @patch("src.safety.mandatory_trade_gate.validate_trade_mandatory")
     @patch("src.safety.milestone_controller.get_milestone_context")
     @patch("src.safety.north_star_guard.get_guard_context")
     def test_injects_guard_and_positions_context_for_openings(
-        self, mock_guard, mock_milestone, mock_gate
+        self, mock_guard, mock_milestone, mock_gate, mock_lessons
     ):
         """safe_submit_order injects dynamic context when it can infer an opening order."""
         guard_ctx = {
@@ -598,6 +627,7 @@ class TestSafeSubmitOrder:
         mock_guard.return_value = guard_ctx
         mock_milestone.return_value = milestone_ctx
         mock_gate.return_value = MagicMock(approved=True, reason="")
+        mock_lessons.return_value.search.return_value = self._protocol_grounded_lessons()
 
         # Use a strict spec so MagicMock doesn't fabricate get_all_positions(),
         # which would prevent _infer_is_closing_order() from inferring openings.
@@ -626,6 +656,7 @@ class TestSafeSubmitOrder:
         assert ctx["positions"]
         mock_client.submit_order.assert_called_once_with(mock_request)
 
+    @patch("src.rag.lessons_search.LessonsSearch")
     @patch("src.safety.mandatory_trade_gate._infer_paper_trading_client", return_value=True)
     @patch("src.safety.mandatory_trade_gate._get_positions_qty_map", return_value={})
     @patch("src.safety.mandatory_trade_gate._estimate_opening_max_loss")
@@ -638,10 +669,12 @@ class TestSafeSubmitOrder:
         mock_estimate_opening_max_loss,
         _mock_qty_map,
         _mock_paper,
+        mock_lessons,
     ):
         """The final order gate gets enough context to keep live/scaling blocked."""
         mock_gate.return_value = MagicMock(approved=True, reason="")
         mock_estimate_opening_max_loss.return_value = (500.0, 35, "SPY")
+        mock_lessons.return_value.search.return_value = self._protocol_grounded_lessons()
 
         mock_client = MagicMock(spec=["get_account", "submit_order"])
         mock_client.get_account.return_value = MagicMock(equity="100000")
@@ -764,14 +797,10 @@ class TestSafeSubmitOrder:
                 reasoning_trace="grounded",
             )
             # Hard RAG require: openings must retrieve at least one lesson
-            mock_lessons.return_value.search.return_value = [
-                MagicMock(
-                    content=(
-                        "Rule #1 don't lose money. Use stop-loss, 15-delta, "
-                        "check VIX, 50% profit or 7 dte exit."
-                    )
-                )
-            ]
+            # (plain object — MagicMock would invent a truthy .snippet)
+            mock_lessons.return_value.search.return_value = (
+                self._protocol_grounded_lessons()
+            )
             # Cold validation: ML consensus deferred (no fake AGREE)
             with patch.object(
                 gate_mod,


### PR DESCRIPTION
## Summary
Addresses **all open Greptile P1/P2 findings** from #4278–#4281 that landed on main without the safety gaps closed.

| Finding | PR | Fix |
|---|---|---|
| Journal undercount bypasses daily cap | #4278 P1 | `max(journal, broker)` put-credit structure count |
| Synthetic protocol baseline makes any lesson pass groundedness | #4281 P1 | Score **lessons only** (no injected baseline) |
| JUROR_UNAVAILABLE hard-blocks every open after edge | #4281 P1 | Allow open **without claiming AGREE** when juror unwired |
| IVR fallback 50.0 on missing history | #4280 P1 | `get_vix_percentile(..., default=None)` for regime gate |
| Counterfactuals discarded | #4280 P1 | Persist `last_counterfactuals` on PCS journal during manage |
| Rolling-20 not time-ordered | #4280 P2 | Sort closed trades by exit time before last-20 |

## Tests
25 focused tests pass (regime, reasoning, gate daily-cap, scorecard order, juror).

## Risk
Paper-only path; no trading constant changes; no live capital path opened.