### PR TITLE
feat: Mercury↔broker remittance loop (/mo after-tax gate)

### DIFF
--- a/.github/workflows/autonomous-money-cycle.yml
+++ b/.github/workflows/autonomous-money-cycle.yml
@@ -50,7 +50,11 @@ jobs:
           APCA_API_KEY_ID: ${{ secrets.ALPACA_PAPER_TRADING_API_KEY }}
           APCA_API_SECRET_KEY: ${{ secrets.ALPACA_PAPER_TRADING_API_SECRET }}
         run: |
-          python3 scripts/autonomous_money_cycle.py --dry-run --fund 0 --remit 0 --json
+          # Nonzero dry-run fund+remit so scheduled cadence logs amount/direction/time
+          # (real ACH still fail-closed inside planner until live gate clears).
+          python3 scripts/autonomous_money_cycle.py --dry-run --fund 100 --remit 100 --json
+          python3 scripts/mercury_broker_transfer.py --direction fund --amount 100 --json
+          python3 scripts/mercury_broker_transfer.py --direction remit --amount 100 --json
           python3 scripts/remittance_status.py --json
 
       - name: Commit audit artifacts

--- a/.github/workflows/autonomous-money-cycle.yml
+++ b/.github/workflows/autonomous-money-cycle.yml
@@ -1,0 +1,68 @@
+name: Autonomous Money Cycle (paper/dry-run)
+
+# Multi-day put-credit manage + bank transfer dry-run plans.
+# Never enables live Mercury ACH or live broker risk without gate clearance
+# (cycle script fail-closes). Default dry-run.
+
+on:
+  schedule:
+    # Weekday mid-session check (approx 11:15 AM ET = 15:15 UTC)
+    - cron: 15 15 * * 1-5
+    # Weekday afternoon manage (approx 2:15 PM ET)
+    - cron: 15 18 * * 1-5
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: autonomous-money-cycle
+  cancel-in-progress: false
+
+jobs:
+  cycle:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          token: ${{ secrets.GH_PAT || github.token }}
+          fetch-depth: 0
+
+      - name: Refresh to latest main
+        run: |
+          git fetch origin main
+          git checkout -B main origin/main
+
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
+        with:
+          python-version: "3.11"
+          cache: pip
+
+      - name: Install deps
+        run: |
+          pip install -r requirements-minimal.txt 2>/dev/null || pip install alpaca-py python-dotenv
+
+      - name: Run autonomous money cycle (dry-run)
+        env:
+          ALPACA_PAPER_TRADING_API_KEY: ${{ secrets.ALPACA_PAPER_TRADING_API_KEY }}
+          ALPACA_PAPER_TRADING_API_SECRET: ${{ secrets.ALPACA_PAPER_TRADING_API_SECRET }}
+          APCA_API_KEY_ID: ${{ secrets.ALPACA_PAPER_TRADING_API_KEY }}
+          APCA_API_SECRET_KEY: ${{ secrets.ALPACA_PAPER_TRADING_API_SECRET }}
+        run: |
+          python3 scripts/autonomous_money_cycle.py --dry-run --fund 0 --remit 0 --json
+          python3 scripts/remittance_status.py --json
+
+      - name: Commit audit artifacts
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add data/audit/autonomous_money_cycle_latest.json \
+                  data/audit/mercury_broker_transfers.jsonl \
+                  data/audit/put_credit_cohort_latest.json 2>/dev/null || true
+          if git diff --cached --quiet; then
+            echo "No audit changes"
+          else
+            git commit -m "chore: autonomous money cycle dry-run audit [auto]"
+            git push origin main || true
+          fi

--- a/data/audit/mercury_broker_transfers.README.json
+++ b/data/audit/mercury_broker_transfers.README.json
@@ -1,0 +1,4 @@
+{
+  "schema": "mercury_broker_transfers.jsonl",
+  "note": "append-only transfer log; no secrets"
+}

