### PR TITLE
fix: Sonar QG for judge panel (path sandbox + coverage)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -36,7 +36,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
+        uses: github/codeql-action/init@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4
         with:
           languages: ${{ matrix.language }}
           config-file: ./.github/codeql/codeql-config.yml

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -36,7 +36,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4
+        uses: github/codeql-action/init@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
         with:
           languages: ${{ matrix.language }}
           config-file: ./.github/codeql/codeql-config.yml

--- a/scripts/judge_panel.py
+++ b/scripts/judge_panel.py
@@ -24,11 +24,10 @@ if str(ROOT) not in sys.path:
 from src.evals.judge_panel import TaskKind, run_panel  # noqa: E402
 
 # Paths may only be read under these roots (absolute after resolve).
+# Do NOT include /tmp — Bandit B108 flags hardcoded temp-dir allowlists.
 _ALLOWED_READ_ROOTS: tuple[Path, ...] = (
     ROOT,
     Path.home() / "Documents" / "AI-Agent-Sync",
-    Path("/tmp"),
-    Path("/private/tmp"),
 )
 
 

--- a/scripts/judge_panel.py
+++ b/scripts/judge_panel.py
@@ -4,9 +4,9 @@
 Does NOT approve trades. Hard risk vetoes always win.
 
 Examples:
