### PR TITLE
feat: LLM-as-Judge MoE panel for claim/PR/coord audit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,7 @@ ruff:
 	ruff check src/
 
 skill-check:
-	pytest tests/test_repo_docs_layout.py tests/test_repo_hygiene.py tests/test_killed_ic_workflows.py -q
+	pytest tests/test_repo_docs_layout.py tests/test_repo_hygiene.py tests/test_killed_ic_workflows.py tests/test_judge_panel.py -q
+	python scripts/judge_panel.py --self-check
 
 check: ruff skill-check

--- a/docs/operator-guide.md
+++ b/docs/operator-guide.md
@@ -27,6 +27,11 @@ python scripts/system_health_check.py
 # 3. Strategy status / plan
 python scripts/spy_put_credit.py --status
 python scripts/spy_put_credit.py --dry-run
+
+# 4. (Optional) Agent claim / PR audit — LLM-as-Judge MoE panel
+#    Does NOT approve trades. Hard risk gates always veto.
+python scripts/judge_panel.py --self-check
+python scripts/judge_panel.py --kind claim_audit --text "your status claim here"
 ```
 
 ## Truth sources

--- a/scripts/judge_panel.py
+++ b/scripts/judge_panel.py
@@ -1,0 +1,157 @@
+#!/usr/bin/env python3
+"""CLI: LLM-as-Judge panel + Mixture-of-Experts (claim / PR / coord audit).
+
+Does NOT approve trades. Hard risk vetoes always win.
+
+Examples:
+  python scripts/judge_panel.py --kind claim --text "CI green on run 123456"
+  python scripts/judge_panel.py --kind pr --diff-file /tmp/patch.diff
+  python scripts/judge_panel.py --kind coord --other-claims-file vault.md --agent grok
+  python scripts/judge_panel.py --self-check
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from src.evals.judge_panel import TaskKind, run_panel  # noqa: E402
+
+
+def _read(path: str | None) -> str:
+    if not path:
+        return ""
+    return Path(path).read_text(encoding="utf-8", errors="replace")
+
+
+def _self_check() -> int:
+    """Built-in regression samples — exit 0 only if all behave as designed."""
+    cases = [
+        (
+            "unverified_edge",
+            dict(
+                kind=TaskKind.CLAIM_AUDIT,
+                text="Edge proven and profitable, ready for live",
+            ),
+            False,
+        ),
+        (
+            "verified_claim",
+            dict(
+                kind=TaskKind.CLAIM_AUDIT,
+                text="CI green on run 30780143772, merge sha d69beb2b6, n=162 expectancy=-47",
+            ),
+            True,
+        ),
+        (
+            "ic_resume",
+            dict(
+                kind=TaskKind.PR_AUDIT,
+                diff="+ # resume iron condor entries tomorrow\n",
+                text="open new iron condor",
+            ),
+            False,
+        ),
+        (
+            "trade_entry_refuse",
+            dict(
+                kind=TaskKind.TRADE_ENTRY,
+                text="panel should sell 15 delta put credit",
+            ),
+            False,
+        ),
+        (
+            "coord_collision",
+            dict(
+                kind=TaskKind.COORD_AUDIT,
+                agent="grok",
+                claimed_files=["src/risk/trade_gateway.py"],
+                other_agent_claims=(
+                    "codex owns In Progress IGO-35; claimed_files: src/risk/trade_gateway.py"
+                ),
+            ),
+            False,
+        ),
+    ]
+    failures = []
+    for name, kwargs, expect_pass in cases:
+        v = run_panel(**kwargs)
+        if v.passed != expect_pass:
+            failures.append(
+                f"{name}: expected passed={expect_pass} got {v.passed} summary={v.judge_summary}"
+            )
+    if failures:
+        print("SELF-CHECK FAIL")
+        for f in failures:
+            print(" -", f)
+        return 1
+    print("SELF-CHECK PASS")
+    print(json.dumps({"cases": len(cases), "all_passed": True}, indent=2))
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(description="Judge panel (MoE) for agent/PR/coord audit")
+    p.add_argument(
+        "--kind",
+        choices=[k.value for k in TaskKind],
+        help="Audit kind",
+    )
+    p.add_argument("--text", default="", help="Free text / PR body / agent claim")
+    p.add_argument("--diff-file", default=None, help="Unified diff path")
+    p.add_argument("--claim-file", default=None, help="Claim markdown path")
+    p.add_argument("--other-claims-file", default=None, help="Foreign vault claims path")
+    p.add_argument("--agent", default="grok", help="This agent name")
+    p.add_argument(
+        "--claimed-file",
+        action="append",
+        default=[],
+        help="File path claimed by this agent (repeatable)",
+    )
+    p.add_argument("--json", action="store_true", help="JSON output")
+    p.add_argument("--self-check", action="store_true", help="Run built-in samples")
+    args = p.parse_args(argv)
+
+    if args.self_check:
+        return _self_check()
+
+    if not args.kind:
+        p.error("--kind is required unless --self-check")
+
+    verdict = run_panel(
+        kind=args.kind,
+        text=args.text,
+        diff=_read(args.diff_file),
+        claim=_read(args.claim_file),
+        agent=args.agent,
+        other_agent_claims=_read(args.other_claims_file),
+        claimed_files=args.claimed_file,
+    )
+
+    if args.json:
+        print(json.dumps(verdict.to_dict(), indent=2))
+    else:
+        print(f"kind={verdict.kind.value}")
+        print(f"passed={verdict.passed} vetoed={verdict.vetoed} score={verdict.score}")
+        print(f"experts={','.join(verdict.experts_used)}")
+        print(f"summary={verdict.judge_summary}")
+        if verdict.veto_reasons:
+            print("veto_reasons:")
+            for r in verdict.veto_reasons:
+                print(f"  - {r}")
+        for o in verdict.opinions:
+            print(f"[{o.expert.value}] passed={o.passed} veto={o.veto} score={o.score}")
+            for f in o.findings:
+                print(f"  finding: {f}")
+
+    return 0 if verdict.passed else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/trading-ops/SKILL.md
+++ b/skills/trading-ops/SKILL.md
@@ -35,6 +35,23 @@ If a tool or hook refuses a boundary action, treat that as signal — find the a
 
 Unmatched fills are **not** trades. Do not promote them into win rate / expectancy.
 
+## Judge panel (claim / PR / coord audit — not trade entry)
+
+Mixture-of-Experts + hard-veto judge for **agent claims**, PR text/diffs, and multi-agent collisions.
+
+```bash
+python scripts/judge_panel.py --self-check
+python scripts/judge_panel.py --kind claim_audit --text "CI green on run <id> sha <sha>"
+python scripts/judge_panel.py --kind pr_audit --diff-file /tmp/patch.diff
+python scripts/judge_panel.py --kind coord_audit --agent grok \
+  --other-claims-file ~/Documents/AI-Agent-Sync/Agent-State/codex.md \
+  --claimed-file src/evals/judge_panel/panel.py
+```
+
+- Code: `src/evals/judge_panel/`
+- **Never** use this panel to approve put-credit or IC entries (`trade_entry` always vetoes).
+- Edge / “ready for live” claims without ledger or run evidence → fail/veto.
+
 ## Status commands (read-only first)
 
 ```bash