--- a/scripts/autonomous_money_cycle.py
+++ b/scripts/autonomous_money_cycle.py
@@ -1,0 +1,202 @@
+#!/usr/bin/env python3
+"""Autonomous fund → trade → remit cycle (schedule-friendly).
+
+Default: paper/dry-run only. Non–day-trading path:
+  - primary: spy_put_credit multi-day holds (min 24h, 30–45 DTE)
+  - optional: long-horizon buy-and-hold plan note (no PDT churn)
+
+Live broker risk and real Mercury transfers only if live_bank gate allows
+(currently refused until edge sample + kill switch clear).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess  # nosec B404
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+
+def _run(args: list[str], *, timeout: int = 180) -> dict[str, Any]:
+    proc = subprocess.run(  # nosec B603
+        args,
+        cwd=str(ROOT),
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+        shell=False,
+    )
+    return {
+        "cmd": args,
+        "rc": proc.returncode,
+        "stdout_tail": (proc.stdout or "")[-3000:],
+        "stderr_tail": (proc.stderr or "")[-1000:],
+    }
+
+
+def run_cycle(
+    *,
+    dry_run: bool = True,
+    fund_amount: float = 0.0,
+    remit_amount: float = 0.0,
+    skip_trade: bool = False,
+) -> dict[str, Any]:
+    from src.bank.live_gate import evaluate_live_bank_gate
+    from src.bank.mercury_transfer import plan_fund_from_mercury, plan_remit_to_mercury
+    from src.bank.remittance import compute_remittance_progress
+    from src.bank.transfer_ledger import load_transfer_ledger
+    from src.core.active_strategy import load_kill_state
+
+    py = ROOT / ".venv" / "bin" / "python"
+    python = str(py if py.is_file() else Path(sys.executable))
+    ts = datetime.now(timezone.utc).isoformat()
+    kill = load_kill_state()
+    gate = evaluate_live_bank_gate()
+
+    report: dict[str, Any] = {
+        "schema_version": "autonomous-money-cycle/1",
+        "ts": ts,
+        "dry_run": dry_run,
+        "strategy_mode": gate.strategy_mode,
+        "non_day_trade": True,
+        "active_family": kill.active_family,
+        "live_gate": gate.as_dict(),
+        "steps": {},
+        "fund": None,
+        "remit": None,
+        "remittance_progress": None,
+        "honesty": (
+            "paper/dry-run default; live bank+trade refused until EDGE_CANDIDATE; "
+            "does not claim daily profits or $1000/mo without ledger remittances"
+        ),
+    }
+
+    # 1) Optional fund plan (Mercury → broker)
+    if fund_amount and fund_amount > 0:
+        fund = plan_fund_from_mercury(
+            float(fund_amount),
+            dry_run=dry_run,
+            force_execute=not dry_run,
+            reason="autonomous_cycle_fund",
+        )
+        report["fund"] = fund.as_dict()
+
+    # 2) Trade path — paper put-credit manage / status (multi-day holds)
+    if not skip_trade:
+        steps = {
+            "inventory": _run([python, "scripts/audit_open_inventory.py"]),
+            "manage_put_credit": _run(
+                [
+                    python,
+                    "scripts/spy_put_credit.py",
+                    "--manage-exits",
+                    *(["--dry-run"] if dry_run else []),
+                ]
+            ),
+            "cohort": _run([python, "scripts/put_credit_cohort_scorecard.py", "--json"]),
+            "status": _run([python, "scripts/spy_put_credit.py", "--status"]),
+        }
+        report["steps"] = {k: {"rc": v["rc"], "stdout_tail": v["stdout_tail"][-800:]} for k, v in steps.items()}
+
+        # Live new risk only if gate allows (will refuse under current kill switch)
+        if not dry_run and gate.live_trading_allowed:
+            entry = _run([python, "scripts/spy_put_credit.py", "--execute-paper"])
+            report["steps"]["live_or_paper_entry"] = {
+                "rc": entry["rc"],
+                "note": "execute-paper only; --live never auto-enabled here",
+            }
+        elif not dry_run and not gate.live_trading_allowed:
+            report["steps"]["live_entry"] = {
+                "rc": 2,
+                "blocked": True,
+                "blockers": list(gate.blockers),
+            }
+
+    # 3) Remit plan (broker → Mercury)
+    if remit_amount and remit_amount > 0:
+        if dry_run:
+            remit = plan_remit_to_mercury(
+                float(remit_amount), dry_run=True, reason="autonomous_cycle_remit"
+            )
+        else:
+            remit = plan_remit_to_mercury(
+                float(remit_amount),
+                dry_run=False,
+                force_execute=True,
+                reason="autonomous_cycle_remit",
+            )
+        report["remit"] = remit.as_dict()
+
+    # 4) Remittance progress (ledger facts only)
+    progress = compute_remittance_progress(load_transfer_ledger())
+    report["remittance_progress"] = progress.as_dict()
+
+    out_dir = ROOT / "data" / "audit"
+    out_dir.mkdir(parents=True, exist_ok=True)
+    out_path = out_dir / "autonomous_money_cycle_latest.json"
+    out_path.write_text(json.dumps(report, indent=2) + "\n", encoding="utf-8")
+    report["report_path"] = str(out_path)
+    return report
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument(
+        "--dry-run",
+        action="store_true",
+        default=True,
+        help="Default: dry-run bank plans + paper-safe trade steps",
+    )
+    p.add_argument(
+        "--execute",
+        action="store_true",
+        help="Allow real bank/live paths (still fail-closed if gate blocks)",
+    )
+    p.add_argument("--fund", type=float, default=0.0, help="Plan fund amount Mercury→broker")
+    p.add_argument("--remit", type=float, default=0.0, help="Plan remit amount broker→Mercury")
+    p.add_argument("--skip-trade", action="store_true")
+    p.add_argument("--json", action="store_true")
+    args = p.parse_args()
+    dry = not args.execute
+    report = run_cycle(
+        dry_run=dry,
+        fund_amount=args.fund,
+        remit_amount=args.remit,
+        skip_trade=args.skip_trade,
+    )
+    if args.json:
+        print(json.dumps(report, indent=2))
+    else:
+        print("=== AUTONOMOUS MONEY CYCLE ===")
+        print(f"dry_run={report['dry_run']} strategy_mode={report['strategy_mode']}")
+        print(f"live_gate.allowed={report['live_gate']['allowed']}")
+        if report["live_gate"]["blockers"]:
+            print("blockers:")
+            for b in report["live_gate"]["blockers"]:
+                print(f"  - {b}")
+        if report.get("fund"):
+            print("fund:", report["fund"].get("message"))
+        if report.get("remit"):
+            print("remit:", report["remit"].get("message"))
+        rp = report.get("remittance_progress") or {}
+        print(
+            f"remittance: ${rp.get('remitted_to_bank_usd')} / "
+            f"${rp.get('target_usd')} target_met={rp.get('target_met')}"
+        )
+        print(rp.get("note"))
+        print("report:", report.get("report_path"))
+    # Exit 0 on successful dry-run cycle; 2 if execute mode fully blocked
+    if not dry and not report["live_gate"]["allowed"]:
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/mercury_broker_transfer.py
+++ b/scripts/mercury_broker_transfer.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""CLI: plan Mercury ↔ brokerage transfers (dry-run default)."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+
+def main() -> int:
+    from src.bank.mercury_transfer import plan_transfer
+
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument(
+        "--direction",
+        choices=["fund", "remit", "mercury_to_broker", "broker_to_mercury"],
+        required=True,
+    )
+    p.add_argument("--amount", type=float, required=True)
+    p.add_argument(
+        "--execute",
+        action="store_true",
+        help="Attempt real transfer (fail-closed unless gates + Mercury API ready)",
+    )
+    p.add_argument("--reason", default="")
+    p.add_argument("--json", action="store_true")
+    args = p.parse_args()
+
+    dry = not args.execute
+    direction = args.direction
+    if direction == "fund":
+        direction = "mercury_to_broker"
+    elif direction == "remit":
+        direction = "broker_to_mercury"
+
+    result = plan_transfer(
+        direction=direction,
+        amount_usd=args.amount,
+        dry_run=dry,
+        force_execute=bool(args.execute),
+        reason=args.reason,
+    )
+    if args.json:
+        print(json.dumps(result.as_dict(), indent=2))
+    else:
+        print(result.message)
+        print(json.dumps(result.record, indent=2))
+    # dry-run ok → 0; blocked real attempt → 2; other failure → 1
+    if result.blocked:
+        return 2
+    if result.ok:
+        return 0
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/remittance_status.py
+++ b/scripts/remittance_status.py
@@ -60,9 +60,10 @@ def main() -> int:
     else:
         print("=== REMITTANCE STATUS ($1000/mo after-tax target) ===")
         print(f"month: {progress.month_yyyy_mm}")
-        print(f"remitted_to_bank: ${progress.remitted_to_bank_usd:.2f}")
+        print(f"remitted_to_bank (confirmed): ${progress.remitted_to_bank_usd:.2f}")
+        print(f"in_flight (submitted): ${progress.in_flight_usd:.2f}")
         print(f"target: ${progress.target_usd:.2f}")
-        print(f"events: {progress.remittance_event_count}")
+        print(f"confirmed_events: {progress.remittance_event_count}")
         print(f"target_met: {progress.target_met} claim_allowed: {progress.claim_allowed}")
         if progress.estimated_after_tax_profit_usd is not None:
             print(f"estimated_after_tax_profit: ${progress.estimated_after_tax_profit_usd:.2f}")

--- a/scripts/remittance_status.py
+++ b/scripts/remittance_status.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+"""$1000/mo after-tax remittance status — ledger facts only.
+
+Never claims target met without confirmed broker→Mercury deposits.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+
+def main() -> int:
+    from src.bank.live_gate import evaluate_live_bank_gate
+    from src.bank.remittance import (
+        MONTHLY_AFTER_TAX_TARGET_USD,
+        compute_remittance_progress,
+    )
+    from src.bank.transfer_ledger import load_transfer_ledger
+
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--json", action="store_true")
+    p.add_argument("--month", default=None, help="YYYY-MM (default: current UTC month)")
+    p.add_argument(
+        "--realized-pnl",
+        type=float,
+        default=None,
+        help="Optional realized pre-tax P/L for after-tax estimate (not a remittance claim)",
+    )
+    args = p.parse_args()
+
+    progress = compute_remittance_progress(
+        load_transfer_ledger(),
+        month_yyyy_mm=args.month,
+        target_usd=MONTHLY_AFTER_TAX_TARGET_USD,
+        realized_pre_tax_pnl_usd=args.realized_pnl,
+    )
+    gate = evaluate_live_bank_gate()
+    payload = {
+        "target_monthly_after_tax_usd": MONTHLY_AFTER_TAX_TARGET_USD,
+        "progress": progress.as_dict(),
+        "live_bank_gate": {
+            "allowed": gate.allowed,
+            "blockers": list(gate.blockers),
+            "strategy_mode": gate.strategy_mode,
+        },
+        "honesty": (
+            "target_met requires confirmed non-dry-run broker_to_mercury ledger rows; "
+            "estimated_after_tax_profit is not bank remittance"
+        ),
+    }
+    if args.json:
+        print(json.dumps(payload, indent=2))
+    else:
+        print("=== REMITTANCE STATUS ($1000/mo after-tax target) ===")
+        print(f"month: {progress.month_yyyy_mm}")
+        print(f"remitted_to_bank: ${progress.remitted_to_bank_usd:.2f}")
+        print(f"target: ${progress.target_usd:.2f}")
+        print(f"events: {progress.remittance_event_count}")
+        print(f"target_met: {progress.target_met} claim_allowed: {progress.claim_allowed}")
+        if progress.estimated_after_tax_profit_usd is not None:
+            print(f"estimated_after_tax_profit: ${progress.estimated_after_tax_profit_usd:.2f}")
+        print(progress.note)
+        print(f"live_bank_gate.allowed: {gate.allowed}")
+        if gate.blockers:
+            for b in gate.blockers:
+                print(f"  block: {b}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/bank/__init__.py
+++ b/src/bank/__init__.py
@@ -1,0 +1,32 @@
+"""Mercury bank ↔ brokerage funding and after-tax remittance accounting.
+
+Live bank transfers and live trading remain hard-gated by kill switch + edge sample.
+Dry-run / paper planning is always allowed for operator readiness.
+"""
+
+from src.bank.live_gate import LiveBankGateDecision, evaluate_live_bank_gate
+from src.bank.remittance import (
+    MONTHLY_AFTER_TAX_TARGET_USD,
+    RemittanceProgress,
+    compute_remittance_progress,
+    estimate_after_tax_profit,
+)
+from src.bank.transfer_ledger import (
+    TransferDirection,
+    TransferRecord,
+    append_transfer_record,
+    load_transfer_ledger,
+)
+
+__all__ = [
+    "MONTHLY_AFTER_TAX_TARGET_USD",
+    "LiveBankGateDecision",
+    "RemittanceProgress",
+    "TransferDirection",
+    "TransferRecord",
+    "append_transfer_record",
+    "compute_remittance_progress",
+    "estimate_after_tax_profit",
+    "evaluate_live_bank_gate",
+    "load_transfer_ledger",
+]

--- a/src/bank/live_gate.py
+++ b/src/bank/live_gate.py
@@ -1,0 +1,153 @@
+"""Hard-gate for live trading and real Mercury bank transfers.
+
+Fail closed when kill switch blocks live or put-credit edge sample is insufficient.
+Dry-run / paper planning is not blocked by this module.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+
+from src.core.active_strategy import load_kill_state
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_COHORT = REPO_ROOT / "data" / "audit" / "put_credit_cohort_latest.json"
+DEFAULT_KILL = REPO_ROOT / "data" / "runtime" / "strategy_kill_switch.json"
+
+EDGE_N_MIN = 30
+EDGE_MIN_EXPECTANCY = 0.0
+EDGE_MIN_PF = 1.0
+
+
+@dataclass(frozen=True)
+class LiveBankGateDecision:
+    allowed: bool
+    live_trading_allowed: bool
+    bank_transfer_allowed: bool
+    blockers: tuple[str, ...]
+    paper_only: bool
+    live_blocked: bool
+    sample_closed_n: int | None
+    expectancy: float | None
+    profit_factor: float | None
+    strategy_mode: str
+    detail: dict[str, Any]
+
+    def as_dict(self) -> dict[str, Any]:
+        d = asdict(self)
+        d["blockers"] = list(self.blockers)
+        return d
+
+
+def _load_cohort_metrics(cohort_path: Path) -> dict[str, Any]:
+    if not cohort_path.is_file():
+        return {}
+    try:
+        raw = json.loads(cohort_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {}
+    if not isinstance(raw, dict):
+        return {}
+    closed = raw.get("closed") if isinstance(raw.get("closed"), dict) else {}
+    kill = closed.get("kill_criteria") if isinstance(closed.get("kill_criteria"), dict) else {}
+    honesty = raw.get("honesty") if isinstance(raw.get("honesty"), dict) else {}
+    return {
+        "closed_n": closed.get("closed_n"),
+        "expectancy": closed.get("expectancy"),
+        "profit_factor": closed.get("profit_factor"),
+        "verdict": kill.get("verdict"),
+        "live_deposit_ready": honesty.get("live_deposit_ready"),
+        "claim_profitable": honesty.get("claim_profitable"),
+    }
+
+
+def evaluate_live_bank_gate(
+    *,
+    cohort_path: Path | None = None,
+    require_edge_sample: bool = True,
+) -> LiveBankGateDecision:
+    """Return whether live trading and real bank transfers may proceed.
+
+    Strategy mode is always multi-day / non-PDT default (put-credit holds or
+    buy-and-hold), never same-day churn as the primary path.
+    """
+    state = load_kill_state()
+    metrics = _load_cohort_metrics(cohort_path or DEFAULT_COHORT)
+    blockers: list[str] = []
+
+    if state.live_blocked:
+        blockers.append(f"kill_switch.live_blocked: {state.reason[:200]}")
+    if state.paper_only:
+        blockers.append("kill_switch.paper_only=true")
+
+    closed_n = metrics.get("closed_n")
+    exp = metrics.get("expectancy")
+    pf = metrics.get("profit_factor")
+    try:
+        # Missing cohort → treat as 0 closed (fail closed for live), not None
+        closed_n_i = int(closed_n) if closed_n is not None else 0
+    except (TypeError, ValueError):
+        closed_n_i = 0
+    try:
+        exp_f = float(exp) if exp is not None else None
+    except (TypeError, ValueError):
+        exp_f = None
+    try:
+        pf_f = float(pf) if pf is not None else None
+    except (TypeError, ValueError):
+        pf_f = None
+
+    if require_edge_sample:
+        if closed_n_i is None or closed_n_i < EDGE_N_MIN:
+            blockers.append(
+                f"insufficient_edge_sample: closed_n={closed_n_i} need>={EDGE_N_MIN}"
+            )
+        else:
+            if exp_f is None or exp_f <= EDGE_MIN_EXPECTANCY:
+                blockers.append(f"expectancy_not_positive: {exp_f}")
+            if pf_f is None or pf_f <= EDGE_MIN_PF:
+                blockers.append(f"profit_factor_not_gt_1: {pf_f}")
+        if metrics.get("live_deposit_ready") is False:
+            blockers.append("cohort.live_deposit_ready=false")
+        if metrics.get("verdict") and str(metrics.get("verdict")) != "EDGE_CANDIDATE":
+            blockers.append(f"kill_verdict={metrics.get('verdict')} (need EDGE_CANDIDATE)")
+
+    # Deduplicate while preserving order
+    seen: set[str] = set()
+    uniq: list[str] = []
+    for b in blockers:
+        if b not in seen:
+            seen.add(b)
+            uniq.append(b)
+
+    allowed = len(uniq) == 0
+    return LiveBankGateDecision(
+        allowed=allowed,
+        live_trading_allowed=allowed,
+        bank_transfer_allowed=allowed,
+        blockers=tuple(uniq),
+        paper_only=bool(state.paper_only),
+        live_blocked=bool(state.live_blocked),
+        sample_closed_n=closed_n_i,
+        expectancy=exp_f,
+        profit_factor=pf_f,
+        strategy_mode="multi_day_hold_or_buy_hold_non_pdt",
+        detail={
+            "active_family": state.active_family,
+            "cohort_verdict": metrics.get("verdict"),
+            "claim_profitable": metrics.get("claim_profitable"),
+        },
+    )
+
+
+def assert_live_bank_allowed(*, action: str = "live_or_bank") -> LiveBankGateDecision:
+    """Raise RuntimeError with block reasons if live/bank not allowed."""
+    decision = evaluate_live_bank_gate()
+    if not decision.allowed:
+        raise RuntimeError(
+            f"{action} REFUSED (fail closed): " + "; ".join(decision.blockers)
+        )
+    return decision

--- a/src/bank/mercury_transfer.py
+++ b/src/bank/mercury_transfer.py
@@ -1,0 +1,188 @@
+"""Mercury AI bank ↔ brokerage transfer planner/executor.
+
+Default is dry-run. Real transfers require live_bank gate AND MERCURY_API_ENABLED=1
+plus vaulted credentials. No secrets in code or logs.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from src.bank.live_gate import evaluate_live_bank_gate
+from src.bank.transfer_ledger import (
+    TransferDirection,
+    TransferStatus,
+    append_transfer_record,
+    build_transfer_record,
+)
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class TransferPlanResult:
+    ok: bool
+    dry_run: bool
+    blocked: bool
+    record: dict[str, Any]
+    message: str
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "ok": self.ok,
+            "dry_run": self.dry_run,
+            "blocked": self.blocked,
+            "record": self.record,
+            "message": self.message,
+        }
+
+
+def _mercury_api_ready() -> tuple[bool, str]:
+    """Check env flags only — never echo secret values."""
+    enabled = os.environ.get("MERCURY_API_ENABLED", "").lower() in {"1", "true", "yes"}
+    if not enabled:
+        return False, "MERCURY_API_ENABLED not set (real ACH disabled)"
+    # Credential presence without loading secrets into logs
+    key_set = bool(os.environ.get("MERCURY_API_KEY") or os.environ.get("MERCURY_TOKEN"))
+    if not key_set:
+        # Optional vault file path presence
+        vault = Path.home() / ".resume_secrets" / "mercury.json"
+        if not vault.is_file():
+            return False, "no MERCURY_API_KEY/MERCURY_TOKEN and no ~/.resume_secrets/mercury.json"
+    return True, "mercury_credentials_present"
+
+
+def plan_transfer(
+    *,
+    direction: TransferDirection | str,
+    amount_usd: float,
+    dry_run: bool = True,
+    reason: str = "",
+    ledger_path: Path | None = None,
+    force_execute: bool = False,
+) -> TransferPlanResult:
+    """Plan (and optionally execute) a Mercury↔broker transfer.
+
+    Real execution requires: dry_run=False, force_execute=True, live gate allowed,
+    and Mercury API ready. Otherwise logs a dry_run or blocked record.
+    """
+    direction_s = (
+        direction.value if isinstance(direction, TransferDirection) else str(direction)
+    )
+    gate = evaluate_live_bank_gate()
+    want_real = (not dry_run) and force_execute
+
+    if want_real and not gate.bank_transfer_allowed:
+        rec = build_transfer_record(
+            direction=direction_s,
+            amount_usd=amount_usd,
+            status=TransferStatus.BLOCKED,
+            dry_run=False,
+            reason=reason or "real_transfer_requested",
+            block_reason="; ".join(gate.blockers) or "live_bank_gate_denied",
+            metadata={"gate": gate.as_dict()},
+        )
+        append_transfer_record(rec, ledger_path=ledger_path)
+        return TransferPlanResult(
+            ok=False,
+            dry_run=False,
+            blocked=True,
+            record=rec.as_dict(),
+            message=f"BANK TRANSFER REFUSED: {rec.block_reason}",
+        )
+
+    if want_real:
+        api_ok, api_msg = _mercury_api_ready()
+        if not api_ok:
+            rec = build_transfer_record(
+                direction=direction_s,
+                amount_usd=amount_usd,
+                status=TransferStatus.BLOCKED,
+                dry_run=False,
+                reason=reason or "real_transfer_requested",
+                block_reason=api_msg,
+                metadata={"gate_allowed": gate.allowed},
+            )
+            append_transfer_record(rec, ledger_path=ledger_path)
+            return TransferPlanResult(
+                ok=False,
+                dry_run=False,
+                blocked=True,
+                record=rec.as_dict(),
+                message=f"BANK TRANSFER REFUSED: {api_msg}",
+            )
+        # Real Mercury ACH is not implemented without vendor API contract.
+        # Fail closed rather than pretend a transfer succeeded.
+        rec = build_transfer_record(
+            direction=direction_s,
+            amount_usd=amount_usd,
+            status=TransferStatus.FAILED,
+            dry_run=False,
+            reason=reason or "real_transfer_requested",
+            block_reason=(
+                "Mercury live ACH executor not configured for production API; "
+                "refusing fabricated transfer receipt"
+            ),
+            metadata={"api": api_msg},
+        )
+        append_transfer_record(rec, ledger_path=ledger_path)
+        return TransferPlanResult(
+            ok=False,
+            dry_run=False,
+            blocked=True,
+            record=rec.as_dict(),
+            message=rec.block_reason,
+        )
+
+    # Dry-run / plan path — always allowed for operator readiness
+    rec = build_transfer_record(
+        direction=direction_s,
+        amount_usd=amount_usd,
+        status=TransferStatus.DRY_RUN,
+        dry_run=True,
+        reason=reason or "dry_run_plan",
+        metadata={
+            "gate_allowed": gate.allowed,
+            "gate_blockers": list(gate.blockers),
+            "would_execute_if_gates_clear": True,
+        },
+    )
+    append_transfer_record(rec, ledger_path=ledger_path)
+    return TransferPlanResult(
+        ok=True,
+        dry_run=True,
+        blocked=False,
+        record=rec.as_dict(),
+        message=(
+            f"DRY-RUN {direction_s} ${float(amount_usd):.2f} planned and logged "
+            f"(live gate allowed={gate.allowed})"
+        ),
+    )
+
+
+def plan_fund_from_mercury(
+    amount_usd: float, *, dry_run: bool = True, **kwargs: Any
+) -> TransferPlanResult:
+    return plan_transfer(
+        direction=TransferDirection.MERCURY_TO_BROKER,
+        amount_usd=amount_usd,
+        dry_run=dry_run,
+        reason=kwargs.pop("reason", "fund_broker_from_mercury"),
+        **kwargs,
+    )
+
+
+def plan_remit_to_mercury(
+    amount_usd: float, *, dry_run: bool = True, **kwargs: Any
+) -> TransferPlanResult:
+    return plan_transfer(
+        direction=TransferDirection.BROKER_TO_MERCURY,
+        amount_usd=amount_usd,
+        dry_run=dry_run,
+        reason=kwargs.pop("reason", "remit_proceeds_to_mercury"),
+        **kwargs,
+    )

