### PR TITLE
fix(ops): stop eval from writing TRADING_HALTED; honest live readiness

### DIFF
--- a/src/eval/eval_harness.py
+++ b/src/eval/eval_harness.py
@@ -100,7 +100,13 @@ class EvalHarness:
             current_eq = case.input_state.get("current_equity", 10000.0)
             peak_eq = case.input_state.get("peak_equity", 10000.0)
             cb = DrawdownCircuitBreaker(max_drawdown_pct=5.0)
-            status = cb.check_equity(current_equity=current_eq, peak_equity=peak_eq)
+            # NEVER persist eval equity into production data/TRADING_HALTED.
+            # Synthetic cases (e.g. 9400/10000) previously halted real paper trading.
+            status = cb.check_equity(
+                current_equity=current_eq,
+                peak_equity=peak_eq,
+                persist=False,
+            )
 
             expected_tripped = case.expected_outcome.get("tripped", False)
             passed = status.tripped == expected_tripped
@@ -109,7 +115,11 @@ class EvalHarness:
                 category=case.category,
                 passed=passed,
                 details=f"Circuit breaker tripped={status.tripped} (expected {expected_tripped})",
-                diagnostics={"drawdown_pct": status.drawdown_pct, "tripped": status.tripped},
+                diagnostics={
+                    "drawdown_pct": status.drawdown_pct,
+                    "tripped": status.tripped,
+                    "persist": False,
+                },
             )
 
         else:

--- a/src/risk/drawdown_circuit_breaker.py
+++ b/src/risk/drawdown_circuit_breaker.py
@@ -38,8 +38,20 @@ class DrawdownCircuitBreaker:
     def __init__(self, max_drawdown_pct: float = DEFAULT_MAX_INTRADAY_DRAWDOWN_PCT):
         self.max_drawdown_pct = max_drawdown_pct
 