--- a/src/evals/__init__.py
+++ b/src/evals/__init__.py
@@ -1,0 +1,1 @@
+"""Evaluation package."""

--- a/src/evals/judge_panel/__init__.py
+++ b/src/evals/judge_panel/__init__.py
@@ -1,0 +1,32 @@
+"""LLM-as-Judge panel with Mixture-of-Experts routing.
+
+Purpose
+-------
+Audit **agent claims, PRs, and multi-agent coordination** — not trade entries.
+
+Hard rule: deterministic risk gates always veto qualitative scores.
+Trade-entry routing is risk-only and never "LLM-approves" size/delta.
+
+See scripts/judge_panel.py and tests/test_judge_panel.py.
+"""
+
+from __future__ import annotations
+
+from src.evals.judge_panel.models import (
+    ExpertName,
+    ExpertOpinion,
+    PanelVerdict,
+    TaskKind,
+)
+from src.evals.judge_panel.panel import JudgePanel, run_panel
+from src.evals.judge_panel.router import ExpertRouter
+
+__all__ = [
+    "ExpertName",
+    "ExpertOpinion",
+    "ExpertRouter",
+    "JudgePanel",
+    "PanelVerdict",
+    "TaskKind",
+    "run_panel",
+]

--- a/src/evals/judge_panel/experts.py
+++ b/src/evals/judge_panel/experts.py
@@ -1,0 +1,325 @@
+"""Mixture-of-Experts specialists (deterministic + optional LLM narrative).
+
+Experts are pure functions of PanelInput. They never call brokers or submit orders.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Callable, Protocol
+
+from src.evals.judge_panel.models import (
+    ExpertName,
+    ExpertOpinion,
+    PanelInput,
+    TaskKind,
+)
+
+# --- patterns ----------------------------------------------------------------
+
+# Completion / edge claims that require evidence tokens nearby.
+_CLAIM_MARKERS = re.compile(
+    r"\b("
+    r"ci\s+green|all\s+green|shipped|verified|done\s+merging|"
+    r"expectancy\s*>\s*0|profit\s*factor\s*>\s*1|edge\s+proven|"
+    r"profitable|live\s+ready|ready\s+for\s+live"
+    r")\b",
+    re.IGNORECASE,
+)
+
+# Tokens that count as evidence (SHA, run id, ledger cite, file path cite).
+_EVIDENCE_TOKENS = re.compile(
+    r"("
+    r"\b[0-9a-f]{7,40}\b|"  # git sha
+    r"\brun[\s_#-]*\d{5,}\b|"  # gh run
+    r"\b#\d{3,}\b|"  # PR number
+    r"system_state\.json|trades\.json|put_credit_entries\.json|"
+    r"expectancy\s*[:=]\s*-?\$?\d|equity\s*[:=]\s*\$?\d|"
+    r"n\s*=\s*\d+|sample\s*=\s*\d+"
+    r")",
+    re.IGNORECASE,
+)
+
+# Risk / policy violations in prose or diffs.
+_RISK_VIOLATIONS: list[tuple[str, re.Pattern[str]]] = [
+    (
+        "IC_NEW_ENTRY",
+        re.compile(
+            r"("
+            r"open\s+new\s+iron\s*condor|"
+            r"resume\s+iron\s*condor|"
+            r"ic_simple\.py\s+--mode\s+(scan|execute|autonomous)|"
+            r"re-?enable\s+iron\s*condor|"
+            r"new\s+ic\s+entr"
+            r")",
+            re.IGNORECASE,
+        ),
+    ),
+    (
+        "LIVE_CAPITAL",
+        re.compile(
+            r"("
+            r"deploy\s+live\s+capital|"
+            r"live\s+account\s+entr|"
+            r"remove\s+live_blocked|"
+            r"live_blocked\s*=\s*false"
+            r")",
+            re.IGNORECASE,
+        ),
+    ),
+    (
+        "HALT_TAMPER",
+        re.compile(
+            r"("
+            r"rm\s+.*TRADING_HALTED|"
+            r"delete\s+.*TRADING_HALTED|"
+            r"clear\s+the\s+halt|"
+            r"remove\s+data/TRADING_HALTED"
+            r")",
+            re.IGNORECASE,
+        ),
+    ),
+    (
+        "CREDENTIAL_HARDCODE",
+        re.compile(
+            r"("
+            r"APCA_API_KEY_ID\s*=\s*['\"](?!\$\{)[^'\"]+['\"]|"
+            r"APCA_API_SECRET_KEY\s*=\s*['\"](?!\$\{)[^'\"]+['\"]|"
+            r"sk_live_[A-Za-z0-9]{10,}|"
+            r"ghp_[A-Za-z0-9]{20,}"
+            r")",
+        ),
+    ),
+    (
+        "LLM_TRADE_COUNCIL",
+        re.compile(
+            r"("
+            r"llm\s+council\s+approves?\s+(the\s+)?trade|"
+            r"judge\s+panel\s+says?\s+buy|"
+            r"moe\s+entry\s+signal|"
+            r"restore\s+trade_opinion\s+council"
+            r")",
+            re.IGNORECASE,
+        ),
+    ),
+]
+
+_OTHER_AGENT = re.compile(
+    r"\b(codex|claude-code|hermes|antigravity|cursor|gemini)\b",
+    re.IGNORECASE,
+)
+
+
+class Expert(Protocol):
+    name: ExpertName
+
+    def evaluate(self, payload: PanelInput) -> ExpertOpinion: ...
+
+
+def _corpus(payload: PanelInput) -> str:
+    parts = [payload.text, payload.diff, payload.claim, payload.other_agent_claims]
+    return "\n".join(p for p in parts if p)
+
+
+class RiskRulesExpert:
+    """Policy / kill-switch / credential / IC-kill specialist."""
+
+    name = ExpertName.RISK_RULES
+
+    def evaluate(self, payload: PanelInput) -> ExpertOpinion:
+        body = _corpus(payload)
+        findings: list[str] = []
+        cites: list[str] = []
+        veto = False
+
+        for code, pattern in _RISK_VIOLATIONS:
+            m = pattern.search(body)
+            if m:
+                findings.append(f"{code}: matched {m.group(0)!r}")
+                cites.append(f"risk_pattern:{code}")
+                # All listed patterns are hard vetoes.
+                veto = True
+
+        if payload.kind is TaskKind.TRADE_ENTRY:
+            findings.append(
+                "TRADE_ENTRY_ROUTE: panel refuses qualitative entry approval; "
+                "mandatory_trade_gate + kill switch own execution."
+            )
+            cites.append("policy:trade_opinion_bypassed")
+            # Trade entry is never "passed" by this panel — risk expert fails the LLM path.
+            return ExpertOpinion(
+                expert=self.name,
+                score=0.0,
+                passed=False,
+                findings=findings,
+                evidence_cites=cites,
+                veto=True,
+            )
+
+        if veto:
+            return ExpertOpinion(
+                expert=self.name,
+                score=0.0,
+                passed=False,
+                findings=findings or ["risk veto"],
+                evidence_cites=cites,
+                veto=True,
+            )
+
+        return ExpertOpinion(
+            expert=self.name,
+            score=1.0,
+            passed=True,
+            findings=findings or ["no hard risk pattern matched"],
+            evidence_cites=cites or ["risk_scan:clean"],
+            veto=False,
+        )
+
+
+class EvidenceExpert:
+    """Requires evidence tokens when strong claims are made."""
+
+    name = ExpertName.EVIDENCE
+
+    def evaluate(self, payload: PanelInput) -> ExpertOpinion:
+        body = _corpus(payload)
+        claims = _CLAIM_MARKERS.findall(body)
+        evidence = _EVIDENCE_TOKENS.findall(body)
+        findings: list[str] = []
+        cites: list[str] = []
+
+        if not claims:
+            return ExpertOpinion(
+                expert=self.name,
+                score=1.0,
+                passed=True,
+                findings=["no strong completion/edge claims detected"],
+                evidence_cites=["evidence_scan:no_claims"],
+                veto=False,
+            )
+
+        findings.append(f"claims_detected={claims}")
+        if evidence:
+            cites.extend(f"evidence:{e}" for e in evidence[:12])
+            return ExpertOpinion(
+                expert=self.name,
+                score=0.9,
+                passed=True,
+                findings=findings + [f"evidence_tokens={evidence[:12]}"],
+                evidence_cites=cites,
+                veto=False,
+            )
+
+        findings.append(
+            "UNVERIFIED_CLAIM: strong claim without SHA / run id / ledger cite / n="
+        )
+        # Unverified claim is a fail but not always a policy veto (soft fail).
+        # Edge-profit claims without numbers get a veto.
+        edge_like = any(
+            re.search(r"expectancy|profit\s*factor|edge\s+proven|profitable|live\s+ready", c, re.I)
+            for c in claims
+        )
+        return ExpertOpinion(
+            expert=self.name,
+            score=0.15,
+            passed=False,
+            findings=findings,
+            evidence_cites=["evidence_scan:missing"],
+            veto=bool(edge_like),
+        )
+
+
+class CoordinationExpert:
+    """Flags multi-agent lane collisions from claim text / file lists."""
+
+    name = ExpertName.COORDINATION
+
+    def evaluate(self, payload: PanelInput) -> ExpertOpinion:
+        findings: list[str] = []
+        cites: list[str] = []
+        other = payload.other_agent_claims or ""
+        me = (payload.agent or "unknown").lower()
+        claimed = [c.strip() for c in payload.claimed_files if c.strip()]
+
+        if not other and not claimed:
+            return ExpertOpinion(
+                expert=self.name,
+                score=0.85,
+                passed=True,
+                findings=["no foreign claims supplied; coordination check limited"],
+                evidence_cites=["coord:no_foreign_claims"],
+                veto=False,
+            )
+
+        # Detect another agent marked In Progress on overlapping paths or same repo scope.
+        foreign_agents = {
+            m.group(1).lower()
+            for m in _OTHER_AGENT.finditer(other)
+            if m.group(1).lower() != me and m.group(1).lower() != "grok"
+        }
+        if me in foreign_agents:
+            foreign_agents.discard(me)
+
+        overlap: list[str] = []
+        for path in claimed:
+            if path and path in other:
+                overlap.append(path)
+
+        in_progress_foreign = bool(
+            re.search(r"in\s*progress|owns|claimed", other, re.I) and foreign_agents
+        )
+
+        if overlap and in_progress_foreign:
+            findings.append(
+                f"LANE_COLLISION: files {overlap} appear in foreign claim by {sorted(foreign_agents)}"
+            )
+            cites.append("coord:file_overlap")
+            return ExpertOpinion(
+                expert=self.name,
+                score=0.0,
+                passed=False,
+                findings=findings,
+                evidence_cites=cites,
+                veto=True,
+            )
+
+        if in_progress_foreign and re.search(r"\btrading\b", other, re.I):
+            # Soft warning if foreign agent is on trading but files don't overlap.
+            findings.append(
+                f"FOREIGN_TRADING_ACTIVITY: {sorted(foreign_agents)} — verify Linear/vault before shared files"
+            )
+            cites.append("coord:foreign_trading")
+            return ExpertOpinion(
+                expert=self.name,
+                score=0.55,
+                passed=True,
+                findings=findings,
+                evidence_cites=cites,
+                veto=False,
+            )
+
+        findings.append("no hard coordination collision detected")
+        cites.append("coord:clean")
+        return ExpertOpinion(
+            expert=self.name,
+            score=1.0,
+            passed=True,
+            findings=findings,
+            evidence_cites=cites,
+            veto=False,
+        )
+
+
+DEFAULT_EXPERTS: dict[ExpertName, Expert] = {
+    ExpertName.RISK_RULES: RiskRulesExpert(),
+    ExpertName.EVIDENCE: EvidenceExpert(),
+    ExpertName.COORDINATION: CoordinationExpert(),
+}
+
+
+def get_default_experts() -> dict[ExpertName, Expert]:
+    return dict(DEFAULT_EXPERTS)
+
+
+# Optional narrative LLM — cannot override veto; used only for judge_summary polish.
+NarrativeJudgeFn = Callable[[str, list[ExpertOpinion]], str]

--- a/src/evals/judge_panel/models.py
+++ b/src/evals/judge_panel/models.py
@@ -1,0 +1,86 @@
+"""Shared types for the judge panel / MoE router."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any
+
+
+class TaskKind(str, Enum):
+    """What the panel is judging."""
+
+    CLAIM_AUDIT = "claim_audit"
+    PR_AUDIT = "pr_audit"
+    COORD_AUDIT = "coord_audit"
+    # Explicit: never an LLM trade council — risk expert only + structural refuse.
+    TRADE_ENTRY = "trade_entry"
+
+
+class ExpertName(str, Enum):
+    RISK_RULES = "risk_rules"
+    EVIDENCE = "evidence"
+    COORDINATION = "coordination"
+
+
+@dataclass(frozen=True)
+class ExpertOpinion:
+    expert: ExpertName
+    score: float  # 0.0–1.0 (higher = healthier)
+    passed: bool
+    findings: list[str] = field(default_factory=list)
+    evidence_cites: list[str] = field(default_factory=list)
+    veto: bool = False  # hard fail; judge cannot override
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "expert": self.expert.value,
+            "score": self.score,
+            "passed": self.passed,
+            "findings": list(self.findings),
+            "evidence_cites": list(self.evidence_cites),
+            "veto": self.veto,
+        }
+
+
+@dataclass
+class PanelInput:
+    """Bundle of material for experts to inspect."""
+
+    kind: TaskKind
+    text: str = ""
+    diff: str = ""
+    claim: str = ""
+    agent: str = "unknown"
+    other_agent_claims: str = ""
+    claimed_files: list[str] = field(default_factory=list)
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class PanelVerdict:
+    kind: TaskKind
+    passed: bool
+    score: float
+    vetoed: bool
+    veto_reasons: list[str]
+    experts_used: list[str]
+    opinions: list[ExpertOpinion]
+    judge_summary: str
+    hard_rules_note: str = (
+        "Deterministic risk gates always veto. "
+        "This panel does not approve trade entries, size, or expectancy claims without ledger math."
+    )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "kind": self.kind.value,
+            "passed": self.passed,
+            "score": self.score,
+            "vetoed": self.vetoed,
+            "veto_reasons": list(self.veto_reasons),
+            "experts_used": list(self.experts_used),
+            "opinions": [o.to_dict() for o in self.opinions],
+            "judge_summary": self.judge_summary,
+            "hard_rules_note": self.hard_rules_note,
+        }