--- a/src/bank/remittance.py
+++ b/src/bank/remittance.py
@@ -1,0 +1,156 @@
+"""After-tax remittance progress toward $1000/mo bank deposits.
+
+Never reports the monthly target as achieved without ledger evidence of
+broker_to_mercury remittances (and optional realized P/L inputs).
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+from typing import Any, Iterable
+
+from src.bank.transfer_ledger import TransferDirection, TransferRecord
+
+# Goal remittance target (user: $1000/mo after-tax). Distinct from North Star $6000.
+MONTHLY_AFTER_TAX_TARGET_USD = 1000.0
+
+# Conservative default short-term capital gains rate for SPY equity options (federal+state est.)
+DEFAULT_SHORT_TERM_TAX_RATE = 0.37
+
+
+@dataclass(frozen=True)
+class RemittanceProgress:
+    """Progress toward monthly after-tax bank remittance — ledger facts only."""
+
+    month_yyyy_mm: str
+    target_usd: float
+    remitted_to_bank_usd: float
+    remittance_event_count: int
+    estimated_after_tax_profit_usd: float | None
+    realized_pre_tax_pnl_usd: float | None
+    tax_rate_used: float
+    pct_of_target: float | None
+    target_met: bool
+    claim_allowed: bool
+    note: str
+
+    def as_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+def estimate_after_tax_profit(
+    realized_pre_tax_pnl: float,
+    *,
+    tax_rate: float = DEFAULT_SHORT_TERM_TAX_RATE,
+    long_term_fraction: float = 0.0,
+    long_term_tax_rate: float = 0.20,
+) -> float:
+    """Estimate after-tax profit from realized pre-tax P/L (pure function).
+
+    Losses: tax benefit is not auto-assumed as cash remittance — returns pnl
+    unchanged when negative (no fabricated refund).
+    """
+    pnl = float(realized_pre_tax_pnl)
+    if pnl <= 0:
+        return round(pnl, 2)
+    lt = max(0.0, min(1.0, float(long_term_fraction)))
+    st = 1.0 - lt
+    tax = pnl * (st * float(tax_rate) + lt * float(long_term_tax_rate))
+    return round(pnl - tax, 2)
+
+
+def _month_key(ts: str, *, fallback: str | None = None) -> str:
+    if ts:
+        # Accept ISO; take first 7 chars YYYY-MM when possible
+        try:
+            if "T" in ts or "+" in ts or ts.endswith("Z"):
+                dt = datetime.fromisoformat(ts.replace("Z", "+00:00"))
+                return dt.strftime("%Y-%m")
+        except ValueError:
+            pass
+        if len(ts) >= 7 and ts[4] == "-":
+            return ts[:7]
+    if fallback:
+        return fallback
+    return datetime.now(timezone.utc).strftime("%Y-%m")
+
+
+def compute_remittance_progress(
+    records: Iterable[TransferRecord],
+    *,
+    month_yyyy_mm: str | None = None,
+    target_usd: float = MONTHLY_AFTER_TAX_TARGET_USD,
+    realized_pre_tax_pnl_usd: float | None = None,
+    tax_rate: float = DEFAULT_SHORT_TERM_TAX_RATE,
+) -> RemittanceProgress:
+    """Compute monthly remittance progress from transfer ledger facts.
+
+    ``target_met`` is True only when confirmed/submitted broker→Mercury remittances
+    in the month sum to >= target. Dry-run and blocked rows do not count.
+    """
+    month = month_yyyy_mm or datetime.now(timezone.utc).strftime("%Y-%m")
+    remitted = 0.0
+    n_events = 0
+    countable = {
+        "submitted",
+        "confirmed",
+    }
+    for rec in records:
+        if rec.direction != TransferDirection.BROKER_TO_MERCURY.value:
+            continue
+        if rec.status not in countable:
+            continue
+        if rec.dry_run:
+            continue
+        if _month_key(rec.timestamp, fallback=month) != month:
+            continue
+        remitted += float(rec.amount_usd or 0)
+        n_events += 1
+
+    remitted = round(remitted, 2)
+    after_tax: float | None = None
+    if realized_pre_tax_pnl_usd is not None:
+        after_tax = estimate_after_tax_profit(
+            float(realized_pre_tax_pnl_usd), tax_rate=tax_rate
+        )
+
+    target = float(target_usd)
+    pct = round(100.0 * remitted / target, 2) if target > 0 else None
+    target_met = remitted + 1e-9 >= target and n_events > 0
+    # Never claim target met without remittance evidence
+    claim_allowed = target_met and remitted > 0
+
+    if n_events == 0:
+        note = (
+            f"No confirmed broker→Mercury remittances in {month}. "
+            f"Cannot claim ${target:.0f}/mo after-tax target met."
+        )
+    elif not target_met:
+        note = (
+            f"Remitted ${remitted:.2f} of ${target:.0f} target in {month} "
+            f"({n_events} deposit(s))."
+        )
+    else:
+        note = (
+            f"Ledger shows ${remitted:.2f} remitted to bank in {month} "
+            f"(>= ${target:.0f} target) across {n_events} deposit(s)."
+        )
+
+    return RemittanceProgress(
+        month_yyyy_mm=month,
+        target_usd=target,
+        remitted_to_bank_usd=remitted,
+        remittance_event_count=n_events,
+        estimated_after_tax_profit_usd=after_tax,
+        realized_pre_tax_pnl_usd=(
+            float(realized_pre_tax_pnl_usd)
+            if realized_pre_tax_pnl_usd is not None
+            else None
+        ),
+        tax_rate_used=float(tax_rate),
+        pct_of_target=pct,
+        target_met=bool(target_met and claim_allowed),
+        claim_allowed=claim_allowed,
+        note=note,
+    )

--- a/src/bank/remittance.py
+++ b/src/bank/remittance.py
@@ -27,6 +27,8 @@ class RemittanceProgress:
     target_usd: float
     remitted_to_bank_usd: float
     remittance_event_count: int
+    in_flight_usd: float
+    in_flight_event_count: int
     estimated_after_tax_profit_usd: float | None
     realized_pre_tax_pnl_usd: float | None
     tax_rate_used: float
@@ -86,29 +88,34 @@ def compute_remittance_progress(
 ) -> RemittanceProgress:
     """Compute monthly remittance progress from transfer ledger facts.
 
