### PR TITLE
fix(evidence): quarantine unverified reconstructed put-credits

### DIFF
--- a/data/put_credit_entries.json
+++ b/data/put_credit_entries.json
@@ -114,7 +114,7 @@
     },
     "structure": "bull_put_credit",
     "submitted_at": "2026-07-24T16:58:19.748755+00:00",
-    "validation_phase": true,
+    "validation_phase": false,
     "exit_reason": "profit_target",
     "exit_submitted_at": "2026-08-03T15:55:00.459888+00:00",
     "estimated_exit_debit": 0.26,
@@ -130,6 +130,7 @@
       "note": "Counterfactuals only \u2014 system still exits at profile TP 25% / exit_dte=7. Used to compare our rules to public 50%/21-DTE research without re-running history."
     },
     "exit_order_id": "3310d412-8ec4-4e91-9a6f-123366586a4a",
-    "exit_filled_at": "2026-08-03T16:48:41.592843+00:00"
+    "exit_filled_at": "2026-08-03T16:48:41.592843+00:00",
+    "evidence_note": "broker_reconstructed_unverified: excluded from protocol validation cohort"
   }
 }

--- a/data/trades.json
+++ b/data/trades.json
@@ -6383,7 +6383,7 @@
       "put_delta": null,
       "selection_method": "broker_reconstructed_unverified",
       "profile_name": "spy-put-credit",
-      "validation_phase": true,
+      "validation_phase": false,
       "strikes": {
         "short_put": 712.0,
         "long_put": 707.0
@@ -6399,7 +6399,8 @@
         "exit": ["3310d412-8ec4-4e91-9a6f-123366586a4a"]
       },
       "journal_key": "PCS_260828_fb85cfe193c14511868bd0e1b0a59220",
-      "evidence_source": "broker_paired_put_credit_journal"
+      "evidence_source": "broker_paired_put_credit_journal",
+      "evidence_note": "broker_reconstructed_unverified: filled order missing durable journal; excluded from protocol validation cohort"
     }
   ]
 }

--- a/src/analytics/trade_evidence.py
+++ b/src/analytics/trade_evidence.py
@@ -307,7 +307,20 @@ def build_trade_evidence(
             if protocol_reasons:
                 for reason in set(protocol_reasons):
                     rejected[reason] += 1
-                invalid_candidate_rows += 1
+                selection = str(
+                    raw.get("selection_method") or raw.get("strike_selection_method") or ""
+                ).lower()
+                # Explicit broker reconstructions are inventory truth, not clean
+                # validation cohort. Quarantine them as warnings so one unrecovered
+                # fill cannot mark the whole verified-evidence surface BROKEN.
+                if "unverified" in selection or "reconstruct" in selection:
+                    rejected["broker_reconstructed_unverified"] += 1
+                    warnings.append(
+                        "quarantined_unverified_reconstruction:"
+                        f"{trade_id}:{','.join(sorted(set(protocol_reasons)))}"
+                    )
+                else:
+                    invalid_candidate_rows += 1
                 continue
 
         normalized = dict(raw)

--- a/tests/test_trade_evidence.py
+++ b/tests/test_trade_evidence.py
@@ -144,6 +144,38 @@ def test_invalid_protocol_row_is_quarantined_and_blocks_learning() -> None:
     assert not evidence.learning_ready
 
 
+def test_broker_reconstructed_unverified_is_warning_not_issue() -> None:
+    """Reconstructed fills stay quarantined without red-lighting evidence health."""
+    payload = {
+        "trades": [
+            _put_credit_row(
+                id="PCS-recon",
+                selection_method="broker_reconstructed_unverified",
+                put_delta=None,
+                validation_phase=False,
+            ),
+            _put_credit_row(
+                id="PCS-good",
+                selection_method="live_delta_band_scan",
+                put_delta=0.1843,
+            ),
+        ],
+        "stats": {"closed_trades": 2, "total_realized_pnl": 150},
+    }
+
+    evidence = build_trade_evidence(
+        payload,
+        strategy_family="spy_put_credit",
+        require_protocol_fields=True,
+    )
+
+    assert [row["id"] for row in evidence.rows] == ["PCS-good"]
+    assert evidence.rejected_by_reason["broker_reconstructed_unverified"] == 1
+    assert any("quarantined_unverified_reconstruction" in w for w in evidence.warnings)
+    assert not any("failed evidence validation" in issue for issue in evidence.issues)
+    assert evidence.learning_ready
+
+
 def test_outcome_mismatch_and_duplicate_ids_are_rejected() -> None:
     first = _put_credit_row(outcome="loss")
     duplicate = deepcopy(first)


### PR DESCRIPTION
# Pull request

## Work item

- Linear issue: AGENT-70
- Agent: grok
- Base SHA: 02a5070198f5e013f5b4f50b6784c76bb967ecb6
- Branch/worktree: fix/agent-70-quarantine-unverified-pc (.worktrees/agent-70-evidence-quarantine)
- Files or systems claimed: src/analytics/trade_evidence.py, data/trades.json, data/put_credit_entries.json, tests/test_trade_evidence.py
- Coordination legacy reason:

## Change

- Scope: system_health_check Verified Trade Evidence was BROKEN because one broker_reconstructed_unverified put-credit failed protocol (no live delta). Quarantine those as warnings; keep verified cohort learning_ready.
- Data honesty: set validation_phase=false on reconstructed PCS_fb85…
- Out of scope: fabricating missing short delta

## Verification

- [x] pytest tests/test_trade_evidence.py (7 passed)
- [x] check_win_rate_validity status OK (1 verified cohort row)
- [ ] CI green on this exact head SHA

## Coordination

- [x] Linear issue and vault claim updated
- [x] No overlapping active claim or worktree
- [x] Claim will be marked done or released after merge