### PR TITLE
docs: Herdr-inspired repo pitch, agent skill, and docs hub

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,15 @@
 # AGENTS
 
+## Scope and audience
+
+These instructions apply to every agent working in this repository.
+
+- **Operator skill** (commands, gates, ledgers): [`skills/trading-ops/SKILL.md`](skills/trading-ops/SKILL.md)
+- **Human + PR path**: [`CONTRIBUTING.md`](CONTRIBUTING.md)
+- **Docs hub**: [`docs/README.md`](docs/README.md)
+
+Load the operator skill when checking status, planning trades, or touching risk/execution code.
+
 ## Core Directive
 
 Always tell the user 100% truth. Never fabricate, hide, or misrepresent status, actions, or results.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,53 @@
+# Contributing
+
+Thanks for improving this lab. The product here is **operational safety and honest validation**, not a marketed edge.
+
+## Before you start
+
+1. Read [AGENTS.md](./AGENTS.md) if you are an AI agent (or working with one).
+2. Read [skills/trading-ops/SKILL.md](./skills/trading-ops/SKILL.md) for operator commands and hard gates.
+3. Confirm active strategy in `data/runtime/strategy_kill_switch.json` — do not “revive” killed IC entry paths.
+
+## Development workflow
+
+```bash
+git fetch origin main
+git worktree add -b feature/<slug> .worktrees/<slug> origin/main
+cd .worktrees/<slug>
+
+# validate
+pytest tests/ -q
+ruff check src/
+```
+
+Open a PR against `main`. Include evidence for claims (command output, CI run IDs).
+
+### Do
+
+- Keep paper-first defaults
+- Prefer dry-run for strategy changes
+- Update tests when changing gates or kill switches
+- Keep secrets out of the repo
+
+### Don’t
+
+- Force-push `main`
+- Hardcode API keys
+- Delete or bypass the guardian / halt files without an explicit override path
+- Re-enable iron condor **entry** workflows without a written hypothesis + CEO-visible kill-criteria update
+
+## Scope of changes
+
+| Welcome                              | Needs extra care                         |
+| ------------------------------------ | ---------------------------------------- |
+| Tests, docs, hygiene                 | Risk constants in `trading_constants.py` |
+| RAG lessons, reports                 | Order submission / exit automation       |
+| Dead-code removal with grep evidence | Live-account paths                       |
+
+## Docs
+
+Human-facing index: [docs/README.md](./docs/README.md).
+
+## License
+
+By contributing, you agree your contributions are under the same license as the repository.

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,20 @@
 SHELL := /bin/bash
 
-.PHONY: hygiene
+.PHONY: hygiene test check ruff skill-check
+
+# Worktree prune helper (local)
 hygiene:
 	scripts/worktree_hygiene.sh --prune
+
+# Full test suite (may be long)
+test:
+	pytest tests/ -q
+
+# Fast default: lint + repo hygiene tests
+ruff:
+	ruff check src/
+
+skill-check:
+	pytest tests/test_repo_docs_layout.py tests/test_repo_hygiene.py tests/test_killed_ic_workflows.py -q
+
+check: ruff skill-check

--- a/README.md
+++ b/README.md
@@ -1,175 +1,99 @@
-<div align="center">
+# trading
 
-# Systematic SPY Options Lab — Guardrail-First Autonomous Trading
+**paper-first SPY options validation lab** with broker-backed ledgers, hard risk gates, and agent-bypass-proof safety.
 
-### Autonomous-Agent Safety Layer | RAG Memory | Broker-Backed Audit Trail
-
-**An honest validation platform: deterministic guardrails on top of a still-unproven SPY iron-condor signal. Trading is the lab; the safety layer is the product.**
-
-[Investor Pitch](docs/INVESTOR_PITCH.md) | [Live Strategy Spec](docs/LIVE_STRATEGY.md) | [Edge Audit (2026-05-19)](docs/research/2026-05-19-edge-analysis.md)
-
-</div>
+[docs](docs/README.md) · [operator guide](docs/operator-guide.md) · [agent skill](skills/trading-ops/SKILL.md) · [live strategy](docs/LIVE_STRATEGY.md)
 
 ---
 
-## 🚀 The Thesis: Operational Excellence, Not Prediction
+**guardrails first. edge second.**
 