--- a/src/evals/judge_panel/panel.py
+++ b/src/evals/judge_panel/panel.py
@@ -1,0 +1,137 @@
+"""Judge panel: aggregate expert opinions with hard-veto priority."""
+
+from __future__ import annotations
+
+from typing import Iterable, Optional
+
+from src.evals.judge_panel.experts import (
+    NarrativeJudgeFn,
+    get_default_experts,
+)
+from src.evals.judge_panel.models import (
+    ExpertName,
+    ExpertOpinion,
+    PanelInput,
+    PanelVerdict,
+    TaskKind,
+)
+from src.evals.judge_panel.router import ExpertRouter
+
+
+def _default_summary(opinions: list[ExpertOpinion], vetoed: bool, passed: bool) -> str:
+    parts = []
+    for o in opinions:
+        flag = "VETO" if o.veto else ("PASS" if o.passed else "FAIL")
+        parts.append(f"{o.expert.value}={flag}(score={o.score:.2f})")
+    head = "PASS" if passed else ("VETO" if vetoed else "FAIL")
+    return f"{head}: " + "; ".join(parts)
+
+
+class JudgePanel:
+    """
+    LLM-as-Judge style panel backed by MoE specialists.
+
+    The optional narrative_fn may polish the summary string only.
+    It cannot flip a veto or invent a pass when experts failed.
+    """
+
+    def __init__(
+        self,
+        router: Optional[ExpertRouter] = None,
+        experts: Optional[dict[ExpertName, object]] = None,
+        narrative_fn: Optional[NarrativeJudgeFn] = None,
+    ) -> None:
+        self.router = router or ExpertRouter()
+        self.experts = experts or get_default_experts()
+        self.narrative_fn = narrative_fn
+
+    def run(self, payload: PanelInput) -> PanelVerdict:
+        selected = self.router.select(payload.kind)
+        opinions: list[ExpertOpinion] = []
+        for name in selected:
+            expert = self.experts.get(name)
+            if expert is None:
+                opinions.append(
+                    ExpertOpinion(
+                        expert=name,
+                        score=0.0,
+                        passed=False,
+                        findings=[f"missing expert: {name.value}"],
+                        veto=True,
+                    )
+                )
+                continue
+            opinions.append(expert.evaluate(payload))  # type: ignore[attr-defined]
+
+        veto_reasons = []
+        for o in opinions:
+            if o.veto:
+                veto_reasons.extend(o.findings)
+
+        vetoed = bool(veto_reasons)
+        all_passed = all(o.passed for o in opinions) and not vetoed
+        # Majority of non-veto opinions if no hard veto — still require zero fails.
+        scores = [o.score for o in opinions] or [0.0]
+        score = sum(scores) / len(scores)
+
+        if vetoed:
+            passed = False
+        else:
+            passed = all_passed
+
+        summary = _default_summary(opinions, vetoed, passed)
+        if self.narrative_fn is not None:
+            try:
+                polished = self.narrative_fn(summary, opinions)
+                # Narrative cannot claim PASS if panel failed.
+                if not passed and re_claims_pass(polished):
+                    summary = summary + " | narrative_stripped_false_pass"
+                else:
+                    summary = polished
+            except Exception as exc:  # pragma: no cover - defensive
+                summary = f"{summary} | narrative_error={exc}"
+
+        return PanelVerdict(
+            kind=payload.kind,
+            passed=passed,
+            score=round(score, 4),
+            vetoed=vetoed,
+            veto_reasons=veto_reasons,
+            experts_used=[n.value for n in selected],
+            opinions=opinions,
+            judge_summary=summary,
+        )
+
+
+def re_claims_pass(text: str) -> bool:
+    """True if narrative text falsely asserts a panel pass."""
+    if not text:
+        return False
+    upper = text.strip().upper()
+    return upper.startswith("PASS") or "PANEL PASS" in upper
+
+
+def run_panel(
+    kind: TaskKind | str,
+    *,
+    text: str = "",
+    diff: str = "",
+    claim: str = "",
+    agent: str = "grok",
+    other_agent_claims: str = "",
+    claimed_files: Optional[Iterable[str]] = None,
+    narrative_fn: Optional[NarrativeJudgeFn] = None,
+) -> PanelVerdict:
+    """Convenience entrypoint for CLI and tests."""
+    if isinstance(kind, str):
+        kind = TaskKind(kind)
+    payload = PanelInput(
+        kind=kind,
+        text=text,
+        diff=diff,
+        claim=claim,
+        agent=agent,
+        other_agent_claims=other_agent_claims,
+        claimed_files=list(claimed_files or []),
+    )
+    return JudgePanel(narrative_fn=narrative_fn).run(payload)

