### PR TITLE
fix(risk): restore SPY-only ticker gate per kill-criteria hard constraints

### DIFF
--- a/src/core/trading_constants.py
+++ b/src/core/trading_constants.py
@@ -6,7 +6,7 @@ import re
 
 from src.core.trading_profiles import get_iron_condor_profile
 
-ALLOWED_TICKERS: set[str] = {"SPY", "SPX", "XSP", "QQQ", "IWM"}  # Liquid index/ETF options per CLAUDE.md & TradeGateway spec
+ALLOWED_TICKERS: set[str] = {"SPY"}  # SPY ONLY per CLAUDE.md
 ACTIVE_IRON_CONDOR_PROFILE = get_iron_condor_profile()
 
 MAX_POSITION_PCT: float = ACTIVE_IRON_CONDOR_PROFILE.position_size_pct

--- a/tests/test_system_1000mo_roadmap_verification.py
+++ b/tests/test_system_1000mo_roadmap_verification.py
@@ -24,12 +24,12 @@ def test_xsp_section_1256_profiles_registered():
     assert pc_xsp.underlying == "XSP"
 
 
-def test_trade_gateway_allows_xsp_and_spy():
-    """Verify TradeGateway allows XSP and SPY index/ETF tickers."""
+def test_trade_gateway_ticker_gate_is_spy_only_during_validation():
+    """XSP profiles stay registered (test above) but the execution gate is
+    SPY-only per kill-criteria.md hard constraints until the put-credit
+    cohort passes and the CEO explicitly signs off on XSP routing."""
     gateway = TradeGateway()
-    allowed_tickers = gateway.ALLOWED_TICKERS
-    assert "XSP" in allowed_tickers
-    assert "SPY" in allowed_tickers
+    assert set(gateway.ALLOWED_TICKERS) == {"SPY"}
 
 
 def test_regime_gate_enforces_iv_rank_and_vix_limits():


### PR DESCRIPTION
## Why

Direct-to-main push `82b207c97` (11:21 today, no PR) widened the canonical risk gate:

```
- ALLOWED_TICKERS = {"SPY"}  # SPY ONLY per CLAUDE.md
+ ALLOWED_TICKERS = {"SPY", "SPX", "XSP", "QQQ", "IWM"}
```

That contradicts written policy — `.claude/rules/trading.md` ("Ticker = SPY (ONLY)"), `.claude/rules/kill-criteria.md` hard constraints ("SPY only" while the spy_put_credit cohort validates, n=0/30), and `.claude/rules/controlled-experiment.md` rule 6 (no parameter drift mid-cohort). QQQ/IWM/SPX aren't even part of the commit's stated Section 1256 rationale. **10 guard tests failed on main** (`test_pre_trade_checklist` ticker validation, `test_mcp_governance` symbol constants) — currently breaking every PR's full-suite run, including #4313.

## What

- Restore `ALLOWED_TICKERS = {"SPY"}` in `src/core/trading_constants.py`
- Keep the inert `xsp-core`/`xsp-put-credit` profile registry entries (no runtime consumers; `test_xsp_section_1256_profiles_registered` still passes)
- Realign `test_trade_gateway_allows_xsp_and_spy` → `test_trade_gateway_ticker_gate_is_spy_only_during_validation`

## CEO decision preserved, not made

XSP/Section 1256 routing is a real tax-efficiency idea — but switching underlyings mid-cohort needs an explicit CEO sign-off plus a rules update. Profiles stay registered so flipping it on later is a one-line gate change **after** that sign-off.

## Evidence

- 10 failing tests on clean origin/main reproduce locally; all pass after this change
- Full sweep of every ticker-referencing test file: 306 passed, 1 skipped, ruff clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)