-Most algorithmic trading systems fail because they bet on a directional edge that adapts away. This lab inverts that: it bets on **operational guardrails** — deterministic, broker-side, agent-bypass-proof — and uses iron condors only as the in-house workload that proves the safety layer in production.
+- **trade gateway** — every new-risk path hits `TradeGateway` before the broker
+- **kill switch** — strategy family is explicit in `data/runtime/strategy_kill_switch.json`
+- **paired ledger** — closed outcomes in `data/trades.json`; unmatched fills stay quarantined
+- **RAG memory** — lessons under `rag_knowledge/lessons_learned/` feed gates and ops
+- **paper only for active validation** — live capital blocked until cohort criteria clear
 
-The earlier framing of this repo (a "60% Thursday win-rate anomaly") **was retracted** on 2026-05-20: the apparent effect did not survive Bonferroni correction across the 14 buckets examined (adj_p = 0.190 vs α=0.05). See `docs/research/2026-05-19-edge-analysis.md` for the full audit. The Thursday-only entry gate has been removed from the code; entries are no longer filtered by weekday.
+Active family: **`spy_put_credit`** (1-lot SPY bull put credit, paper). Iron condor **new entries are killed**; residual IC legs are exit-only.
 
-## 🧠 What This Lab Builds
-
-- **`TradeGateway` (`src/risk/trade_gateway.py`)**: the mandatory pre-broker checkpoint. Lot-size cap, IV-rank floor, daily-loss circuit breaker, drawdown circuit breaker, position-count cap, illiquid-option rejection, FOMC blackout, magic-word override, RAG-lesson-driven blocks. **Every decision is appended to `data/gateway_decisions.jsonl`** for audit and product analytics.
-- **`TRADING_HALTED` kill-switch (`src/safety/crisis_monitor.py`)**: file-flag global halt; auto-armed when position count, unrealized loss, or single-position loss cross thresholds.
-- **Lessons-Learned RAG (`src/rag/lessons_learned_rag.py`)**: 249 audited prior incidents — gateway queries this before approving credit strategies.
-- **Iron-condor execution loop (`scripts/iron_condor_trader.py`)**: 1-lot, 30-45 DTE, 15-20 delta, defined-risk-both-sides, 7 DTE / 50% profit exits.
-
-## 📊 Performance & Operational Truth
-
-This is **not** a profitable system today. Honest current state (verifiable in `data/system_state.json`):
-
-- **North Star**: $6,000/mo after-tax — currently unrealized. No proven edge yet (PF 0.22, 23.2% win rate over 69 closed trades).
-- **Validation cohort**: 3 / 30 trades under `.claude/rules/controlled-experiment.md`. Too small to claim anything.
-- **Paper equity drawdown**: ~5% from $100K start. Auto-kill floor at $84,351 per `.claude/rules/kill-criteria.md`.
-- **Live brokerage equity**: $0 (inactive). No customer capital. No real money at risk.
-
-But the repo should be understood for what it actually is today:
-
-- **paper-first validation infrastructure**
-- **live trading inactive by default**
-- **edge not yet verified for scaling**
-
-Current gate state and evidence live in the canonical ledgers and generated public bundle, not in this README:
-
-- [docs/data/public_status.json](/Users/igorganapolsky/workspace/git/igor/trading/.worktrees/gsd-learning-freshness-guard/docs/data/public_status.json)
-- [data/system_state.json](/Users/igorganapolsky/workspace/git/igor/trading/.worktrees/gsd-learning-freshness-guard/data/system_state.json)
-- [data/trades.json](/Users/igorganapolsky/workspace/git/igor/trading/.worktrees/gsd-learning-freshness-guard/data/trades.json)
+This is **not** a proven profitable system. Current edge is unproven until the put-credit cohort hits n≥30 with expectancy > 0 and PF > 1. Read ledgers, not marketing.
 
 ---
 