-    ``target_met`` is True only when confirmed/submitted broker→Mercury remittances
-    in the month sum to >= target. Dry-run and blocked rows do not count.
+    ``target_met`` / ``claim_allowed`` require **confirmed** (dry_run=false)
+    broker→Mercury deposits summing to >= target. SUBMITTED is tracked only as
+    ``in_flight_usd`` and never unlocks the claim (AC3 / skeptic).
     """
     month = month_yyyy_mm or datetime.now(timezone.utc).strftime("%Y-%m")
     remitted = 0.0
     n_events = 0
-    countable = {
-        "submitted",
-        "confirmed",
-    }
+    in_flight = 0.0
+    n_in_flight = 0
     for rec in records:
         if rec.direction != TransferDirection.BROKER_TO_MERCURY.value:
-            continue
-        if rec.status not in countable:
             continue
         if rec.dry_run:
             continue
         if _month_key(rec.timestamp, fallback=month) != month:
             continue
-        remitted += float(rec.amount_usd or 0)
-        n_events += 1
+        status = str(rec.status or "").lower()
+        amount = float(rec.amount_usd or 0)
+        if status == "confirmed":
+            remitted += amount
+            n_events += 1
+        elif status == "submitted":
+            # In-flight ACH — not bank evidence of completed remittance
+            in_flight += amount
+            n_in_flight += 1
 
     remitted = round(remitted, 2)
+    in_flight = round(in_flight, 2)
     after_tax: float | None = None
     if realized_pre_tax_pnl_usd is not None:
         after_tax = estimate_after_tax_profit(
@@ -117,8 +124,8 @@ def compute_remittance_progress(
 
     target = float(target_usd)
     pct = round(100.0 * remitted / target, 2) if target > 0 else None
+    # Confirmed deposits only
     target_met = remitted + 1e-9 >= target and n_events > 0
-    # Never claim target met without remittance evidence
     claim_allowed = target_met and remitted > 0
 
     if n_events == 0:
@@ -126,14 +133,18 @@ def compute_remittance_progress(
             f"No confirmed broker→Mercury remittances in {month}. "
             f"Cannot claim ${target:.0f}/mo after-tax target met."
         )
+        if n_in_flight:
+            note += f" In-flight (submitted, not confirmed): ${in_flight:.2f}."
     elif not target_met:
         note = (
-            f"Remitted ${remitted:.2f} of ${target:.0f} target in {month} "
+            f"Confirmed remitted ${remitted:.2f} of ${target:.0f} target in {month} "
             f"({n_events} deposit(s))."
         )
+        if n_in_flight:
+            note += f" In-flight: ${in_flight:.2f} (not counted toward target)."
     else:
         note = (
-            f"Ledger shows ${remitted:.2f} remitted to bank in {month} "
+            f"Ledger shows ${remitted:.2f} confirmed remitted to bank in {month} "
             f"(>= ${target:.0f} target) across {n_events} deposit(s)."
         )
 
@@ -142,6 +153,8 @@ def compute_remittance_progress(
         target_usd=target,
         remitted_to_bank_usd=remitted,
         remittance_event_count=n_events,
+        in_flight_usd=in_flight,
+        in_flight_event_count=n_in_flight,
         estimated_after_tax_profit_usd=after_tax,
         realized_pre_tax_pnl_usd=(
             float(realized_pre_tax_pnl_usd)

--- a/src/bank/transfer_ledger.py
+++ b/src/bank/transfer_ledger.py
@@ -1,0 +1,175 @@
+"""Durable transfer ledger: Mercury ↔ brokerage ACH/API plans and outcomes.
+
+Every transfer (planned or executed) is logged with amount, direction, and time.
+Secrets never appear in records.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import uuid
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from enum import Enum
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_LEDGER_PATH = REPO_ROOT / "data" / "audit" / "mercury_broker_transfers.jsonl"
+
+
+class TransferDirection(str, Enum):
+    """Money movement direction relative to the trading brokerage."""
+
+    MERCURY_TO_BROKER = "mercury_to_broker"  # fund trading account
+    BROKER_TO_MERCURY = "broker_to_mercury"  # remit proceeds to bank
+
+
+class TransferStatus(str, Enum):
+    PLANNED = "planned"
+    DRY_RUN = "dry_run"
+    BLOCKED = "blocked"
+    SUBMITTED = "submitted"
+    CONFIRMED = "confirmed"
+    FAILED = "failed"
+
+
+@dataclass(frozen=True)
+class TransferRecord:
+    """One transfer plan or execution row (no secrets)."""
+
+    transfer_id: str
+    direction: str
+    amount_usd: float
+    timestamp: str
+    status: str
+    dry_run: bool
+    source: str
+    destination: str
+    reason: str = ""
+    block_reason: str = ""
+    external_ref: str = ""
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    def as_dict(self) -> dict[str, Any]:
+        payload = asdict(self)
+        # Never allow secret-like keys into durable log
+        meta = dict(payload.get("metadata") or {})
+        for banned in list(meta.keys()):
+            low = str(banned).lower()
+            if any(tok in low for tok in ("secret", "password", "token", "api_key", "apikey")):
+                meta.pop(banned, None)
+        payload["metadata"] = meta
+        return payload
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def new_transfer_id() -> str:
+    return f"xfer_{uuid.uuid4().hex[:16]}"
+
+
+def build_transfer_record(
+    *,
+    direction: TransferDirection | str,
+    amount_usd: float,
+    status: TransferStatus | str,
+    dry_run: bool,
+    reason: str = "",
+    block_reason: str = "",
+    external_ref: str = "",
+    metadata: dict[str, Any] | None = None,
+    transfer_id: str | None = None,
+    timestamp: str | None = None,
+) -> TransferRecord:
+    """Construct a validated transfer record (pure)."""
+    amt = float(amount_usd)
+    if amt < 0:
+        raise ValueError("amount_usd must be non-negative")
+    direction_s = (
+        direction.value if isinstance(direction, TransferDirection) else str(direction)
+    )
+    if direction_s not in {d.value for d in TransferDirection}:
+        raise ValueError(f"invalid direction: {direction_s}")
+    status_s = status.value if isinstance(status, TransferStatus) else str(status)
+
+    if direction_s == TransferDirection.MERCURY_TO_BROKER.value:
+        source, destination = "mercury_ai_bank", "brokerage_live"
+    else:
+        source, destination = "brokerage_live", "mercury_ai_bank"
+
+    return TransferRecord(
+        transfer_id=transfer_id or new_transfer_id(),
+        direction=direction_s,
+        amount_usd=round(amt, 2),
+        timestamp=timestamp or _now_iso(),
+        status=status_s,
+        dry_run=bool(dry_run),
+        source=source,
+        destination=destination,
+        reason=str(reason or ""),
+        block_reason=str(block_reason or ""),
+        external_ref=str(external_ref or ""),
+        metadata=dict(metadata or {}),
+    )
+
+
+def append_transfer_record(
+    record: TransferRecord,
+    *,
+    ledger_path: Path | None = None,
+) -> Path:
+    """Append one JSONL row. Creates parent dirs. Returns path written."""
+    path = ledger_path or Path(
+        os.environ.get("MERCURY_TRANSFER_LEDGER", str(DEFAULT_LEDGER_PATH))
+    )
+    path.parent.mkdir(parents=True, exist_ok=True)
+    line = json.dumps(record.as_dict(), sort_keys=True) + "\n"
+    with path.open("a", encoding="utf-8") as fh:
+        fh.write(line)
+    return path
+
+
+def load_transfer_ledger(*, ledger_path: Path | None = None) -> list[TransferRecord]:
+    """Load all transfer records from JSONL (skips bad lines)."""
+    path = ledger_path or Path(
+        os.environ.get("MERCURY_TRANSFER_LEDGER", str(DEFAULT_LEDGER_PATH))
+    )
+    if not path.is_file():
+        return []
+    out: list[TransferRecord] = []
+    for line in path.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            raw = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(raw, dict):
+            continue
+        try:
+            out.append(
+                TransferRecord(
+                    transfer_id=str(raw.get("transfer_id") or ""),
+                    direction=str(raw.get("direction") or ""),
+                    amount_usd=float(raw.get("amount_usd") or 0),
+                    timestamp=str(raw.get("timestamp") or ""),
+                    status=str(raw.get("status") or ""),
+                    dry_run=bool(raw.get("dry_run", True)),
+                    source=str(raw.get("source") or ""),
+                    destination=str(raw.get("destination") or ""),
+                    reason=str(raw.get("reason") or ""),
+                    block_reason=str(raw.get("block_reason") or ""),
+                    external_ref=str(raw.get("external_ref") or ""),
+                    metadata=dict(raw.get("metadata") or {})
+                    if isinstance(raw.get("metadata"), dict)
+                    else {},
+                )
+            )
+        except (TypeError, ValueError):
+            continue
+    return out

