### PR TITLE
fix(rag): production path truth (defended sources + put-credit guard)

### DIFF
--- a/docs/RAG_QUALITY_SCORECARD.md
+++ b/docs/RAG_QUALITY_SCORECARD.md
@@ -1,7 +1,27 @@
 # Trading RAG quality scorecard (AGENT-70 A+ platform)
 
-**Updated:** 2026-08-03  
+**Updated:** 2026-08-04  
 **Scope:** Paper SPY put-credit lab — not multi-tenant SaaS, not live HFT.
+
+**Honesty:** Architecture A+ (capability matrix + `verify_rag_aplus.py`) is **not** the same
+as measured holdout A+ (`scripts/evaluate_rag.py`) or trading edge (n≥30 paired closes).
+Webhook/LessonsLearnedRAG default to **defended** retrieval; LanceDB is fallback only.
+Re-run evaluate_rag after retrieval changes; do not copy stale bake-off numbers.
+
+## Measured holdout (lab eval) (fresh 2026-08-04, tip of main worktree)
+
+Re-run: `python scripts/evaluate_rag.py` on 10 default queries, k=5, ~174 lessons.
+
+| Metric                   |      Value | Lab A+ gate |    Stretch |
+| ------------------------ | ---------: | ----------: | ---------: |
+| Precision@5              | **0.5600** |  ≥0.40 PASS | ≥0.50 PASS |
+| Recall@5                 | **0.7200** |  ≥0.60 PASS | ≥0.75 FAIL |
+| MRR                      | **0.9500** |  ≥0.50 PASS | ≥0.80 PASS |
+| nDCG@5                   | **0.7294** |  ≥0.55 PASS | ≥0.80 FAIL |
+| Queries with ≥1 relevant |      10/10 |           — |          — |
+| Graph golden             |    **5/5** |           — |          — |
+
+**Lab grade (script gates): A+.** Stretch A+ not claimed (recall/nDCG).
 
 RAG quality reduces preventable operational errors. It does **not** create a
 trading edge and does **not** prove $1,000–$6,000/month after tax. That outcome

--- a/rag_knowledge/lessons_learned/LL-365-rag-prod-path-source-truth.md
+++ b/rag_knowledge/lessons_learned/LL-365-rag-prod-path-source-truth.md
@@ -1,0 +1,21 @@
+# LL-365: RAG production path source labels must match runtime
+
+**Severity**: HIGH  
+**Date**: 2026-08-04  
+**Tags**: `rag`, `webhook`, `defended`, `honesty`
+
+## What happened
+
+Docs and webhook still claimed LanceDB-first while `LessonsLearnedRAG.query` defaulted to
+defended `retrieve_for_trade`. Response headers could mislabel retrieval source.
+
+## Prevention
+
+1. Source-aware response headers (`defended` | `pipeline` | `lancedb` | `keyword`).
+2. RAGSafetyGuard queries put-credit by default (not iron condor).
+3. Scorecard separates architecture A+, lab holdout A+, stretch A+, trading edge.
+4. Re-run `evaluate_rag.py` after retrieval changes; never invent metrics.
+
+## Sensitivity
+
+operator

--- a/src/agents/rag_webhook.py
+++ b/src/agents/rag_webhook.py
@@ -17,12 +17,13 @@ Version History:
 - v3.7.0 Jan 16, 2026: Fix trades_loaded=0 - check system_state.json for trade_history
 - v3.9.0 Jan 16, 2026: Fix trade data source priority - system_state.json FIRST (Alpaca source of truth)
 
-Architecture (v3.0.0):
-- Primary: LanceDB local semantic search
-- Fallback: Keyword-based search
+Architecture (v3.10 / AGENT-70):
+- Primary: defended retrieve_for_trade (FTS5 + hybrid + multi-query + rerank + ACL + OOD)
+  via LessonsLearnedRAG when TRADING_RAG_DEFENDED=true (default)
+- Fallback: TradingRAGPipeline → LanceDB (if available) → keyword
+- Do not claim LanceDB when last_source is defended/pipeline/keyword
 
-CEO Directive: "I want to be able to ask about my trades and get accurate information"
-requires semantic search.
+CEO Directive: accurate trade/lesson answers; no fabricated edge claims.
 """
 
 from __future__ import annotations
@@ -121,7 +122,7 @@ def get_local_rag() -> LessonsLearnedRAG:
     if local_rag is None:
         local_rag = LessonsLearnedRAG()
         logger.info(
-            "RAG initialized with %s lessons (LanceDB-first, keyword fallback)",
+            "RAG initialized with %s lessons (defended-first → pipeline → LanceDB → keyword)",
             len(local_rag.lessons),
         )
     return local_rag
@@ -129,16 +130,29 @@ def get_local_rag() -> LessonsLearnedRAG:
 
 def query_rag_hybrid(query: str, top_k: int = 5) -> tuple[list, str]:
     """
