### PR TITLE
fix: broker snapshots degrade instead of crashing Sync Alpaca Status

### DIFF
--- a/src/analytics/daily_scorecard.py
+++ b/src/analytics/daily_scorecard.py
@@ -728,15 +728,24 @@ def build_daily_scorecard(
         "paired_closed_trades": _load_paired_closed_trade_status(repo_root, now),
     }
 
+    # Broker snapshots must degrade, never crash the sync workflow: revoked or
+    # rotated credentials (401) mark the account unavailable with the reason
+    # (5 consecutive Sync Alpaca Status failures on 2026-07-27/28).
     if paper_client is not None:
-        paper_orders = paper_client.get_orders(filter=_build_order_history_filter())
-        scorecard["paper"] = _build_account_scorecard(
-            "paper",
-            paper_client.get_account(),
-            paper_client.get_all_positions(),
-            paper_orders,
-            now,
-        )
+        try:
+            paper_orders = paper_client.get_orders(filter=_build_order_history_filter())
+            scorecard["paper"] = _build_account_scorecard(
+                "paper",
+                paper_client.get_account(),
+                paper_client.get_all_positions(),
+                paper_orders,
+                now,
+            )
+        except Exception as exc:  # noqa: BLE001
+            scorecard["paper"] = {
+                "available": False,
+                "reason": f"Paper Alpaca account unavailable: {exc}",
+            }
     else:
         scorecard["paper"] = {
             "available": False,
@@ -744,13 +753,19 @@ def build_daily_scorecard(
         }
 
     if live_client is not None:
-        scorecard["live"] = _build_account_scorecard(
-            "live",
-            live_client.get_account(),
-            live_client.get_all_positions(),
-            [],
-            now,
-        )
+        try:
+            scorecard["live"] = _build_account_scorecard(
+                "live",
+                live_client.get_account(),
+                live_client.get_all_positions(),
+                [],
+                now,
+            )
+        except Exception as exc:  # noqa: BLE001
+            scorecard["live"] = {
+                "available": False,
+                "reason": f"Live Alpaca account unavailable: {exc}",
+            }
     else:
         scorecard["live"] = {"available": False, "reason": "Live Alpaca credentials not available."}
 

--- a/tests/test_daily_scorecard.py
+++ b/tests/test_daily_scorecard.py
@@ -791,3 +791,33 @@ def test_summarize_why_today_loss_flat_and_no_driver_paths():
         flat_with_positions["summary"]
         == "Today's flat result comes from open-position repricing $0.00."
     )
+
+
+class _RaisingClient:
+    """Simulates revoked/rotated credentials: every broker call raises 401."""
+
+    def _boom(self, *args, **kwargs):
+        raise RuntimeError("401 Client Error: Unauthorized for url: /v2/account")
+
+    get_account = _boom
+    get_all_positions = _boom
+    get_orders = _boom
+
+
+def test_unavailable_broker_accounts_degrade_instead_of_crashing(tmp_path):
+    """Regression: 2026-07-27/28 the live account 401 crashed the entire
+    Sync Alpaca Status workflow. Credential failures must yield an
+    available=False block with the reason, never an exception."""
+    now = datetime(2026, 7, 28, 10, 0, tzinfo=ET)
+    scorecard = build_daily_scorecard(
+        tmp_path,
+        now=now,
+        paper_client=_RaisingClient(),
+        live_client=_RaisingClient(),
+        sync_paired_ledger=False,
+    )
+    assert scorecard["paper"]["available"] is False
+    assert "Unauthorized" in scorecard["paper"]["reason"]
+    assert scorecard["live"]["available"] is False
+    assert "Unauthorized" in scorecard["live"]["reason"]
+    assert scorecard["north_star"] is not None


### PR DESCRIPTION
## Why
`Sync Alpaca Status` has failed 5 consecutive runs since 2026-07-27T19:31Z: the live-account fetch in `build_daily_scorecard` gets **401 Unauthorized** from `api.alpaca.markets/v2/account` (the `ALPACA_BROKERAGE_TRADING_*` repo secret is revoked or rotated) and the unguarded exception kills the whole workflow — including the paper-state sync it exists for.

## What
- `src/analytics/daily_scorecard.py`: paper and live account fetches fail soft to `{available: false, reason: ...}` — snapshots degrade, the workflow completes, the outage is reported honestly in the artifact
- Regression test with raising stub clients

## Not in this PR
Rotating the live Alpaca API key / updating the GitHub secret — CEO-only action (flagged in the session report). Until rotated, the scorecard will show `live: unavailable (401)` instead of failing CI.

## Test plan
- [x] 11/11 daily_scorecard tests pass locally; ruff clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)