--- a/tests/test_bank_remittance_loop.py
+++ b/tests/test_bank_remittance_loop.py
@@ -100,6 +100,7 @@ def test_remittance_progress_never_claims_without_ledger(tmp_path: Path):
 
 
 def test_remittance_progress_counts_confirmed_deposits(tmp_path: Path):
+    """Only CONFIRMED broker→Mercury counts toward target_met (not SUBMITTED)."""
     path = tmp_path / "ledger.jsonl"
     append_transfer_record(
         build_transfer_record(
@@ -111,6 +112,7 @@ def test_remittance_progress_counts_confirmed_deposits(tmp_path: Path):
         ),
         ledger_path=path,
     )
+    # SUBMITTED must be in-flight only — never unlock $1000/mo claim alone
     append_transfer_record(
         build_transfer_record(
             direction=TransferDirection.BROKER_TO_MERCURY,
@@ -135,10 +137,53 @@ def test_remittance_progress_counts_confirmed_deposits(tmp_path: Path):
     progress = compute_remittance_progress(
         load_transfer_ledger(ledger_path=path), month_yyyy_mm="2026-07"
     )
-    assert progress.remitted_to_bank_usd == 1000.0
-    assert progress.remittance_event_count == 2
-    assert progress.target_met is True
-    assert progress.claim_allowed is True
+    assert progress.remitted_to_bank_usd == 600.0
+    assert progress.remittance_event_count == 1
+    assert progress.in_flight_usd == 400.0
+    assert progress.in_flight_event_count == 1
+    assert progress.target_met is False
+    assert progress.claim_allowed is False
+
+    # Second CONFIRMED deposit reaches target
+    append_transfer_record(
+        build_transfer_record(
+            direction=TransferDirection.BROKER_TO_MERCURY,
+            amount_usd=400.0,
+            status=TransferStatus.CONFIRMED,
+            dry_run=False,
+            timestamp="2026-07-25T12:00:00+00:00",
+        ),
+        ledger_path=path,
+    )
+    progress2 = compute_remittance_progress(
+        load_transfer_ledger(ledger_path=path), month_yyyy_mm="2026-07"
+    )
+    assert progress2.remitted_to_bank_usd == 1000.0
+    assert progress2.remittance_event_count == 2
+    assert progress2.in_flight_usd == 400.0  # submitted still tracked separately
+    assert progress2.target_met is True
+    assert progress2.claim_allowed is True
+
+
+def test_submitted_alone_never_meets_target(tmp_path: Path):
+    path = tmp_path / "ledger.jsonl"
+    append_transfer_record(
+        build_transfer_record(
+            direction=TransferDirection.BROKER_TO_MERCURY,
+            amount_usd=1000.0,
+            status=TransferStatus.SUBMITTED,
+            dry_run=False,
+            timestamp="2026-07-15T12:00:00+00:00",
+        ),
+        ledger_path=path,
+    )
+    progress = compute_remittance_progress(
+        load_transfer_ledger(ledger_path=path), month_yyyy_mm="2026-07"
+    )
+    assert progress.remitted_to_bank_usd == 0.0
+    assert progress.in_flight_usd == 1000.0
+    assert progress.target_met is False
+    assert progress.claim_allowed is False
 
 
 def test_live_bank_gate_refuses_when_kill_switch_blocks(tmp_path: Path, monkeypatch):

--- a/tests/test_bank_remittance_loop.py
+++ b/tests/test_bank_remittance_loop.py
@@ -1,0 +1,235 @@
+"""Tests for Mercury↔broker transfer ledger, remittance math, and live gates.
+
+Drives real shipped modules — no reimplementation of gate logic in the test.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from src.bank.live_gate import evaluate_live_bank_gate
+from src.bank.mercury_transfer import plan_fund_from_mercury, plan_remit_to_mercury, plan_transfer
+from src.bank.remittance import (
+    MONTHLY_AFTER_TAX_TARGET_USD,
+    compute_remittance_progress,
+    estimate_after_tax_profit,
+)
+from src.bank.transfer_ledger import (
+    TransferDirection,
+    TransferStatus,
+    append_transfer_record,
+    build_transfer_record,
+    load_transfer_ledger,
+)
+
+
+def test_estimate_after_tax_profit_short_term():
+    # $1000 pre-tax at 37% → $630 after-tax
+    assert estimate_after_tax_profit(1000.0, tax_rate=0.37) == 630.0
+    assert estimate_after_tax_profit(-500.0) == -500.0
+
+
+def test_transfer_record_schema_has_amount_direction_time(tmp_path: Path):
+    rec = build_transfer_record(
+        direction=TransferDirection.MERCURY_TO_BROKER,
+        amount_usd=250.0,
+        status=TransferStatus.DRY_RUN,
+        dry_run=True,
+        reason="unit_test",
+    )
+    d = rec.as_dict()
+    assert d["amount_usd"] == 250.0
+    assert d["direction"] == "mercury_to_broker"
+    assert d["timestamp"]
+    assert d["source"] == "mercury_ai_bank"
+    assert d["destination"] == "brokerage_live"
+    # secrets stripped from metadata
+    dirty = build_transfer_record(
+        direction=TransferDirection.BROKER_TO_MERCURY,
+        amount_usd=10,
+        status=TransferStatus.PLANNED,
+        dry_run=True,
+        metadata={"api_key": "SECRET", "note": "ok"},
+    )
+    assert "api_key" not in dirty.as_dict()["metadata"]
+    assert dirty.as_dict()["metadata"]["note"] == "ok"
+
+    path = tmp_path / "ledger.jsonl"
+    append_transfer_record(rec, ledger_path=path)
+    loaded = load_transfer_ledger(ledger_path=path)
+    assert len(loaded) == 1
+    assert loaded[0].amount_usd == 250.0
+
+
+def test_remittance_progress_never_claims_without_ledger(tmp_path: Path):
+    progress = compute_remittance_progress([], month_yyyy_mm="2026-07")
+    assert progress.target_usd == MONTHLY_AFTER_TAX_TARGET_USD
+    assert progress.remitted_to_bank_usd == 0.0
+    assert progress.target_met is False
+    assert progress.claim_allowed is False
+
+    path = tmp_path / "ledger.jsonl"
+    # dry-run must not count
+    append_transfer_record(
+        build_transfer_record(
+            direction=TransferDirection.BROKER_TO_MERCURY,
+            amount_usd=5000,
+            status=TransferStatus.DRY_RUN,
+            dry_run=True,
+            timestamp="2026-07-15T12:00:00+00:00",
+        ),
+        ledger_path=path,
+    )
+    # blocked must not count
+    append_transfer_record(
+        build_transfer_record(
+            direction=TransferDirection.BROKER_TO_MERCURY,
+            amount_usd=5000,
+            status=TransferStatus.BLOCKED,
+            dry_run=False,
+            timestamp="2026-07-15T12:00:00+00:00",
+        ),
+        ledger_path=path,
+    )
+    p2 = compute_remittance_progress(
+        load_transfer_ledger(ledger_path=path), month_yyyy_mm="2026-07"
+    )
+    assert p2.target_met is False
+    assert p2.remitted_to_bank_usd == 0.0
+
+
+def test_remittance_progress_counts_confirmed_deposits(tmp_path: Path):
+    path = tmp_path / "ledger.jsonl"
+    append_transfer_record(
+        build_transfer_record(
+            direction=TransferDirection.BROKER_TO_MERCURY,
+            amount_usd=600.0,
+            status=TransferStatus.CONFIRMED,
+            dry_run=False,
+            timestamp="2026-07-10T12:00:00+00:00",
+        ),
+        ledger_path=path,
+    )
+    append_transfer_record(
+        build_transfer_record(
+            direction=TransferDirection.BROKER_TO_MERCURY,
+            amount_usd=400.0,
+            status=TransferStatus.SUBMITTED,
+            dry_run=False,
+            timestamp="2026-07-20T12:00:00+00:00",
+        ),
+        ledger_path=path,
+    )
+    # fund direction must not count as remittance
+    append_transfer_record(
+        build_transfer_record(
+            direction=TransferDirection.MERCURY_TO_BROKER,
+            amount_usd=9999.0,
+            status=TransferStatus.CONFIRMED,
+            dry_run=False,
+            timestamp="2026-07-12T12:00:00+00:00",
+        ),
+        ledger_path=path,
+    )
+    progress = compute_remittance_progress(
+        load_transfer_ledger(ledger_path=path), month_yyyy_mm="2026-07"
+    )
+    assert progress.remitted_to_bank_usd == 1000.0
+    assert progress.remittance_event_count == 2
+    assert progress.target_met is True
+    assert progress.claim_allowed is True
+
+
+def test_live_bank_gate_refuses_when_kill_switch_blocks(tmp_path: Path, monkeypatch):
+    """Drive real evaluate_live_bank_gate against kill switch + insufficient sample."""
+    runtime = tmp_path / "data" / "runtime"
+    runtime.mkdir(parents=True)
+    audit = tmp_path / "data" / "audit"
+    audit.mkdir(parents=True)
+    kill = {
+        "active_family": "spy_put_credit",
+        "killed_families": ["ic_simple", "iron_condor"],
+        "paper_only": True,
+        "live_blocked": True,
+        "reason": "test block",
+        "successor_family": "spy_put_credit",
+    }
+    (runtime / "strategy_kill_switch.json").write_text(json.dumps(kill), encoding="utf-8")
+    cohort = {
+        "closed": {
+            "closed_n": 0,
+            "expectancy": None,
+            "profit_factor": None,
+            "kill_criteria": {"verdict": "INSUFFICIENT_SAMPLE"},
+        },
+        "honesty": {"live_deposit_ready": False, "claim_profitable": False},
+    }
+    cohort_path = audit / "put_credit_cohort_latest.json"
+    cohort_path.write_text(json.dumps(cohort), encoding="utf-8")
+
+    # Point active_strategy kill file at temp
+    import src.core.active_strategy as active_mod
+    import src.bank.live_gate as gate_mod
+
+    monkeypatch.setattr(active_mod, "KILL_FILE", runtime / "strategy_kill_switch.json")
+    monkeypatch.setattr(active_mod, "HYPOTHESIS_FILE", runtime / "strategy_validation_hypothesis.json")
+    monkeypatch.setattr(gate_mod, "DEFAULT_COHORT", cohort_path)
+
+    decision = evaluate_live_bank_gate(cohort_path=cohort_path)
+    assert decision.allowed is False
+    assert decision.live_trading_allowed is False
+    assert decision.bank_transfer_allowed is False
+    assert decision.strategy_mode == "multi_day_hold_or_buy_hold_non_pdt"
+    assert any("live_blocked" in b for b in decision.blockers)
+    assert any("insufficient_edge_sample" in b for b in decision.blockers)
+
+
+def test_plan_transfer_dry_run_logs_and_execute_blocks(tmp_path: Path, monkeypatch):
+    path = tmp_path / "ledger.jsonl"
+    # Force gate blocked via empty sample + default kill from repo may vary;
+    # monkeypatch evaluate_live_bank_gate
+    import src.bank.mercury_transfer as mt
+    from src.bank.live_gate import LiveBankGateDecision
+
+    blocked = LiveBankGateDecision(
+        allowed=False,
+        live_trading_allowed=False,
+        bank_transfer_allowed=False,
+        blockers=("kill_switch.live_blocked: test",),
+        paper_only=True,
+        live_blocked=True,
+        sample_closed_n=0,
+        expectancy=None,
+        profit_factor=None,
+        strategy_mode="multi_day_hold_or_buy_hold_non_pdt",
+        detail={},
+    )
+    monkeypatch.setattr(mt, "evaluate_live_bank_gate", lambda: blocked)
+
+    dry = plan_fund_from_mercury(100.0, dry_run=True, ledger_path=path)
+    assert dry.ok is True
+    assert dry.dry_run is True
+    assert dry.record["direction"] == "mercury_to_broker"
+    assert dry.record["amount_usd"] == 100.0
+    assert dry.record["timestamp"]
+    assert dry.record["status"] == "dry_run"
+
+    remit = plan_remit_to_mercury(50.0, dry_run=True, ledger_path=path)
+    assert remit.ok is True
+    assert remit.record["direction"] == "broker_to_mercury"
+
+    real = plan_transfer(
+        direction=TransferDirection.MERCURY_TO_BROKER,
+        amount_usd=100.0,
+        dry_run=False,
+        force_execute=True,
+        ledger_path=path,
+    )
+    assert real.ok is False
+    assert real.blocked is True
+    assert real.record["status"] == "blocked"
+    assert "live_blocked" in real.record["block_reason"]
+
+    rows = load_transfer_ledger(ledger_path=path)
+    assert len(rows) >= 3


### PR DESCRIPTION
## Summary
Implements the autonomous **fund → multi-day trade path → remit** control plane with hard fail-closed live/bank gates.

### Shipped
- `src/bank/` — transfer ledger, after-tax remittance progress ($1000/mo target), live gate, Mercury transfer planner
- CLIs: `mercury_broker_transfer.py`, `remittance_status.py`, `autonomous_money_cycle.py`
- GH workflow dry-run schedule (weekdays)
- Unit tests: `tests/test_bank_remittance_loop.py`

### Safety (honest)
- Live bank transfers and live trading **refuse** while `live_blocked` / paper_only / sample &lt; 30
- Dry-run default; no hardcoded secrets; no fabricated Mercury ACH receipts
- Strategy mode: multi-day hold / buy-hold non-PDT (not day-trading churn)
- Does **not** claim $1000/mo met without confirmed broker→Mercury ledger deposits

## Test plan
- [x] `pytest tests/test_bank_remittance_loop.py`
- [x] dry-run fund + remit log amount/direction/time
- [x] `--execute` bank transfer exits 2 when gated
- [x] autonomous cycle dry-run exit 0