### PR TITLE
feat: read-only Mercury bank status via the real Mercury API

### DIFF
--- a/scripts/mercury_status.py
+++ b/scripts/mercury_status.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""Read-only Mercury bank status via the real Mercury API.
+
+Prints account names, kinds, and balances as JSON. This path is read-only by
+construction twice over: the code only ever issues GET requests, and the
+vaulted token it loads was created with read_only permissions (2026-07-26,
+nickname "trading-readonly") - Mercury's API rejects any transfer attempt made
+with it. Wiring real transfers remains a separate, explicit change gated by
+MercuryBankAdapter's MERCURY_LIVE_TRANSFERS_ENABLED requirement
+(src/adapters/bank_adapter.py).
+
+Token resolution order:
+  1. MERCURY_API_TOKEN environment variable
+  2. ~/.resume_secrets/mercury.json (chmod 600 vault file, "api_token" key)
+
+The token value is never printed.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Any
+
+MERCURY_API_BASE_URL = "https://api.mercury.com/api/v1"
+VAULT_PATH = Path.home() / ".resume_secrets" / "mercury.json"
+
+
+def load_token() -> str:
+    token = os.environ.get("MERCURY_API_TOKEN")
+    if token:
+        return token
+    if VAULT_PATH.is_file():
+        try:
+            payload = json.loads(VAULT_PATH.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as exc:
+            raise SystemExit(f"Failed to read {VAULT_PATH}: {exc}") from exc
+        token = payload.get("api_token")
+        if token:
+            return token
+    raise SystemExit(
+        "No Mercury token: set MERCURY_API_TOKEN or store api_token in ~/.resume_secrets/mercury.json"
+    )
+
+
+def summarize_accounts(payload: dict[str, Any]) -> list[dict[str, Any]]:
+    """Reduce the raw /accounts response to a masked, no-secrets summary."""
+    summary = []
+    for account in payload.get("accounts", []):
+        if not isinstance(account, dict):
+            continue
+        number = str(account.get("accountNumber") or "")
+        summary.append(
+            {
+                "name": account.get("name"),
+                "kind": account.get("kind"),
+                "status": account.get("status"),
+                "current_balance_usd": account.get("currentBalance"),
+                "available_balance_usd": account.get("availableBalance"),
+                "account_number_last4": number[-4:] if number else None,
+            }
+        )
+    return summary
+
+
+def fetch_accounts(token: str) -> dict[str, Any]:
+    import requests
+
+    response = requests.get(
+        f"{MERCURY_API_BASE_URL}/accounts",
+        headers={"Authorization": f"Bearer {token}"},
+        timeout=30,
+    )
+    response.raise_for_status()
+    return response.json()
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--json", action="store_true", help="Emit machine-readable JSON")
+    args = parser.parse_args()
+
+    accounts = summarize_accounts(fetch_accounts(load_token()))
+    total = sum(float(a.get("available_balance_usd") or 0.0) for a in accounts)
+    report = {"accounts": accounts, "total_available_usd": total, "read_only": True}
+
+    if args.json:
+        print(json.dumps(report, indent=2))
+    else:
+        print("=== MERCURY BANK STATUS (read-only) ===")
+        for a in accounts:
+            print(
+                f"  {a['name']} [{a['kind']}] {a['status']}: "
+                f"${float(a['available_balance_usd'] or 0):,.2f} available"
+            )
+        print(f"  TOTAL available: ${total:,.2f}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_mercury_status.py
+++ b/tests/test_mercury_status.py
@@ -1,0 +1,35 @@
+from scripts.mercury_status import summarize_accounts
+
+
+class TestSummarizeAccounts:
+    def test_masks_account_numbers_to_last4(self):
+        payload = {
+            "accounts": [
+                {
+                    "name": "Mercury Checking",
+                    "kind": "checking",
+                    "status": "active",
+                    "currentBalance": 100.0,
+                    "availableBalance": 100.0,
+                    "accountNumber": "123456787725",
+                }
+            ]
+        }
+        summary = summarize_accounts(payload)
+        assert summary[0]["account_number_last4"] == "7725"
+        assert "123456787725" not in str(summary)
+
+    def test_handles_empty_and_malformed_rows(self):
+        assert summarize_accounts({}) == []
+        assert summarize_accounts({"accounts": ["not-a-dict", None]}) == []
+
+    def test_missing_account_number_yields_none(self):
+        summary = summarize_accounts({"accounts": [{"name": "X", "accountNumber": None}]})
+        assert summary[0]["account_number_last4"] is None
+
+    def test_balances_pass_through(self):
+        summary = summarize_accounts(
+            {"accounts": [{"currentBalance": 12.5, "availableBalance": 10.0}]}
+        )
+        assert summary[0]["current_balance_usd"] == 12.5
+        assert summary[0]["available_balance_usd"] == 10.0


### PR DESCRIPTION
## Summary
- First **real** Mercury integration for the trading system: `scripts/mercury_status.py` reads live account balances from Mercury's production API.
- A read-only API token (nickname `trading-readonly`, permissions **Read Only**) was created 2026-07-26 in the authenticated Mercury dashboard with the user present and directing, and vaulted at `~/.resume_secrets/mercury.json` (chmod 600). The token value never appears in code, output, logs, or this PR.
- Read-only by construction twice over: the script only issues GET requests, and the token itself has read_only permissions — Mercury's API rejects any transfer attempt made with it regardless of code. Real transfers remain gated behind `MercuryBankAdapter`'s `MERCURY_LIVE_TRANSFERS_ENABLED` requirement (src/adapters/bank_adapter.py) and a read-write token that deliberately does not exist.
- Account numbers are masked to last-4 in all output (test-covered).

## Verification (live, 2026-07-26)
- `GET /api/v1/accounts` → HTTP 200
- `Mercury Checking ••7725 [checking] active: $0.00 available`
- `Mercury Savings ••9689 [savings] active: $0.00 available`

## Test plan
- [x] `pytest tests/test_mercury_status.py -q` — 4 passed
- [x] `ruff check` — clean
- [x] Live smoke test against the real Mercury API — succeeded (output above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)