-    def check_equity(self, current_equity: float, peak_equity: float) -> CircuitBreakerStatus:
-        """Check current equity against peak equity. Trips TRADING_HALTED if threshold breached."""
+    def check_equity(
+        self,
+        current_equity: float,
+        peak_equity: float,
+        *,
+        persist: bool = True,
+    ) -> CircuitBreakerStatus:
+        """Check current equity against peak equity.
+
+        When ``persist`` is True (default), a trip writes ``data/TRADING_HALTED``
+        and the circuit-breaker audit log. Callers that only *simulate* a trip
+        (eval harness, unit tests that assert logic without side effects) MUST
+        pass ``persist=False`` so synthetic equity numbers cannot halt production.
+        """
         if peak_equity <= 0:
             return CircuitBreakerStatus(
                 tripped=False,
@@ -55,9 +67,16 @@ class DrawdownCircuitBreaker:
         if drawdown_pct >= self.max_drawdown_pct:
             reason = (
                 f"INTRADAY_DRAWDOWN_EXCEEDED: Current equity ${current_equity:.2f} is "
-                f"{drawdown_pct:.2f}% below peak ${peak_equity:.2f} (max allowed: {self.max_drawdown_pct:.2f}%)."
+                f"{drawdown_pct:.2f}% below peak ${peak_equity:.2f} "
+                f"(max allowed: {self.max_drawdown_pct:.2f}%)."
             )
-            self._trip_circuit_breaker(reason, current_equity, peak_equity, drawdown_pct)
+            if persist:
+                self._trip_circuit_breaker(reason, current_equity, peak_equity, drawdown_pct)
+            else:
+                logger.info(
+                    "Circuit breaker would trip (persist=False): %s",
+                    reason,
+                )
             return CircuitBreakerStatus(
                 tripped=True,
                 current_equity=current_equity,

--- a/src/trading/live_trading_switch.py
+++ b/src/trading/live_trading_switch.py
@@ -1,7 +1,11 @@
 """Live Real Money Trading Switch & Readiness Verifier.
 
-Monitors live Alpaca account balance and API credentials to seamlessly switch
-from paper execution to live real money options trading as soon as capital is funded.
+Monitors live Alpaca account balance and API credentials. Reports readiness
+honestly: API connectivity, cash/options level, AND policy gates (kill switch).
+
+``live_trading_active`` means the system is allowed to place *live* risk —
+not merely that a funded live account exists. Cash alone never implies
+"LIVE REAL MONEY TRADING ACTIVE" while paper_only / live_blocked is on.
 """
 
 from __future__ import annotations
@@ -9,15 +13,17 @@ from __future__ import annotations
 import json
 import logging
 import os
-import requests
 from dataclasses import asdict, dataclass
 from pathlib import Path
+
+import requests
 from dotenv import dotenv_values
 
 logger = logging.getLogger(__name__)
 
 ROOT = Path(__file__).resolve().parents[2]
 LIVE_READINESS_FILE = ROOT / "data" / "audit" / "live_trading_readiness.json"
+KILL_SWITCH_FILE = ROOT / "data" / "runtime" / "strategy_kill_switch.json"
 
 
 @dataclass
@@ -29,10 +35,40 @@ class LiveReadinessReport:
     options_approved_level: int
     live_trading_active: bool
     status_message: str
+    # Explicit policy / funding decomposition (optional for older readers)
+    account_funded: bool = False
+    policy_live_blocked: bool = True
+    policy_block_reason: str = ""
+
+
+def _load_policy_live_block() -> tuple[bool, str]:
+    """Return (blocked, reason) from kill switch. Default blocked if missing/unreadable."""
+    if not KILL_SWITCH_FILE.exists():
+        return True, "kill_switch_missing (default deny live)"
+    try:
+        payload = json.loads(KILL_SWITCH_FILE.read_text(encoding="utf-8"))
+    except (OSError, ValueError, TypeError):
+        return True, "kill_switch_unreadable (default deny live)"
+    if not isinstance(payload, dict):
+        return True, "kill_switch_invalid (default deny live)"
+
+    paper_only = bool(payload.get("paper_only", True))
+    live_blocked = bool(payload.get("live_blocked", True))
+    if paper_only or live_blocked:
+        reasons = []
+        if paper_only:
+            reasons.append("paper_only=true")
+        if live_blocked:
+            reasons.append("live_blocked=true")
+        reason_txt = payload.get("reason")
+        if reason_txt:
+            reasons.append(str(reason_txt)[:160])
+        return True, "; ".join(reasons)
+    return False, ""
 
 
 class LiveTradingSwitch:
-    """Verifies live Alpaca brokerage readiness and toggles live execution."""
+    """Verifies live Alpaca brokerage readiness under policy gates."""
 
     def __init__(self, env_path: Path | None = None):
         self.env_path = env_path or (ROOT / ".env")
@@ -42,8 +78,20 @@ class LiveTradingSwitch:
         if self.env_path.exists():
             vals = dotenv_values(self.env_path)
 
-        key = vals.get("ALPACA_LIVE_API_KEY") or vals.get("ALPACA_BROKERAGE_TRADING_API_KEY") or os.environ.get("ALPACA_LIVE_API_KEY")
-        secret = vals.get("ALPACA_LIVE_API_SECRET") or vals.get("ALPACA_BROKERAGE_TRADING_API_SECRET") or os.environ.get("ALPACA_LIVE_API_SECRET")
+        key = (
+            vals.get("ALPACA_LIVE_API_KEY")
+            or vals.get("ALPACA_BROKERAGE_TRADING_API_KEY")
+            or os.environ.get("ALPACA_LIVE_API_KEY")
+            or os.environ.get("ALPACA_BROKERAGE_TRADING_API_KEY")
+        )
+        secret = (
+            vals.get("ALPACA_LIVE_API_SECRET")
+            or vals.get("ALPACA_BROKERAGE_TRADING_API_SECRET")
+            or os.environ.get("ALPACA_LIVE_API_SECRET")
+            or os.environ.get("ALPACA_BROKERAGE_TRADING_API_SECRET")
+        )
+
+        policy_blocked, policy_reason = _load_policy_live_block()
 
         if not key or not secret:
             report = LiveReadinessReport(
@@ -54,6 +102,9 @@ class LiveTradingSwitch:
                 options_approved_level=0,
                 live_trading_active=False,
                 status_message="Live Alpaca API key/secret missing in .env (ALPACA_LIVE_API_KEY)",
+                account_funded=False,
+                policy_live_blocked=policy_blocked,
+                policy_block_reason=policy_reason,
             )
             self._save_report(report)
             return report
@@ -65,6 +116,7 @@ class LiveTradingSwitch:
         try:
             r = requests.get(url, headers=headers, timeout=10.0)
             if r.status_code != 200:
+                body = (r.text or "")[:200]
                 report = LiveReadinessReport(
                     live_credentials_present=True,
                     live_api_valid=False,
@@ -72,19 +124,43 @@ class LiveTradingSwitch:
                     live_buying_power=0.0,
                     options_approved_level=0,
                     live_trading_active=False,
-                    status_message=f"Live API returned HTTP {r.status_code}: {r.text}",
+                    status_message=f"Live API returned HTTP {r.status_code}: {body}",
+                    account_funded=False,
+                    policy_live_blocked=policy_blocked,
+                    policy_block_reason=policy_reason,
                 )
                 self._save_report(report)
                 return report
 
             data = r.json()
-            cash = float(data.get("cash", 0.0))
-            bp = float(data.get("buying_power", 0.0))
-            opt_lvl = int(data.get("options_approved_level", 0))
+            cash = float(data.get("cash", 0.0) or 0.0)
+            bp = float(data.get("buying_power", 0.0) or 0.0)
+            opt_lvl = int(data.get("options_approved_level", 0) or 0)
 
-            live_active = (cash > 0.0) and (opt_lvl >= 2)
+            account_funded = (cash > 0.0) and (opt_lvl >= 2)
+            # Active only when funded AND policy allows live risk.
+            live_active = account_funded and (not policy_blocked)
 
-            msg = "✅ LIVE REAL MONEY TRADING ACTIVE" if live_active else f"Live account connected but cash balance is ${cash:,.2f}. Deposit cash to initiate live trades."
+            if live_active:
+                msg = (
+                    "LIVE REAL MONEY TRADING ACTIVE "
+                    f"(cash=${cash:,.2f}, options_level={opt_lvl})"
+                )
+            elif policy_blocked and account_funded:
+                msg = (
+                    f"Live account funded (cash=${cash:,.2f}, options_level={opt_lvl}) "
+                    f"but LIVE RISK BLOCKED by policy: {policy_reason}"
+                )
+            elif policy_blocked:
+                msg = (
+                    f"Live API valid (cash=${cash:,.2f}) but LIVE RISK BLOCKED by policy: "
+                    f"{policy_reason}"
+                )
+            else:
+                msg = (
+                    f"Live account connected but not funded for options trading "
+                    f"(cash=${cash:,.2f}, options_level={opt_lvl})."
+                )
 
             report = LiveReadinessReport(
                 live_credentials_present=True,
@@ -94,6 +170,9 @@ class LiveTradingSwitch:
                 options_approved_level=opt_lvl,
                 live_trading_active=live_active,
                 status_message=msg,
+                account_funded=account_funded,
+                policy_live_blocked=policy_blocked,
+                policy_block_reason=policy_reason,
             )
             self._save_report(report)
             return report
@@ -107,6 +186,9 @@ class LiveTradingSwitch:
                 options_approved_level=0,
                 live_trading_active=False,
                 status_message=f"Live API connection error: {e}",
+                account_funded=False,
+                policy_live_blocked=policy_blocked,
+                policy_block_reason=policy_reason,
             )
             self._save_report(report)
             return report

--- a/tests/test_drawdown_circuit_breaker.py
+++ b/tests/test_drawdown_circuit_breaker.py
@@ -1,5 +1,3 @@
-from pathlib import Path
-import pytest
 from src.risk.drawdown_circuit_breaker import DrawdownCircuitBreaker
 
 
@@ -22,3 +20,22 @@ def test_drawdown_circuit_breaker_tripped(monkeypatch, tmp_path):
     assert status.drawdown_pct == 6.0
     assert halt_file.exists()
     assert "TRADING_HALTED" in halt_file.read_text()
+
+
+def test_drawdown_circuit_breaker_persist_false_does_not_write_halt(monkeypatch, tmp_path):
+    """Eval/simulation must not poison production TRADING_HALTED."""
+    halt_file = tmp_path / "TRADING_HALTED"
+    log_file = tmp_path / "circuit_breaker_log.json"
+    monkeypatch.setattr("src.risk.drawdown_circuit_breaker.HALT_FILE_PATH", halt_file)
+    monkeypatch.setattr("src.risk.drawdown_circuit_breaker.CIRCUIT_LOG_PATH", log_file)
+
+    cb = DrawdownCircuitBreaker(max_drawdown_pct=5.0)
+    status = cb.check_equity(
+        current_equity=9400.0,
+        peak_equity=10000.0,
+        persist=False,
+    )
+    assert status.tripped is True
+    assert status.drawdown_pct == 6.0
+    assert not halt_file.exists()
+    assert not log_file.exists()

--- a/tests/test_live_trading_switch.py
+++ b/tests/test_live_trading_switch.py
@@ -1,5 +1,4 @@
 import json
-from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 from src.trading.live_trading_switch import LiveTradingSwitch

--- a/tests/test_live_trading_switch.py
+++ b/tests/test_live_trading_switch.py
@@ -1,12 +1,25 @@
-import pytest
+import json
 from pathlib import Path
-from unittest.mock import patch, MagicMock
-from src.trading.live_trading_switch import LiveTradingSwitch, LiveReadinessReport
+from unittest.mock import MagicMock, patch
+
+from src.trading.live_trading_switch import LiveTradingSwitch
 
 
-def test_live_trading_switch_missing_credentials(tmp_path):
+def test_live_trading_switch_missing_credentials(tmp_path, monkeypatch):
     env_file = tmp_path / ".env"
     env_file.write_text("SOME_OTHER_KEY=123", encoding="utf-8")
+    kill = tmp_path / "kill.json"
+    kill.write_text(
+        json.dumps({"paper_only": True, "live_blocked": True, "reason": "test"}),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(
+        "src.trading.live_trading_switch.KILL_SWITCH_FILE", kill
+    )
+    monkeypatch.setattr(
+        "src.trading.live_trading_switch.LIVE_READINESS_FILE",
+        tmp_path / "readiness.json",
+    )
 
     switch = LiveTradingSwitch(env_path=env_file)
     report = switch.inspect_live_readiness()
@@ -17,9 +30,31 @@ def test_live_trading_switch_missing_credentials(tmp_path):
 
 
 @patch("requests.get")
-def test_live_trading_switch_active_cash(mock_get, tmp_path):
+def test_live_trading_switch_funded_but_policy_blocked(mock_get, tmp_path, monkeypatch):
+    """Cash alone must NOT claim live trading active while kill switch blocks live."""
     env_file = tmp_path / ".env"
-    env_file.write_text("ALPACA_LIVE_API_KEY=test_key\nALPACA_LIVE_API_SECRET=test_secret", encoding="utf-8")
+    env_file.write_text(
+        "ALPACA_LIVE_API_KEY=test_key\nALPACA_LIVE_API_SECRET=test_secret",
+        encoding="utf-8",
+    )
+    kill = tmp_path / "kill.json"
+    kill.write_text(
+        json.dumps(
+            {
+                "paper_only": True,
+                "live_blocked": True,
+                "reason": "IC killed; put-credit paper validation only",
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(
+        "src.trading.live_trading_switch.KILL_SWITCH_FILE", kill
+    )
+    monkeypatch.setattr(
+        "src.trading.live_trading_switch.LIVE_READINESS_FILE",
+        tmp_path / "readiness.json",
+    )
 
     mock_resp = MagicMock()
     mock_resp.status_code = 200
@@ -37,4 +72,78 @@ def test_live_trading_switch_active_cash(mock_get, tmp_path):
     assert report.live_api_valid is True
     assert report.live_cash_balance == 5000.0
     assert report.options_approved_level == 3
+    assert report.account_funded is True
+    assert report.policy_live_blocked is True
+    assert report.live_trading_active is False
+    assert "LIVE RISK BLOCKED" in report.status_message
+    assert "LIVE REAL MONEY TRADING ACTIVE" not in report.status_message
+
+
+@patch("requests.get")
+def test_live_trading_switch_active_when_policy_allows(mock_get, tmp_path, monkeypatch):
+    env_file = tmp_path / ".env"
+    env_file.write_text(
+        "ALPACA_LIVE_API_KEY=test_key\nALPACA_LIVE_API_SECRET=test_secret",
+        encoding="utf-8",
+    )
+    kill = tmp_path / "kill.json"
+    kill.write_text(
+        json.dumps(
+            {
+                "paper_only": False,
+                "live_blocked": False,
+                "reason": "edge proven",
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(
+        "src.trading.live_trading_switch.KILL_SWITCH_FILE", kill
+    )
+    monkeypatch.setattr(
+        "src.trading.live_trading_switch.LIVE_READINESS_FILE",
+        tmp_path / "readiness.json",
+    )
+
+    mock_resp = MagicMock()
+    mock_resp.status_code = 200
+    mock_resp.json.return_value = {
+        "cash": "5000.00",
+        "buying_power": "20000.00",
+        "options_approved_level": "3",
+    }
+    mock_get.return_value = mock_resp
+
+    switch = LiveTradingSwitch(env_path=env_file)
+    report = switch.inspect_live_readiness()
+
     assert report.live_trading_active is True
+    assert report.account_funded is True
+    assert report.policy_live_blocked is False
+    assert "LIVE REAL MONEY TRADING ACTIVE" in report.status_message
+
+
+@patch("requests.get")
+def test_live_trading_switch_api_401(mock_get, tmp_path, monkeypatch):
+    env_file = tmp_path / ".env"
+    env_file.write_text(
+        "ALPACA_LIVE_API_KEY=test_key\nALPACA_LIVE_API_SECRET=test_secret",
+        encoding="utf-8",
+    )
+    kill = tmp_path / "kill.json"
+    kill.write_text(json.dumps({"paper_only": True, "live_blocked": True}), encoding="utf-8")
+    monkeypatch.setattr("src.trading.live_trading_switch.KILL_SWITCH_FILE", kill)
+    monkeypatch.setattr(
+        "src.trading.live_trading_switch.LIVE_READINESS_FILE",
+        tmp_path / "readiness.json",
+    )
+
+    mock_resp = MagicMock()
+    mock_resp.status_code = 401
+    mock_resp.text = '{"message": "unauthorized."}'
+    mock_get.return_value = mock_resp
+
+    report = LiveTradingSwitch(env_path=env_file).inspect_live_readiness()
+    assert report.live_api_valid is False
+    assert report.live_trading_active is False
+    assert "401" in report.status_message


### PR DESCRIPTION
## Why

1. **False production halt**: `EvalHarness` risk_gate cases call `DrawdownCircuitBreaker.check_equity(9400, 10000)`, which wrote `data/TRADING_HALTED` with synthetic equity. Audit log shows repeated trips at exactly `$9400/$10000` while paper is ~`$94k`. That blocked paper put-credit validation entries.
2. **False live-money claim**: `live_trading_switch` set `live_trading_active=True` whenever live cash > 0 and options level ≥ 2 — even while kill switch `paper_only` / `live_blocked` is true. Operators saw "LIVE REAL MONEY TRADING ACTIVE" while live risk is policy-blocked (and live API currently 401).

## What

- `DrawdownCircuitBreaker.check_equity(..., persist=True)` — eval/simulations pass `persist=False`
- `eval_harness` risk_gate uses `persist=False`
- `LiveTradingSwitch` decomposes `account_funded` vs `policy_live_blocked`; `live_trading_active` requires both funded API account and policy allow
- Tests for persist=False, policy block, 401, and policy-allow active path

## Evidence

- Local: 7/7 unit tests pass for these modules
- Does **not** enable live trading; kill switch still blocks live

## Follow-up (ops, this session)

- Clear contaminated `TRADING_HALTED` after merge
- Live Alpaca keys return 401 — rotate separately; paper still works