-  python scripts/judge_panel.py --kind claim --text "CI green on run 123456"
-  python scripts/judge_panel.py --kind pr --diff-file /tmp/patch.diff
-  python scripts/judge_panel.py --kind coord --other-claims-file vault.md --agent grok
+  python scripts/judge_panel.py --kind claim_audit --text "CI green on run 123456"
+  python scripts/judge_panel.py --kind pr_audit --diff-file ./patch.diff
+  python scripts/judge_panel.py --kind coord_audit --other-claims-file vault.md --agent grok
   python scripts/judge_panel.py --self-check
 """
 
@@ -23,11 +23,46 @@ if str(ROOT) not in sys.path:
 
 from src.evals.judge_panel import TaskKind, run_panel  # noqa: E402
 
+# Paths may only be read under these roots (absolute after resolve).
+_ALLOWED_READ_ROOTS: tuple[Path, ...] = (
+    ROOT,
+    Path.home() / "Documents" / "AI-Agent-Sync",
+    Path("/tmp"),
+    Path("/private/tmp"),
+)
 
-def _read(path: str | None) -> str:
+
+def safe_read_text(path: str | None, *, roots: tuple[Path, ...] | None = None) -> str:
+    """Read a UTF-8 text file only if it resolves under an allowed root.
+
+    Prevents path traversal / arbitrary FS reads from CLI args (Sonar S8707).
+    """
     if not path:
         return ""
-    return Path(path).read_text(encoding="utf-8", errors="replace")
+    allowed = roots if roots is not None else _ALLOWED_READ_ROOTS
+    try:
+        candidate = Path(path).expanduser().resolve(strict=True)
+    except (OSError, RuntimeError) as exc:
+        raise SystemExit(f"error: cannot resolve path {path!r}: {exc}") from exc
+
+    if not candidate.is_file():
+        raise SystemExit(f"error: not a file: {path!r}")
+
+    for root in allowed:
+        try:
+            root_resolved = root.expanduser().resolve()
+        except (OSError, RuntimeError):
+            continue
+        try:
+            candidate.relative_to(root_resolved)
+            return candidate.read_text(encoding="utf-8", errors="replace")
+        except ValueError:
+            continue
+
+    roots_disp = ", ".join(str(r) for r in allowed)
+    raise SystemExit(
+        f"error: path outside allowed roots ({roots_disp}): {path!r}"
+    )
 
 
 def _self_check() -> int:
@@ -35,47 +70,51 @@ def _self_check() -> int:
     cases = [
         (
             "unverified_edge",
-            dict(
-                kind=TaskKind.CLAIM_AUDIT,
-                text="Edge proven and profitable, ready for live",
-            ),
+            {
+                "kind": TaskKind.CLAIM_AUDIT,
+                "text": "Edge proven and profitable, ready for live",
+            },
             False,
         ),
         (
             "verified_claim",
-            dict(
-                kind=TaskKind.CLAIM_AUDIT,
-                text="CI green on run 30780143772, merge sha d69beb2b6, n=162 expectancy=-47",
-            ),
+            {
+                "kind": TaskKind.CLAIM_AUDIT,
+                "text": (
+                    "CI green on run 30780143772, merge sha d69beb2b6, "
+                    "n=162 expectancy=-47"
+                ),
+            },
             True,
         ),
         (
             "ic_resume",
-            dict(
-                kind=TaskKind.PR_AUDIT,
-                diff="+ # resume iron condor entries tomorrow\n",
-                text="open new iron condor",
-            ),
+            {
+                "kind": TaskKind.PR_AUDIT,
+                "diff": "+ # resume iron condor entries tomorrow\n",
+                "text": "open new iron condor",
+            },
             False,
         ),
         (
             "trade_entry_refuse",
-            dict(
-                kind=TaskKind.TRADE_ENTRY,
-                text="panel should sell 15 delta put credit",
-            ),
+            {
+                "kind": TaskKind.TRADE_ENTRY,
+                "text": "panel should sell 15 delta put credit",
+            },
             False,
         ),
         (
             "coord_collision",
-            dict(
-                kind=TaskKind.COORD_AUDIT,
-                agent="grok",
-                claimed_files=["src/risk/trade_gateway.py"],
-                other_agent_claims=(
-                    "codex owns In Progress IGO-35; claimed_files: src/risk/trade_gateway.py"
+            {
+                "kind": TaskKind.COORD_AUDIT,
+                "agent": "grok",
+                "claimed_files": ["src/risk/trade_gateway.py"],
+                "other_agent_claims": (
+                    "codex owns In Progress IGO-35; "
+                    "claimed_files: src/risk/trade_gateway.py"
                 ),
-            ),
+            },
             False,
         ),
     ]
@@ -84,7 +123,8 @@ def _self_check() -> int:
         v = run_panel(**kwargs)
         if v.passed != expect_pass:
             failures.append(
-                f"{name}: expected passed={expect_pass} got {v.passed} summary={v.judge_summary}"
+                f"{name}: expected passed={expect_pass} got {v.passed} "
+                f"summary={v.judge_summary}"
             )
     if failures:
         print("SELF-CHECK FAIL")
@@ -94,6 +134,21 @@ def _self_check() -> int:
     print("SELF-CHECK PASS")
     print(json.dumps({"cases": len(cases), "all_passed": True}, indent=2))
     return 0
+
+
+def _print_human(verdict) -> None:
+    print(f"kind={verdict.kind.value}")
+    print(f"passed={verdict.passed} vetoed={verdict.vetoed} score={verdict.score}")
+    print(f"experts={','.join(verdict.experts_used)}")
+    print(f"summary={verdict.judge_summary}")
+    if verdict.veto_reasons:
+        print("veto_reasons:")
+        for r in verdict.veto_reasons:
+            print(f"  - {r}")
+    for o in verdict.opinions:
+        print(f"[{o.expert.value}] passed={o.passed} veto={o.veto} score={o.score}")
+        for f in o.findings:
+            print(f"  finding: {f}")
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -127,28 +182,17 @@ def main(argv: list[str] | None = None) -> int:
     verdict = run_panel(
         kind=args.kind,
         text=args.text,
-        diff=_read(args.diff_file),
-        claim=_read(args.claim_file),
+        diff=safe_read_text(args.diff_file),
+        claim=safe_read_text(args.claim_file),
         agent=args.agent,
-        other_agent_claims=_read(args.other_claims_file),
+        other_agent_claims=safe_read_text(args.other_claims_file),
         claimed_files=args.claimed_file,
     )
 
     if args.json:
         print(json.dumps(verdict.to_dict(), indent=2))
     else:
-        print(f"kind={verdict.kind.value}")
-        print(f"passed={verdict.passed} vetoed={verdict.vetoed} score={verdict.score}")
-        print(f"experts={','.join(verdict.experts_used)}")
-        print(f"summary={verdict.judge_summary}")
-        if verdict.veto_reasons:
-            print("veto_reasons:")
-            for r in verdict.veto_reasons:
-                print(f"  - {r}")
-        for o in verdict.opinions:
-            print(f"[{o.expert.value}] passed={o.passed} veto={o.veto} score={o.score}")
-            for f in o.findings:
-                print(f"  finding: {f}")
+        _print_human(verdict)
 
     return 0 if verdict.passed else 2
 

--- a/scripts/judge_panel.py
+++ b/scripts/judge_panel.py
@@ -59,9 +59,7 @@ def safe_read_text(path: str | None, *, roots: tuple[Path, ...] | None = None) -
             continue
 
     roots_disp = ", ".join(str(r) for r in allowed)
-    raise SystemExit(
-        f"error: path outside allowed roots ({roots_disp}): {path!r}"
-    )
+    raise SystemExit(f"error: path outside allowed roots ({roots_disp}): {path!r}")
 
 
 def _self_check() -> int:
@@ -79,10 +77,7 @@ def _self_check() -> int:
             "verified_claim",
             {
                 "kind": TaskKind.CLAIM_AUDIT,
-                "text": (
-                    "CI green on run 30780143772, merge sha d69beb2b6, "
-                    "n=162 expectancy=-47"
-                ),
+                "text": ("CI green on run 30780143772, merge sha d69beb2b6, n=162 expectancy=-47"),
             },
             True,
         ),
@@ -110,8 +105,7 @@ def _self_check() -> int:
                 "agent": "grok",
                 "claimed_files": ["src/risk/trade_gateway.py"],
                 "other_agent_claims": (
-                    "codex owns In Progress IGO-35; "
-                    "claimed_files: src/risk/trade_gateway.py"
+                    "codex owns In Progress IGO-35; claimed_files: src/risk/trade_gateway.py"
                 ),
             },
             False,
@@ -122,8 +116,7 @@ def _self_check() -> int:
         v = run_panel(**kwargs)
         if v.passed != expect_pass:
             failures.append(
-                f"{name}: expected passed={expect_pass} got {v.passed} "
-                f"summary={v.judge_summary}"
+                f"{name}: expected passed={expect_pass} got {v.passed} summary={v.judge_summary}"
             )
     if failures:
         print("SELF-CHECK FAIL")

--- a/src/evals/judge_panel/panel.py
+++ b/src/evals/judge_panel/panel.py
@@ -35,9 +35,7 @@ def _verdict_head(passed: bool, vetoed: bool) -> str:
 
 
 def _default_summary(opinions: list[ExpertOpinion], vetoed: bool, passed: bool) -> str:
-    parts = [
-        f"{o.expert.value}={_opinion_flag(o)}(score={o.score:.2f})" for o in opinions
-    ]
+    parts = [f"{o.expert.value}={_opinion_flag(o)}(score={o.score:.2f})" for o in opinions]
     head = _verdict_head(passed, vetoed)
     return f"{head}: " + "; ".join(parts)
 

--- a/src/evals/judge_panel/panel.py
+++ b/src/evals/judge_panel/panel.py
@@ -18,13 +18,82 @@ from src.evals.judge_panel.models import (
 from src.evals.judge_panel.router import ExpertRouter
 
 
+def _opinion_flag(opinion: ExpertOpinion) -> str:
+    if opinion.veto:
+        return "VETO"
+    if opinion.passed:
+        return "PASS"
+    return "FAIL"
+
+
+def _verdict_head(passed: bool, vetoed: bool) -> str:
+    if passed:
+        return "PASS"
+    if vetoed:
+        return "VETO"
+    return "FAIL"
+
+
 def _default_summary(opinions: list[ExpertOpinion], vetoed: bool, passed: bool) -> str:
-    parts = []
-    for o in opinions:
-        flag = "VETO" if o.veto else ("PASS" if o.passed else "FAIL")
-        parts.append(f"{o.expert.value}={flag}(score={o.score:.2f})")
-    head = "PASS" if passed else ("VETO" if vetoed else "FAIL")
+    parts = [
+        f"{o.expert.value}={_opinion_flag(o)}(score={o.score:.2f})" for o in opinions
+    ]
+    head = _verdict_head(passed, vetoed)
     return f"{head}: " + "; ".join(parts)
+
+
+def _collect_opinions(
+    selected: tuple[ExpertName, ...],
+    experts: dict[ExpertName, object],
+    payload: PanelInput,
+) -> list[ExpertOpinion]:
+    opinions: list[ExpertOpinion] = []
+    for name in selected:
+        expert = experts.get(name)
+        if expert is None:
+            opinions.append(
+                ExpertOpinion(
+                    expert=name,
+                    score=0.0,
+                    passed=False,
+                    findings=[f"missing expert: {name.value}"],
+                    veto=True,
+                )
+            )
+            continue
+        opinions.append(expert.evaluate(payload))  # type: ignore[attr-defined]
+    return opinions
+
+
+def _aggregate(opinions: list[ExpertOpinion]) -> tuple[bool, bool, float, list[str]]:
+    veto_reasons: list[str] = []
+    for o in opinions:
+        if o.veto:
+            veto_reasons.extend(o.findings)
+    vetoed = bool(veto_reasons)
+    scores = [o.score for o in opinions] or [0.0]
+    score = sum(scores) / len(scores)
+    all_passed = all(o.passed for o in opinions) and not vetoed
+    passed = False if vetoed else all_passed
+    return passed, vetoed, score, veto_reasons
+
+
+def _apply_narrative(
+    summary: str,
+    passed: bool,
+    narrative_fn: NarrativeJudgeFn | None,
+    opinions: list[ExpertOpinion],
+) -> str:
+    if narrative_fn is None:
+        return summary
+    try:
+        polished = narrative_fn(summary, opinions)
+    except Exception as exc:  # pragma: no cover - defensive
+        return f"{summary} | narrative_error={exc}"
+    # Narrative cannot claim PASS if panel failed.
+    if not passed and re_claims_pass(polished):
+        return summary + " | narrative_stripped_false_pass"
+    return polished
 
 
 class JudgePanel:
@@ -42,54 +111,16 @@ class JudgePanel:
         narrative_fn: Optional[NarrativeJudgeFn] = None,
     ) -> None:
         self.router = router or ExpertRouter()
-        self.experts = experts or get_default_experts()
+        # Allow empty dict to mean "no experts" (must not fall back via `or`).
+        self.experts = get_default_experts() if experts is None else experts
         self.narrative_fn = narrative_fn
 
     def run(self, payload: PanelInput) -> PanelVerdict:
         selected = self.router.select(payload.kind)
-        opinions: list[ExpertOpinion] = []
-        for name in selected:
-            expert = self.experts.get(name)
-            if expert is None:
-                opinions.append(
-                    ExpertOpinion(
-                        expert=name,
-                        score=0.0,
-                        passed=False,
-                        findings=[f"missing expert: {name.value}"],
-                        veto=True,
-                    )
-                )
-                continue
-            opinions.append(expert.evaluate(payload))  # type: ignore[attr-defined]
-
-        veto_reasons = []
-        for o in opinions:
-            if o.veto:
-                veto_reasons.extend(o.findings)
-
-        vetoed = bool(veto_reasons)
-        all_passed = all(o.passed for o in opinions) and not vetoed
-        # Majority of non-veto opinions if no hard veto — still require zero fails.
-        scores = [o.score for o in opinions] or [0.0]
-        score = sum(scores) / len(scores)
-
-        if vetoed:
-            passed = False
-        else:
-            passed = all_passed
-
+        opinions = _collect_opinions(selected, self.experts, payload)
+        passed, vetoed, score, veto_reasons = _aggregate(opinions)
         summary = _default_summary(opinions, vetoed, passed)
-        if self.narrative_fn is not None:
-            try:
-                polished = self.narrative_fn(summary, opinions)
-                # Narrative cannot claim PASS if panel failed.
-                if not passed and re_claims_pass(polished):
-                    summary = summary + " | narrative_stripped_false_pass"
-                else:
-                    summary = polished
-            except Exception as exc:  # pragma: no cover - defensive
-                summary = f"{summary} | narrative_error={exc}"
+        summary = _apply_narrative(summary, passed, self.narrative_fn, opinions)
 
         return PanelVerdict(
             kind=payload.kind,

--- a/tests/test_judge_panel.py
+++ b/tests/test_judge_panel.py
@@ -127,8 +127,7 @@ class TestEvidenceExpert:
             PanelInput(
                 kind=TaskKind.CLAIM_AUDIT,
                 text=(
-                    "CI green on run 30780143772 merge sha d69beb2b6ec419b8 "
-                    "n=162 expectancy=-47"
+                    "CI green on run 30780143772 merge sha d69beb2b6ec419b8 n=162 expectancy=-47"
                 ),
             )
         )
@@ -207,9 +206,7 @@ class TestCoordExpert:
         assert o.veto is True
 
     def test_empty_claims_limited_check(self):
-        o = CoordinationExpert().evaluate(
-            PanelInput(kind=TaskKind.COORD_AUDIT, agent="grok")
-        )
+        o = CoordinationExpert().evaluate(PanelInput(kind=TaskKind.COORD_AUDIT, agent="grok"))
         assert o.passed is True
         assert "coord:no_foreign_claims" in o.evidence_cites
 
@@ -252,9 +249,7 @@ class TestPanel:
         assert "experts agree" in v.judge_summary
 
     def test_missing_expert_vetoes(self):
-        v = JudgePanel(experts={}).run(
-            PanelInput(kind=TaskKind.CLAIM_AUDIT, text="docs only")
-        )
+        v = JudgePanel(experts={}).run(PanelInput(kind=TaskKind.CLAIM_AUDIT, text="docs only"))
         assert v.passed is False
         assert v.vetoed is True
         assert any("missing expert" in r for r in v.veto_reasons)

--- a/tests/test_judge_panel.py
+++ b/tests/test_judge_panel.py
@@ -7,10 +7,14 @@ import subprocess
 import sys
 from pathlib import Path
 
-
 from src.evals.judge_panel import ExpertName, ExpertRouter, JudgePanel, TaskKind, run_panel
+from src.evals.judge_panel.experts import (
+    CoordinationExpert,
+    EvidenceExpert,
+    RiskRulesExpert,
+)
 from src.evals.judge_panel.models import PanelInput
-from src.evals.judge_panel.experts import RiskRulesExpert, EvidenceExpert, CoordinationExpert
+from src.evals.judge_panel.panel import re_claims_pass
 
 ROOT = Path(__file__).resolve().parents[1]
 
@@ -33,6 +37,11 @@ class TestRouter:
             ExpertName.EVIDENCE,
             ExpertName.COORDINATION,
         }
+
+    def test_coord_routes_coord_and_risk(self):
+        r = ExpertRouter().select(TaskKind.COORD_AUDIT)
+        assert ExpertName.COORDINATION in r
+        assert ExpertName.RISK_RULES in r
 
 
 class TestRiskExpert:
@@ -80,6 +89,27 @@ class TestRiskExpert:
         assert fake_value not in " ".join(o.findings)
         assert "[REDACTED]" in " ".join(o.findings)
 
+    def test_live_capital_veto(self):
+        o = RiskRulesExpert().evaluate(
+            PanelInput(kind=TaskKind.PR_AUDIT, text="deploy live capital now")
+        )
+        assert o.veto is True
+
+    def test_halt_tamper_veto(self):
+        o = RiskRulesExpert().evaluate(
+            PanelInput(kind=TaskKind.PR_AUDIT, text="rm data/TRADING_HALTED")
+        )
+        assert o.veto is True
+
+    def test_llm_trade_council_veto(self):
+        o = RiskRulesExpert().evaluate(
+            PanelInput(
+                kind=TaskKind.PR_AUDIT,
+                text="llm council approves the trade for entry",
+            )
+        )
+        assert o.veto is True
+
 
 class TestEvidenceExpert:
     def test_unverified_edge_claim_vetoes(self):
@@ -96,7 +126,10 @@ class TestEvidenceExpert:
         o = EvidenceExpert().evaluate(
             PanelInput(
                 kind=TaskKind.CLAIM_AUDIT,
-                text="CI green on run 30780143772 merge sha d69beb2b6ec419b8 n=162 expectancy=-47",
+                text=(
+                    "CI green on run 30780143772 merge sha d69beb2b6ec419b8 "
+                    "n=162 expectancy=-47"
+                ),
             )
         )
         assert o.passed is True
@@ -111,6 +144,21 @@ class TestEvidenceExpert:
         )
         assert o.passed is False
         assert o.veto is True
+
+    def test_no_claims_passes(self):
+        o = EvidenceExpert().evaluate(
+            PanelInput(kind=TaskKind.CLAIM_AUDIT, text="docs only, no status claim")
+        )
+        assert o.passed is True
+        assert o.score == 1.0
+
+    def test_soft_claim_without_edge_fails_not_veto(self):
+        # "shipped" is a claim marker but not edge-like → fail without veto
+        o = EvidenceExpert().evaluate(
+            PanelInput(kind=TaskKind.CLAIM_AUDIT, text="Feature shipped to users")
+        )
+        assert o.passed is False
+        assert o.veto is False
 
 
 class TestCoordExpert:
@@ -135,10 +183,12 @@ class TestCoordExpert:
                 agent="grok",
                 claimed_files=["src/evals/judge_panel/panel.py"],
                 other_agent_claims=(
-                    "codex In Progress IGO-35 trading cleanup claimed_files: scripts/audit_open_inventory.py"
+                    "codex In Progress IGO-35 trading cleanup "
+                    "claimed_files: scripts/audit_open_inventory.py"
                 ),
             )
         )
+        # Soft foreign trading warning but still passed
         assert o.passed is True
         assert o.veto is False
 
@@ -156,6 +206,25 @@ class TestCoordExpert:
         assert o.passed is False
         assert o.veto is True
 
+    def test_empty_claims_limited_check(self):
+        o = CoordinationExpert().evaluate(
+            PanelInput(kind=TaskKind.COORD_AUDIT, agent="grok")
+        )
+        assert o.passed is True
+        assert "coord:no_foreign_claims" in o.evidence_cites
+
+    def test_clean_when_no_in_progress(self):
+        o = CoordinationExpert().evaluate(
+            PanelInput(
+                kind=TaskKind.COORD_AUDIT,
+                agent="grok",
+                claimed_files=["src/foo.py"],
+                other_agent_claims="codex finished yesterday on other work",
+            )
+        )
+        assert o.passed is True
+        assert o.veto is False
+
 
 class TestPanel:
     def test_veto_cannot_be_overridden_by_narrative(self):
@@ -172,6 +241,24 @@ class TestPanel:
         assert v.vetoed is True
         assert "narrative_stripped_false_pass" in v.judge_summary or not v.passed
 
+    def test_honest_narrative_kept_on_pass(self):
+        def ok_narrative(summary, opinions):
+            return "PASS: experts agree on docs-only change"
+
+        v = JudgePanel(narrative_fn=ok_narrative).run(
+            PanelInput(kind=TaskKind.CLAIM_AUDIT, text="docs only")
+        )
+        assert v.passed is True
+        assert "experts agree" in v.judge_summary
+
+    def test_missing_expert_vetoes(self):
+        v = JudgePanel(experts={}).run(
+            PanelInput(kind=TaskKind.CLAIM_AUDIT, text="docs only")
+        )
+        assert v.passed is False
+        assert v.vetoed is True
+        assert any("missing expert" in r for r in v.veto_reasons)
+
     def test_run_panel_convenience(self):
         v = run_panel(
             TaskKind.CLAIM_AUDIT,
@@ -181,12 +268,53 @@ class TestPanel:
         assert "evidence" in v.experts_used
         assert "risk_rules" in v.experts_used
 
+    def test_run_panel_string_kind(self):
+        v = run_panel("trade_entry", text="buy")
+        assert v.kind is TaskKind.TRADE_ENTRY
+        assert v.passed is False
+
     def test_to_dict_serializable(self):
         v = run_panel(TaskKind.TRADE_ENTRY, text="enter")
         d = v.to_dict()
         json.dumps(d)
         assert d["passed"] is False
         assert d["vetoed"] is True
+
+    def test_re_claims_pass_helpers(self):
+        assert re_claims_pass("") is False
+        assert re_claims_pass("PASS: ok") is True
+        assert re_claims_pass("panel pass confirmed") is True
+        assert re_claims_pass("FAIL: no") is False
+
+
+class TestSafeRead:
+    def test_safe_read_allows_repo_file(self, tmp_path):
+        # Import from script module path
+        sys.path.insert(0, str(ROOT / "scripts"))
+        import judge_panel as cli  # type: ignore
+
+        target = ROOT / "scripts" / "judge_panel.py"
+        text = cli.safe_read_text(str(target), roots=(ROOT,))
+        assert "safe_read_text" in text or "Judge panel" in text
+
+    def test_safe_read_rejects_outside_root(self, tmp_path):
+        sys.path.insert(0, str(ROOT / "scripts"))
+        import judge_panel as cli  # type: ignore
+
+        outsider = tmp_path / "secret.txt"
+        outsider.write_text("leak", encoding="utf-8")
+        try:
+            cli.safe_read_text(str(outsider), roots=(ROOT,))
+            raise AssertionError("expected SystemExit")
+        except SystemExit as exc:
+            assert "outside allowed roots" in str(exc)
+
+    def test_safe_read_empty_path(self):
+        sys.path.insert(0, str(ROOT / "scripts"))
+        import judge_panel as cli  # type: ignore
+
+        assert cli.safe_read_text(None) == ""
+        assert cli.safe_read_text("") == ""
 
 
 class TestCLI:
@@ -222,3 +350,32 @@ class TestCLI:
         assert proc.returncode == 2
         data = json.loads(proc.stdout)
         assert data["passed"] is False
+
+    def test_cli_reads_diff_file_under_repo(self, tmp_path):
+        # write under repo root via relative path in cwd
+        diff = ROOT / "artifacts"
+        diff.mkdir(exist_ok=True)
+        f = diff / "judge_panel_test.diff"
+        f.write_text("+ open new iron condor\n", encoding="utf-8")
+        try:
+            script = ROOT / "scripts" / "judge_panel.py"
+            proc = subprocess.run(
+                [
+                    sys.executable,
+                    str(script),
+                    "--kind",
+                    "pr_audit",
+                    "--diff-file",
+                    str(f),
+                    "--json",
+                ],
+                cwd=str(ROOT),
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            assert proc.returncode == 2
+            data = json.loads(proc.stdout)
+            assert data["vetoed"] is True
+        finally:
+            f.unlink(missing_ok=True)


### PR DESCRIPTION
## Summary
Closes Sonar quality-gate failures from #4327:

| Gate | Was | Fix |
|------|-----|-----|
| Security Rating | C (S8707 path traversal on CLI reads) | `safe_read_text()` allowlisted roots only |
| Coverage new code | 73% (<80%) | Expanded unit tests (35 pass, ~97% local on package) |
| Cognitive complexity / smells | panel nested ternaries, dict() | Helpers + literals |

## Evidence
- Computer Use: Sonar PR 4327 dashboard showed **Quality gate Failed** — Security C + Coverage 73%
- Local: `pytest tests/test_judge_panel.py` → 35 passed
- Local coverage on `src/evals/judge_panel` + script ≈ 97%

## Test plan
- [x] Local pytest + self-check
- [ ] CI Run All Tests
- [ ] SonarCloud Code Analysis on this PR (expect security A + coverage ≥80% on new lines)