### PR TITLE
fix(risk): name the market data feed in the regime average fetch [AGENT-260]

### DIFF
--- a/.github/workflows/put-credit-validation.yml
+++ b/.github/workflows/put-credit-validation.yml
@@ -167,8 +167,8 @@ jobs:
           else
             # Paper MLEG only — live blocked by strategy_kill_switch.json
             python3 scripts/spy_put_credit.py --execute-paper || {
-              echo "Put-credit entry skipped or no opportunity (exit 0 so workflow continues)"
-              true
+              echo "::error::entry attempt failed - no trade was evaluated"
+              exit 1
             }
           fi
 

--- a/.github/workflows/put-credit-validation.yml
+++ b/.github/workflows/put-credit-validation.yml
@@ -167,8 +167,8 @@ jobs:
           else
             # Paper MLEG only — live blocked by strategy_kill_switch.json
             python3 scripts/spy_put_credit.py --execute-paper || {
-              echo "::error::entry attempt failed - no trade was evaluated"
-              exit 1
+              echo "Put-credit entry skipped or no opportunity (exit 0 so workflow continues)"
+              true
             }
           fi
 

--- a/src/risk/put_credit_regime.py
+++ b/src/risk/put_credit_regime.py
@@ -74,6 +74,12 @@ def _spy_sma_200(spy_price: float | None) -> tuple[float | None, bool | None, st
             timeframe=TimeFrame.Day,
             start=start,
             end=end,
+            # Without an explicit feed the SDK falls back to a data tier this account
+            # is not entitled to. Every request failed, the 200-day average came back
+            # None, and fail_closed_on_missing correctly refused every entry -- for 12
+            # days, while the scheduled check reported success. Mirrors
+            # src/utils/market_data.py, which already defaults to iex.
+            feed=os.getenv("ALPACA_DATA_FEED", "iex"),
         )
         bars = client.get_stock_bars(req)
         rows = bars.data.get("SPY") if hasattr(bars, "data") else None

--- a/tests/test_put_credit_regime_feed.py
+++ b/tests/test_put_credit_regime_feed.py
@@ -1,0 +1,84 @@
+"""The regime average fetch must name its market data feed explicitly.
+
+Regression for AGENT-260. Omitting `feed` let the SDK fall back to a data tier this
+account is not entitled to. Every request failed, the 200-day average returned None,
+and `fail_closed_on_missing` correctly refused every entry -- silently, for 12 days,
+while the scheduled check reported success.
+
+The assertion is on the request kwargs, not on a live call: the defect was a missing
+argument, so the argument is what the test pins.
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+
+import pytest
+
+from src.risk import put_credit_regime
+
+
+@pytest.fixture
+def captured(monkeypatch):
+    """Stub the Alpaca SDK and capture the bar-request kwargs."""
+    seen: dict = {}
+
+    class FakeBarsRequest:
+        def __init__(self, **kwargs):
+            seen.update(kwargs)
+
+    class FakeBar:
+        close = 100.0
+
+    class FakeClient:
+        def __init__(self, *a, **k):
+            pass
+
+        def get_stock_bars(self, req):
+            return types.SimpleNamespace(data={"SPY": [FakeBar() for _ in range(250)]})
+
+    monkeypatch.setitem(
+        sys.modules,
+        "alpaca.data.historical",
+        types.SimpleNamespace(StockHistoricalDataClient=FakeClient),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "alpaca.data.requests",
+        types.SimpleNamespace(StockBarsRequest=FakeBarsRequest),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "alpaca.data.timeframe",
+        types.SimpleNamespace(TimeFrame=types.SimpleNamespace(Day="1Day")),
+    )
+    monkeypatch.setattr(
+        put_credit_regime,
+        "get_alpaca_credentials",
+        lambda: ("k", "s"),
+        raising=False,
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "src.utils.alpaca_client",
+        types.SimpleNamespace(get_alpaca_credentials=lambda: ("k", "s")),
+    )
+    return seen
+
+
+def test_request_names_its_feed_explicitly(captured, monkeypatch) -> None:
+    monkeypatch.delenv("ALPACA_DATA_FEED", raising=False)
+    sma, above, err = put_credit_regime._spy_sma_200(100.0)
+
+    assert err is None, f"unexpected error: {err}"
+    assert "feed" in captured, "request omitted feed; SDK would fall back to an unentitled tier"
+    assert captured["feed"] == "iex"
+    assert sma == pytest.approx(100.0)
+    assert above is True
+
+
+def test_feed_is_overridable_by_env(captured, monkeypatch) -> None:
+    monkeypatch.setenv("ALPACA_DATA_FEED", "sip")
+    put_credit_regime._spy_sma_200(100.0)
+    assert captured["feed"] == "sip", "operator override must be honoured"


### PR DESCRIPTION
- Linear issue: AGENT-260
- Branch/worktree: fix/AGENT-260-regime-feed (.worktrees/agent-260-regime-feed)
- Base SHA: 2d31843e2341e9b785d77155292c75f6677dd778
- Files or systems claimed: src/risk/put_credit_regime.py, tests/test_put_credit_regime_feed.py
- Agent: claude-code

- [x] Linear issue and vault claim updated
- [x] No overlapping active claim or worktree

## The entry path was dead for 12 days, reporting success

`_spy_sma_200()` built its bar request without an explicit `feed`, so the SDK fell back to a data tier this account is not entitled to. Every request failed, the 200-day average returned `None`, and `fail_closed_on_missing` correctly refused every entry.

The strategy journal holds 2 entries total, both from 2026-07-23/24, none since. `EDGE_N_MIN = 30` in the bank live gate was being evaluated against a cohort that could not grow.

`src/utils/market_data.py` already resolves this via `os.getenv("ALPACA_DATA_FEED", "iex")`. The call sites had drifted; this aligns them.

## Verification

- Negative control: removing the argument fails both new tests; restoring passes
- 134 regime tests green; Run All Tests green in CI
- ruff check + format clean; trunk reports no new issues

## Not fixed here

The workflow swallows a failed entry into exit 0. I attempted that and reverted it (6e1e32f45): exit code 2 currently means both "evaluated and declined" and "could not evaluate", so failing on 2 would go red on every legitimate no-trade day. Correct fix is a distinct code when source_errors is populated. Separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NpoFEQ1XYAV9XvXpCpPq7q