-    Query RAG using LanceDB-first retrieval with keyword fallback.
+    Query RAG via LessonsLearnedRAG (defended retrieve_for_trade first by default).
 
     Returns:
-        Tuple of (results_list, source_name)
+        Tuple of (results_list, source_name) where source is one of:
+        defended | pipeline | lancedb | keyword | none
     """
     rag = get_local_rag()
     results = rag.query(query, top_k=top_k)
     source = rag.last_source or "keyword"
-    logger.info(f"RAG returned {len(results)} results (source={source})")
+    logger.info("RAG returned %s results (source=%s)", len(results), source)
     return results, source
+
+
+def _source_header(source: str) -> str:
+    """Human-readable source label — never claim LanceDB when path was defended."""
+    labels = {
+        "defended": "Based on defended trading retrieval (FTS5 + hybrid + rerank):\n",
+        "pipeline": "Based on TradingRAGPipeline hybrid index:\n",
+        "lancedb": "Based on our semantic index (LanceDB):\n",
+        "keyword": "Based on our keyword index:\n",
+        "none": "Based on RAG (source unknown):\n",
+    }
+    return labels.get((source or "keyword").lower(), f"Based on RAG source={source}:\n")
 
 
 def format_rag_response(results: list, query: str, source: str) -> str:
@@ -149,13 +163,7 @@ def format_rag_response(results: list, query: str, source: str) -> str:
             "Try searching for: trading, risk, CI, RAG, verification, or operational."
         )
 
-    response_parts = []
-    header = (
-        "Based on our semantic index (LanceDB):\n"
-        if source == "lancedb"
-        else "Based on our keyword index:\n"
-    )
-    response_parts.append(header)
+    response_parts = [_source_header(source)]
 
     for lesson in results:
         lesson_id = lesson.get("id", "unknown")
@@ -2255,7 +2263,7 @@ Please check directly:
 Or ask me about **lessons learned** instead (e.g., "What lessons did we learn about risk management?")"""
                         logger.warning("Trade query but no portfolio data available")
         else:
-            # Query RAG system for relevant lessons (LanceDB-first)
+            # Query RAG system for relevant lessons (defended-first)
             results, source = query_rag_hybrid(user_query, top_k=5)
 
             if not results:
@@ -2339,7 +2347,7 @@ async def root():
         "rag_last_source": rag.last_source,
         "endpoints": {
             "/webhook": "POST - RAG Webhook (lessons + trades + readiness)",
-            "/rag-search": "POST - RAG search (LanceDB-first, JSON response)",
+            "/rag-search": "POST - RAG search (defended-first, JSON response)",
             "/portfolio-status": "GET - Broker-backed portfolio snapshot for dashboard/status surfaces",
             "/health": "GET - Health check",
             "/diagnostics": "GET - Detailed diagnostic info for debugging",

--- a/src/rag/lessons_learned_rag.py
+++ b/src/rag/lessons_learned_rag.py
@@ -1,6 +1,10 @@
-"""Lessons learned RAG with LanceDB-first retrieval and keyword fallback.
+"""Lessons learned RAG with defended-first retrieval and layered fallback.
 
-Updated Feb 9, 2026: LanceDB-first semantic retrieval with keyword fallback.
+Default path (TRADING_RAG_DEFENDED=true):
+  retrieve_for_trade (FTS5 + hybrid + multi-query + rerank + ACL + OOD)
+  → TradingRAGPipeline → LanceDB (optional) → keyword.
+
+Updated Aug 4, 2026: docs match runtime; do not claim LanceDB when source=defended.
 """
 
 import logging
@@ -30,7 +34,7 @@ except ImportError:
 
 
 class LessonsLearnedRAG:
-    """RAG for lessons learned with LanceDB-first retrieval."""
+    """RAG for lessons learned: defended retrieve_for_trade first, then fallbacks."""
 
     def __init__(self, knowledge_dir: Optional[str] = None):
         self.knowledge_dir = Path(knowledge_dir or "rag_knowledge/lessons_learned")
@@ -39,7 +43,7 @@ class LessonsLearnedRAG:
         self.last_source = "none"
         self.last_retrieve_meta: dict = {}
 
-        # LanceDB-first retrieval (semantic)
+        # Optional LanceDB semantic fallback (not the default path)
         self.lancedb_rag = None
 
         # --- TradingRAGPipeline backend (FTS5 + bigram-Jaccard + CE rerank) ---

--- a/src/safety/rag_safety_guard.py
+++ b/src/safety/rag_safety_guard.py
@@ -1,62 +1,120 @@
 """
 RAG-Backed Safety Guard - Step 6 of Strategy Upgrade.
-Uses historical lessons to provide a 'soft' veto or warning on current trade parameters.
+Uses historical lessons to provide a soft veto or warning on current trade parameters.
+
+Active family is spy_put_credit (IC new entries killed). Queries must not default to
+iron-condor playbooks.
 """
+
+from __future__ import annotations
 
 import logging
 from typing import Any
-
-from src.rag.rag_pipeline import get_trading_rag_pipeline
 
 logger = logging.getLogger(__name__)
 
 
 class RAGSafetyGuard:
-    """Consults the RAG database for similar past incidents before entry.
+    """Consults the RAG corpus for similar past incidents before entry.
 
-    Uses TradingRAGPipeline with SQLite FTS5 + bigram-Jaccard hybrid + cross-encoder
-    reranking for robust lesson retrieval.
+    Prefer defended retrieve_for_trade (FTS5 + hybrid + ACL + OOD). Soft warning only —
+    hard risk rejection remains TradeGateway.
     """
 
-    def __init__(self):
-        self.pipeline = get_trading_rag_pipeline()
+    def __init__(self) -> None:
+        self.last_source = "none"
+        self.last_meta: dict[str, Any] = {}
 
-    def check_safety(self, symbol: str, vix: float, iv: float) -> dict[str, Any]:
+    def check_safety(
+        self,
+        ticker: str,
+        vix: float,
+        iv: float,
+        *,
+        strategy_family: str = "spy_put_credit",
+    ) -> dict[str, Any]:
         """
-        Query RAG for similar volatility regimes and return risk assessment.
+        Query RAG for similar volatility / risk regimes and return risk assessment.
         """
-        query = f"SPY iron condor risk at VIX {vix:.1f} and IV {iv:.1%}."
+        t = (ticker or "SPY").upper()
+        # Active validation family: put-credit; residual IC only for exit-only inventory context
+        if strategy_family in {"iron_condor", "ic", "ic_simple"}:
+            query = (
+                f"{t} residual iron condor exit risk at VIX {vix:.1f} and IV {iv:.1%}. "
+                "inventory hygiene stop loss orphan legs"
+            )
+        else:
+            query = (
+                f"{t} put credit spread risk at VIX {vix:.1f} and IV {iv:.1%}. "
+                "stop loss inventory sizing kill switch"
+            )
+            strategy_family = "spy_put_credit"
+
         try:
-            results = self.pipeline.query(query=query, top_k=3, rerank=True)
+            from src.rag.retrieve_for_trade import retrieve_for_trade
 
-            if not results:
-                return {"veto": False, "reason": "No similar historical data found."}
+            defended = retrieve_for_trade(
+                query,
+                top_k=3,
+                strategy_family=strategy_family,
+                use_llm_rerank=False,
+                parent_expand=True,
+            )
+            self.last_source = "defended"
+            self.last_meta = dict(defended.meta or {})
+            results = defended.lessons
+        except Exception as primary_exc:
+            logger.warning("Defended safety RAG failed (%s); falling back to pipeline", primary_exc)
+            try:
+                from src.rag.rag_pipeline import get_trading_rag_pipeline
 
-            # Simple logic: if any retrieved lesson has 'CRITICAL' or 'FAILURE' in content
-            # and matches the regime, we flag a warning.
-            warnings = []
-            for doc in results:
-                content = (doc.get("content_snippet", "") or doc.get("content", "") or "").upper()
-                # Check severity from the lesson record
-                severity = str(doc.get("severity", "")).upper()
-                if (
-                    "FAILURE" in content
-                    or "LOSS" in content
-                    or "CRITICAL" in content
-                    or severity in ("CRITICAL", "HIGH")
-                ):
-                    warnings.append(doc.get("id", "Unknown Lesson"))
-
-            if warnings:
+                results = get_trading_rag_pipeline().query(query=query, top_k=3, rerank=True)
+                self.last_source = "pipeline"
+                self.last_meta = {"fallback_from": str(primary_exc)}
+            except Exception as e:
+                logger.error("RAG safety check failed: %s", e)
                 return {
-                    "veto": False,  # Soft veto (warning)
-                    "warning": True,
-                    "reason": f"Historical parallels found in lessons: {', '.join(warnings)}",
-                    "lessons": warnings,
+                    "veto": False,
+                    "warning": False,
+                    "reason": f"Safety check error: {e}",
+                    "source": "error",
                 }
 
-            return {"veto": False, "warning": False, "reason": "No immediate historical red flags."}
+        if not results:
+            return {
+                "veto": False,
+                "warning": False,
+                "reason": "No similar historical data found.",
+                "source": self.last_source,
+            }
 
-        except Exception as e:
-            logger.error(f"RAG safety check failed: {e}")
-            return {"veto": False, "reason": f"Safety check error: {e}"}
+        warnings: list[str] = []
+        for doc in results:
+            content = (doc.get("content_snippet", "") or doc.get("content", "") or "").upper()
+            severity = str(doc.get("severity", "")).upper()
+            if (
+                "FAILURE" in content
+                or "LOSS" in content
+                or "CRITICAL" in content
+                or severity in ("CRITICAL", "HIGH")
+            ):
+                warnings.append(str(doc.get("id", "Unknown Lesson")))
+
+        if warnings:
+            return {
+                "veto": False,  # Soft veto (warning); hard block is TradeGateway
+                "warning": True,
+                "reason": f"Historical parallels found in lessons: {', '.join(warnings)}",
+                "lessons": warnings,
+                "source": self.last_source,
+                "strategy_family": strategy_family,
+                "path": self.last_meta.get("path"),
+            }
+
+        return {
+            "veto": False,
+            "warning": False,
+            "reason": "No immediate historical red flags.",
+            "source": self.last_source,
+            "strategy_family": strategy_family,
+        }

--- a/tests/test_rag_prod_path_truth.py
+++ b/tests/test_rag_prod_path_truth.py
@@ -1,0 +1,57 @@
+"""Production path honesty: source labels and put-credit safety guard."""
+
+from __future__ import annotations
+
+from src.agents.rag_webhook import _source_header, format_rag_response
+from src.safety.rag_safety_guard import RAGSafetyGuard
+
+
+def test_source_header_never_claims_lancedb_for_defended():
+    assert "defended" in _source_header("defended").lower()
+    assert "lancedb" not in _source_header("defended").lower()
+    assert "lancedb" in _source_header("lancedb").lower()
+    assert "keyword" in _source_header("keyword").lower()
+
+
+def test_format_rag_response_uses_source_label():
+    text = format_rag_response(
+        [{"id": "LL-1", "severity": "HIGH", "content": "stop at 200% credit"}],
+        "stop loss",
+        "defended",
+    )
+    assert "defended" in text.lower()
+    assert "LanceDB" not in text
+    assert "LL-1" in text
+
+
+def test_safety_guard_put_credit_query_not_iron_condor_default(monkeypatch):
+    captured: dict = {}
+
+    def fake_retrieve(query, **kwargs):
+        captured["query"] = query
+        captured["kwargs"] = kwargs
+
+        class R:
+            lessons = [
+                {
+                    "id": "LL-test",
+                    "severity": "CRITICAL",
+                    "content": "CRITICAL stop loss inventory failure",
+                }
+            ]
+            meta = {"path": "fts+hybrid+acl"}
+
+        return R()
+
+    monkeypatch.setattr(
+        "src.rag.retrieve_for_trade.retrieve_for_trade",
+        fake_retrieve,
+    )
+
+    guard = RAGSafetyGuard()
+    out = guard.check_safety("SPY", 18.0, 0.15)
+    assert "put credit" in captured["query"].lower()
+    assert "iron condor" not in captured["query"].lower()
+    assert captured["kwargs"].get("strategy_family") == "spy_put_credit"
+    assert out.get("warning") is True
+    assert out.get("source") == "defended"


### PR DESCRIPTION
# Pull request

## Work item

- Linear issue: AGENT-70
- Agent: grok
- Base SHA: 7a7ddf82a79458a3be8dbef26a85a41ef6945236
- Branch/worktree: feat/agent-70-rag-prod-harden (.worktrees/agent-70-rag-prod-harden)
- Files or systems claimed: src/agents/rag_webhook.py, src/rag/lessons_learned_rag.py, src/safety/rag_safety_guard.py, docs/RAG_QUALITY_SCORECARD.md
- Coordination legacy reason: follow-through on #4359 honesty gaps

## Change

- Scope: Stop claiming LanceDB-first when runtime is defended retrieve_for_trade; source-aware headers; put-credit safety guard query; publish measured holdout numbers
- Out of scope: stretch holdout A+; Cloud Run redeploy; trading edge

## Verification

- [x] verify_rag_aplus.py PASS (architecture 10.0)
- [x] evaluate_rag.py lab A+ gates: P@5=0.56 R@5=0.72 MRR=0.95 nDCG@5=0.73
- [x] verify_graph_rag.py 5/5
- [x] pytest test_rag_prod_path_truth + test_rag_aplus_platform (16 passed)
- [ ] CI green on this exact head SHA (6db4086636815cf49b86670eace5e02e65ce1d98)

## Evidence boundaries

- Test result: 16 passed local
- Measured retrieval: lab A+ only; stretch recall/nDCG not met
- Broker/order/fill impact: none

## Coordination

- [x] Linear issue and vault claim updated
- [x] No overlapping active claim or worktree
- [x] Claim will be marked done or released after merge
<!-- revalidate 2026-08-04T15:42Z -->