-## Current Operating Truth
-
-The system is not positioned as a finished black-box profit engine.
-
-It is currently:
-
-- validating a defined-risk SPY options process in paper
-- using weekly gates to block scale until there is enough paired closed-trade evidence
-- using a broker-backed scorecard to separate realized activity, open-position repricing, and paired closed-trade outcomes
-
-It is not currently:
-
-- a fully validated live strategy
-- a claim of proven profitability
-- a hands-off capital allocator that should be trusted without supervision
-
-If you want the latest numbers, use the live artifacts and dashboards, not hardcoded README badges.
-
----
-
-## System Design
-
-The core architecture is built around five layers:
-
-1. **Execution and Brokerage**
-   - Alpaca is the primary broker and execution source of truth.
-   - Daily scorecards read broker state directly.
-
-2. **Trade Safety**
-   - Pre-trade gates enforce ticker restrictions, volatility/risk conditions, and weekly operating constraints.
-   - Defined-risk structures only.
-
-3. **Paired-Trade Accounting**
-   - The system distinguishes fill flow from completed paired closed trades.
-   - Expectancy and scale decisions are supposed to come from paired outcomes, not raw order noise.
-
-4. **RAG and Learning**
-   - Lessons learned are stored and retrieved for operator context.
-   - Always-on workflows refresh ingest, retraining, and proof artifacts.
-
-5. **Operational Proof**
-   - GitHub Actions, smoke checks, workflow validation, and broker-backed artifacts provide evidence for system state.
-
----
-
-## Active Strategy Scope
-
-The active scope is intentionally narrow:
-
-- **Underlying**: SPY
-- **Structure family**: defined-risk options income structures, with iron condors as the primary validated playbook
-- **Typical DTE band**: 30-45 days
-- **Short strike target**: around 15 delta when the gate path allows it
-- **Exit discipline**: profit-taking, stop-loss, and time-based exits enforced through the strategy stack
-
-Whether that playbook is currently allowed to open new risk is determined by the active weekly gate, not by this static document.
-
-The exact active operating spec lives here:
-
-- [docs/LIVE_STRATEGY.md](/Users/igorganapolsky/workspace/git/igor/trading/.worktrees/gsd-learning-freshness-guard/docs/LIVE_STRATEGY.md)
-
----
-
-## Tech Stack
-
-- **Python 3.11**
-- **Alpaca** for brokerage, orders, account state, and paper/live parity
-- **GitHub Actions** for CI, hygiene, and scheduled automation
-- **LanceDB/local retrieval** for lessons and RAG access
-- **Structured JSON ledgers** for canonical state and paired-trade evidence
-- **Optional market/research providers** behind guarded interfaces, not hard dependencies in the critical trading path
-
----
-
-## Quick Start
+## quick start
 
 ```bash
-git clone https://github.com/IgorGanapolsky/trading.git
+git clone https://github.com/IgorGanapolsky/trading
 cd trading
-pip install -r requirements.txt
-cp .env.example .env
+python3 -m venv .venv && source .venv/bin/activate
+pip install -r requirements-minimal.txt   # or: uv sync
+
+# status (no orders)
+python scripts/spy_put_credit.py --status
+python scripts/audit_open_inventory.py
 python scripts/system_health_check.py
-python scripts/daily_scorecard.py --repo-root .
+
+# plan only (no submit)
+python scripts/spy_put_credit.py --dry-run
 ```
 
-Useful entry points:
-
-- `python scripts/system_health_check.py`
-- `python scripts/daily_scorecard.py --repo-root .`
-- `python scripts/always_on_learning_loop.py --phase morning_proof --repo-root .`
+Credentials: Alpaca paper keys via env / `get_alpaca_credentials()` — never hardcode.
 
 ---
 
-## What Makes This Repo Valuable
+## docs
 
-The value is not “AI that trades for you.”
-
-The value is that it tries to turn discretionary options trading into something:
-
-- auditable
-- broker-backed
-- risk-gated
-- regression-tested
-- measurable from completed trade evidence
-
-That is a more serious asset than a marketing bot with a P/L claim.
+| Path                                                       | Purpose                             |
+| ---------------------------------------------------------- | ----------------------------------- |
+| [docs/README.md](docs/README.md)                           | docs index                          |
+| [docs/operator-guide.md](docs/operator-guide.md)           | human operator runbook              |
+| [docs/LIVE_STRATEGY.md](docs/LIVE_STRATEGY.md)             | strategy spec                       |
+| [skills/trading-ops/SKILL.md](skills/trading-ops/SKILL.md) | agent skill (operate this repo)     |
+| [AGENTS.md](AGENTS.md)                                     | agent instructions for contributors |
+| [CONTRIBUTING.md](CONTRIBUTING.md)                         | PR / issue path                     |
 
 ---
 
-## What Still Needs Work
+## current truth (verify on disk)
 
-This repository still has real gaps:
+| Source                                   | Question                            |
+| ---------------------------------------- | ----------------------------------- |
+| `data/system_state.json`                 | broker equity, positions, last sync |
+| `data/trades.json`                       | paired closed-structure outcomes    |
+| `data/put_credit_entries.json`           | active put-credit journal           |
+| `data/runtime/strategy_kill_switch.json` | active vs killed families           |
 
