### PR TITLE
fix: restore RLHF stats.json for health check

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -146,6 +146,7 @@ data/silver/
 data/gold/
 wiki/
 data/feedback/
+!data/feedback/stats.json
 data/backups/
 data/lancedb_feedback/
 data/chroma/
@@ -237,6 +238,7 @@ data/options_signals/
 data/sentiment/
 data/evaluations/
 data/feedback/
+!data/feedback/stats.json
 data/memory/
 data/ipo/
 data/archive/

--- a/data/feedback/stats.json
+++ b/data/feedback/stats.json
@@ -1,0 +1,8 @@
+{
+  "positive": 78,
+  "negative": 98,
+  "total": 176,
+  "last_feedback": "positive",
+  "last_updated": "2026-07-07T21:32:28.233291+00:00",
+  "satisfaction_rate": 44.32
+}

--- a/tests/test_repo_hygiene.py
+++ b/tests/test_repo_hygiene.py
@@ -61,6 +61,7 @@ REQUIRED_TRACKED = (
     "data/strategy_params.json",
     "data/runtime/strategy_kill_switch.json",
     "data/revenue/outbound_target_leads.json",
+    "data/feedback/stats.json",
     ".gitignore",
 )
 


### PR DESCRIPTION
## Summary
- Restore `data/feedback/stats.json` after #4323 untracked the whole `data/feedback/` tree
- Whitelist it in `.gitignore` so runtime jsonl dumps stay ignored
- Main Head Verification was failing: `stats.json not found`

## Test plan
- [x] File present on branch
- [ ] Main Head Verification / system_health_check feedback check green