### PR TITLE
feat: Mercury bank MCP server, CLI, and read-only client integration

### DIFF
--- a/mcp/registry.json
+++ b/mcp/registry.json
@@ -33,6 +33,16 @@
       }
     },
     {
+      "id": "mercury",
+      "display_name": "Mercury Bank (read-only)",
+      "module": "mcp.servers.mercury",
+      "tools": {
+        "get_bank_status": "get_bank_status",
+        "get_bank_transactions": "get_bank_transactions",
+        "get_bank_health": "get_bank_health"
+      }
+    },
+    {
       "id": "gmail",
       "display_name": "Gmail Integration",
       "module": "mcp.servers.gmail",

--- a/mcp/servers/mercury.py
+++ b/mcp/servers/mercury.py
@@ -1,0 +1,105 @@
+"""
+Mercury Bank MCP Server - read-only bank visibility
+
+Provides tools for:
+- Account balances and status
+- Recent transaction history
+- Bank connectivity health checks
+
+Every tool is read-only: the underlying MercuryReadOnlyClient
+(src/adapters/mercury_readonly.py) is GET-only by construction. Money
+movement is deliberately NOT exposed here - it stays behind
+MercuryBankAdapter's MERCURY_LIVE_TRANSFERS_ENABLED hard stop.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from datetime import datetime, timezone
+from typing import Any
+
+from src.adapters.mercury_readonly import MercuryReadOnlyClient
+
+logger = logging.getLogger(__name__)
+
+_client: MercuryReadOnlyClient | None = None
+
+
+def _get_client() -> MercuryReadOnlyClient:
+    global _client
+    if _client is None:
+        _client = MercuryReadOnlyClient.from_env()
+    return _client
+
+
+def _reset_client() -> None:
+    """Test hook: drop the cached client so from_env runs again."""
+    global _client
+    _client = None
+
+
+def get_bank_status() -> dict[str, Any]:
+    """
+    Masked snapshot of all Mercury accounts with total available balance.
+
+    Returns:
+        Snapshot dict with accounts, total_available_usd, read_only flag.
+    """
+    try:
+        snapshot = _get_client().snapshot()
+        return {"success": True, **snapshot}
+    except Exception as e:  # noqa: BLE001 - MCP tools report errors, never raise
+        logger.error("Mercury bank status failed: %s", e)
+        return {"success": False, "error": str(e)}
+
+
+def get_bank_transactions(account: str = "checking", limit: int = 20) -> dict[str, Any]:
+    """
+    Recent transactions for one account.
+
+    Args:
+        account: "checking", "savings", or a raw Mercury account id.
+        limit: Maximum rows to return (1-500).
+
+    Returns:
+        Masked transaction summaries plus the account alias queried.
+    """
+    try:
+        result = _get_client().get_transactions(account, limit=limit)
+        return {
+            "success": True,
+            "account": account,
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+            **result,
+        }
+    except Exception as e:  # noqa: BLE001
+        logger.error("Mercury transactions failed: %s", e)
+        return {"success": False, "account": account, "error": str(e)}
+
+
+def get_bank_health() -> dict[str, Any]:
+    """
+    Connectivity check: token resolves and the accounts endpoint answers.
+
+    Returns:
+        Health dict with reachable flag, account count, and latency.
+    """
+    start = time.perf_counter()
+    try:
+        accounts = _get_client().list_accounts()
+        return {
+            "success": True,
+            "reachable": True,
+            "accounts": len(accounts),
+            "latency_ms": round((time.perf_counter() - start) * 1000, 1),
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+        }
+    except Exception as e:  # noqa: BLE001
+        return {
+            "success": False,
+            "reachable": False,
+            "error": str(e),
+            "latency_ms": round((time.perf_counter() - start) * 1000, 1),
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+        }

--- a/scripts/mercury_cli.py
+++ b/scripts/mercury_cli.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+"""Mercury Bank CLI - read-only operator surface.
+
+Subcommands:
+  accounts       List accounts with balances (masked)
+  transactions   Recent transactions for one account
+  sync           Write a masked snapshot to data/mercury_state.json
+  health         Exit 0 if the Mercury API is reachable with the vault token
+
+All commands are read-only by construction (MercuryReadOnlyClient is GET-only).
+Money movement stays behind MercuryBankAdapter's MERCURY_LIVE_TRANSFERS_ENABLED
+hard stop and is not reachable from this CLI. The token is never printed.
+
+Examples:
+  .venv/bin/python scripts/mercury_cli.py accounts
+  .venv/bin/python scripts/mercury_cli.py transactions --account savings --limit 10
+  .venv/bin/python scripts/mercury_cli.py sync
+  .venv/bin/python scripts/mercury_cli.py health
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from src.adapters.mercury_readonly import MercuryReadOnlyClient  # noqa: E402
+
+DEFAULT_STATE_PATH = ROOT / "data" / "mercury_state.json"
+
+
+def cmd_accounts(client: MercuryReadOnlyClient, args: argparse.Namespace) -> int:
+    snapshot = client.snapshot()
+    if args.json:
+        print(json.dumps(snapshot, indent=2))
+        return 0
+    print("=== MERCURY ACCOUNTS (read-only) ===")
+    for a in snapshot["accounts"]:
+        print(
+            f"  {a['name']} [{a['kind']}] {a['status']}: "
+            f"${float(a['available_balance_usd'] or 0):,.2f} available"
+        )
+    print(f"  TOTAL available: ${snapshot['total_available_usd']:,.2f}")
+    return 0
+
+
+def cmd_transactions(client: MercuryReadOnlyClient, args: argparse.Namespace) -> int:
+    result = client.get_transactions(args.account, limit=args.limit)
+    if args.json:
+        print(json.dumps(result, indent=2))
+        return 0
+    rows = result["transactions"]
+    print(f"=== MERCURY TRANSACTIONS [{args.account}] ({len(rows)} of {result['total']}) ===")
+    for t in rows:
+        amount = float(t["amount_usd"] or 0)
+        print(
+            f"  {t['created_at']} {t['kind'] or '?'} ${amount:,.2f} "
+            f"{t['status'] or '?'} {t['counterparty'] or t['description'] or ''}"
+        )
+    if not rows:
+        print("  (no transactions)")
+    return 0
+
+
+def cmd_sync(client: MercuryReadOnlyClient, args: argparse.Namespace) -> int:
+    snapshot = client.snapshot()
+    args.state_path.parent.mkdir(parents=True, exist_ok=True)
+    args.state_path.write_text(json.dumps(snapshot, indent=2) + "\n", encoding="utf-8")
+    print(
+        f"✅ Mercury sync complete: {len(snapshot['accounts'])} accounts, "
+        f"${snapshot['total_available_usd']:,.2f} available -> {args.state_path}"
+    )
+    return 0
+
+
+def cmd_health(client: MercuryReadOnlyClient, args: argparse.Namespace) -> int:
+    accounts = client.list_accounts()
+    active = sum(1 for a in accounts if a.get("status") == "active")
+    print(f"✅ Mercury API reachable: {len(accounts)} accounts ({active} active)")
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    p_accounts = sub.add_parser("accounts", help="List accounts with balances")
+    p_accounts.add_argument("--json", action="store_true")
+    p_accounts.set_defaults(func=cmd_accounts)
+
+    p_txn = sub.add_parser("transactions", help="Recent transactions for one account")
+    p_txn.add_argument("--account", default="checking", help="checking|savings|<account id>")
+    p_txn.add_argument("--limit", type=int, default=20)
+    p_txn.add_argument("--json", action="store_true")
+    p_txn.set_defaults(func=cmd_transactions)
+
+    p_sync = sub.add_parser("sync", help="Write snapshot to data/mercury_state.json")
+    p_sync.add_argument("--state-path", type=Path, default=DEFAULT_STATE_PATH)
+    p_sync.set_defaults(func=cmd_sync)
+
+    p_health = sub.add_parser("health", help="Exit 0 if Mercury API is reachable")
+    p_health.set_defaults(func=cmd_health)
+
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    try:
+        client = MercuryReadOnlyClient.from_env()
+    except ValueError as exc:
+        print(f"❌ Mercury credentials missing: {exc}")
+        return 1
+    try:
+        return args.func(client, args)
+    except Exception as exc:  # noqa: BLE001 - operator CLI reports, never tracebacks
+        print(f"❌ Mercury {args.command} failed: {exc}")
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/mercury_status.py
+++ b/scripts/mercury_status.py
@@ -38,7 +38,7 @@ def load_token() -> str:
             payload = json.loads(VAULT_PATH.read_text(encoding="utf-8"))
         except (OSError, json.JSONDecodeError) as exc:
             raise SystemExit(f"Failed to read {VAULT_PATH}: {exc}") from exc
-        token = payload.get("api_token")
+        token = payload.get("MERCURY_API_TOKEN") or payload.get("api_token")
         if token:
             return token
     raise SystemExit(

--- a/src/adapters/mercury_readonly.py
+++ b/src/adapters/mercury_readonly.py
@@ -1,0 +1,183 @@
+"""Read-only Mercury API client.
+
+This client is GET-only by construction: it has no method that can create,
+mutate, or move money, and its transport helper refuses non-GET verbs. It is
+the shared seam for every read surface (scripts/mercury_cli.py,
+scripts/mercury_status.py, mcp/servers/mercury.py). Real transfers remain
+exclusively behind MercuryBankAdapter and its MERCURY_LIVE_TRANSFERS_ENABLED
+hard stop (src/adapters/bank_adapter.py).
+
+Token resolution order:
+  1. MERCURY_API_TOKEN environment variable
+  2. Vault file (MERCURY_SECRETS_PATH env override, default
+     ~/.resume_secrets/mercury.json) under the "MERCURY_API_TOKEN" or legacy
+     "api_token" key
+
+The token value is never logged, printed, or included in any return value.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from collections.abc import Callable
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+MERCURY_API_BASE_URL = os.environ.get("MERCURY_API_BASE_URL", "https://api.mercury.com/api/v1")
+DEFAULT_VAULT_PATH = Path.home() / ".resume_secrets" / "mercury.json"
+
+ACCOUNT_ALIAS_KEYS = {
+    "checking": "MERCURY_ACCOUNT_ID",
+    "savings": "MERCURY_SAVINGS_ACCOUNT_ID",
+}
+
+HttpGet = Callable[[str, dict[str, Any], dict[str, str]], dict[str, Any]]
+
+
+def _default_http_get(url: str, params: dict[str, Any], headers: dict[str, str]) -> dict[str, Any]:
+    import requests
+
+    response = requests.get(url, params=params, headers=headers, timeout=30)
+    response.raise_for_status()
+    return response.json()
+
+
+def _load_vault(secrets_path: Path | None = None) -> dict[str, Any]:
+    env_override = os.environ.get("MERCURY_SECRETS_PATH")
+    path = secrets_path or (Path(env_override) if env_override else DEFAULT_VAULT_PATH)
+    if not path.is_file():
+        return {}
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {}
+
+
+def resolve_token(secrets_path: Path | None = None) -> str | None:
+    token = os.environ.get("MERCURY_API_TOKEN")
+    if token:
+        return token
+    vault = _load_vault(secrets_path)
+    return vault.get("MERCURY_API_TOKEN") or vault.get("api_token")
+
+
+def summarize_account(account: dict[str, Any]) -> dict[str, Any]:
+    """Reduce a raw account row to a masked, no-secrets summary."""
+    number = str(account.get("accountNumber") or "")
+    account_id = str(account.get("id") or "")
+    return {
+        "id_prefix": account_id[:8] or None,
+        "name": account.get("name"),
+        "kind": account.get("kind"),
+        "status": account.get("status"),
+        "current_balance_usd": account.get("currentBalance"),
+        "available_balance_usd": account.get("availableBalance"),
+        "account_number_last4": number[-4:] if number else None,
+    }
+
+
+def summarize_transaction(txn: dict[str, Any]) -> dict[str, Any]:
+    """Reduce a raw transaction row to a masked summary."""
+    txn_id = str(txn.get("id") or "")
+    return {
+        "id_prefix": txn_id[:8] or None,
+        "amount_usd": txn.get("amount"),
+        "kind": txn.get("kind"),
+        "status": txn.get("status"),
+        "created_at": txn.get("createdAt"),
+        "posted_at": txn.get("postedAt"),
+        "counterparty": txn.get("counterpartyName"),
+        "description": txn.get("bankDescription"),
+    }
+
+
+class MercuryReadOnlyClient:
+    """GET-only Mercury API client. No write capability exists on this class."""
+
+    READ_METHODS = ("list_accounts", "get_account", "get_transactions", "snapshot")
+
+    def __init__(
+        self,
+        api_token: str,
+        *,
+        account_aliases: dict[str, str] | None = None,
+        base_url: str | None = None,
+        http_get: HttpGet | None = None,
+    ) -> None:
+        if not api_token:
+            raise ValueError(
+                "MercuryReadOnlyClient requires a token: set MERCURY_API_TOKEN or store "
+                "MERCURY_API_TOKEN in ~/.resume_secrets/mercury.json"
+            )
+        self._api_token = api_token
+        self._account_aliases = account_aliases or {}
+        self._base_url = base_url or MERCURY_API_BASE_URL
+        self._http_get = http_get or _default_http_get
+
+    @classmethod
+    def from_env(
+        cls,
+        *,
+        secrets_path: Path | None = None,
+        http_get: HttpGet | None = None,
+    ) -> MercuryReadOnlyClient:
+        token = resolve_token(secrets_path)
+        if not token:
+            raise ValueError(
+                "No Mercury token: set MERCURY_API_TOKEN or store it in "
+                "~/.resume_secrets/mercury.json"
+            )
+        vault = _load_vault(secrets_path)
+        aliases = {}
+        for alias, key in ACCOUNT_ALIAS_KEYS.items():
+            account_id = os.environ.get(key) or vault.get(key)
+            if account_id:
+                aliases[alias] = account_id
+        return cls(token, account_aliases=aliases, http_get=http_get)
+
+    def resolve_account_id(self, alias_or_id: str) -> str:
+        return self._account_aliases.get(alias_or_id, alias_or_id)
+
+    def _get(self, path: str, params: dict[str, Any] | None = None) -> dict[str, Any]:
+        headers = {"Authorization": f"Bearer {self._api_token}"}
+        return self._http_get(f"{self._base_url}{path}", params or {}, headers)
+
+    def list_accounts(self) -> list[dict[str, Any]]:
+        payload = self._get("/accounts")
+        return [
+            summarize_account(a) for a in payload.get("accounts", []) if isinstance(a, dict)
+        ]
+
+    def get_account(self, alias_or_id: str) -> dict[str, Any]:
+        account_id = self.resolve_account_id(alias_or_id)
+        return summarize_account(self._get(f"/account/{account_id}"))
+
+    def get_transactions(
+        self, alias_or_id: str, *, limit: int = 20, offset: int = 0
+    ) -> dict[str, Any]:
+        account_id = self.resolve_account_id(alias_or_id)
+        payload = self._get(
+            f"/account/{account_id}/transactions",
+            {"limit": max(1, min(int(limit), 500)), "offset": max(0, int(offset))},
+        )
+        return {
+            "total": payload.get("total"),
+            "transactions": [
+                summarize_transaction(t)
+                for t in payload.get("transactions", [])
+                if isinstance(t, dict)
+            ],
+        }
+
+    def snapshot(self) -> dict[str, Any]:
+        """Masked point-in-time snapshot suitable for data/mercury_state.json."""
+        accounts = self.list_accounts()
+        total = sum(float(a.get("available_balance_usd") or 0.0) for a in accounts)
+        return {
+            "generated_at": datetime.now(timezone.utc).isoformat(),
+            "read_only": True,
+            "accounts": accounts,
+            "total_available_usd": total,
+        }

--- a/tests/test_mercury_mcp.py
+++ b/tests/test_mercury_mcp.py
@@ -1,0 +1,88 @@
+import importlib
+
+import pytest
+
+import mcp.servers.mercury as mercury_server
+from mcp.registry import load_registry
+from src.adapters.mercury_readonly import MercuryReadOnlyClient
+
+
+@pytest.fixture(autouse=True)
+def reset_cached_client():
+    mercury_server._reset_client()
+    yield
+    mercury_server._reset_client()
+
+
+class TestRegistryConsistency:
+    def test_mercury_server_registered(self):
+        registry = load_registry()
+        assert "mercury" in registry
+
+    def test_registered_tools_exist_in_module(self):
+        """Drift guard: every registry tool must resolve to a module function."""
+        server = load_registry().get("mercury")
+        module = importlib.import_module(server.module)
+        for tool_name, function_name in server.tools.items():
+            assert callable(getattr(module, function_name, None)), (
+                f"registry tool '{tool_name}' points at missing function "
+                f"'{server.module}.{function_name}'"
+            )
+
+
+def _install_fake_client(monkeypatch, response):
+    client = MercuryReadOnlyClient("tok", http_get=lambda u, p, h: response)
+    monkeypatch.setattr(mercury_server, "_client", client)
+    return client
+
+
+class TestTools:
+    def test_get_bank_status_success(self, monkeypatch):
+        _install_fake_client(
+            monkeypatch,
+            {"accounts": [{"id": "a", "availableBalance": 42.0, "status": "active"}]},
+        )
+        result = mercury_server.get_bank_status()
+        assert result["success"] is True
+        assert result["total_available_usd"] == 42.0
+        assert result["read_only"] is True
+
+    def test_get_bank_transactions_success(self, monkeypatch):
+        _install_fake_client(
+            monkeypatch,
+            {"total": 1, "transactions": [{"id": "t1", "amount": -5.0}]},
+        )
+        result = mercury_server.get_bank_transactions(account="checking", limit=5)
+        assert result["success"] is True
+        assert result["account"] == "checking"
+        assert result["total"] == 1
+
+    def test_get_bank_health_success(self, monkeypatch):
+        _install_fake_client(monkeypatch, {"accounts": [{"id": "a"}, {"id": "b"}]})
+        result = mercury_server.get_bank_health()
+        assert result["success"] is True
+        assert result["reachable"] is True
+        assert result["accounts"] == 2
+
+    def test_tools_report_errors_instead_of_raising(self, monkeypatch):
+        def boom(url, params, headers):
+            raise RuntimeError("api down")
+
+        client = MercuryReadOnlyClient("tok", http_get=boom)
+        monkeypatch.setattr(mercury_server, "_client", client)
+
+        for tool in (
+            mercury_server.get_bank_status,
+            mercury_server.get_bank_transactions,
+            mercury_server.get_bank_health,
+        ):
+            result = tool()
+            assert result["success"] is False
+            assert "api down" in result["error"]
+
+    def test_missing_credentials_is_reported_not_raised(self, monkeypatch, tmp_path):
+        monkeypatch.delenv("MERCURY_API_TOKEN", raising=False)
+        monkeypatch.setenv("MERCURY_SECRETS_PATH", str(tmp_path / "missing.json"))
+        result = mercury_server.get_bank_status()
+        assert result["success"] is False
+        assert "MERCURY_API_TOKEN" in result["error"]

--- a/tests/test_mercury_readonly.py
+++ b/tests/test_mercury_readonly.py
@@ -1,0 +1,163 @@
+import json
+
+import pytest
+
+from src.adapters.mercury_readonly import (
+    MercuryReadOnlyClient,
+    resolve_token,
+    summarize_account,
+    summarize_transaction,
+)
+
+
+@pytest.fixture
+def clean_env(monkeypatch, tmp_path):
+    """Isolate tests from the real env vars and the real vault file."""
+    for key in ("MERCURY_API_TOKEN", "MERCURY_ACCOUNT_ID", "MERCURY_SAVINGS_ACCOUNT_ID"):
+        monkeypatch.delenv(key, raising=False)
+    monkeypatch.setenv("MERCURY_SECRETS_PATH", str(tmp_path / "missing.json"))
+    return tmp_path
+
+
+def _write_vault(tmp_path, payload):
+    vault = tmp_path / "mercury.json"
+    vault.write_text(json.dumps(payload), encoding="utf-8")
+    return vault
+
+
+class TestTokenResolution:
+    def test_env_var_wins(self, clean_env, monkeypatch):
+        monkeypatch.setenv("MERCURY_API_TOKEN", "env-token")
+        assert resolve_token() == "env-token"
+
+    def test_vault_canonical_key(self, clean_env, monkeypatch):
+        vault = _write_vault(clean_env, {"MERCURY_API_TOKEN": "vault-token"})
+        monkeypatch.setenv("MERCURY_SECRETS_PATH", str(vault))
+        assert resolve_token() == "vault-token"
+
+    def test_vault_legacy_key(self, clean_env, monkeypatch):
+        vault = _write_vault(clean_env, {"api_token": "legacy-token"})
+        monkeypatch.setenv("MERCURY_SECRETS_PATH", str(vault))
+        assert resolve_token() == "legacy-token"
+
+    def test_missing_everywhere_is_none(self, clean_env):
+        assert resolve_token() is None
+
+    def test_from_env_refuses_without_token(self, clean_env):
+        with pytest.raises(ValueError, match="MERCURY_API_TOKEN"):
+            MercuryReadOnlyClient.from_env()
+
+    def test_from_env_loads_account_aliases(self, clean_env, monkeypatch):
+        vault = _write_vault(
+            clean_env,
+            {
+                "MERCURY_API_TOKEN": "vault-token",
+                "MERCURY_ACCOUNT_ID": "checking-id",
+                "MERCURY_SAVINGS_ACCOUNT_ID": "savings-id",
+            },
+        )
+        monkeypatch.setenv("MERCURY_SECRETS_PATH", str(vault))
+        client = MercuryReadOnlyClient.from_env(http_get=lambda u, p, h: {})
+        assert client.resolve_account_id("checking") == "checking-id"
+        assert client.resolve_account_id("savings") == "savings-id"
+        assert client.resolve_account_id("raw-uuid") == "raw-uuid"
+
+
+class TestReadOnlyGuarantee:
+    def test_public_surface_is_read_only(self):
+        client = MercuryReadOnlyClient("t", http_get=lambda u, p, h: {})
+        public = {m for m in dir(client) if not m.startswith("_")}
+        assert public == {
+            "list_accounts",
+            "get_account",
+            "get_transactions",
+            "snapshot",
+            "resolve_account_id",
+            "from_env",
+            "READ_METHODS",
+        }
+
+    def test_no_transfer_methods_exist(self):
+        for forbidden in ("send_to_broker", "create_transaction", "post", "transfer"):
+            assert not hasattr(MercuryReadOnlyClient, forbidden)
+
+
+class TestRequests:
+    def _recording_client(self, response):
+        calls = []
+
+        def http_get(url, params, headers):
+            calls.append({"url": url, "params": params, "headers": headers})
+            return response
+
+        return MercuryReadOnlyClient("tok", http_get=http_get), calls
+
+    def test_list_accounts_masks_rows(self):
+        response = {
+            "accounts": [
+                {
+                    "id": "644ce680-aaaa-bbbb-cccc-dddddddddddd",
+                    "name": "Mercury Checking",
+                    "kind": "checking",
+                    "status": "active",
+                    "currentBalance": 12.5,
+                    "availableBalance": 10.0,
+                    "accountNumber": "123456787725",
+                },
+                "not-a-dict",
+            ]
+        }
+        client, calls = self._recording_client(response)
+        accounts = client.list_accounts()
+        assert len(accounts) == 1
+        assert accounts[0]["account_number_last4"] == "7725"
+        assert accounts[0]["id_prefix"] == "644ce680"
+        assert "123456787725" not in json.dumps(accounts)
+        assert calls[0]["url"].endswith("/accounts")
+        assert calls[0]["headers"]["Authorization"] == "Bearer tok"
+
+    def test_transactions_clamps_limit_and_masks(self):
+        response = {
+            "total": 1,
+            "transactions": [
+                {
+                    "id": "txn-12345678",
+                    "amount": -25.0,
+                    "kind": "externalTransfer",
+                    "status": "sent",
+                    "createdAt": "2026-07-26T00:00:00Z",
+                    "counterpartyName": "Alpaca",
+                }
+            ],
+        }
+        client, calls = self._recording_client(response)
+        result = client.get_transactions("acct-1", limit=9999, offset=-5)
+        assert calls[0]["params"] == {"limit": 500, "offset": 0}
+        assert result["total"] == 1
+        assert result["transactions"][0]["counterparty"] == "Alpaca"
+        assert result["transactions"][0]["id_prefix"] == "txn-1234"
+
+    def test_snapshot_totals_available_balances(self):
+        response = {
+            "accounts": [
+                {"id": "a", "availableBalance": 10.0},
+                {"id": "b", "availableBalance": 5.5},
+                {"id": "c", "availableBalance": None},
+            ]
+        }
+        client, _ = self._recording_client(response)
+        snapshot = client.snapshot()
+        assert snapshot["total_available_usd"] == 15.5
+        assert snapshot["read_only"] is True
+        assert "generated_at" in snapshot
+
+
+class TestSummarizers:
+    def test_summarize_account_handles_missing_fields(self):
+        assert summarize_account({})["account_number_last4"] is None
+        assert summarize_account({})["id_prefix"] is None
+
+    def test_summarize_transaction_handles_missing_fields(self):
+        row = summarize_transaction({})
+        assert row["id_prefix"] is None
+        assert row["amount_usd"] is None

--- a/tests/test_mercury_status.py
+++ b/tests/test_mercury_status.py
@@ -1,4 +1,29 @@
+import json
+
+import pytest
+
+import scripts.mercury_status as mercury_status
 from scripts.mercury_status import summarize_accounts
+
+
+class TestLoadToken:
+    """Regression: the vault stores MERCURY_API_TOKEN, not api_token (2026-07-26)."""
+
+    @pytest.fixture(autouse=True)
+    def no_env_token(self, monkeypatch):
+        monkeypatch.delenv("MERCURY_API_TOKEN", raising=False)
+
+    def test_reads_canonical_vault_key(self, monkeypatch, tmp_path):
+        vault = tmp_path / "mercury.json"
+        vault.write_text(json.dumps({"MERCURY_API_TOKEN": "vault-token"}), encoding="utf-8")
+        monkeypatch.setattr(mercury_status, "VAULT_PATH", vault)
+        assert mercury_status.load_token() == "vault-token"
+
+    def test_reads_legacy_vault_key(self, monkeypatch, tmp_path):
+        vault = tmp_path / "mercury.json"
+        vault.write_text(json.dumps({"api_token": "legacy-token"}), encoding="utf-8")
+        monkeypatch.setattr(mercury_status, "VAULT_PATH", vault)
+        assert mercury_status.load_token() == "legacy-token"
 
 
 class TestSummarizeAccounts:


### PR DESCRIPTION
## Summary
- **`src/adapters/mercury_readonly.py`** — `MercuryReadOnlyClient`, GET-only by construction: no transfer method exists on the class, guarded by a public-surface test. Token resolves from `MERCURY_API_TOKEN` env or the `~/.resume_secrets/mercury.json` vault; all outputs are masked (last-4 account numbers, 8-char id prefixes); the token is never printed or returned.
- **`mcp/servers/mercury.py` + `mcp/registry.json`** — house-pattern MCP server `mercury` with tools `get_bank_status`, `get_bank_transactions`, `get_bank_health`. Callable via the harness: `python -m mcp.harness mercury get_bank_status`.
- **`scripts/mercury_cli.py`** — operator CLI: `accounts`, `transactions --account checking|savings`, `sync` (writes masked snapshot to `data/mercury_state.json`, gitignored runtime state), `health` (exit 0/1).
- **Bug fix**: `scripts/mercury_status.py` vault fallback looked up `api_token`, but the vault stores `MERCURY_API_TOKEN` — it always exited 1 without the env var. Now accepts both keys, with regression tests.

## Safety
Read-only twice over: the client issues only GETs, and the vaulted token was created with Read permission in Mercury. Money movement remains exclusively behind `MercuryBankAdapter`'s `MERCURY_LIVE_TRANSFERS_ENABLED` hard stop — unreachable from every surface in this PR.

## Evidence (live, 2026-07-26)
```
=== MERCURY ACCOUNTS (read-only) ===
  Mercury Checking ••7725 [checking] active: $0.00 available
  Mercury Savings ••9689 [savings] active: $0.00 available
  TOTAL available: $0.00
✅ Mercury API reachable: 2 accounts (2 active)
✅ Mercury sync complete: 2 accounts, $0.00 available -> data/mercury_state.json
```
MCP path: `get_bank_health` → `{'success': True, 'reachable': True, 'accounts': 2}`

## Test plan
- [x] `pytest tests/test_mercury_readonly.py tests/test_mercury_mcp.py tests/test_mercury_status.py tests/test_bank_adapter.py` — 36 passed
- [x] `ruff check` clean on all touched files
- [x] Live CLI + MCP verification against the real Mercury API
- [ ] CI green

## Prevention (compound engineering)
- Registry↔module drift guard test (`test_registered_tools_exist_in_module`)
- Read-only surface guard test (`test_public_surface_is_read_only`)
- Vault-key regression tests for both key spellings

🤖 Generated with [Claude Code](https://claude.com/claude-code)