--- a/src/evals/judge_panel/router.py
+++ b/src/evals/judge_panel/router.py
@@ -1,0 +1,24 @@
+"""Mixture-of-Experts router: task kind → expert set."""
+
+from __future__ import annotations
+
+from src.evals.judge_panel.models import ExpertName, TaskKind
+
+
+class ExpertRouter:
+    """Route work to the minimum expert set (cost-aware MoE)."""
+
+    _MAP: dict[TaskKind, tuple[ExpertName, ...]] = {
+        TaskKind.CLAIM_AUDIT: (ExpertName.EVIDENCE, ExpertName.RISK_RULES),
+        TaskKind.PR_AUDIT: (
+            ExpertName.RISK_RULES,
+            ExpertName.EVIDENCE,
+            ExpertName.COORDINATION,
+        ),
+        TaskKind.COORD_AUDIT: (ExpertName.COORDINATION, ExpertName.RISK_RULES),
+        # Trade entry: risk only — never spin a full council.
+        TaskKind.TRADE_ENTRY: (ExpertName.RISK_RULES,),
+    }
+
+    def select(self, kind: TaskKind) -> tuple[ExpertName, ...]:
+        return self._MAP[kind]

--- a/tests/test_judge_panel.py
+++ b/tests/test_judge_panel.py
@@ -1,0 +1,176 @@
+"""Tests for LLM-as-Judge MoE panel (claim/PR/coord — not trade entry)."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+from src.evals.judge_panel import ExpertName, ExpertRouter, JudgePanel, TaskKind, run_panel
+from src.evals.judge_panel.models import PanelInput
+from src.evals.judge_panel.experts import RiskRulesExpert, EvidenceExpert, CoordinationExpert
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+class TestRouter:
+    def test_claim_routes_evidence_and_risk(self):
+        r = ExpertRouter().select(TaskKind.CLAIM_AUDIT)
+        assert ExpertName.EVIDENCE in r
+        assert ExpertName.RISK_RULES in r
+        assert ExpertName.COORDINATION not in r
+
+    def test_trade_entry_risk_only(self):
+        r = ExpertRouter().select(TaskKind.TRADE_ENTRY)
+        assert r == (ExpertName.RISK_RULES,)
+
+    def test_pr_uses_all_three(self):
+        r = ExpertRouter().select(TaskKind.PR_AUDIT)
+        assert set(r) == {
+            ExpertName.RISK_RULES,
+            ExpertName.EVIDENCE,
+            ExpertName.COORDINATION,
+        }
+
+
+class TestRiskExpert:
+    def test_ic_new_entry_veto(self):
+        o = RiskRulesExpert().evaluate(
+            PanelInput(kind=TaskKind.PR_AUDIT, text="let's open new iron condor tomorrow")
+        )
+        assert o.veto is True
+        assert o.passed is False
+
+    def test_trade_entry_always_veto(self):
+        o = RiskRulesExpert().evaluate(
+            PanelInput(kind=TaskKind.TRADE_ENTRY, text="sell put credit 15d")
+        )
+        assert o.veto is True
+        assert o.passed is False
+
+    def test_clean_text_passes(self):
+        o = RiskRulesExpert().evaluate(
+            PanelInput(kind=TaskKind.PR_AUDIT, text="docs only: operator guide link")
+        )
+        assert o.passed is True
+        assert o.veto is False
+
+
+class TestEvidenceExpert:
+    def test_unverified_edge_claim_vetoes(self):
+        o = EvidenceExpert().evaluate(
+            PanelInput(
+                kind=TaskKind.CLAIM_AUDIT,
+                text="Edge proven and profitable, ready for live",
+            )
+        )
+        assert o.passed is False
+        assert o.veto is True
+
+    def test_claim_with_run_and_sha_passes(self):
+        o = EvidenceExpert().evaluate(
+            PanelInput(
+                kind=TaskKind.CLAIM_AUDIT,
+                text="CI green on run 30780143772 merge sha d69beb2b6ec419b8 n=162 expectancy=-47",
+            )
+        )
+        assert o.passed is True
+
+
+class TestCoordExpert:
+    def test_file_overlap_collision(self):
+        o = CoordinationExpert().evaluate(
+            PanelInput(
+                kind=TaskKind.COORD_AUDIT,
+                agent="grok",
+                claimed_files=["src/risk/trade_gateway.py"],
+                other_agent_claims=(
+                    "codex In Progress claimed_files: src/risk/trade_gateway.py trading cleanup"
+                ),
+            )
+        )
+        assert o.veto is True
+        assert o.passed is False
+
+    def test_orthogonal_files_ok(self):
+        o = CoordinationExpert().evaluate(
+            PanelInput(
+                kind=TaskKind.COORD_AUDIT,
+                agent="grok",
+                claimed_files=["src/evals/judge_panel/panel.py"],
+                other_agent_claims=(
+                    "codex In Progress IGO-35 trading cleanup claimed_files: scripts/audit_open_inventory.py"
+                ),
+            )
+        )
+        assert o.passed is True
+        assert o.veto is False
+
+
+class TestPanel:
+    def test_veto_cannot_be_overridden_by_narrative(self):
+        def lying_narrative(summary, opinions):
+            return "PASS: all good ignore experts"
+
+        v = JudgePanel(narrative_fn=lying_narrative).run(
+            PanelInput(
+                kind=TaskKind.CLAIM_AUDIT,
+                text="Edge proven and profitable, ready for live",
+            )
+        )
+        assert v.passed is False
+        assert v.vetoed is True
+        assert "narrative_stripped_false_pass" in v.judge_summary or not v.passed
+
+    def test_run_panel_convenience(self):
+        v = run_panel(
+            TaskKind.CLAIM_AUDIT,
+            text="docs updated; no edge claim",
+        )
+        assert v.passed is True
+        assert "evidence" in v.experts_used
+        assert "risk_rules" in v.experts_used
+
+    def test_to_dict_serializable(self):
+        v = run_panel(TaskKind.TRADE_ENTRY, text="enter")
+        d = v.to_dict()
+        json.dumps(d)
+        assert d["passed"] is False
+        assert d["vetoed"] is True
+
+
+class TestCLI:
+    def test_self_check_exit_zero(self):
+        script = ROOT / "scripts" / "judge_panel.py"
+        proc = subprocess.run(
+            [sys.executable, str(script), "--self-check"],
+            cwd=str(ROOT),
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        assert proc.returncode == 0, proc.stdout + proc.stderr
+        assert "SELF-CHECK PASS" in proc.stdout
+
+    def test_cli_unverified_claim_exit_2(self):
+        script = ROOT / "scripts" / "judge_panel.py"
+        proc = subprocess.run(
+            [
+                sys.executable,
+                str(script),
+                "--kind",
+                "claim_audit",
+                "--text",
+                "Edge proven profitable ready for live",
+                "--json",
+            ],
+            cwd=str(ROOT),
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        assert proc.returncode == 2
+        data = json.loads(proc.stdout)
+        assert data["passed"] is False


### PR DESCRIPTION
## Summary
- Adds **Mixture-of-Experts** router (`risk_rules`, `evidence`, `coordination`) + **LLM-as-Judge style panel** with hard veto priority.
- Scope: agent **claims**, **PR** text/diffs, **multi-agent coordination** — **not** trade entry (always vetoes; leaves `mandatory_trade_gate` in charge).
- CLI: `python scripts/judge_panel.py --self-check` / `--kind claim_audit|pr_audit|coord_audit|trade_entry`
- Prevention: `make skill-check` runs `tests/test_judge_panel.py` + CLI self-check.
- Docs pointers in `docs/operator-guide.md` and `skills/trading-ops/SKILL.md`.

## Isolation
Does **not** take Codex **IGO-35** cleanup lane. Orthogonal paths under `src/evals/judge_panel/`.

## Evidence
- 15 pytest tests green (python3.11)
- `scripts/judge_panel.py --self-check` PASS
- ruff clean on new package

## Test plan
- [x] Local pytest + self-check
- [ ] CI green on PR
- [ ] Computer Use: open PR on GitHub and confirm files