-- overall test coverage is improving but not complete
-- some large orchestration surfaces still need deeper verification
-- the trading process still needs cleaner cadence and cleaner paired closed-trade evidence
-- documentation must continue to stay aligned with actual gate state and actual broker-backed results
-
-This README is intentionally conservative. It is better to under-claim than to advertise a capability the ledgers do not support.
+Do not invent P/L or win rate. Cite the ledger.
 
 ---
 
-## License
+## agent instructions
 
-[MIT](LICENSE)
+If you are an AI agent working in this repository:
+
+1. Read [`AGENTS.md`](AGENTS.md) before changing code
+2. Install/use the operator skill: [`skills/trading-ops/SKILL.md`](skills/trading-ops/SKILL.md)
+3. Read [`CONTRIBUTING.md`](CONTRIBUTING.md) before opening PRs
+
+Repo layout ideas (skills, docs hub, clean README pitch) were inspired by
+[Herdr](https://github.com/herdrdev/herdr) / [herdr.dev](https://herdr.dev) —
+agent skill + plugins docs at [herdr.dev/docs/agent-skill](https://herdr.dev/docs/agent-skill/)
+and [herdr.dev/docs/plugins](https://herdr.dev/docs/plugins/). No affiliation.
+
+---
+
+## development
+
+```bash
+make check          # ruff (src) + focused pytest if available
+make test           # pytest tests/ -q
+make hygiene        # worktree prune helper
+```
+
+Use a dedicated git worktree for feature work (see AGENTS.md). Never force-push `main`.
+
+---
+
+## license
+
+See [LICENSE](LICENSE).

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,41 @@
+# Docs
+
+Operator and design docs for the trading lab.
+
+## Start here
+
+| Doc                                                              | Audience        | Purpose                              |
+| ---------------------------------------------------------------- | --------------- | ------------------------------------ |
+| [operator-guide.md](./operator-guide.md)                         | Human operator  | Daily commands, gates, truth sources |
+| [../skills/trading-ops/SKILL.md](../skills/trading-ops/SKILL.md) | Coding agents   | How to operate the repo safely       |
+| [LIVE_STRATEGY.md](./LIVE_STRATEGY.md)                           | Strategy        | Active validation design             |
+| [../AGENTS.md](../AGENTS.md)                                     | Agents          | Project contribution rules           |
+| [../CONTRIBUTING.md](../CONTRIBUTING.md)                         | Humans + agents | PR path                              |
+
+## Strategy & research
+
+| Doc                                                                | Notes                      |
+| ------------------------------------------------------------------ | -------------------------- |
+| [LIVE_STRATEGY.md](./LIVE_STRATEGY.md)                             | Current operating strategy |
+| [research/](./research/)                                           | Edge audits and deep dives |
+| [RAG_11_STAGES_SPECIFICATION.md](./RAG_11_STAGES_SPECIFICATION.md) | RAG pipeline stages        |
+
+## Pitch / archive (not operating truth)
+
+| Doc                                      | Notes                                               |
+| ---------------------------------------- | --------------------------------------------------- |
+| [INVESTOR_PITCH.md](./INVESTOR_PITCH.md) | Narrative deck — verify numbers against ledgers     |
+| [AI*OPS*\*.md](./)                       | Outreach collateral — outside default trading scope |
+
+## Data artifacts (generated / live)
+
+Prefer repo-root ledgers over hardcoded README claims:
+
+- `data/system_state.json`
+- `data/trades.json`
+- `data/runtime/strategy_kill_switch.json`
+
+## Layout inspiration
+
+Docs hub + first-class agent skill layout inspired by [Herdr](https://github.com/herdrdev/herdr)
+([agent skill](https://herdr.dev/docs/agent-skill/), [plugins](https://herdr.dev/docs/plugins/)). No affiliation.

--- a/docs/operator-guide.md
+++ b/docs/operator-guide.md
@@ -1,0 +1,60 @@
+# Operator guide
+
+Short human runbook. Agents should also load [`skills/trading-ops/SKILL.md`](../skills/trading-ops/SKILL.md).
+
+## What is live today
+
+| Item           | Value                    |
+| -------------- | ------------------------ |
+| Active family  | `spy_put_credit` (paper) |
+| Live capital   | Blocked                  |
+| IC new entries | Killed                   |
+| Residual IC    | Exit/manage only         |
+
+Source: `data/runtime/strategy_kill_switch.json`.
+
+## Daily loop
+
+```bash
+# 1. Broker truth
+python scripts/sync_alpaca_state.py
+python scripts/sync_closed_positions.py
+
+# 2. Hygiene
+python scripts/audit_open_inventory.py   # must be clean for new risk
+python scripts/system_health_check.py
+
+# 3. Strategy status / plan
+python scripts/spy_put_credit.py --status
+python scripts/spy_put_credit.py --dry-run
+```
+
+## Truth sources
+
+| Question                | File                             |
+| ----------------------- | -------------------------------- |
+| Equity / positions      | `data/system_state.json`         |
+| Closed structure P/L    | `data/trades.json`               |
+| Open put-credit journal | `data/put_credit_entries.json`   |
+| Lessons                 | `rag_knowledge/lessons_learned/` |
+
+## Hard rules
+
+1. Paper validation only until n≥30 put-credit cohort with expectancy > 0 and PF > 1.
+2. Do not freehand-close options outside guardian / residual exit scripts.
+3. Do not clear halt files to force trading.
+4. Do not re-enable IC entry workflows.
+
+## Tests before merge
+
+```bash
+pytest tests/ -q
+ruff check src/
+```
+
+## When something fails
+
+1. Read the failing command output.
+2. Query RAG lessons for the error pattern.
+3. Fix with a test when possible.
+4. Log a lesson if severity ≥ 4 or the mistake already happened once.

--- a/rag_knowledge/lessons_learned/ll_herdr_style_repo_org_2026-08-02.md
+++ b/rag_knowledge/lessons_learned/ll_herdr_style_repo_org_2026-08-02.md
@@ -1,0 +1,28 @@
+# LL — Herdr-style repo organization (2026-08-02)
+
+## Context
+
+CEO asked to steal high-ROI ideas from Herdr’s public repo and docs
+([herdrdev/herdr](https://github.com/herdrdev/herdr), agent-skill + plugins docs).
+
+## What we copied (adapted)
+
+1. **Clean README pitch** — short value prop, quick start, docs links, honest non-claim
+2. **First-class agent skill** — `skills/trading-ops/SKILL.md` (operate vs teach split)
+3. **Docs hub** — `docs/README.md` + `docs/operator-guide.md`
+4. **CONTRIBUTING.md** — PR path for humans/agents
+5. **AGENTS.md pointer** — skill + contributing at top
+6. **make check** — fast lint + layout tests
+
+## What we did not copy
+
+- Plugin marketplace / herdr-plugin.toml (not applicable to trading lab yet)
+- Multi-channel release docs pipeline
+
+## Rule
+
+Public README must not claim proven edge. Point to ledgers. Credit Herdr as inspiration without affiliation.
+
+## Tags
+
+#docs #skill #repo-org #herdr-inspired

--- a/skills/trading-ops/SKILL.md
+++ b/skills/trading-ops/SKILL.md
@@ -1,0 +1,88 @@
+---
+name: trading-ops
+description: "Operate the Igor trading lab (paper SPY put-credit validation, broker sync, safety gates, RAG). Use when working in the trading repo, checking status, planning trades, or touching risk/execution code. Prefer dry-run and ledger evidence over claims."
+---
+
+# Trading ops (agent skill)
+
+This skill teaches an agent how to **operate** this repository safely. It is not a profit claim.
+
+Repo: paper-first SPY options validation. Active family: **`spy_put_credit`**. Iron condor **new entries killed**.
+
+## Safety gates (hard)
+
+Before any action that could submit orders or close positions:
+
+1. Read `data/runtime/strategy_kill_switch.json` — confirm `active_family` and `live_blocked`.
+2. Prefer **paper** paths only. Live is blocked until kill criteria clear.
+3. **Do not** freehand-close positions outside the guardian / residual exit path.
+4. **Do not** remove `data/TRADING_HALTED` / halt flags to “unblock” trading.
+5. **Do not** reopen iron condor entry workflows (must remain STRATEGY_KILLED no-ops).
+6. Never hardcode Alpaca keys; use `get_alpaca_credentials()`.
+
+If a tool or hook refuses a boundary action, treat that as signal — find the allowed path or stop.
+
+## Canonical files
+
+| Path                                     | Authority                                   |
+| ---------------------------------------- | ------------------------------------------- |
+| `data/system_state.json`                 | Broker snapshot (equity, positions, orders) |
+| `data/trades.json`                       | Paired closed structures (edge metrics)     |
+| `data/put_credit_entries.json`           | Put-credit lifecycle journal                |
+| `data/runtime/strategy_kill_switch.json` | Active / killed strategy families           |
+| `src/core/trading_constants.py`          | Policy constants                            |
+| `rag_knowledge/lessons_learned/`         | Operator memory                             |
+
+Unmatched fills are **not** trades. Do not promote them into win rate / expectancy.
+
+## Status commands (read-only first)
+
+```bash
+python scripts/spy_put_credit.py --status
+python scripts/audit_open_inventory.py
+python scripts/system_health_check.py
+# optional refresh (mutates local state files; does not open risk by itself)
+python scripts/sync_alpaca_state.py
+python scripts/sync_closed_positions.py
+```
+
+Inventory unclean (`exit 2`) → **no new risk**.
+
+## Plan vs execute
+
+```bash
+# plan only — no submit
+python scripts/spy_put_credit.py --dry-run
+
+# residual IC exit-only (not new IC entries)
+python scripts/ic_simple.py --mode exit
+```
+
+Never describe a dry-run plan as an executed trade.
+
+## Evidence rules
+
+- Equity / P/L / win rate: cite `data/system_state.json` or `data/trades.json` with numbers.
+- 0 put-credit closed trades in cohort → no profitability claim.
+- Prefer `RETRIEVE → CITE → SPEAK`.
+
+## Git / change protocol
+
+- Feature work in a dedicated `git worktree` under `.worktrees/`.
+- PRs for all changes; merge only with green CI evidence.
+- No force-push to `main`.
+- After substantive ops work, record lessons in `rag_knowledge/lessons_learned/` when severity ≥ 4 or a repeat mistake occurred.
+
+## Tests
+
+```bash
+pytest tests/ -q
+ruff check src/
+pytest tests/test_killed_ic_workflows.py tests/test_repo_hygiene.py -q
+```
+
+## What this skill is not
+
+- Not permission to deploy live capital.
+- Not a substitute for broker truth.
+- Not a claim that put-credit has edge before n≥30 cohort gates pass.

--- a/tests/test_repo_docs_layout.py
+++ b/tests/test_repo_docs_layout.py
@@ -1,0 +1,35 @@
+"""Prevention: keep Herdr-inspired docs/skill layout present."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+REQUIRED_PATHS = (
+    "README.md",
+    "AGENTS.md",
+    "CONTRIBUTING.md",
+    "docs/README.md",
+    "docs/operator-guide.md",
+    "skills/trading-ops/SKILL.md",
+)
+
+
+def test_required_docs_and_skill_exist() -> None:
+    missing = [p for p in REQUIRED_PATHS if not (ROOT / p).is_file()]
+    assert missing == [], f"missing layout files: {missing}"
+
+
+def test_readme_points_at_skill_and_honest_strategy() -> None:
+    text = (ROOT / "README.md").read_text(encoding="utf-8")
+    assert "skills/trading-ops/SKILL.md" in text
+    assert "spy_put_credit" in text
+    assert "not" in text.lower() and "proven" in text.lower()
+
+
+def test_skill_has_safety_gates() -> None:
+    text = (ROOT / "skills/trading-ops/SKILL.md").read_text(encoding="utf-8")
+    assert "strategy_kill_switch" in text
+    assert "dry-run" in text
+    assert "TRADING_HALTED" in text or "halt" in text.lower()


### PR DESCRIPTION
## Summary

High-ROI repo organization patterns adapted from [Herdr](https://github.com/herdrdev/herdr) / [herdr.dev](https://herdr.dev) (no affiliation):

| Herdr pattern | Our implementation |
|---------------|-------------------|
| Clean README pitch + install/quick start | Rewrote `README.md` (put-credit truth, no fake edge) |
| First-class agent skill | `skills/trading-ops/SKILL.md` |
| Separate human docs | `docs/operator-guide.md` + `docs/README.md` hub |
| CONTRIBUTING + AGENTS | New `CONTRIBUTING.md`; AGENTS points at skill |
| Fast local check | `make check` + layout prevention tests |

Not ported (low ROI here): plugin marketplace / `herdr-plugin.toml` runtime.

## Test plan

- [x] `pytest tests/test_repo_docs_layout.py tests/test_repo_hygiene.py tests/test_killed_ic_workflows.py` — 9 passed
- [x] `trunk check` clean on changed files
- [ ] CI green