### PR TITLE
feat(rag): temporal trade graph + provenance fixes across retrieval

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,10 @@ coverage:
 
 audit:
 	$(VENV_PYTHON) scripts/audit_repository_hygiene.py --check
+	$(VENV_PYTHON) scripts/check_exit_reason_coverage.py
+
+graph:
+	$(VENV_PYTHON) scripts/trade_graph.py --build
 
 security:
 	$(VENV_PYTHON) -m pip_audit
@@ -46,6 +50,7 @@ skill-check:
 check: lint audit security skill-check test
 
 dry-run: health
+	$(VENV_PYTHON) scripts/check_exit_reason_coverage.py
 	$(VENV_PYTHON) scripts/spy_put_credit.py --dry-run
 	$(VENV_PYTHON) scripts/residual_ic_manager.py --dry-run
 

--- a/data/rag/.gitignore
+++ b/data/rag/.gitignore
@@ -6,6 +6,11 @@ sentiment_rag.db-wal
 # ChromaDB vector database (regenerated with vectorize_rag_knowledge.py --rebuild)
 chroma_db/
 
+# Temporal trade graph (regenerated with scripts/trade_graph.py --build)
+trade_graph.sqlite
+trade_graph.sqlite-shm
+trade_graph.sqlite-wal
+
 # Large RAG source files (download on demand)
 berkshire_letters/raw/*.pdf
 bogleheads/raw/

--- a/rag_knowledge/lessons_learned/LL-361-graph-rag-exit-reason-instrumentation-gap.md
+++ b/rag_knowledge/lessons_learned/LL-361-graph-rag-exit-reason-instrumentation-gap.md
@@ -1,0 +1,86 @@
+# LL-361: Graph RAG Exposed a 94% Exit-Reason Instrumentation Gap
+
+**Date**: August 3, 2026
+**Category**: RAG / Data Integrity / Post-Mortem
+**Severity**: HIGH
+**Related**: LL-323, kill-criteria.md, data-integrity.md
+
+## Summary
+
+A temporal knowledge graph was built over the system's own causal history (trades,
+policy windows from git, lessons) to answer multi-hop questions vector RAG cannot.
+The first query it ran revealed that **154 of 164 trades have no recorded exit reason
+(6.1% coverage)**. The realized loss of 7,662 USD on `iron_condor` cannot be attributed
+to any exit path, because the attribution data was never written.
+
+## Key Findings
+
+| Finding                                  | Value                        |
+| ---------------------------------------- | ---------------------------- |
+| Trades in graph                          | 164 (162 ledger + 2 journal) |
+| Exit reason recorded                     | 10 (6.1%)                    |
+| `iron_condor` realized P/L               | -7,662 USD (n=161, PF 0.167) |
+| Losses attributable to a known exit path | 1 (`stop_loss`, -267 USD)    |
+| Policy windows recovered from git        | 20                           |
+
+### Tightest stop-loss cohort bled the most
+
+Cohorts split by the `IRON_CONDOR_STOP_LOSS_MULTIPLIER` value in force at entry:
+
+| Value | Window                   | n   | Wins | Realized P/L | Expectancy |
+| ----- | ------------------------ | --- | ---- | ------------ | ---------- |
+| 1.0   | 2026-02-16 to 2026-02-25 | 9   | 2    | -369 USD     | -41.00 USD |
+| 2.0   | 2026-02-25 to 2026-03-01 | 15  | 4    | -767 USD     | -51.13 USD |
+| 1.0   | 2026-03-01 to 2026-04-08 | 129 | 10   | -6,520 USD   | -50.54 USD |
+
+**This is observational, not causal.** The cohorts are not randomized, the windows
+differ in market regime, and other parameters changed inside them. It is a hypothesis
+generator, not evidence that a stop-loss value caused the losses.
+
+## Root Cause
+
+The exit path was never journaled for iron-condor closes. `data/trades.json` carries
+`realized_pnl` and `outcome`, but `exit_reason` was only added later and only populated
+for the active bull-put family and a handful of manual closes. Post-mortem attribution
+is therefore impossible for the killed strategy's entire cohort.
+
+## Prevention
+
+1. `src/rag/graph/` records a missing exit path as `unrecorded` and **never** infers it
+   from the P/L sign. Locked by `test_exit_reason_is_never_inferred`.
+2. `loss_attribution()` reports `exit_reason_coverage` on every call, so a table built
+   on 6% of the data cannot read as complete.
+3. `scripts/check_exit_reason_coverage.py` fails when coverage regresses below the
+   recorded baseline, so newly closed structures must journal an exit path.
+4. Cohort ratios (win rate, profit factor) are withheld below n=30, mirroring the
+   promotion gate. Locked by `test_ratios_withheld_below_minimum_sample`.
+5. A policy window **closes** when its constant stops being a readable literal, so
+   trades after a refactor get no `GOVERNED_BY` edge instead of being attributed to a
+   stale value. Locked by `test_policy_window_closes_when_value_stops_being_a_literal`.
+
+## Secondary Lesson: The Graph Found a Bug In Itself
+
+The first build attributed 140 trades to `IRON_CONDOR_STOP_LOSS_MULTIPLIER = 1.0`. The
+effective runtime value is **2.0** (it resolves through `ACTIVE_IRON_CONDOR_PROFILE`).
+The extractor had read the last _literal_ in git (set 2026-03-01) and left that window
+open forever, straight through the 2026-04-08 refactor that replaced the literal with a
+profile lookup. 99 false `GOVERNED_BY` edges were being minted.
+
+**A derived value that silently outlives its source is worse than a missing one.**
+Unknown must be representable, and it must be reported — `indeterminate_since` now names
+all 12 affected parameters and the date attribution stops.
+
+## Operator
+
+```bash
+python scripts/trade_graph.py --build
+python scripts/trade_graph.py --losses
+python scripts/trade_graph.py --policy IRON_CONDOR_STOP_LOSS_MULTIPLIER
+python scripts/check_exit_reason_coverage.py
+```
+
+## What This Does Not Justify
+
+No projection, no claim of edge, and no change to the active bull-put validation, which
+stands at n=3 — far below the n>=30 gate. The graph explains history; it does not
+create evidence.

--- a/rag_knowledge/lessons_learned/LL-362-rag-write-read-contract-broken.md
+++ b/rag_knowledge/lessons_learned/LL-362-rag-write-read-contract-broken.md
@@ -1,0 +1,63 @@
+# LL-362: RAG Write/Read Contract Was Broken and the Health Check Was Right
+
+**Date**: August 3, 2026
+**Category**: RAG / Data Integrity / Verification
+**Severity**: CRITICAL
+**Related**: LL-361, data-integrity.md, compound-engineering.md
+
+## Summary
+
+`system_health_check.py` reported **"RAG System: BROKEN — write/read round trip failed"**
+and held `make dry-run` red. It was a true positive that had been treated as noise.
+
+`LessonsLearnedRAG.add_lesson()` wrote the markdown file and refreshed the legacy
+keyword list, but never re-indexed the `TradingRAGPipeline` that `query()` actually
+reads from. The lesson existed on disk and was **unretrievable**. Every lesson captured
+at runtime was invisible to the very next retrieval.
+
+## The three defects found, same investigation
+
+| #   | Defect                                                         | Impact                                                               |
+| --- | -------------------------------------------------------------- | -------------------------------------------------------------------- |
+| 1   | `add_lesson()` did not re-index the pipeline                   | Writes invisible to reads                                            |
+| 2   | `query()` returned pipeline rows without setting `last_source` | CLI reported `source: "none"` beside real results — a provenance lie |
+| 3   | Test/health fixtures lacked a severity or prevention section   | `quality_gate()` correctly rejected them; looked like a search bug   |
+
+Defect 3 appeared **three separate times** (a CLI test fixture, the health probe, and
+a lessons fixture). Fixtures written before a gate existed do not fail loudly — they
+fail as a plausible-looking empty result.
+
+## Root Cause
+
+The write path and the read path were never exercised together in a test. Each side had
+coverage; the contract between them had none. The one check that did exercise it — the
+health probe — was failing and had been tolerated.
+
+## Prevention
+
+1. `add_lesson()` now re-indexes the pipeline after writing. Locked by
+   `test_add_lesson_is_immediately_retrievable`.
+2. `query()` records `last_source = "pipeline"` on the primary path. Locked by
+   `test_last_source_is_never_none_when_results_are_returned`.
+3. Fixtures must satisfy `quality_gate()` (severity marker + prevention/action section)
+   or they are silently dropped at ingestion.
+4. `make dry-run` runs `system_health_check.py`, which now genuinely exercises the round
+   trip instead of failing on an invalid probe.
+
+## Rule
+
+**A red check is evidence until proven otherwise.** "That check is always broken" is a
+claim requiring the same verification as any other. Here it was correct, and the cost of
+having dismissed it was that runtime-captured lessons were unretrievable.
+
+**Never repair a failing probe by weakening it.** The first fix attempted was to make
+the probe lesson valid; that was necessary but not sufficient, and stopping there would
+have turned a true positive into a green light over a still-broken system.
+
+## Verification
+
+```bash
+python scripts/system_health_check.py     # ALL CHECKS PASSED
+python -m pytest tests/test_query_lessons_learned.py -q
+make lint
+```

--- a/rag_knowledge/lessons_learned/LL-363-journal-rows-inflated-live-capital-gate.md
+++ b/rag_knowledge/lessons_learned/LL-363-journal-rows-inflated-live-capital-gate.md
@@ -1,0 +1,71 @@
+# LL-363: Entry-Journal Rows Inflated the Sample Size Gating Live Capital
+
+**Date**: August 3, 2026
+**Category**: Data Integrity / Risk / Graph RAG
+**Severity**: CRITICAL
+**Related**: LL-361, LL-362, data-integrity.md, kill-criteria.md
+
+## Summary
+
+The temporal trade graph counted rows from `data/put_credit_entries.json` — the **entry
+lifecycle journal** — as closed trades. One of them was still `exit_pending`. Neither
+carries `realized_pnl`, so both defaulted to zero and were classified as breakeven.
+
+Effect on the active strategy family:
+
+| Metric          | Reported | Truth (paired ledger) |
+| --------------- | -------- | --------------------- |
+| Sample size `n` | 3        | **1**                 |
+| Expectancy      | 5.67     | **17.00**             |
+| Scorable total  | 164      | **162**               |
+
+## Why this was the most dangerous defect of the session
+
+`src/bank/live_gate.py` gates real capital on `EDGE_N_MIN = 30` against this exact
+sample count. The bug moved the reported number **toward** the threshold. An error that
+overstates progress toward deploying money is categorically worse than one that
+understates it — the failure mode is funding an unproven approach, not delaying a proven
+one.
+
+`data-integrity.md` already said this plainly:
+
+> Unmatched orders are never trades. Their cash stays in the unpaired reconciliation
+> fields and is excluded from sample size, win rate, expectancy, profit factor, ML
+> labels, and RAG outcome documents.
+
+The rule existed; the new code simply did not honor it.
+
+## Root Cause
+
+`build.py` reused one node-construction path for both sources and tagged neither, so
+downstream aggregation had no way to tell a broker-reconciled close from an open entry.
+Convenience at ingestion became a correctness hole at the metric.
+
+## Fix
+
+1. Every trade node carries `evidence_tier`: `paired_ledger` or `journal`.
+2. `policy_cohorts()` and `loss_attribution()` score **only** `paired_ledger`.
+3. Journal rows stay in the graph for lifecycle traversal but are counted nowhere.
+4. `loss_attribution()` returns `excluded_non_scorable` so the exclusion is visible
+   rather than silent — a table that quietly drops rows reads as complete when it is not.
+
+## Prevention
+
+- `test_journal_rows_never_enter_metrics` — asserts n stays 1, not 3, and that
+  exclusions are reported.
+- `test_policy_cohorts_exclude_journal_rows` — a journal row cannot form a cohort.
+
+## Rule
+
+**When a number feeds a capital gate, its provenance is part of its definition.** A count
+is not "trades" — it is "broker-reconciled paired closes from the active family." Any
+aggregation that cannot name which tier each row came from must not be allowed to
+produce that number.
+
+## Verification
+
+```bash
+python scripts/trade_graph.py --build
+python scripts/trade_graph.py --losses   # scorable 162, excluded {'journal': 2}, n=1
+python -m pytest tests/test_temporal_trade_graph.py -q
+```

--- a/scripts/check_exit_reason_coverage.py
+++ b/scripts/check_exit_reason_coverage.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+"""Fail when a closed structure in the active strategy family has no journaled exit path.
+
+Why this exists (LL-361): 154 of 164 trades in the ledger carry no `exit_reason`, so the
+realized loss on the killed iron-condor cohort can never be attributed to a stop, a
+profit target, or a time exit. That data is gone. This guard makes sure the successor
+strategy does not repeat it.
+
+The historical cohort is not repairable, so it is not the gate. The gate is: every
+**newly closed** structure in the active family must record how it was closed. Legacy
+rows are reported for visibility and explicitly excluded from the pass/fail decision.
+
+    python scripts/check_exit_reason_coverage.py           # exit 1 on any violation
+    python scripts/check_exit_reason_coverage.py --json    # machine-readable
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+TRADES_PATH = PROJECT_ROOT / "data" / "trades.json"
+JOURNAL_PATH = PROJECT_ROOT / "data" / "put_credit_entries.json"
+
+# Families whose historical rows predate exit-reason journaling. These are frozen
+# evidence, not a backlog to fix -- excluded from the gate, still reported.
+LEGACY_FAMILIES = {"iron_condor", "ic_simple"}
+
+CLOSED_STATUSES = {"closed", "exit_filled"}
+
+
+def _load(path: Path) -> Any:
+    if not path.exists():
+        return {}
+    with path.open() as handle:
+        return json.load(handle)
+
+
+def _family(row: dict) -> str:
+    return row.get("strategy") or row.get("strategy_family") or "unknown"
+
+
+def collect() -> dict[str, Any]:
+    """Return coverage stats plus the list of gate violations."""
+    ledger = _load(TRADES_PATH)
+    trades = ledger.get("trades", []) if isinstance(ledger, dict) else []
+
+    journal = _load(JOURNAL_PATH)
+    journal_rows = [
+        {**entry, "id": key}
+        for key, entry in (journal.items() if isinstance(journal, dict) else [])
+    ]
+
+    rows: list[tuple[str, dict]] = [("ledger", r) for r in trades]
+    rows += [("journal", r) for r in journal_rows]
+
+    total = 0
+    recorded = 0
+    legacy_missing = 0
+    violations: list[dict[str, str]] = []
+
+    for source, row in rows:
+        status = str(row.get("status", "")).lower()
+        # Journal rows are lifecycle records; only graded once actually closed.
+        if source == "journal" and status not in CLOSED_STATUSES:
+            continue
+
+        total += 1
+        family = _family(row)
+        has_reason = bool(row.get("exit_reason"))
+        if has_reason:
+            recorded += 1
+            continue
+
+        if family in LEGACY_FAMILIES:
+            legacy_missing += 1
+            continue
+
+        violations.append(
+            {
+                "id": str(row.get("id", "<no id>")),
+                "source": source,
+                "strategy": family,
+                "status": status or "<none>",
+            }
+        )
+
+    return {
+        "total_closed": total,
+        "exit_reason_recorded": recorded,
+        "coverage": round(recorded / total, 4) if total else None,
+        "legacy_missing": legacy_missing,
+        "legacy_families": sorted(LEGACY_FAMILIES),
+        "violations": violations,
+        "passed": not violations,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--json", action="store_true", help="emit JSON instead of text")
+    args = parser.parse_args()
+
+    report = collect()
+
+    if args.json:
+        print(json.dumps(report, indent=2))
+        return 0 if report["passed"] else 1
+
+    coverage = report["coverage"]
+    coverage_str = f"{coverage:.1%}" if coverage is not None else "n/a"
+    print(f"Closed structures graded : {report['total_closed']}")
+    print(f"Exit reason recorded     : {report['exit_reason_recorded']} ({coverage_str})")
+    print(f"Legacy rows without one  : {report['legacy_missing']} (excluded from gate; LL-361)")
+
+    if report["violations"]:
+        print(f"\nFAIL: {len(report['violations'])} active-family close(s) with no exit_reason:")
+        for violation in report["violations"]:
+            print(
+                f"  - {violation['id']} [{violation['source']}]"
+                f" strategy={violation['strategy']} status={violation['status']}"
+            )
+        print("\nA close without a journaled exit path cannot be attributed later.")
+        return 1
+
+    print("\nPASS: every active-family close journals an exit path.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/evaluate_rag.py
+++ b/scripts/evaluate_rag.py
@@ -30,12 +30,17 @@ from src.rag.evaluation import (
 )
 
 
-def print_report(report: EvaluationReport, verbose: bool = False) -> None:
+def print_report(
+    report: EvaluationReport, verbose: bool = False, engine_source: str | None = None
+) -> None:
     """Print evaluation report to console."""
     print("\n" + "=" * 60)
     print("RAG EVALUATION REPORT")
     print("=" * 60)
     print(f"Timestamp: {report.timestamp}")
+    # Provenance: a retrieval score is only interpretable against the backend that
+    # produced it. This harness previously scored an engine the app never calls.
+    print(f"Engine scored: {engine_source or 'unknown'}")
     print(f"Queries evaluated: {report.num_queries}")
     print(f"k (top results considered): {report.k}")
 
@@ -237,7 +242,7 @@ Examples:
     if args.json:
         print(json.dumps(report.to_dict(), indent=2))
     else:
-        print_report(report, verbose=args.verbose)
+        print_report(report, verbose=args.verbose, engine_source=engine_source)
 
     # Save if requested
     if args.save:

--- a/scripts/micro_capital_gate.py
+++ b/scripts/micro_capital_gate.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+"""Micro-cap deployment decision CLI (feat/live-micro-trade-cap).
+
+Turn Igor's directive into a runnable check:
+
+    "start trading very small (as small as possible); as I deposit more money,
+     we can trade more."
+
+Reads a balance (default paper simulation) and prints the gate's decision:
+how much we *could* micro-deploy (equity fractional DCA) and whether live
+execution is actually credentialed.
+
+This is a DECISION surface, not an execution one: the CLI never moves money.
+Real transfer still demands the existing bank/broker live credential + the
+MERCURY_LIVE_TRANSFERS_ENABLED=1 hard stop (its own adapter gate).
+
+Examples:
+    uv run python scripts/micro_capital_gate.py --balance 100.0
+    uv run python scripts/micro_capital_gate.py --balance 250.0 --json
+    uv run python scripts/micro_capital_gate.py --check-live-readiness
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from src.micro.micro_capital_gate import (  # noqa: E402
+    DEFAULT_DEPLOY_FRACTION,
+    DEFAULT_HARD_FLOOR_USD,
+    DEFAULT_LIVE_CAP_USD,
+    compute_micro_cap,
+    options_require_larger_capital,
+)
+
+
+def _live_readiness(env: dict[str, str]) -> dict[str, bool]:
+    """Report whether live creds + hard-stop are present without printing them."""
+    return {
+        "MERCURY_API_TOKEN": bool(env.get("MERCURY_API_TOKEN")),
+        "MERCURY_ACCOUNT_ID": bool(env.get("MERCURY_ACCOUNT_ID")),
+        "MERCURY_LIVE_TRANSFERS_ENABLED": env.get("MERCURY_LIVE_TRANSFERS_ENABLED") == "1",
+        "ALPACA_LIVE_API_KEY": bool(
+            env.get("ALPACA_LIVE_API_KEY") or env.get("DIVIDEND_GROWTH_ALPACA_API_KEY")
+        ),
+    }
+
+
+def _run(args: argparse.Namespace) -> int:
+    dec = compute_micro_cap(
+        args.balance,
+        hard_floor_usd=args.hard_floor_usd,
+        deploy_fraction=args.deploy_fraction,
+        live_cap_usd=args.live_cap_usd,
+    )
+
+    if args.json:
+        payload = {"micro_cap": dec.to_dict()}
+        if args.live_readiness:
+            payload["live_readiness"] = _live_readiness(dict(__import__("os").environ))
+        print(json.dumps(payload, indent=2))
+        return 0 if dec.can_deploy else 1
+
+    floor, frac, cap = args.hard_floor_usd, args.deploy_fraction, args.live_cap_usd
+    print(f"Micro-cap deploy gate (balance ${dec.available_balance_usd:.2f})")
+    print(f"  hard floor    : ${floor:.2f}  (keep as Mercury buffer)")
+    print(f"  deploy fraction: {frac:.0%}")
+    print(f"  live cap       : ${cap:.2f}  (single live transfer bound)")
+    if dec.can_deploy:
+        print(
+            f"  DECISION: deploy ${dec.deployable_usd:.2f} -> {', '.join(dec.deployable_symbols)}"
+        )
+        print(
+            f"  (as small as possible at ${dec.available_balance_usd:.2f}; "
+            f"deposit more to raise this)"
+        )
+    else:
+        print("  DECISION: nothing to deploy")
+        if dec.blocked_reason:
+            print(f"  reason: {dec.blocked_reason}")
+    print(f"  options: {options_require_larger_capital()}")
+    if args.live_readiness:
+        print("  live_readiness:", _live_readiness(__import__("os").environ))
+    return 0 if dec.can_deploy else 1
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--balance", type=float, default=100.0, help="bank balance USD (default 100.0)"
+    )
+    parser.add_argument("--hard-floor-usd", type=float, default=DEFAULT_HARD_FLOOR_USD)
+    parser.add_argument("--deploy-fraction", type=float, default=DEFAULT_DEPLOY_FRACTION)
+    parser.add_argument("--live-cap-usd", type=float, default=DEFAULT_LIVE_CAP_USD)
+    parser.add_argument("--json", action="store_true", help="machine-readable output")
+    parser.add_argument(
+        "--live-readiness",
+        action="store_true",
+        help="also print whether live creds + hard-stop are present (booleans only)",
+    )
+    args = parser.parse_args()
+    return _run(args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/system_health_check.py
+++ b/scripts/system_health_check.py
@@ -186,9 +186,18 @@ def check_rag_system():
         # Verify the read/write contract without mutating the repository.
         with tempfile.TemporaryDirectory(prefix="trading-rag-health-") as tmpdir:
             writable_rag = LessonsLearnedRAG(knowledge_dir=tmpdir)
+            # The probe must satisfy quality_gate(): a severity marker AND a
+            # prevention/action section. Without the section the lesson is rejected at
+            # ingestion, so the round trip could never succeed and this check reported
+            # "RAG System: BROKEN" permanently -- a broken probe, not a broken RAG.
             writable_rag.add_lesson(
                 "LL-HEALTH",
-                "# Health Probe\n\n**Severity**: LOW\n\nRAG write and read round trip.",
+                "# Health Probe\n\n"
+                "**Severity**: LOW\n\n"
+                "## Summary\n"
+                "RAG write and read round trip.\n\n"
+                "## Prevention\n"
+                "Keep the health probe lesson valid so the round trip stays meaningful.",
             )
             round_trip = writable_rag.query("round trip", top_k=1)
             if not round_trip or round_trip[0]["id"] != "LL-HEALTH":
@@ -196,6 +205,17 @@ def check_rag_system():
                 results["status"] = "BROKEN"
                 return results
             results["details"].append("✓ RAG write/read round trip works")
+
+        # Name the active retrieval tier. Degradation here is allowed (trading must
+        # never be blocked by a search index), but it must never be invisible: the
+        # weak tier measured precision@5 0.20 against 0.36 with the cross-encoder.
+        try:
+            from src.rag.retrieval_tier import describe_retrieval_tier, tier_summary_line
+
+            marker = "⚠️" if describe_retrieval_tier()["quality_degraded"] else "✓"
+            results["details"].append(f"{marker} {tier_summary_line()}")
+        except Exception as exc:
+            results["details"].append(f"⚠️ Retrieval tier unknown: {exc}")
 
         # Test QueryRewriter & ParentChildRetriever modules
         try:

--- a/scripts/trade_graph.py
+++ b/scripts/trade_graph.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+"""Build and query the temporal trade knowledge graph.
+
+    python scripts/trade_graph.py --build
+    python scripts/trade_graph.py --stats
+    python scripts/trade_graph.py --losses
+    python scripts/trade_graph.py --policy IRON_CONDOR_STOP_LOSS_MULTIPLIER
+    python scripts/trade_graph.py --context "stop loss" "iron condor" --hops 2
+
+Read-only with respect to trading: this inspects history, it never submits an order.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from src.rag.graph.build import (  # noqa: E402
+    JOURNAL_PATH,
+    TRADES_PATH,
+    build_graph,  # noqa: E402
+)
+from src.rag.graph.queries import (  # noqa: E402
+    graph_context,
+    loss_attribution,
+    policy_cohorts,
+    seeds_from_terms,
+)
+from src.rag.graph.temporal_graph import TemporalGraph  # noqa: E402
+
+
+def _emit(payload: object) -> None:
+    print(json.dumps(payload, indent=2, default=str))
+
+
+def stale_sources(db_path: Path, sources: list[Path]) -> list[str]:
+    """Return source files newer than the graph database.
+
+    A graph built before the last trade close answers cohort questions with a ledger
+    that no longer exists, and it does so confidently. Staleness has to be loud --
+    a silently outdated answer is the failure mode this whole module exists to remove.
+    """
+    if not db_path.exists():
+        return []
+    built_at = db_path.stat().st_mtime
+    return [str(p) for p in sources if p.exists() and p.stat().st_mtime > built_at]
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--build", action="store_true", help="rebuild the graph from repo data")
+    parser.add_argument("--stats", action="store_true", help="show node/edge counts")
+    parser.add_argument("--losses", action="store_true", help="loss attribution by exit path")
+    parser.add_argument("--policy", metavar="NAME", help="cohort metrics per policy value")
+    parser.add_argument("--strategy", metavar="NAME", help="restrict to one strategy family")
+    parser.add_argument("--context", nargs="+", metavar="TERM", help="serialize a subgraph")
+    parser.add_argument("--hops", type=int, default=2)
+    parser.add_argument("--budget", type=int, default=60, help="max nodes in a context subgraph")
+    parser.add_argument("--as-of", metavar="ISO_TS", help="traverse the graph as it was at a time")
+    parser.add_argument("--db", metavar="PATH", help="graph database path")
+    parser.add_argument(
+        "--rebuild-if-stale",
+        action="store_true",
+        help="rebuild automatically when a source ledger is newer than the graph",
+    )
+    args = parser.parse_args()
+
+    if args.build:
+        _emit(build_graph(args.db))
+        if not (args.stats or args.losses or args.policy or args.context):
+            return 0
+
+    graph = TemporalGraph(args.db)
+    try:
+        if graph.stats()["nodes"] == 0:
+            print("Graph is empty. Run: python scripts/trade_graph.py --build", file=sys.stderr)
+            return 2
+
+        if not args.build:
+            stale = stale_sources(graph.db_path, [TRADES_PATH, JOURNAL_PATH])
+            if stale:
+                if args.rebuild_if_stale:
+                    print(
+                        f"Graph is stale ({len(stale)} newer source(s)); rebuilding.",
+                        file=sys.stderr,
+                    )
+                    graph.close()
+                    build_graph(args.db)
+                    graph = TemporalGraph(args.db)
+                else:
+                    for path in stale:
+                        print(f"STALE: {path} is newer than the graph", file=sys.stderr)
+                    print(
+                        "Results below predate that data. Rerun with --build or "
+                        "--rebuild-if-stale.",
+                        file=sys.stderr,
+                    )
+
+        if args.stats:
+            _emit(graph.stats())
+        if args.losses:
+            _emit(loss_attribution(graph, strategy=args.strategy))
+        if args.policy:
+            _emit(policy_cohorts(graph, args.policy, strategy=args.strategy))
+        if args.context:
+            seeds = seeds_from_terms(graph, args.context)
+            if not seeds:
+                print(f"No graph entities matched: {args.context}", file=sys.stderr)
+                return 1
+            print(
+                graph_context(
+                    graph, seeds, hops=args.hops, node_budget=args.budget, as_of=args.as_of
+                )
+            )
+
+        if not any([args.stats, args.losses, args.policy, args.context, args.build]):
+            parser.print_help()
+    finally:
+        graph.close()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/micro/micro_capital_gate.py
+++ b/src/micro/micro_capital_gate.py
@@ -1,0 +1,128 @@
+"""Micro-capital deployment gate (feat/live-micro-trade-cap).
+
+Owns the rule that turns Igor's directive into code:
+
+  "start trading very small (as small as possible); as I deposit more money,
+   we can trade more."
+
+This is the sizing + safety gate for the *equity fractional DCA* path
+(SCHD via mercury_income_loop / DividendGrowthStrategy) — the only surface
+that can trade at all under ~$500. Options (spy_put_credit) are hard-excluded
+here by construction: option contracts bind ~$500+ collateral each, so a
+sub-$500 account physically cannot open options. This gate refuses to deploy
+into them and records why.
+
+Design rules (Karpathy-simple on purpose):
+
+  * micro=True -> we deploy only when the available surplus EXCEEDS a small
+    hard floor. The deployable amount is `min(surplus, deposit_fraction *
+    balance)`. Both are tiny by default so "as small as possible".
+  * As Igor deposits more, `surplus` grows -> deployable grows. This is the
+    literal "deposit more, trade more" curve with no magic knobs.
+  * A hard LIVE cap (`live_cap_usd`) bounds the single-transfer amount; it
+    gates live mode only, never paper. Intentionally no secret-shuffling:
+    real money still requires existing Mercury/Alpaca live credentials and
+    MERCURY_LIVE_TRANSFERS_ENABLED=1 (see src/adapters/bank_adapter.py).
+
+Everything here is pure/deterministic so it is unit-testable and safe to
+call from cron. No network, no side effects.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+DEFAULT_HARD_FLOOR_USD = 25.0  # keep a small buffer in Mercury; trade the surplus
+DEFAULT_DEPLOY_FRACTION = 0.10  # deploy at most 10% of balance per cycle
+DEFAULT_LIVE_CAP_USD = 50.0  # single live transfer never exceeds $50 (honeypot)
+DEFAULT_UNIVERSE = ("SCHD",)  # match DividendGrowthStrategy.DEFAULT_UNIVERSE
+
+
+@dataclass(frozen=True)
+class MicroCapDecision:
+    """Result of running the deploy gate against a bank balance."""
+
+    available_balance_usd: float
+    hard_floor_usd: float
+    deploy_fraction: float
+    live_cap_usd: float
+    deployable_usd: float
+    deployable_symbols: tuple[str, ...]
+    blocked_reason: str | None = None
+
+    @property
+    def can_deploy(self) -> bool:
+        return self.deployable_usd > 0 and self.blocked_reason is None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "balance_usd": round(self.available_balance_usd, 2),
+            "deployable_usd": round(self.deployable_usd, 2),
+            "deployable": self.can_deploy,
+            "deployable_symbols": list(self.deployable_symbols),
+            "blocked_reason": self.blocked_reason,
+        }
+
+
+def compute_micro_cap(
+    balance_usd: float,
+    *,
+    hard_floor_usd: float = DEFAULT_HARD_FLOOR_USD,
+    deploy_fraction: float = DEFAULT_DEPLOY_FRACTION,
+    live_cap_usd: float = DEFAULT_LIVE_CAP_USD,
+    universe: tuple[str, ...] = DEFAULT_UNIVERSE,
+) -> MicroCapDecision:
+    """Decide how much (if any) to deploy from `balance_usd`.
+
+    Pure function: no I/O, no network, no global state. Callers (the CLI or
+    any orchestrator) are responsible for actually moving money only after
+    checking `.can_deploy` AND their own live-credential check.
+    """
+    if balance_usd <= 0:
+        return MicroCapDecision(
+            available_balance_usd=balance_usd,
+            hard_floor_usd=hard_floor_usd,
+            deploy_fraction=deploy_fraction,
+            live_cap_usd=live_cap_usd,
+            deployable_usd=0.0,
+            deployable_symbols=tuple(),
+            blocked_reason="balance is non-positive",
+        )
+
+    surplus = balance_usd - hard_floor_usd
+    if surplus <= 0:
+        return MicroCapDecision(
+            available_balance_usd=balance_usd,
+            hard_floor_usd=hard_floor_usd,
+            deploy_fraction=deploy_fraction,
+            live_cap_usd=live_cap_usd,
+            deployable_usd=0.0,
+            deployable_symbols=tuple(),
+            blocked_reason=(
+                f"balance ${balance_usd:.2f} is at/below the ${hard_floor_usd:.2f} "
+                "hard floor; keep the buffer and wait for the next deposit"
+            ),
+        )
+
+    # Deploy the smaller of (fraction of surplus) vs the hard live cap.
+    # This guarantees "as small as possible" at every balance level and keeps
+    # a single transfer bounded in live mode.
+    deployable = min(surplus * deploy_fraction, live_cap_usd)
+    return MicroCapDecision(
+        available_balance_usd=balance_usd,
+        hard_floor_usd=hard_floor_usd,
+        deploy_fraction=deploy_fraction,
+        live_cap_usd=live_cap_usd,
+        deployable_usd=max(0.0, deployable),
+        deployable_symbols=universe,
+    )
+
+
+def options_require_larger_capital() -> str:
+    """Human-readable reason options are excluded from micro trading."""
+    return (
+        "options require ~$500+ collateral per contract, so a sub-$500 account "
+        "cannot open an option leg; options are only reachable after the equity "
+        "DCA prove-out and a live account above $500"
+    )

--- a/src/rag/evaluation.py
+++ b/src/rag/evaluation.py
@@ -272,40 +272,54 @@ class RAGEvaluator:
                 "yes",
             }
         self.prefer_lancedb = prefer_lancedb
+        # Opt-in only: score the legacy standalone term-counter instead of the path the
+        # application actually serves. Useful as a baseline, never as the default.
+        self.legacy_keyword_engine = os.getenv("RAG_EVAL_LEGACY_ENGINE", "").lower() in {
+            "1",
+            "true",
+            "yes",
+        }
         self._search_engine = None
         self._engine_source = None
 
     def _get_search_engine(self):
-        """Lazy load the search engine."""
+        """Lazy load the retriever under evaluation.
+
+        Defaults to the **production** entry point, `LessonsLearnedRAG.query()`, which
+        prefers TradingRAGPipeline (FTS5 + bigram-Jaccard + multi-query + rerank).
+
+        Previously this defaulted to the standalone `LessonsSearch` term-counter, so the
+        harness scored a retriever the application never calls and published the result
+        as a CI pass/fail gate. A metric whose provenance does not match its label is
+        worse than no metric: it manufactures confidence. `_engine_source` now names the
+        backend that actually served the queries, and the report prints it.
+        """
         if self._search_engine is None:
-            if self.prefer_lancedb:
-                try:
-                    from src.rag.lessons_learned_rag import LessonsLearnedRAG
-
-                    self._search_engine = LessonsLearnedRAG()
-                    if getattr(self._search_engine, "lancedb_rag", None) is not None:
-                        self._engine_source = "lancedb"
-                    else:
-                        self._engine_source = "keyword"
-                    return self._search_engine
-                except Exception as e:
-                    logger.warning(f"LanceDB RAG unavailable: {e} - using keyword search")
-
-            try:
+            if self.legacy_keyword_engine:
                 from src.rag.lessons_search import get_lessons_search
 
                 self._search_engine = get_lessons_search()
-                self._engine_source = "keyword"
-            except ImportError:
-                # Fallback to LessonsLearnedRAG
+                self._engine_source = "legacy_keyword(LessonsSearch)"
+                return self._search_engine
+
+            try:
                 from src.rag.lessons_learned_rag import LessonsLearnedRAG
 
                 self._search_engine = LessonsLearnedRAG()
-                self._engine_source = (
-                    "lancedb"
-                    if getattr(self._search_engine, "lancedb_rag", None) is not None
-                    else "keyword"
-                )
+                if getattr(self._search_engine, "lancedb_rag", None) is not None:
+                    self._engine_source = "production(lancedb)"
+                elif getattr(self._search_engine, "_pipeline", None) is not None:
+                    self._engine_source = "production(pipeline)"
+                else:
+                    self._engine_source = "production(keyword_fallback)"
+                return self._search_engine
+            except Exception as e:
+                logger.warning("Production retriever unavailable (%s); scoring legacy engine", e)
+
+            from src.rag.lessons_search import get_lessons_search
+
+            self._search_engine = get_lessons_search()
+            self._engine_source = "legacy_keyword(LessonsSearch)"
         return self._search_engine
 
     def get_engine_source(self) -> Optional[str]:
@@ -535,9 +549,7 @@ class RAGEvaluator:
             return 0.0
 
         # Normalize graded_relevance keys to match normalized retrieved IDs
-        normalized_relevance = {
-            self._normalize_match_id(k): v for k, v in graded_relevance.items()
-        }
+        normalized_relevance = {self._normalize_match_id(k): v for k, v in graded_relevance.items()}
 
         dcg = 0.0
         for i, doc in enumerate(retrieved[:k]):

--- a/src/rag/graph/__init__.py
+++ b/src/rag/graph/__init__.py
@@ -1,0 +1,29 @@
+"""Temporal knowledge graph layer over the trading system's own causal history.
+
+Complements the existing vector/BM25 retrieval in `src.rag` rather than replacing it:
+the hybrid retriever finds relevant text, this finds the joins between entities.
+"""
+
+from src.rag.graph.build import build_graph, extract_policy_history
+from src.rag.graph.queries import (
+    explain_trade,
+    graph_context,
+    loss_attribution,
+    policy_cohorts,
+    seeds_from_terms,
+)
+from src.rag.graph.temporal_graph import Edge, Node, Subgraph, TemporalGraph
+
+__all__ = [
+    "Edge",
+    "Node",
+    "Subgraph",
+    "TemporalGraph",
+    "build_graph",
+    "explain_trade",
+    "extract_policy_history",
+    "graph_context",
+    "loss_attribution",
+    "policy_cohorts",
+    "seeds_from_terms",
+]

--- a/src/rag/graph/build.py
+++ b/src/rag/graph/build.py
@@ -1,0 +1,487 @@
+"""Build the temporal trade graph from canonical repo data.
+
+Sources, all already in the repo -- no external feeds, no new infrastructure:
+
+* `data/trades.json`             -> paired closed structures (the outcome ledger)
+* `data/put_credit_entries.json` -> active strategy lifecycle journal
+* `src/core/trading_constants.py` git history -> policy validity windows
+* `rag_knowledge/lessons_learned/` -> lessons, linked to what they warn about
+
+The policy windows are the reason this is a *temporal* graph rather than a static one.
+`git log` on the constants file tells us exactly when each risk parameter changed, so a
+trade opened in March 2026 is joined to the stop-loss multiplier that was in force in
+March 2026 -- not to today's value. That join is what makes "did the policy change help"
+answerable instead of guessable.
+"""
+
+from __future__ import annotations
+
+import ast
+import json
+import logging
+import re
+import subprocess  # nosec B404 - used only to read local git history, never user input
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from src.rag.graph.temporal_graph import Edge, Node, TemporalGraph
+
+logger = logging.getLogger(__name__)
+
+PROJECT_ROOT = Path(__file__).resolve().parents[3]
+TRADES_PATH = PROJECT_ROOT / "data" / "trades.json"
+JOURNAL_PATH = PROJECT_ROOT / "data" / "put_credit_entries.json"
+CONSTANTS_REL = "src/core/trading_constants.py"
+LESSONS_DIR = PROJECT_ROOT / "rag_knowledge" / "lessons_learned"
+
+# Risk parameters worth tracking through time. Deliberately narrow: every extra key
+# multiplies GOVERNED_BY edges by the trade count without adding explanatory power.
+TRACKED_POLICIES = (
+    "IRON_CONDOR_STOP_LOSS_MULTIPLIER",
+    "IC_PROFIT_TARGET_PCT",
+    "IRON_CONDOR_EXIT_DTE",
+    "IRON_CONDOR_TARGET_DELTA",
+    "IRON_CONDOR_WING_WIDTH",
+    "MAX_POSITIONS",
+    "MAX_CONCURRENT_IRON_CONDORS",
+    "MAX_DAILY_STRUCTURES",
+    "MAX_CONTRACTS_PER_TRADE",
+    "MAX_POSITION_PCT",
+    "MAX_DAILY_LOSS_PCT",
+    "MIN_DTE",
+    "MAX_DTE",
+)
+
+_ASSIGN_RE = re.compile(
+    r"^(?P<name>[A-Z][A-Z0-9_]*)\s*(?::\s*[^=]+?)?\s*=\s*(?P<value>.+?)\s*(?:#.*)?$"
+)
+
+
+# --------------------------------------------------------------------- policies
+
+
+@dataclass(frozen=True)
+class PolicyWindow:
+    """A risk parameter holding one value over a half-open time interval."""
+
+    name: str
+    value: Any
+    valid_from: str
+    valid_to: str | None
+    commit: str
+
+    @property
+    def node_id(self) -> str:
+        return f"policy:{self.name}@{self.valid_from[:10]}"
+
+
+@dataclass(frozen=True)
+class IndeterminateSpan:
+    """A period where a tracked policy exists but its value is not statically knowable.
+
+    Constants that delegate to a runtime profile (`= ACTIVE_IRON_CONDOR_PROFILE.x`) cannot
+    be resolved from the file alone. Trades in such a span get no GOVERNED_BY edge, so
+    they are excluded from cohort attribution instead of being silently bucketed under
+    the last literal that happened to be readable.
+    """
+
+    name: str
+    since: str
+    commit: str
+    reason: str
+
+
+@dataclass
+class PolicyHistory:
+    """Resolved policy windows plus the spans we deliberately refused to guess."""
+
+    windows: list[PolicyWindow]
+    indeterminate: list[IndeterminateSpan]
+
+
+def _git(args: list[str], cwd: Path) -> str:
+    # nosec B603 B607 - fixed argv (no shell), `git` resolved from PATH by design so the
+    # caller's toolchain is used; `args` are module constants and commit SHAs from
+    # `git log`, never user input.
+    result = subprocess.run(  # nosec B603 B607
+        ["git", *args], cwd=str(cwd), capture_output=True, text=True, check=False
+    )
+    if result.returncode != 0:
+        logger.warning("git %s failed: %s", " ".join(args), result.stderr.strip())
+        return ""
+    return result.stdout
+
+
+def _parse_literal(raw: str) -> Any | None:
+    """Return the literal value of an assignment RHS, or None if it is not a literal.
+
+    Many constants delegate to `ACTIVE_IRON_CONDOR_PROFILE.<field>`. Those are recorded
+    as unresolved rather than guessed -- an invented policy value would silently
+    corrupt every cohort attribution built on top of it.
+    """
+    try:
+        return ast.literal_eval(raw)
+    except (ValueError, SyntaxError):
+        return None
+
+
+def extract_policy_history(repo_root: Path | None = None) -> PolicyHistory:
+    """Reconstruct policy validity windows from the git history of the constants file.
+
+    A window closes when the value changes, when the constant is deleted, or when it
+    stops being a readable literal. That last case matters: on 2026-04-08 the constants
+    file was refactored to delegate to a runtime profile, and treating the pre-refactor
+    literal as still-in-force would misattribute every subsequent trade.
+    """
+    root = repo_root or PROJECT_ROOT
+    log = _git(["log", "--format=%H|%aI", "--reverse", "--", CONSTANTS_REL], root)
+    commits = [line.split("|", 1) for line in log.splitlines() if "|" in line]
+    if not commits:
+        return PolicyHistory(windows=[], indeterminate=[])
+
+    # name -> (value, valid_from, commit) for the currently-open window
+    open_windows: dict[str, tuple[Any, str, str]] = {}
+    closed: list[PolicyWindow] = []
+    indeterminate: dict[str, IndeterminateSpan] = {}
+
+    def close(name: str, at: str) -> None:
+        prior = open_windows.pop(name, None)
+        if prior is not None:
+            closed.append(
+                PolicyWindow(
+                    name=name, value=prior[0], valid_from=prior[1], valid_to=at, commit=prior[2]
+                )
+            )
+
+    for sha, iso_date in commits:
+        blob = _git(["show", f"{sha}:{CONSTANTS_REL}"], root)
+        if not blob:
+            continue
+        values, unresolved = _parse_constants(blob)
+
+        for name, value in values.items():
+            indeterminate.pop(name, None)
+            prior = open_windows.get(name)
+            if prior is None:
+                open_windows[name] = (value, iso_date, sha)
+            elif prior[0] != value:
+                close(name, iso_date)
+                open_windows[name] = (value, iso_date, sha)
+
+        # Present but not statically readable -> stop attributing, and say why.
+        for name in unresolved:
+            close(name, iso_date)
+            indeterminate.setdefault(
+                name,
+                IndeterminateSpan(
+                    name=name,
+                    since=iso_date,
+                    commit=sha,
+                    reason="value delegates to a runtime profile; not resolvable from source",
+                ),
+            )
+
+        # Removed from the file entirely.
+        for name in set(open_windows) - set(values) - unresolved:
+            close(name, iso_date)
+
+    for name, (value, valid_from, sha) in open_windows.items():
+        closed.append(
+            PolicyWindow(name=name, value=value, valid_from=valid_from, valid_to=None, commit=sha)
+        )
+
+    return PolicyHistory(
+        windows=sorted(closed, key=lambda w: (w.name, w.valid_from)),
+        indeterminate=sorted(indeterminate.values(), key=lambda s: s.name),
+    )
+
+
+def _parse_constants(source: str) -> tuple[dict[str, Any], set[str]]:
+    """Return (resolved literals, names present but not resolvable) for one revision."""
+    found: dict[str, Any] = {}
+    unresolved: set[str] = set()
+    for line in source.splitlines():
+        match = _ASSIGN_RE.match(line.strip())
+        if not match:
+            continue
+        name = match.group("name")
+        if name not in TRACKED_POLICIES:
+            continue
+        value = _parse_literal(match.group("value"))
+        if value is None:
+            unresolved.add(name)
+            found.pop(name, None)
+        else:
+            found[name] = value
+            unresolved.discard(name)
+    return found, unresolved
+
+
+# ----------------------------------------------------------------------- trades
+
+
+def _entry_ts(trade: dict) -> str | None:
+    return trade.get("entry_time") or trade.get("entry_date")
+
+
+def _load_json(path: Path) -> Any:
+    if not path.exists():
+        logger.warning("missing data source: %s", path)
+        return {}
+    with path.open() as handle:
+        return json.load(handle)
+
+
+def _trade_nodes_and_edges(
+    trades: list[dict],
+    windows: list[PolicyWindow],
+    evidence_tier: str = "paired_ledger",
+) -> tuple[list[Node], list[Edge]]:
+    """Build trade nodes. `evidence_tier` decides whether a row may score.
+
+    `paired_ledger` rows come from `data/trades.json` and are broker-reconciled closed
+    structures. `journal` rows come from the entry lifecycle file: they may still be
+    open, they carry no `realized_pnl`, and per data-integrity.md they are never trades.
+    Both are stored -- only the former is allowed into any metric.
+    """
+    nodes: list[Node] = []
+    edges: list[Edge] = []
+    seen_kinds: set[str] = set()
+
+    by_policy: dict[str, list[PolicyWindow]] = {}
+    for window in windows:
+        by_policy.setdefault(window.name, []).append(window)
+
+    for trade in trades:
+        trade_id = trade.get("id")
+        if not trade_id:
+            continue
+        node_id = f"trade:{trade_id}"
+        entry = _entry_ts(trade)
+        exit_ts = trade.get("exit_time") or trade.get("exit_date")
+        pnl = float(trade.get("realized_pnl") or 0.0)
+        strategy = trade.get("strategy") or trade.get("strategy_family") or "unknown"
+        outcome = trade.get("outcome") or "unknown"
+        exit_reason = trade.get("exit_reason")
+
+        nodes.append(
+            Node(
+                id=node_id,
+                kind="trade",
+                label=f"{trade.get('symbol', '?')} {strategy} {pnl:+.2f}",
+                attrs={
+                    "symbol": trade.get("symbol"),
+                    "strategy": strategy,
+                    "realized_pnl": pnl,
+                    "outcome": outcome,
+                    "entry_credit": trade.get("entry_credit"),
+                    "exit_debit": trade.get("exit_debit"),
+                    "signature": trade.get("signature"),
+                    "quantity": trade.get("quantity"),
+                    "exit_reason": exit_reason,
+                    "evidence_tier": evidence_tier,
+                    "status": trade.get("status"),
+                },
+                valid_from=entry,
+                valid_to=exit_ts,
+            )
+        )
+
+        for kind, key in (("strategy", strategy), ("outcome", outcome)):
+            target = f"{kind}:{key}"
+            if target not in seen_kinds:
+                seen_kinds.add(target)
+                nodes.append(Node(id=target, kind=kind, label=str(key)))
+
+        edges.append(
+            Edge(node_id, "BELONGS_TO", f"strategy:{strategy}", valid_from=entry, valid_to=exit_ts)
+        )
+        edges.append(
+            Edge(
+                node_id,
+                "RESULTED_IN",
+                f"outcome:{outcome}",
+                weight=abs(pnl),
+                attrs={"realized_pnl": pnl},
+                valid_from=exit_ts,
+            )
+        )
+
+        # exit_reason is present on only a fraction of the ledger. Absent is recorded
+        # as `unrecorded`, never inferred from the P/L sign -- a guessed exit reason
+        # would fabricate the very attribution this graph exists to provide.
+        reason_key = exit_reason or "unrecorded"
+        reason_node = f"exit_reason:{reason_key}"
+        if reason_node not in seen_kinds:
+            seen_kinds.add(reason_node)
+            nodes.append(
+                Node(
+                    id=reason_node,
+                    kind="exit_reason",
+                    label=reason_key,
+                    attrs={"inferred": False, "recorded": exit_reason is not None},
+                )
+            )
+        edges.append(Edge(node_id, "EXITED_VIA", reason_node, valid_from=exit_ts))
+
+        signature = trade.get("signature") or ""
+        expiry_match = re.search(r"(\d{4}-\d{2}-\d{2})", signature)
+        if expiry_match:
+            expiry_node = f"expiry:{expiry_match.group(1)}"
+            if expiry_node not in seen_kinds:
+                seen_kinds.add(expiry_node)
+                nodes.append(Node(id=expiry_node, kind="expiry", label=expiry_match.group(1)))
+            edges.append(Edge(node_id, "CONCENTRATED_IN", expiry_node, valid_from=entry))
+
+        # The temporal join: which policy value was actually in force at entry.
+        if entry:
+            for name, name_windows in by_policy.items():
+                window = _window_at(name_windows, entry)
+                if window is None:
+                    continue
+                edges.append(
+                    Edge(
+                        node_id,
+                        "GOVERNED_BY",
+                        window.node_id,
+                        attrs={"policy": name, "value": window.value},
+                        valid_from=entry,
+                        valid_to=exit_ts,
+                    )
+                )
+
+    return nodes, edges
+
+
+def _window_at(windows: list[PolicyWindow], timestamp: str) -> PolicyWindow | None:
+    for window in windows:
+        if window.valid_from <= timestamp and (
+            window.valid_to is None or timestamp < window.valid_to
+        ):
+            return window
+    return None
+
+
+# ---------------------------------------------------------------------- lessons
+
+
+def _lesson_nodes_and_edges(strategies: set[str]) -> tuple[list[Node], list[Edge]]:
+    nodes: list[Node] = []
+    edges: list[Edge] = []
+    if not LESSONS_DIR.exists():
+        return nodes, edges
+
+    for path in sorted(LESSONS_DIR.glob("*.md")):
+        text = path.read_text(errors="replace")
+        lesson_id = f"lesson:{path.stem}"
+        title = next(
+            (ln.lstrip("# ").strip() for ln in text.splitlines() if ln.startswith("#")),
+            path.stem,
+        )
+        severity = "HIGH" if re.search(r"severity[:\s]*(HIGH|CRITICAL)", text, re.I) else "MEDIUM"
+        nodes.append(
+            Node(
+                id=lesson_id,
+                kind="lesson",
+                label=title[:120],
+                attrs={"path": str(path.relative_to(PROJECT_ROOT)), "severity": severity},
+            )
+        )
+
+        upper = text.upper()
+        for strategy in strategies:
+            token = strategy.upper().replace("_", " ")
+            if strategy.upper() in upper or token in upper:
+                edges.append(Edge(lesson_id, "WARNED_ABOUT", f"strategy:{strategy}"))
+        for policy in TRACKED_POLICIES:
+            if policy in text:
+                edges.append(
+                    Edge(lesson_id, "WARNED_ABOUT", f"policy_name:{policy}", attrs={"exact": True})
+                )
+
+    return nodes, edges
+
+
+# ------------------------------------------------------------------------ build
+
+
+def build_graph(db_path: str | Path | None = None, rebuild: bool = True) -> dict[str, Any]:
+    """Build (or rebuild) the trade graph. Returns ingestion stats."""
+    graph = TemporalGraph(db_path)
+    if rebuild:
+        graph.clear()
+
+    history = extract_policy_history()
+    windows = history.windows
+    policy_nodes: list[Node] = []
+    policy_edges: list[Edge] = []
+    by_name: dict[str, list[PolicyWindow]] = {}
+
+    for window in windows:
+        by_name.setdefault(window.name, []).append(window)
+        policy_nodes.append(
+            Node(
+                id=window.node_id,
+                kind="policy",
+                label=f"{window.name}={window.value}",
+                attrs={"name": window.name, "value": window.value, "commit": window.commit},
+                valid_from=window.valid_from,
+                valid_to=window.valid_to,
+            )
+        )
+
+    # A stable per-parameter node so lessons can point at the parameter itself, and
+    # SUPERSEDED_BY chains so "what did this value replace" is one hop.
+    for name, name_windows in by_name.items():
+        policy_nodes.append(Node(id=f"policy_name:{name}", kind="policy_name", label=name))
+        for window in name_windows:
+            policy_edges.append(Edge(window.node_id, "INSTANCE_OF", f"policy_name:{name}"))
+        for earlier, later in zip(name_windows, name_windows[1:], strict=False):
+            policy_edges.append(
+                Edge(
+                    earlier.node_id,
+                    "SUPERSEDED_BY",
+                    later.node_id,
+                    attrs={"from": earlier.value, "to": later.value},
+                    valid_from=later.valid_from,
+                )
+            )
+
+    ledger = _load_json(TRADES_PATH)
+    trades = ledger.get("trades", []) if isinstance(ledger, dict) else []
+    trade_nodes, trade_edges = _trade_nodes_and_edges(trades, windows)
+
+    journal = _load_json(JOURNAL_PATH)
+    journal_trades = [
+        {**entry, "id": key, "symbol": "SPY", "strategy": entry.get("strategy_family", "unknown")}
+        for key, entry in (journal.items() if isinstance(journal, dict) else [])
+    ]
+    journal_nodes, journal_edges = _trade_nodes_and_edges(
+        journal_trades, windows, evidence_tier="journal"
+    )
+
+    strategies = {
+        n.attrs.get("strategy", "unknown") for n in trade_nodes + journal_nodes if n.kind == "trade"
+    }
+    lesson_nodes, lesson_edges = _lesson_nodes_and_edges(strategies)
+
+    graph.add_many(
+        nodes=[*policy_nodes, *trade_nodes, *journal_nodes, *lesson_nodes],
+        edges=[*policy_edges, *trade_edges, *journal_edges, *lesson_edges],
+    )
+
+    stats = graph.stats()
+    stats["policy_windows"] = len(windows)
+    stats["never_resolved_policies"] = sorted(
+        set(TRACKED_POLICIES) - set(by_name) - {s.name for s in history.indeterminate}
+    )
+    # Surfaced, not swallowed: these parameters have no attributable cohort after the
+    # listed date, so any cohort table for them is knowingly incomplete.
+    stats["indeterminate_since"] = [
+        {"policy": s.name, "since": s.since[:10], "reason": s.reason} for s in history.indeterminate
+    ]
+    stats["ledger_trades"] = len(trades)
+    stats["journal_entries"] = len(journal_trades)
+    graph.close()
+    return stats

--- a/src/rag/graph/queries.py
+++ b/src/rag/graph/queries.py
@@ -1,0 +1,315 @@
+"""Multi-hop questions over the trade graph.
+
+Each function here answers something that vector retrieval structurally cannot, because
+the answer is a join across entities rather than a passage in a document:
+
+* `policy_cohorts`     -- did changing this risk parameter change the outcome?
+* `loss_attribution`   -- which exit path is actually bleeding, per strategy?
+* `explain_trade`      -- the causal chain around one structure.
+* `graph_context`      -- a bounded subgraph serialized for a language model.
+
+Every aggregate reports its own sample size and refuses to emit ratios that the sample
+cannot support. Cohort statistics on n=3 are noise wearing a decimal point.
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from dataclasses import dataclass, field
+from typing import Any
+
+from src.rag.graph.temporal_graph import Subgraph, TemporalGraph
+
+# Below this, ratio metrics are withheld rather than reported. Mirrors the n>=30
+# promotion gate in .claude/rules/kill-criteria.md.
+MIN_COHORT_FOR_RATIOS = 30
+
+# Only broker-reconciled paired closes may enter a metric. Entry-journal rows can be
+# open, carry no realized P/L, and per data-integrity.md "unmatched orders are never
+# trades". Counting them inflates sample size toward the n>=30 live-capital gate --
+# the one direction an error here must never go.
+SCORING_TIER = "paired_ledger"
+
+
+def _is_scorable(trade_attrs: dict[str, Any]) -> bool:
+    return trade_attrs.get("evidence_tier", SCORING_TIER) == SCORING_TIER
+
+
+@dataclass
+class Cohort:
+    """Trades sharing one policy value, with row-derived metrics."""
+
+    key: str
+    label: str
+    valid_from: str | None
+    valid_to: str | None
+    trade_ids: list[str] = field(default_factory=list)
+    wins: int = 0
+    losses: int = 0
+    breakeven: int = 0
+    gross_profit: float = 0.0
+    gross_loss: float = 0.0
+
+    @property
+    def n(self) -> int:
+        return len(self.trade_ids)
+
+    @property
+    def realized_pnl(self) -> float:
+        return round(self.gross_profit - self.gross_loss, 2)
+
+    def metrics(self) -> dict[str, Any]:
+        """Row-derived metrics. Ratios are None until the sample supports them."""
+        base: dict[str, Any] = {
+            "n": self.n,
+            "wins": self.wins,
+            "losses": self.losses,
+            "breakeven": self.breakeven,
+            "realized_pnl": self.realized_pnl,
+            "sufficient_sample": self.n >= MIN_COHORT_FOR_RATIOS,
+        }
+        if self.n == 0:
+            base.update(win_rate=None, expectancy=None, profit_factor=None)
+            return base
+
+        base["expectancy"] = round(self.realized_pnl / self.n, 2)
+        if self.n < MIN_COHORT_FOR_RATIOS:
+            # Withheld on purpose: a 3-trade "profit factor" invites exactly the
+            # over-reading that killed the previous strategy.
+            base.update(win_rate=None, profit_factor=None)
+            base["note"] = f"n={self.n} < {MIN_COHORT_FOR_RATIOS}; ratios withheld"
+            return base
+
+        base["win_rate"] = round(self.wins / self.n, 4)
+        base["profit_factor"] = (
+            round(self.gross_profit / self.gross_loss, 4) if self.gross_loss > 0 else None
+        )
+        return base
+
+
+def _accumulate(cohort: Cohort, trade_attrs: dict[str, Any], trade_id: str) -> None:
+    pnl = float(trade_attrs.get("realized_pnl") or 0.0)
+    outcome = trade_attrs.get("outcome")
+    cohort.trade_ids.append(trade_id)
+    if outcome == "win":
+        cohort.wins += 1
+    elif outcome == "loss":
+        cohort.losses += 1
+    else:
+        cohort.breakeven += 1
+    if pnl >= 0:
+        cohort.gross_profit += pnl
+    else:
+        cohort.gross_loss += abs(pnl)
+
+
+def policy_cohorts(
+    graph: TemporalGraph,
+    policy_name: str,
+    strategy: str | None = None,
+) -> list[dict[str, Any]]:
+    """Split trades by the policy value in force at entry, and score each cohort.
+
+    This is the question a stop-loss change actually poses -- "was the cohort under the
+    new value better than the cohort under the old one" -- and it needs the temporal
+    edge to answer, because today's constants file says nothing about March.
+    """
+    cohorts: dict[str, Cohort] = {}
+
+    for policy_node in graph.nodes_of_kind("policy"):
+        if policy_node.attrs.get("name") != policy_name:
+            continue
+        cohort = Cohort(
+            key=policy_node.id,
+            label=policy_node.label,
+            valid_from=policy_node.valid_from,
+            valid_to=policy_node.valid_to,
+        )
+        for _edge, neighbor_id in graph.neighbors(
+            policy_node.id, rels=["GOVERNED_BY"], direction="in"
+        ):
+            trade = graph.get_node(neighbor_id)
+            if trade is None or trade.kind != "trade":
+                continue
+            if not _is_scorable(trade.attrs):
+                continue
+            if strategy and trade.attrs.get("strategy") != strategy:
+                continue
+            _accumulate(cohort, trade.attrs, trade.id)
+        cohorts[policy_node.id] = cohort
+
+    ordered = sorted(cohorts.values(), key=lambda c: c.valid_from or "")
+    return [
+        {
+            "policy": policy_name,
+            "value": graph.get_node(c.key).attrs.get("value") if graph.get_node(c.key) else None,
+            "valid_from": c.valid_from,
+            "valid_to": c.valid_to,
+            **c.metrics(),
+        }
+        for c in ordered
+        if c.n > 0
+    ]
+
+
+def loss_attribution(graph: TemporalGraph, strategy: str | None = None) -> dict[str, Any]:
+    """Decompose realized losses by exit path and strategy.
+
+    Reports `unrecorded` exits explicitly instead of dropping them, because an
+    attribution table that quietly omits most of the ledger reads as complete when it
+    is not.
+    """
+    by_reason: dict[str, Cohort] = {}
+    by_strategy: dict[str, Cohort] = {}
+    excluded: dict[str, int] = defaultdict(int)
+
+    for trade in graph.nodes_of_kind("trade"):
+        if strategy and trade.attrs.get("strategy") != strategy:
+            continue
+        if not _is_scorable(trade.attrs):
+            # Counted nowhere, reported here. Silently dropping these would hide that
+            # the ledger and the journal disagree about how many trades exist.
+            excluded[trade.attrs.get("evidence_tier", "unknown")] += 1
+            continue
+        reason = trade.attrs.get("exit_reason") or "unrecorded"
+        strat = trade.attrs.get("strategy") or "unknown"
+
+        cohort = by_reason.setdefault(
+            reason, Cohort(key=reason, label=reason, valid_from=None, valid_to=None)
+        )
+        _accumulate(cohort, trade.attrs, trade.id)
+
+        scohort = by_strategy.setdefault(
+            strat, Cohort(key=strat, label=strat, valid_from=None, valid_to=None)
+        )
+        _accumulate(scohort, trade.attrs, trade.id)
+
+    total = sum(c.n for c in by_reason.values())
+    recorded = sum(c.n for c in by_reason.values() if c.key != "unrecorded")
+
+    return {
+        "total_trades": total,
+        "scoring_tier": SCORING_TIER,
+        "excluded_non_scorable": dict(excluded),
+        "exit_reason_recorded": recorded,
+        "exit_reason_coverage": round(recorded / total, 4) if total else None,
+        "by_exit_reason": sorted(
+            ({"exit_reason": k, **c.metrics()} for k, c in by_reason.items()),
+            key=lambda r: r["realized_pnl"],
+        ),
+        "by_strategy": sorted(
+            ({"strategy": k, **c.metrics()} for k, c in by_strategy.items()),
+            key=lambda r: r["realized_pnl"],
+        ),
+    }
+
+
+def explain_trade(graph: TemporalGraph, trade_id: str, hops: int = 2) -> dict[str, Any]:
+    """The causal neighbourhood of one structure: policy, outcome, exit, lessons."""
+    node_id = trade_id if trade_id.startswith("trade:") else f"trade:{trade_id}"
+    trade = graph.get_node(node_id)
+    if trade is None:
+        return {"error": f"unknown trade: {trade_id}"}
+
+    sub = graph.expand([node_id], hops=hops, node_budget=80)
+    governed_by = [
+        graph.get_node(e.dst) for e in sub.edges if e.src == node_id and e.rel == "GOVERNED_BY"
+    ]
+    return {
+        "trade": {"id": trade.id, "label": trade.label, **trade.attrs},
+        "entry": trade.valid_from,
+        "exit": trade.valid_to,
+        "governed_by": [
+            {"policy": n.attrs.get("name"), "value": n.attrs.get("value"), "since": n.valid_from}
+            for n in governed_by
+            if n is not None
+        ],
+        "related_lessons": [n.label for n in sub.by_kind("lesson")],
+        "subgraph_size": len(sub),
+        "truncated": sub.truncated,
+    }
+
+
+def graph_context(
+    graph: TemporalGraph,
+    seeds: list[str],
+    hops: int = 2,
+    node_budget: int = 60,
+    as_of: str | None = None,
+) -> str:
+    """Serialize a bounded subgraph into compact text for a language model.
+
+    The node budget is enforced during traversal rather than by truncating the string
+    afterwards, so the cost ceiling holds regardless of how dense the seed region is.
+    Truncation is stated in the output -- a partial subgraph must never read as the
+    whole picture.
+    """
+    sub = graph.expand(seeds, hops=hops, node_budget=node_budget, as_of=as_of)
+    if not sub.nodes:
+        return "No graph context found for the given seeds."
+
+    lines: list[str] = []
+    if as_of:
+        lines.append(f"# Graph context as of {as_of}")
+    lines.append(f"# {len(sub.nodes)} entities, {len(sub.edges)} relationships")
+    if sub.truncated:
+        lines.append(f"# TRUNCATED at node budget {node_budget} -- this subgraph is incomplete")
+
+    grouped: dict[str, list[str]] = defaultdict(list)
+    for node in sub.nodes.values():
+        window = ""
+        if node.valid_from:
+            window = f" [{node.valid_from[:10]}..{(node.valid_to or 'open')[:10]}]"
+        grouped[node.kind].append(f"  - {node.label}{window}")
+
+    lines.append("\n## Entities")
+    for kind in sorted(grouped):
+        lines.append(f"\n### {kind} ({len(grouped[kind])})")
+        lines.extend(sorted(grouped[kind])[:25])
+        if len(grouped[kind]) > 25:
+            lines.append(f"  ... {len(grouped[kind]) - 25} more {kind} entities omitted")
+
+    lines.append("\n## Relationships")
+    for edge in sub.edges[:60]:
+        src = sub.nodes.get(edge.src)
+        dst = sub.nodes.get(edge.dst)
+        if src is None or dst is None:
+            continue
+        lines.append(f"  ({src.label}) -[{edge.rel}]-> ({dst.label})")
+    if len(sub.edges) > 60:
+        lines.append(f"  ... {len(sub.edges) - 60} more relationships omitted")
+
+    return "\n".join(lines)
+
+
+def seeds_from_terms(graph: TemporalGraph, terms: list[str], limit: int = 10) -> list[str]:
+    """Resolve free-text terms to node ids by label match.
+
+    Deliberately dumb: the existing hybrid retriever already does semantic ranking. The
+    graph's job is expansion from an anchor, not competing at relevance scoring.
+    """
+    wanted = [t.lower() for t in terms if t.strip()]
+    if not wanted:
+        return []
+    hits: list[tuple[int, str]] = []
+    for kind in ("strategy", "policy", "policy_name", "exit_reason", "lesson", "outcome"):
+        for node in graph.nodes_of_kind(kind):
+            haystack = f"{node.id} {node.label}".lower()
+            score = sum(1 for term in wanted if term in haystack)
+            if score:
+                hits.append((score, node.id))
+    hits.sort(key=lambda pair: (-pair[0], pair[1]))
+    return [node_id for _, node_id in hits[:limit]]
+
+
+def subgraph_summary(sub: Subgraph) -> dict[str, Any]:
+    """Compact stats for logging and tests."""
+    kinds: dict[str, int] = defaultdict(int)
+    for node in sub.nodes.values():
+        kinds[node.kind] += 1
+    return {
+        "nodes": len(sub.nodes),
+        "edges": len(sub.edges),
+        "kinds": dict(kinds),
+        "truncated": sub.truncated,
+    }

--- a/src/rag/graph/temporal_graph.py
+++ b/src/rag/graph/temporal_graph.py
@@ -1,0 +1,370 @@
+"""Bitemporal knowledge graph over the trading system's own causal history.
+
+Vector RAG retrieves chunks that *look like* the query. It cannot answer a question
+whose answer is a join -- "which policy was in force when this cohort lost money, and
+which lesson already warned about it". No single chunk contains that; it lives in the
+edges. This module stores those edges.
+
+Temporal semantics follow the bitemporal model: every node and edge carries a validity
+interval (`valid_from`, `valid_to`) describing when the fact was true in the world, plus
+`ingested_at` describing when we learned it. Traversal is always `as_of` a timestamp, so
+a query about March 2026 sees the risk policy that was actually in force in March 2026 --
+not today's constants.
+
+Backed by the SQLite already in the repo. No graph server, no new infrastructure.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from collections import deque
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any, Iterable, Iterator, Literal
+
+PROJECT_ROOT = Path(__file__).resolve().parents[3]
+DEFAULT_DB_PATH = PROJECT_ROOT / "data" / "rag" / "trade_graph.sqlite"
+
+Direction = Literal["out", "in", "both"]
+
+_SCHEMA = """
+CREATE TABLE IF NOT EXISTS nodes (
+    id          TEXT PRIMARY KEY,
+    kind        TEXT NOT NULL,
+    label       TEXT NOT NULL,
+    attrs_json  TEXT NOT NULL DEFAULT '{}',
+    valid_from  TEXT,
+    valid_to    TEXT,
+    ingested_at TEXT NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_nodes_kind ON nodes(kind);
+
+CREATE TABLE IF NOT EXISTS edges (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    src         TEXT NOT NULL,
+    rel         TEXT NOT NULL,
+    dst         TEXT NOT NULL,
+    weight      REAL NOT NULL DEFAULT 1.0,
+    attrs_json  TEXT NOT NULL DEFAULT '{}',
+    valid_from  TEXT,
+    valid_to    TEXT,
+    ingested_at TEXT NOT NULL,
+    UNIQUE(src, rel, dst, valid_from)
+);
+CREATE INDEX IF NOT EXISTS idx_edges_src ON edges(src, rel);
+CREATE INDEX IF NOT EXISTS idx_edges_dst ON edges(dst, rel);
+"""
+
+
+def _utcnow() -> str:
+    return datetime.now(UTC).isoformat()
+
+
+@dataclass(frozen=True)
+class Node:
+    """A typed entity. `id` is namespaced by kind, e.g. `trade:IC_SPY_...`."""
+
+    id: str
+    kind: str
+    label: str
+    attrs: dict[str, Any] = field(default_factory=dict)
+    valid_from: str | None = None
+    valid_to: str | None = None
+
+
+@dataclass(frozen=True)
+class Edge:
+    """A directed, time-scoped relationship."""
+
+    src: str
+    rel: str
+    dst: str
+    weight: float = 1.0
+    attrs: dict[str, Any] = field(default_factory=dict)
+    valid_from: str | None = None
+    valid_to: str | None = None
+
+
+@dataclass
+class Subgraph:
+    """Result of a bounded traversal.
+
+    `truncated` is True when the node budget stopped the expansion early. Callers must
+    surface that rather than presenting a partial subgraph as complete -- a truncated
+    traversal that reads as exhaustive is how a graph answer becomes a confident lie.
+    """
+
+    nodes: dict[str, Node] = field(default_factory=dict)
+    edges: list[Edge] = field(default_factory=list)
+    depth_of: dict[str, int] = field(default_factory=dict)
+    truncated: bool = False
+
+    def __len__(self) -> int:
+        return len(self.nodes)
+
+    def by_kind(self, kind: str) -> list[Node]:
+        return [n for n in self.nodes.values() if n.kind == kind]
+
+
+def _row_to_node(row: sqlite3.Row) -> Node:
+    return Node(
+        id=row["id"],
+        kind=row["kind"],
+        label=row["label"],
+        attrs=json.loads(row["attrs_json"]),
+        valid_from=row["valid_from"],
+        valid_to=row["valid_to"],
+    )
+
+
+def _row_to_edge(row: sqlite3.Row) -> Edge:
+    return Edge(
+        src=row["src"],
+        rel=row["rel"],
+        dst=row["dst"],
+        weight=row["weight"],
+        attrs=json.loads(row["attrs_json"]),
+        valid_from=row["valid_from"],
+        valid_to=row["valid_to"],
+    )
+
+
+class TemporalGraph:
+    """SQLite-backed bitemporal property graph.
+
+    Read paths are pure SQL over two indexed tables; a k-hop expansion on a graph of this
+    size is sub-millisecond, which is several orders of magnitude inside the latency
+    budget of a strategy that holds positions for 30-45 days.
+    """
+
+    def __init__(self, db_path: str | Path | None = None) -> None:
+        self.db_path = Path(db_path) if db_path else DEFAULT_DB_PATH
+        if str(self.db_path) != ":memory:":
+            self.db_path.parent.mkdir(parents=True, exist_ok=True)
+        self._conn = sqlite3.connect(str(self.db_path))
+        self._conn.row_factory = sqlite3.Row
+        self._conn.executescript(_SCHEMA)
+        self._conn.commit()
+
+    def close(self) -> None:
+        self._conn.close()
+
+    def __enter__(self) -> TemporalGraph:
+        return self
+
+    def __exit__(self, *exc: object) -> None:
+        self.close()
+
+    # ------------------------------------------------------------------ writes
+
+    def add_node(self, node: Node) -> None:
+        self._conn.execute(
+            """INSERT INTO nodes (id, kind, label, attrs_json, valid_from, valid_to, ingested_at)
+               VALUES (?, ?, ?, ?, ?, ?, ?)
+               ON CONFLICT(id) DO UPDATE SET
+                   kind=excluded.kind,
+                   label=excluded.label,
+                   attrs_json=excluded.attrs_json,
+                   valid_from=excluded.valid_from,
+                   valid_to=excluded.valid_to,
+                   ingested_at=excluded.ingested_at""",
+            (
+                node.id,
+                node.kind,
+                node.label,
+                json.dumps(node.attrs, sort_keys=True, default=str),
+                node.valid_from,
+                node.valid_to,
+                _utcnow(),
+            ),
+        )
+
+    def add_edge(self, edge: Edge) -> None:
+        self._conn.execute(
+            """INSERT INTO edges (src, rel, dst, weight, attrs_json, valid_from, valid_to, ingested_at)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+               ON CONFLICT(src, rel, dst, valid_from) DO UPDATE SET
+                   weight=excluded.weight,
+                   attrs_json=excluded.attrs_json,
+                   valid_to=excluded.valid_to,
+                   ingested_at=excluded.ingested_at""",
+            (
+                edge.src,
+                edge.rel,
+                edge.dst,
+                edge.weight,
+                json.dumps(edge.attrs, sort_keys=True, default=str),
+                edge.valid_from,
+                edge.valid_to,
+                _utcnow(),
+            ),
+        )
+
+    def add_many(self, nodes: Iterable[Node] = (), edges: Iterable[Edge] = ()) -> None:
+        for node in nodes:
+            self.add_node(node)
+        for edge in edges:
+            self.add_edge(edge)
+        self._conn.commit()
+
+    def clear(self) -> None:
+        self._conn.executescript("DELETE FROM edges; DELETE FROM nodes;")
+        self._conn.commit()
+
+    # ------------------------------------------------------------------- reads
+
+    def get_node(self, node_id: str) -> Node | None:
+        row = self._conn.execute("SELECT * FROM nodes WHERE id = ?", (node_id,)).fetchone()
+        return _row_to_node(row) if row else None
+
+    def nodes_of_kind(self, kind: str) -> list[Node]:
+        rows = self._conn.execute("SELECT * FROM nodes WHERE kind = ? ORDER BY id", (kind,))
+        return [_row_to_node(r) for r in rows]
+
+    def stats(self) -> dict[str, Any]:
+        node_kinds = {
+            r["kind"]: r["n"]
+            for r in self._conn.execute("SELECT kind, COUNT(*) n FROM nodes GROUP BY kind")
+        }
+        edge_rels = {
+            r["rel"]: r["n"]
+            for r in self._conn.execute("SELECT rel, COUNT(*) n FROM edges GROUP BY rel")
+        }
+        return {
+            "nodes": sum(node_kinds.values()),
+            "edges": sum(edge_rels.values()),
+            "node_kinds": node_kinds,
+            "edge_relations": edge_rels,
+            "db_path": str(self.db_path),
+        }
+
+    def neighbors(
+        self,
+        node_id: str,
+        rels: Iterable[str] | None = None,
+        direction: Direction = "both",
+        as_of: str | None = None,
+    ) -> Iterator[tuple[Edge, str]]:
+        """Yield `(edge, neighbor_id)` for edges valid at `as_of`.
+
+        An edge is valid at T when `valid_from <= T` (or is open) and `valid_to > T`
+        (or is open). Passing `as_of=None` ignores time entirely.
+        """
+        clauses: list[str] = []
+        params: list[Any] = []
+
+        if direction == "out":
+            clauses.append("src = ?")
+            params.append(node_id)
+        elif direction == "in":
+            clauses.append("dst = ?")
+            params.append(node_id)
+        else:
+            clauses.append("(src = ? OR dst = ?)")
+            params.extend([node_id, node_id])
+
+        rel_list = list(rels) if rels else []
+        if rel_list:
+            clauses.append(f"rel IN ({','.join('?' for _ in rel_list)})")
+            params.extend(rel_list)
+
+        if as_of is not None:
+            clauses.append("(valid_from IS NULL OR valid_from <= ?)")
+            params.append(as_of)
+            clauses.append("(valid_to IS NULL OR valid_to > ?)")
+            params.append(as_of)
+
+        # Every fragment in `clauses` is a module-literal; all user data is parameterized.
+        where = " AND ".join(clauses)
+        # `where` is built only from the module-literal fragments appended above; every
+        # caller-supplied value goes through `params` as a bound parameter.
+        sql = f"SELECT * FROM edges WHERE {where} ORDER BY weight DESC, id"  # noqa: S608 # nosec B608
+        for row in self._conn.execute(sql, params):
+            edge = _row_to_edge(row)
+            yield edge, (edge.dst if edge.src == node_id else edge.src)
+
+    def expand(
+        self,
+        seeds: Iterable[str],
+        hops: int = 2,
+        node_budget: int = 200,
+        rels: Iterable[str] | None = None,
+        direction: Direction = "both",
+        as_of: str | None = None,
+    ) -> Subgraph:
+        """Breadth-first expansion from `seeds`, bounded by `hops` and `node_budget`.
+
+        The budget is the cost gateway: multi-hop expansion over a dense node (an
+        `outcome:loss` touching 138 trades) explodes context if left unbounded. Breadth
+        is capped here, before anything reaches a model, rather than trimmed afterwards.
+        """
+        rel_list = list(rels) if rels else None
+        sub = Subgraph()
+        queue: deque[tuple[str, int]] = deque()
+
+        for seed in seeds:
+            node = self.get_node(seed)
+            if node is None or seed in sub.nodes:
+                continue
+            sub.nodes[seed] = node
+            sub.depth_of[seed] = 0
+            queue.append((seed, 0))
+
+        seen_edges: set[tuple[str, str, str, str | None]] = set()
+
+        while queue:
+            current, depth = queue.popleft()
+            if depth >= hops:
+                continue
+            for edge, neighbor_id in self.neighbors(
+                current, rels=rel_list, direction=direction, as_of=as_of
+            ):
+                key = (edge.src, edge.rel, edge.dst, edge.valid_from)
+                if key not in seen_edges:
+                    seen_edges.add(key)
+                    sub.edges.append(edge)
+                if neighbor_id in sub.nodes:
+                    continue
+                if len(sub.nodes) >= node_budget:
+                    sub.truncated = True
+                    return sub
+                neighbor = self.get_node(neighbor_id)
+                if neighbor is None:
+                    continue
+                sub.nodes[neighbor_id] = neighbor
+                sub.depth_of[neighbor_id] = depth + 1
+                queue.append((neighbor_id, depth + 1))
+
+        return sub
+
+    def paths(
+        self,
+        source: str,
+        target: str,
+        max_hops: int = 4,
+        as_of: str | None = None,
+    ) -> list[list[Edge]]:
+        """All simple paths from `source` to `target` within `max_hops`.
+
+        This is the multi-hop answer vector search cannot produce: the concrete chain
+        connecting a policy change to a loss cohort to the lesson that warned about it.
+        """
+        results: list[list[Edge]] = []
+        stack: list[tuple[str, list[Edge], set[str]]] = [(source, [], {source})]
+
+        while stack:
+            current, path, visited = stack.pop()
+            if len(path) >= max_hops:
+                continue
+            for edge, neighbor_id in self.neighbors(current, as_of=as_of):
+                if neighbor_id in visited:
+                    continue
+                new_path = [*path, edge]
+                if neighbor_id == target:
+                    results.append(new_path)
+                    continue
+                stack.append((neighbor_id, new_path, visited | {neighbor_id}))
+
+        return sorted(results, key=len)

--- a/src/rag/lessons_learned_rag.py
+++ b/src/rag/lessons_learned_rag.py
@@ -45,9 +45,11 @@ class LessonsLearnedRAG:
         self._pipeline = None
         try:
             from src.rag.rag_pipeline import TradingRAGPipeline, get_trading_rag_pipeline
+
             if self._custom_dir:
                 # Custom directory: create a separate pipeline (not the singleton)
                 import tempfile as _tempfile
+
                 _fd, _db_path = _tempfile.mkstemp(suffix=".db")
                 os.close(_fd)
                 self._pipeline = TradingRAGPipeline(
@@ -285,7 +287,14 @@ class LessonsLearnedRAG:
         """
         if self._pipeline is not None:
             try:
-                return self._pipeline.query(query=query, top_k=top_k, severity_filter=severity_filter)
+                results = self._pipeline.query(
+                    query=query, top_k=top_k, severity_filter=severity_filter
+                )
+                # Record provenance. Without this the primary backend served results
+                # while `last_source` stayed at its "none" default, so the CLI reported
+                # no source for rows it had just returned.
+                self.last_source = "pipeline"
+                return results
             except Exception as e:
                 logger.warning(f"TradingRAGPipeline query failed: {e} - using legacy search")
 
@@ -505,8 +514,18 @@ class LessonsLearnedRAG:
         return scored_results[:top_k]
 
     def add_lesson(self, lesson_id: str, content: str) -> None:
-        """Add a new lesson (writes to file)."""
+        """Add a new lesson (writes to file) and make it immediately retrievable."""
         self.knowledge_dir.mkdir(parents=True, exist_ok=True)
         lesson_file = self.knowledge_dir / f"{lesson_id}.md"
         lesson_file.write_text(content, encoding="utf-8")
-        self._load_lessons()  # Reload
+        self._load_lessons()  # Reload the legacy keyword corpus
+
+        # query() prefers the pipeline backend, so a write that never reaches the
+        # pipeline index is invisible to the very next read. Without this re-index the
+        # write/read contract silently did not hold: the file existed on disk and the
+        # lesson was unretrievable.
+        if self._pipeline is not None:
+            try:
+                self._pipeline.index_from_markdown_dir(str(self.knowledge_dir))
+            except Exception as e:
+                logger.warning(f"Pipeline re-index after add_lesson failed: {e}")

--- a/src/rag/rag_pipeline.py
+++ b/src/rag/rag_pipeline.py
@@ -24,7 +24,7 @@ import re
 import sqlite3
 import threading
 from dataclasses import dataclass, field
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any, Optional
 
@@ -46,7 +46,15 @@ DOMAIN_SYNONYMS: dict[str, list[str]] = {
     "vix": ["volatility", "vxv", "volatility index", "vix spike"],
     "delta": ["15 delta", "20 delta", "strike selection", "probability otm"],
     "dte": ["days to expiration", "expiry", "time decay", "7 dte", "0 dte"],
-    "position sizing": ["position limit", "allocation", "risk per trade", "notional", "size", "sizing", "limit"],
+    "position sizing": [
+        "position limit",
+        "allocation",
+        "risk per trade",
+        "notional",
+        "size",
+        "sizing",
+        "limit",
+    ],
     "stop loss": ["stop-loss", "max loss", "loss limit", "drawdown halt"],
     "section 1256": ["xsp", "spx", "60/40 tax", "index option", "60-40"],
     "1256": ["section 1256", "xsp", "spx", "60/40 tax treatment"],
@@ -64,13 +72,64 @@ TICKER_REGEX = re.compile(
 # Stopwords for tokenization
 _STOPWORDS: frozenset[str] = frozenset(
     {
-        "the", "and", "for", "with", "from", "that", "this", "into", "over",
-        "your", "you", "our", "are", "was", "were", "why", "how", "what",
-        "when", "where", "who", "which", "about", "after", "before",
-        "they", "them", "their", "then", "than", "but", "not", "can",
-        "could", "should", "would", "will", "just", "does", "did", "had",
-        "has", "have", "it", "its", "be", "as", "at", "by", "or", "if",
-        "in", "on", "to", "of", "a", "an", "is",
+        "the",
+        "and",
+        "for",
+        "with",
+        "from",
+        "that",
+        "this",
+        "into",
+        "over",
+        "your",
+        "you",
+        "our",
+        "are",
+        "was",
+        "were",
+        "why",
+        "how",
+        "what",
+        "when",
+        "where",
+        "who",
+        "which",
+        "about",
+        "after",
+        "before",
+        "they",
+        "them",
+        "their",
+        "then",
+        "than",
+        "but",
+        "not",
+        "can",
+        "could",
+        "should",
+        "would",
+        "will",
+        "just",
+        "does",
+        "did",
+        "had",
+        "has",
+        "have",
+        "it",
+        "its",
+        "be",
+        "as",
+        "at",
+        "by",
+        "or",
+        "if",
+        "in",
+        "on",
+        "to",
+        "of",
+        "a",
+        "an",
+        "is",
     }
 )
 
@@ -94,6 +153,7 @@ _SECTION_HEADERS = (
 # ---------------------------------------------------------------------------
 # Data structures
 # ---------------------------------------------------------------------------
+
 
 @dataclass(frozen=True)
 class LessonResult:
@@ -305,7 +365,7 @@ class SQLiteFTS5Store:
 
     # --- FTS5 query escaping ---
     _FTS_STOPWORDS_REMOVED = False
-    _FTS_SPECIAL_CHARS = set('-+*<>(){}[]!"\'')
+    _FTS_SPECIAL_CHARS = set("-+*<>(){}[]!\"'")
 
     @staticmethod
     def _escape_fts_query(query: str) -> str:
@@ -372,9 +432,7 @@ class SQLiteFTS5Store:
     def get_by_id(self, lesson_id: str) -> Optional[dict[str, Any]]:
         conn = self._get_conn()
         with self._lock:
-            row = conn.execute(
-                "SELECT * FROM lessons WHERE lesson_id = ?", (lesson_id,)
-            ).fetchone()
+            row = conn.execute("SELECT * FROM lessons WHERE lesson_id = ?", (lesson_id,)).fetchone()
         return dict(row) if row else None
 
     def upsert_many(self, records: list[LessonRecord]) -> int:
@@ -388,8 +446,16 @@ class SQLiteFTS5Store:
                 VALUES (?, ?, ?, ?, ?, ?, ?, ?)
                 """,
                 [
-                    (r.lesson_id, r.title, r.content, r.severity, r.prevention,
-                     r.tags, r.source, r.created_at)
+                    (
+                        r.lesson_id,
+                        r.title,
+                        r.content,
+                        r.severity,
+                        r.prevention,
+                        r.tags,
+                        r.source,
+                        r.created_at,
+                    )
                     for r in records
                 ],
             )
@@ -400,6 +466,7 @@ class SQLiteFTS5Store:
 # ---------------------------------------------------------------------------
 # Quality gate
 # ---------------------------------------------------------------------------
+
 
 def quality_gate(content: str) -> tuple[bool, str]:
     """Normalize and quality-check lesson content before storage.
@@ -479,13 +546,14 @@ def parse_lesson_markdown(content: str, lesson_id: str | None = None) -> LessonR
         prevention=prevention,
         tags=tags,
         source="markdown",
-        created_at=datetime.now(timezone.utc).isoformat(),
+        created_at=datetime.now(UTC).isoformat(),
     )
 
 
 # ---------------------------------------------------------------------------
 # Multi-query engine
 # ---------------------------------------------------------------------------
+
 
 def generate_query_variants(query: str, max_variants: int = 3) -> list[QueryVariant]:
     """Generate up to *max_variants* query variants for multi-query retrieval.
@@ -521,7 +589,9 @@ def generate_query_variants(query: str, max_variants: int = 3) -> list[QueryVari
     tickers = TICKER_REGEX.findall(query)
     tokens = tokenize(query)
     keyword_parts = list(dict.fromkeys(tokens))  # dedupe, preserve order
-    keyword_str = " ".join(tickers[:3] + keyword_parts[:8]) if tickers else " ".join(keyword_parts[:8])
+    keyword_str = (
+        " ".join(tickers[:3] + keyword_parts[:8]) if tickers else " ".join(keyword_parts[:8])
+    )
     variants.append(QueryVariant(text=keyword_str or query, kind="keyword_focused"))
 
     return variants[:max_variants]
@@ -530,6 +600,32 @@ def generate_query_variants(query: str, max_variants: int = 3) -> list[QueryVari
 # ---------------------------------------------------------------------------
 # Reranker
 # ---------------------------------------------------------------------------
+
+CROSS_ENCODER_MODEL = "cross-encoder/ms-marco-MiniLM-L-6-v2"
+
+# Cross-encoder weights are immutable and ~80MB; loading them cost ~3-4s on EVERY
+# RAGEReranker() construction, and a reranker is built per pipeline. That doubled the
+# test suite (640s -> 1277s) and put multiple seconds on the first query of every new
+# pipeline. The model is stateless for scoring, so one process-wide instance is correct.
+_cross_encoder_cache: dict[str, Any] = {}
+_cross_encoder_lock = threading.Lock()
+
+
+def _load_cross_encoder(model_name: str):
+    """Return a process-wide cross-encoder, loading it at most once per model."""
+    cached = _cross_encoder_cache.get(model_name)
+    if cached is not None:
+        return cached
+    with _cross_encoder_lock:
+        # Re-check inside the lock: two threads can race past the fast path above.
+        cached = _cross_encoder_cache.get(model_name)
+        if cached is None:
+            from sentence_transformers import CrossEncoder
+
+            cached = CrossEncoder(model_name)
+            _cross_encoder_cache[model_name] = cached
+    return cached
+
 
 class RAGEReranker:
     """Reranker that uses a cross-encoder when available, LLM when an API key is present,
@@ -543,9 +639,19 @@ class RAGEReranker:
 
     # Domain keywords that get a priority boost in the heuristic fallback
     _HIGH_PRIORITY_KEYWORDS: list[str] = [
-        "drawdown", "circuit breaker", "safety buffer", "stop loss",
-        "position sizing", "risk management", "section 1256", "200-dma",
-        "bogleheads", "wash sale", "pdt", "margin", "tax",
+        "drawdown",
+        "circuit breaker",
+        "safety buffer",
+        "stop loss",
+        "position sizing",
+        "risk management",
+        "section 1256",
+        "200-dma",
+        "bogleheads",
+        "wash sale",
+        "pdt",
+        "margin",
+        "tax",
     ]
 
     def __init__(self) -> None:
@@ -559,11 +665,9 @@ class RAGEReranker:
         """Detect the best available reranker and initialize it."""
         # 1. Try cross-encoder
         try:
-            from sentence_transformers import CrossEncoder
-
-            self._cross_encoder = CrossEncoder("cross-encoder/ms-marco-MiniLM-L-6-v2")
+            self._cross_encoder = _load_cross_encoder(CROSS_ENCODER_MODEL)
             self._reranker_type = "cross-encoder"
-            logger.info("RAGEReranker: using cross-encoder/ms-marco-MiniLM-L-6-v2")
+            logger.info("RAGEReranker: using %s", CROSS_ENCODER_MODEL)
             return
         except Exception:
             logger.debug("Cross-encoder unavailable, falling through to LLM/heuristic")
@@ -661,7 +765,11 @@ class RAGEReranker:
             # Title-match boost: query tokens appearing in the title get a boost
             title_lower = (c.get("title", "") + " " + str(c.get("id", ""))).lower()
             title_tokens = set(tokenize(title_lower))
-            title_overlap = len(query_tokens & title_tokens) / max(len(query_tokens), 1) if query_tokens else 0.0
+            title_overlap = (
+                len(query_tokens & title_tokens) / max(len(query_tokens), 1)
+                if query_tokens
+                else 0.0
+            )
             title_boost = title_overlap * 0.12
 
             c["rerank_score"] = round(
@@ -679,7 +787,7 @@ class RAGEReranker:
             return []
 
         # Limit to a manageable number for LLM reranking
-        top_candidates = candidates[:min(10, len(candidates))]
+        top_candidates = candidates[: min(10, len(candidates))]
         prompt = self._build_llm_rerank_prompt(query, top_candidates)
 
         try:
@@ -726,9 +834,9 @@ class RAGEReranker:
         ]
         for i, c in enumerate(candidates):
             snippet = (c.get("content_snippet") or c.get("content", ""))[:200]
-            lines.append(f"[{i}] id={c.get('id')} title={c.get('title','')} snippet={snippet}")
+            lines.append(f"[{i}] id={c.get('id')} title={c.get('title', '')} snippet={snippet}")
         lines.append("")
-        lines.append("Output format: [\"id1\", \"id2\", ...]")
+        lines.append('Output format: ["id1", "id2", ...]')
         return "\n".join(lines)
 
     def _parse_llm_rerank_output(self, text: str) -> list[str]:
@@ -769,7 +877,11 @@ class RAGEReranker:
             stemmed_doc = _stem_tokens(doc_tokens)
             if stemmed_query and stemmed_doc:
                 overlap = len(stemmed_query & stemmed_doc) / max(len(stemmed_query), 1)
-                unigram_jaccard = len(stemmed_query & stemmed_doc) / len(stemmed_query | stemmed_doc) if (stemmed_query | stemmed_doc) else 0.0
+                unigram_jaccard = (
+                    len(stemmed_query & stemmed_doc) / len(stemmed_query | stemmed_doc)
+                    if (stemmed_query | stemmed_doc)
+                    else 0.0
+                )
             else:
                 overlap = 0.0
                 unigram_jaccard = 0.0
@@ -783,7 +895,11 @@ class RAGEReranker:
 
             # Title match boost
             title_tokens = set(tokenize(title.lower()))
-            title_match = len(query_tokens & title_tokens) / max(len(query_tokens), 1) if query_tokens else 0.0
+            title_match = (
+                len(query_tokens & title_tokens) / max(len(query_tokens), 1)
+                if query_tokens
+                else 0.0
+            )
 
             # Domain priority keyword boost
             priority_boost = 0.0
@@ -815,6 +931,7 @@ class RAGEReranker:
 # ---------------------------------------------------------------------------
 # Pragmatic hybrid search (bigram-Jaccard + keyword)
 # ---------------------------------------------------------------------------
+
 
 @dataclass
 class HybridHit:
@@ -896,14 +1013,20 @@ def pragmatic_hybrid_search(
         if stemmed_query and stemmed_doc:
             unigram = len(stemmed_query & stemmed_doc) / len(stemmed_query | stemmed_doc)
         else:
-            unigram = len(query_tokens & doc_tokens) / len(query_tokens | doc_tokens) if (query_tokens and doc_tokens) else 0.0
+            unigram = (
+                len(query_tokens & doc_tokens) / len(query_tokens | doc_tokens)
+                if (query_tokens and doc_tokens)
+                else 0.0
+            )
 
         # --- Phrase matching bonus ---
         phrase_bonus = 0.15 if query_lower and query_lower in text_lower else 0.0
 
         # --- Title boost ---
         title_tokens = set(tokenize(title_lower))
-        title_match = len(query_tokens & title_tokens) / max(len(query_tokens), 1) if query_tokens else 0.0
+        title_match = (
+            len(query_tokens & title_tokens) / max(len(query_tokens), 1) if query_tokens else 0.0
+        )
 
         # --- Keyword: BM25 (from SQLite FTS5, or TF fallback) ---
         raw_bm25 = abs(float(lesson.get("bm25_score", 0.0)))
@@ -957,6 +1080,7 @@ def pragmatic_hybrid_search(
 # ---------------------------------------------------------------------------
 # Deterministic gate
 # ---------------------------------------------------------------------------
+
 
 @dataclass(frozen=True)
 class GateDecision:
@@ -1017,9 +1141,10 @@ def gate_decision(top_lessons: list[tuple[LessonResult, float]]) -> GateDecision
         max_score = max(max_score, score)
         sev = lesson.severity.upper()
 
-        if sev == "CRITICAL" and score > _BLOCK_THRESHOLD_CRITICAL:
-            blocking.append(f"[{sev}] {lesson.title} (score={score:.2f})")
-        elif sev == "HIGH" and score > _BLOCK_THRESHOLD_HIGH:
+        is_blocking = (sev == "CRITICAL" and score > _BLOCK_THRESHOLD_CRITICAL) or (
+            sev == "HIGH" and score > _BLOCK_THRESHOLD_HIGH
+        )
+        if is_blocking:
             blocking.append(f"[{sev}] {lesson.title} (score={score:.2f})")
         elif sev in ("CRITICAL", "HIGH") and score > _WARN_THRESHOLD:
             warnings.append(f"[{sev}] {lesson.title} (score={score:.2f})")
@@ -1057,6 +1182,7 @@ def gate_decision(top_lessons: list[tuple[LessonResult, float]]) -> GateDecision
 # ---------------------------------------------------------------------------
 # The full pipeline
 # ---------------------------------------------------------------------------
+
 
 class TradingRAGPipeline:
     """End-to-end RAG pipeline for the trading system.
@@ -1107,15 +1233,13 @@ class TradingRAGPipeline:
             prevention=record.prevention,
             tags=record.tags,
             source=source,
-            created_at=datetime.now(timezone.utc).isoformat(),
+            created_at=datetime.now(UTC).isoformat(),
         )
         self.store.put(record)
         self._cache_loaded = False  # invalidate cache
         return True, f"Stored lesson '{record.lesson_id}'"
 
-    def add_lesson(
-        self, lesson_id: str, content: str, *, source: str = "manual"
-    ) -> bool:
+    def add_lesson(self, lesson_id: str, content: str, *, source: str = "manual") -> bool:
         """Convenience alias: add a lesson with quality gate."""
         normalized = re.sub(r"\s+", " ", content).strip()
         passes, reason = quality_gate(normalized)
@@ -1131,7 +1255,7 @@ class TradingRAGPipeline:
             prevention=record.prevention,
             tags=record.tags,
             source=source,
-            created_at=datetime.now(timezone.utc).isoformat(),
+            created_at=datetime.now(UTC).isoformat(),
         )
         self.store.put(record)
         self._cache_loaded = False
@@ -1209,7 +1333,11 @@ class TradingRAGPipeline:
         # bigram-Jaccard + cross-encoder handle precision.
         fts_results = self.store.fts_search(query, top_k=200)
         if severity_filter:
-            fts_results = [item for item in fts_results if item.get("severity", "").upper() == severity_filter.upper()]
+            fts_results = [
+                item
+                for item in fts_results
+                if item.get("severity", "").upper() == severity_filter.upper()
+            ]
 
         # Pragmatic hybrid search: bigram-Jaccard on top of FTS5 BM25 results
         hits = pragmatic_hybrid_search(query, fts_results, top_k=top_k * 8)
@@ -1224,7 +1352,11 @@ class TradingRAGPipeline:
             for variant in variants:
                 v_fts = self.store.fts_search(variant.text, top_k=100)
                 if severity_filter:
-                    v_fts = [item for item in v_fts if item.get("severity", "").upper() == severity_filter.upper()]
+                    v_fts = [
+                        item
+                        for item in v_fts
+                        if item.get("severity", "").upper() == severity_filter.upper()
+                    ]
                 v_hits = pragmatic_hybrid_search(variant.text, v_fts, top_k=top_k * 2)
                 # Merge by lesson_id, keeping highest combined_score
                 existing_ids = {h.id for h in hits}
@@ -1268,7 +1400,9 @@ class TradingRAGPipeline:
             # (not batch-relative), so OOD queries get near-zero scores
             if self._reranker._cross_encoder is not None and candidates:
                 ce_candidates = [dict(c) for c in candidates]
-                ce_pass = self._reranker._rerank_cross_encoder(query, ce_candidates, top_n=len(ce_candidates))
+                ce_pass = self._reranker._rerank_cross_encoder(
+                    query, ce_candidates, top_n=len(ce_candidates)
+                )
                 max_ce_sig = max((float(r.get("_ce_sigmoid", 0.0)) for r in ce_pass), default=0.0)
                 if max_ce_sig < _CE_OOD_THRESHOLD:
                     return []  # Out-of-domain — all CE scores too low
@@ -1277,42 +1411,52 @@ class TradingRAGPipeline:
             reranked = self._reranker.rerank(query, candidates, top_n=top_k * 8)
 
             # Filter by minimum rerank score
-            reranked = [r for r in reranked if float(r.get("rerank_score", 0.0)) >= _MIN_RESULT_SCORE]
+            reranked = [
+                r for r in reranked if float(r.get("rerank_score", 0.0)) >= _MIN_RESULT_SCORE
+            ]
 
             results = []
             for c in reranked:
-                results.append({
-                    "id": c["id"],
-                    "title": c["title"],
-                    "severity": c["severity"].upper(),
-                    "snippet": c.get("content_snippet", c.get("content", ""))[:500],
-                    "content": c.get("content", ""),
-                    "prevention": c.get("prevention", ""),
-                    "file": c.get("file", ""),
-                    "score": c.get("rerank_score", c.get("score", 0.0)),
-                    "lexical_score": next((h.lexical_score for h in hits if h.id == c["id"]), 0.0),
-                    "keyword_score": next((h.keyword_score for h in hits if h.id == c["id"]), 0.0),
-                    "reranker_type": self._reranker.reranker_type,
-                })
+                results.append(
+                    {
+                        "id": c["id"],
+                        "title": c["title"],
+                        "severity": c["severity"].upper(),
+                        "snippet": c.get("content_snippet", c.get("content", ""))[:500],
+                        "content": c.get("content", ""),
+                        "prevention": c.get("prevention", ""),
+                        "file": c.get("file", ""),
+                        "score": c.get("rerank_score", c.get("score", 0.0)),
+                        "lexical_score": next(
+                            (h.lexical_score for h in hits if h.id == c["id"]), 0.0
+                        ),
+                        "keyword_score": next(
+                            (h.keyword_score for h in hits if h.id == c["id"]), 0.0
+                        ),
+                        "reranker_type": self._reranker.reranker_type,
+                    }
+                )
             return results[:top_k]
 
         # --- No rerank — return hybrid results with OOD filter ---
         results = []
         for h in hits[:top_k]:
             if h.combined_score >= _MIN_RESULT_SCORE:
-                results.append({
-                    "id": h.id,
-                    "title": h.title,
-                    "severity": h.severity.upper(),
-                    "snippet": h.snippet,
-                    "content": h.raw.get("content", h.snippet),
-                    "prevention": h.prevention,
-                    "file": h.file,
-                    "score": h.combined_score,
-                    "lexical_score": h.lexical_score,
-                    "keyword_score": h.keyword_score,
-                    "reranker_type": self._reranker.reranker_type,
-                })
+                results.append(
+                    {
+                        "id": h.id,
+                        "title": h.title,
+                        "severity": h.severity.upper(),
+                        "snippet": h.snippet,
+                        "content": h.raw.get("content", h.snippet),
+                        "prevention": h.prevention,
+                        "file": h.file,
+                        "score": h.combined_score,
+                        "lexical_score": h.lexical_score,
+                        "keyword_score": h.keyword_score,
+                        "reranker_type": self._reranker.reranker_type,
+                    }
+                )
         return results
 
     def search(
@@ -1359,8 +1503,7 @@ class TradingRAGPipeline:
         context_parts = []
         for i, (lesson, score) in enumerate(results, 1):
             context_parts.append(
-                f"[{i}] ({lesson.severity}) {lesson.title} | score={score:.3f} | "
-                f"id={lesson.id}"
+                f"[{i}] ({lesson.severity}) {lesson.title} | score={score:.3f} | id={lesson.id}"
             )
             context_parts.append(lesson.snippet[:300])
             context_parts.append("")
@@ -1371,7 +1514,9 @@ class TradingRAGPipeline:
     def get_critical_lessons(self) -> list[dict[str, Any]]:
         """Return all CRITICAL severity lessons."""
         self._ensure_loaded()
-        return [item for item in self._lessons_cache if item.get("severity", "").upper() == "CRITICAL"]
+        return [
+            item for item in self._lessons_cache if item.get("severity", "").upper() == "CRITICAL"
+        ]
 
     def close(self) -> None:
         self.store.close()
@@ -1396,6 +1541,8 @@ def get_trading_rag_pipeline(
         with _default_lock:
             if _default_pipeline is None or refresh:
                 db = db_path or DEFAULT_DB_PATH
-                lessons = lessons_dir or (Path(__file__).parent.parent.parent / "rag_knowledge" / "lessons_learned")
+                lessons = lessons_dir or (
+                    Path(__file__).parent.parent.parent / "rag_knowledge" / "lessons_learned"
+                )
                 _default_pipeline = TradingRAGPipeline(db_path=db, lessons_dir=lessons)
     return _default_pipeline

--- a/src/rag/retrieval_tier.py
+++ b/src/rag/retrieval_tier.py
@@ -1,0 +1,88 @@
+"""Report which retrieval tier is actually running.
+
+The RAG stack degrades silently by design: BGE embeddings fall back to TF-IDF, the
+cross-encoder reranker falls back to a heuristic, LanceDB falls back to keyword search.
+That design is deliberate -- a search-index failure must never block trade execution
+(Feb 10-13, 2026 outage).
+
+Silent degradation is not the same as *invisible* degradation. Measured on the repo's
+own golden set, the degraded tier scored precision@5 0.20 against 0.36 for the full
+tier -- retrieval quality nearly halved with no alarm, and a release billed as an
+improvement shipped as a measured regression, because nothing named the active tier.
+
+This module names it. Callers decide whether to warn; nobody has to infer it.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from typing import Any
+
+# Measured with scripts/evaluate_rag.py against the production retriever, 2026-08-04.
+# Both rows were taken with lancedb ABSENT; the only variable was sentence-transformers.
+# Labelling matters: attributing these numbers to "any optional dep missing" would blame
+# lancedb for a gap it was never measured against.
+MEASURED_WITH_CROSS_ENCODER = {"precision_at_5": 0.36, "recall_at_5": 0.575, "mrr": 0.725}
+MEASURED_WITHOUT_CROSS_ENCODER = {"precision_at_5": 0.20, "recall_at_5": 0.3083, "mrr": 0.50}
+
+# Missing this measurably halves retrieval quality -- it drives both the embedder and
+# the reranker tier.
+_QUALITY_CRITICAL_DEP = "sentence_transformers"
+# Optional capability with no measured effect on the golden set. Reported, not alarmed.
+_UNMEASURED_DEPS = ("sklearn", "lancedb")
+_DEP_DISPLAY = {
+    "sentence_transformers": "sentence-transformers",
+    "sklearn": "scikit-learn",
+    "lancedb": "lancedb",
+}
+
+
+def _installed(module: str) -> bool:
+    try:
+        return importlib.util.find_spec(module) is not None
+    except (ImportError, ValueError):
+        return False
+
+
+def describe_retrieval_tier() -> dict[str, Any]:
+    """Return the active retrieval components and whether quality is degraded.
+
+    `quality_degraded` keys ONLY on the dependency whose absence was actually measured
+    to halve retrieval quality. Other absent optionals are listed under
+    `unmeasured_absent` so they stay visible without implying a quality claim nobody
+    measured.
+    """
+    has_critical = _installed(_QUALITY_CRITICAL_DEP)
+    unmeasured_absent = [_DEP_DISPLAY[n] for n in _UNMEASURED_DEPS if not _installed(n)]
+
+    return {
+        "quality_degraded": not has_critical,
+        "embedder": "BAAI/bge-base-en-v1.5" if has_critical else "tfidf-fallback",
+        "reranker": "cross-encoder" if has_critical else "heuristic",
+        "semantic_index": "lancedb" if _installed("lancedb") else "none(keyword-only)",
+        "quality_critical_dep": _DEP_DISPLAY[_QUALITY_CRITICAL_DEP],
+        "unmeasured_absent": unmeasured_absent,
+        "remedy": "sync the declared [rag] extra into the venv",
+        "measured_with_cross_encoder": MEASURED_WITH_CROSS_ENCODER,
+        "measured_without_cross_encoder": MEASURED_WITHOUT_CROSS_ENCODER,
+    }
+
+
+def tier_summary_line() -> str:
+    """One-line human summary suitable for a health check or log banner."""
+    tier = describe_retrieval_tier()
+    absent = tier["unmeasured_absent"]
+    tail = f"; absent (no measured effect): {', '.join(absent)}" if absent else ""
+
+    if not tier["quality_degraded"]:
+        return (
+            f"retrieval tier FULL (embedder={tier['embedder']}, reranker={tier['reranker']}){tail}"
+        )
+
+    good = tier["measured_with_cross_encoder"]["precision_at_5"]
+    bad = tier["measured_without_cross_encoder"]["precision_at_5"]
+    return (
+        f"retrieval tier DEGRADED — missing {tier['quality_critical_dep']} "
+        f"(embedder={tier['embedder']}, reranker={tier['reranker']}); "
+        f"measured precision@5 {bad} vs {good} with the cross-encoder{tail}"
+    )

--- a/src/safety/rag_safety_guard.py
+++ b/src/safety/rag_safety_guard.py
@@ -39,7 +39,12 @@ class RAGSafetyGuard:
                 content = (doc.get("content_snippet", "") or doc.get("content", "") or "").upper()
                 # Check severity from the lesson record
                 severity = str(doc.get("severity", "")).upper()
-                if "FAILURE" in content or "LOSS" in content or "CRITICAL" in content or severity in ("CRITICAL", "HIGH"):
+                if (
+                    "FAILURE" in content
+                    or "LOSS" in content
+                    or "CRITICAL" in content
+                    or severity in ("CRITICAL", "HIGH")
+                ):
                     warnings.append(doc.get("id", "Unknown Lesson"))
 
             if warnings:

--- a/tests/test_exit_reason_coverage_guard.py
+++ b/tests/test_exit_reason_coverage_guard.py
@@ -1,0 +1,120 @@
+"""Tests for the exit-reason coverage guard (LL-361).
+
+The guard's whole value is that it FAILS when a close is unattributable. These tests
+assert the failure path first -- a gate that only ever passes is decoration.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT_PATH = PROJECT_ROOT / "scripts" / "check_exit_reason_coverage.py"
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("check_exit_reason_coverage", SCRIPT_PATH)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture
+def guard(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    module = _load_module()
+
+    def write(trades: list[dict[str, Any]], journal: dict[str, Any] | None = None) -> None:
+        trades_file = tmp_path / "trades.json"
+        trades_file.write_text(json.dumps({"trades": trades}))
+        journal_file = tmp_path / "journal.json"
+        journal_file.write_text(json.dumps(journal or {}))
+        monkeypatch.setattr(module, "TRADES_PATH", trades_file)
+        monkeypatch.setattr(module, "JOURNAL_PATH", journal_file)
+
+    module.write_fixtures = write
+    return module
+
+
+def test_active_family_close_without_exit_reason_fails(guard) -> None:
+    guard.write_fixtures(
+        [{"id": "PCS_1", "strategy": "spy_put_credit", "status": "closed", "realized_pnl": -50.0}]
+    )
+    report = guard.collect()
+
+    assert report["passed"] is False
+    assert len(report["violations"]) == 1
+    assert report["violations"][0]["id"] == "PCS_1"
+    assert guard.main.__call__ is not None  # sanity: CLI entrypoint exists
+
+
+def test_legacy_iron_condor_row_is_excluded_from_the_gate(guard) -> None:
+    """Historical rows cannot be repaired; they are reported, never a failure."""
+    guard.write_fixtures(
+        [{"id": "IC_1", "strategy": "iron_condor", "status": "closed", "realized_pnl": -300.0}]
+    )
+    report = guard.collect()
+
+    assert report["passed"] is True
+    assert report["legacy_missing"] == 1
+    assert report["violations"] == []
+
+
+def test_recorded_exit_reason_passes(guard) -> None:
+    guard.write_fixtures(
+        [
+            {
+                "id": "PCS_2",
+                "strategy": "spy_put_credit",
+                "status": "closed",
+                "exit_reason": "profit_target",
+            }
+        ]
+    )
+    report = guard.collect()
+
+    assert report["passed"] is True
+    assert report["exit_reason_recorded"] == 1
+    assert report["coverage"] == 1.0
+
+
+def test_open_journal_row_is_not_graded(guard) -> None:
+    """A structure still open has no exit path yet -- grading it would be a false alarm."""
+    guard.write_fixtures(
+        [],
+        {"PCS_OPEN": {"strategy_family": "spy_put_credit", "status": "open"}},
+    )
+    report = guard.collect()
+
+    assert report["total_closed"] == 0
+    assert report["passed"] is True
+
+
+def test_closed_journal_row_without_exit_reason_fails(guard) -> None:
+    guard.write_fixtures(
+        [],
+        {"PCS_CLOSED": {"strategy_family": "spy_put_credit", "status": "closed"}},
+    )
+    report = guard.collect()
+
+    assert report["passed"] is False
+    assert report["violations"][0]["source"] == "journal"
+
+
+def test_cli_exit_code_is_nonzero_on_violation(guard, monkeypatch, capsys) -> None:
+    guard.write_fixtures([{"id": "PCS_3", "strategy": "spy_put_credit", "status": "closed"}])
+    monkeypatch.setattr("sys.argv", ["check_exit_reason_coverage.py"])
+
+    assert guard.main() == 1
+    assert "FAIL" in capsys.readouterr().out
+
+
+def test_real_repo_state_passes_the_gate() -> None:
+    """The committed ledger must satisfy the gate, or CI is red for a real reason."""
+    module = _load_module()
+    report = module.collect()
+    assert report["passed"] is True, f"unattributable closes: {report['violations']}"

--- a/tests/test_micro_capital_gate.py
+++ b/tests/test_micro_capital_gate.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""Micro-cap deployment gate tests (feat/live-micro-trade-cap).
+
+Pure-function tests only: compute_micro_cap is deterministic and has no I/O,
+so these never touch the network, the kill-switch, or real creds. They assert
+the "deposit more, trade more as small as possible" curve it encodes.
+"""
+
+import pytest
+
+from src.micro.micro_capital_gate import (
+    compute_micro_cap,
+    options_require_larger_capital,
+)
+
+
+@pytest.mark.parametrize(
+    "balance,hard_floor,deploy_fraction,live_cap,exp_deploy,exp_can",
+    [
+        # Non-positive balance -> nothing.
+        (0.0, 25.0, 0.10, 50.0, 0.0, False),
+        (-5.0, 25.0, 0.10, 50.0, 0.0, False),
+        # At/below the hard floor -> deploy nothing, keep buffer.
+        (25.0, 25.0, 0.10, 50.0, 0.0, False),
+        # "As small as possible": (balance-floor)*fraction.
+        (100.0, 25.0, 0.10, 50.0, 7.50, True),
+        # Live cap binds: surplus*frac (97.5) would exceed $50 cap.
+        (1000.0, 25.0, 0.10, 50.0, 50.0, True),
+        # Fraction scales with deposits ("more in -> more trade").
+        (250.0, 25.0, 0.10, 50.0, 22.50, True),
+        (500.0, 25.0, 0.10, 50.0, 47.50, True),
+    ],
+)
+def test_compute_micro_cap_deployable(
+    balance, hard_floor, deploy_fraction, live_cap, exp_deploy, exp_can
+):
+    dec = compute_micro_cap(
+        balance,
+        hard_floor_usd=hard_floor,
+        deploy_fraction=deploy_fraction,
+        live_cap_usd=live_cap,
+    )
+    assert dec.deployable_usd == pytest.approx(exp_deploy)
+    assert dec.can_deploy == exp_can
+
+
+def test_income_loop_can_consume_gate():
+    """A $100 balance (Igor's current) deploys exactly ~$7.50 and is > $0."""
+    dec = compute_micro_cap(100.0)
+    assert dec.can_deploy is True
+    assert dec.deployable_usd == pytest.approx(7.50)
+
+
+def test_balance_below_floor_blocks_and_records_reason():
+    dec = compute_micro_cap(10.0)
+    assert dec.can_deploy is False
+    assert dec.deployable_usd == 0.0
+    assert dec.blocked_reason is not None
+    assert "hard floor" in dec.blocked_reason
+
+
+def test_options_excluded_with_explanation():
+    reason = options_require_larger_capital()
+    assert "500" in reason
+    assert "option" in reason.lower()

--- a/tests/test_query_lessons_learned.py
+++ b/tests/test_query_lessons_learned.py
@@ -14,10 +14,18 @@ def test_limit_aliases_share_one_destination() -> None:
 def test_query_cli_uses_dependency_free_custom_corpus(tmp_path: Path, capsys, monkeypatch) -> None:
     lesson = tmp_path / "ll_999_inventory_reconciliation.md"
     lesson.write_text(
+        # Must satisfy quality_gate(): severity marker + a prevention/action section.
+        # Without those the lesson is rejected at ingestion, the corpus is empty, and
+        # the CLI correctly reports source="none" -- which looked like a search bug.
         """# LL-999 Inventory reconciliation
+
+**Severity**: HIGH
 
 ## Summary
 Reconcile broker inventory before allowing new risk.
+
+## Prevention
+Block new risk until the broker book matches the journal.
 
 ## Tags
 `inventory`, `risk`
@@ -37,6 +45,78 @@ Reconcile broker inventory before allowing new risk.
 
     payload = json.loads(capsys.readouterr().out)
     assert result == 0
-    assert payload["source"] == "keyword"
     assert payload["count"] == 1
     assert payload["results"][0]["id"] == "ll_999_inventory_reconciliation"
+    # Provenance must name the backend that actually served the rows. "none" alongside
+    # a non-empty result set is the bug this assertion exists to catch.
+    assert payload["source"] in {"pipeline", "keyword"}
+    assert payload["source"] != "none"
+
+
+def test_last_source_is_never_none_when_results_are_returned(tmp_path: Path) -> None:
+    """Regression: the pipeline path returned rows without recording provenance.
+
+    `LessonsLearnedRAG.query()` delegated to TradingRAGPipeline and returned its results
+    directly, leaving `last_source` at its "none" default. Callers then reported results
+    with no retrievable source, which this repo's evidence rules forbid.
+    """
+    from src.rag.lessons_learned_rag import LessonsLearnedRAG
+
+    lesson = tmp_path / "ll_998_stop_loss_discipline.md"
+    lesson.write_text(
+        """# LL-998 Stop loss discipline
+
+**Severity**: CRITICAL
+
+## Summary
+Honor the defined stop on every structure.
+
+## Prevention
+Reject any exit rule that omits a stop.
+""",
+        encoding="utf-8",
+    )
+
+    rag = LessonsLearnedRAG(knowledge_dir=str(tmp_path))
+    try:
+        results = rag.query("stop loss discipline", top_k=3)
+        assert results, "expected the seeded lesson to be retrievable"
+        assert rag.last_source != "none", (
+            f"returned {len(results)} result(s) but reported source 'none'"
+        )
+    finally:
+        pipeline = getattr(rag, "_pipeline", None)
+        if pipeline is not None:
+            pipeline.close()
+
+
+def test_add_lesson_is_immediately_retrievable(tmp_path: Path) -> None:
+    """Regression: a written lesson must be visible to the very next read.
+
+    `add_lesson()` wrote the markdown file and refreshed the legacy keyword list, but
+    never re-indexed the pipeline that `query()` actually reads from. The file existed
+    on disk and was unretrievable, which kept `system_health_check.py` reporting
+    "RAG System: BROKEN" and held `make dry-run` red.
+    """
+    from src.rag.lessons_learned_rag import LessonsLearnedRAG
+
+    rag = LessonsLearnedRAG(knowledge_dir=str(tmp_path))
+    try:
+        rag.add_lesson(
+            "LL-HEALTH",
+            "# Health Probe\n\n"
+            "**Severity**: LOW\n\n"
+            "## Summary\n"
+            "RAG write and read round trip.\n\n"
+            "## Prevention\n"
+            "Keep the probe lesson valid so the round trip stays meaningful.",
+        )
+
+        assert (tmp_path / "LL-HEALTH.md").exists(), "lesson file was not written"
+        results = rag.query("round trip", top_k=1)
+        assert results, "lesson was written to disk but is not retrievable"
+        assert results[0]["id"] == "LL-HEALTH"
+    finally:
+        pipeline = getattr(rag, "_pipeline", None)
+        if pipeline is not None:
+            pipeline.close()

--- a/tests/test_rag_pipeline.py
+++ b/tests/test_rag_pipeline.py
@@ -1,10 +1,10 @@
 """Unit tests for the 5-stage TradingRAGPipeline:
 
-  Stage 1: Capture 👎 → normalize/quality-gate → store lesson (SQLite FTS5)
-  Stage 2: Retrieve: bigram-Jaccard + keyword pragmatic-hybrid-search
-  Stage 3: Multi-query (3 variants, combined-score threshold trigger)
-  Stage 4: Cross-encoder reranker (LLM if key, else heuristic)
-  Stage 5: Assemble context + deterministic gate
+Stage 1: Capture 👎 → normalize/quality-gate → store lesson (SQLite FTS5)
+Stage 2: Retrieve: bigram-Jaccard + keyword pragmatic-hybrid-search
+Stage 3: Multi-query (3 variants, combined-score threshold trigger)
+Stage 4: Cross-encoder reranker (LLM if key, else heuristic)
+Stage 5: Assemble context + deterministic gate
 """
 
 from __future__ import annotations
@@ -13,6 +13,7 @@ import os
 import sys
 import tempfile
 import logging
+from pathlib import Path
 
 import pytest
 
@@ -132,10 +133,7 @@ class TestStage1CaptureAndStore:
         """Lesson without prevention section should be rejected."""
         from src.rag.rag_pipeline import quality_gate
 
-        content = (
-            "# CRITICAL: Bad Trade\n\n"
-            "## Severity\nCRITICAL\n"
-        )
+        content = "# CRITICAL: Bad Trade\n\n## Severity\nCRITICAL\n"
         passed, reason = quality_gate(content)
         assert passed is False
 
@@ -275,8 +273,25 @@ class TestStage3MultiQuery:
 
 class TestStage4Reranker:
     def test_reranker_type_is_cross_encoder(self, pipeline):
-        """Reranker should use cross-encoder when available."""
-        assert pipeline._reranker.reranker_type == "cross-encoder"
+        """Cross-encoder when the optional dep is installed; documented fallback otherwise.
+
+        `sentence_transformers` is optional. Asserting it is always present made this
+        test fail on any environment without it, which is a report about the machine,
+        not about the pipeline. The invariant that matters is that the reranker resolves
+        to a known backend and never silently ends up in an undefined state.
+        """
+        try:
+            import sentence_transformers  # noqa: F401
+
+            cross_encoder_available = True
+        except ImportError:
+            cross_encoder_available = False
+
+        reranker_type = pipeline._reranker.reranker_type
+        if cross_encoder_available:
+            assert reranker_type == "cross-encoder"
+        else:
+            assert reranker_type in {"llm", "heuristic"}
 
     def test_cross_encoder_scores_in_range(self, pipeline):
         """CE ensemble scores should be in [0, 1] range."""
@@ -307,8 +322,13 @@ class TestStage4Reranker:
         assert reranker.reranker_type == "heuristic"
         # Should not crash on simple candidates
         candidates = [
-            {"id": "ll-001", "title": "test", "severity": "HIGH",
-             "content_snippet": "test content", "score": 0.5},
+            {
+                "id": "ll-001",
+                "title": "test",
+                "severity": "HIGH",
+                "content_snippet": "test content",
+                "score": 0.5,
+            },
         ]
         results = reranker.rerank("test query", candidates, top_n=1)
         assert len(results) == 1
@@ -317,9 +337,12 @@ class TestStage4Reranker:
 # -- Stage 5: Assemble context + deterministic gate --
 
 
-def _make_lesson_result(lesson_id: str, title: str, severity: str, prevention: str = "Prevent this", score: float = 0.5):
+def _make_lesson_result(
+    lesson_id: str, title: str, severity: str, prevention: str = "Prevent this", score: float = 0.5
+):
     """Helper to create a LessonResult for gate tests."""
     from src.rag.rag_pipeline import LessonResult
+
     return LessonResult(
         id=lesson_id,
         title=title,
@@ -387,7 +410,9 @@ class TestStage5DeterministicGate:
 
     def test_retrieve_and_gate_integration(self, pipeline):
         """Full pipeline: retrieve + gate should return (results, decision, context)."""
-        results, decision, context = pipeline.retrieve_and_gate("iron condor exit strategy", top_k=5)
+        results, decision, context = pipeline.retrieve_and_gate(
+            "iron condor exit strategy", top_k=5
+        )
         assert isinstance(results, list)
         assert decision is not None
         assert decision.severity in ("APPROVED", "WARN", "BLOCK")
@@ -406,8 +431,16 @@ class TestLessonsLearnedRAGDelegation:
         rag = LessonsLearnedRAG()
         try:
             assert rag._pipeline is not None
-            # The standard lessons dir has 320 lessons
-            assert rag._pipeline.lesson_count >= 300
+            # Assert against the corpus that actually exists rather than a hardcoded
+            # count. The old `>= 300` encoded a stale snapshot and broke as soon as the
+            # lessons directory changed size, which says nothing about delegation.
+            lessons_dir = Path(__file__).resolve().parents[1] / "rag_knowledge" / "lessons_learned"
+            on_disk = len(list(lessons_dir.glob("*.md")))
+            assert on_disk > 0, "lessons corpus is empty; nothing to delegate to"
+            assert rag._pipeline.lesson_count > 0
+            assert rag._pipeline.lesson_count <= on_disk, (
+                "pipeline reports more lessons than exist on disk"
+            )
         finally:
             if rag._pipeline:
                 rag._pipeline.close()

--- a/tests/test_reranker_model_cache.py
+++ b/tests/test_reranker_model_cache.py
@@ -1,0 +1,65 @@
+"""The cross-encoder must load once per process, not once per reranker.
+
+Loading it per construction cost ~3-4s each time and a reranker is built per pipeline.
+That doubled the test suite (640s -> 1277s) and put seconds on the first query of every
+new pipeline. Caching is a latency fix, so the test asserts the load count -- timing
+assertions are flaky, call counts are not.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from src.rag import rag_pipeline
+
+
+@pytest.fixture(autouse=True)
+def clear_cache():
+    rag_pipeline._cross_encoder_cache.clear()
+    yield
+    rag_pipeline._cross_encoder_cache.clear()
+
+
+def test_cross_encoder_loads_once_across_many_rerankers(monkeypatch) -> None:
+    loads: list[str] = []
+
+    class FakeCrossEncoder:
+        def __init__(self, model_name: str) -> None:
+            loads.append(model_name)
+
+    fake_module = type("M", (), {"CrossEncoder": FakeCrossEncoder})
+    monkeypatch.setitem(__import__("sys").modules, "sentence_transformers", fake_module)
+
+    for _ in range(5):
+        reranker = rag_pipeline.RAGEReranker()
+        assert reranker.reranker_type == "cross-encoder"
+
+    assert loads == [rag_pipeline.CROSS_ENCODER_MODEL], (
+        f"model loaded {len(loads)} times; expected exactly 1"
+    )
+
+
+def test_cached_instance_is_shared(monkeypatch) -> None:
+    class FakeCrossEncoder:
+        def __init__(self, model_name: str) -> None:
+            self.model_name = model_name
+
+    fake_module = type("M", (), {"CrossEncoder": FakeCrossEncoder})
+    monkeypatch.setitem(__import__("sys").modules, "sentence_transformers", fake_module)
+
+    first = rag_pipeline.RAGEReranker()._cross_encoder
+    second = rag_pipeline.RAGEReranker()._cross_encoder
+    assert first is second, "each reranker must reuse the one process-wide model"
+
+
+def test_missing_dependency_still_falls_back(monkeypatch) -> None:
+    """Caching must not break the degradation path that keeps trading unblocked."""
+
+    def boom(name, *args, **kwargs):
+        raise ImportError("sentence_transformers not installed")
+
+    monkeypatch.setattr(rag_pipeline, "_load_cross_encoder", boom)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+
+    assert rag_pipeline.RAGEReranker().reranker_type == "heuristic"

--- a/tests/test_retrieval_tier.py
+++ b/tests/test_retrieval_tier.py
@@ -1,0 +1,79 @@
+"""Tests for retrieval-tier reporting.
+
+The point of this module is that a degraded retrieval stack must never be invisible.
+These tests assert the *labelling* is honest, because the original bug was not a crash
+-- it was a correct-looking number attached to the wrong configuration.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+
+import pytest
+
+from src.rag import retrieval_tier
+
+
+@pytest.fixture
+def hide(monkeypatch):
+    """Make chosen modules look absent to the tier reporter."""
+
+    def _hide(*names: str):
+        original = importlib.util.find_spec
+
+        def fake(name, *args, **kwargs):
+            if name in names:
+                return None
+            return original(name, *args, **kwargs)
+
+        monkeypatch.setattr(importlib.util, "find_spec", fake)
+
+    return _hide
+
+
+def test_missing_cross_encoder_marks_quality_degraded(hide) -> None:
+    hide("sentence_transformers")
+    tier = retrieval_tier.describe_retrieval_tier()
+
+    assert tier["quality_degraded"] is True
+    assert tier["embedder"] == "tfidf-fallback"
+    assert tier["reranker"] == "heuristic"
+    assert "0.2" in retrieval_tier.tier_summary_line()
+
+
+def test_absent_unmeasured_dep_does_not_claim_quality_loss(hide) -> None:
+    """Regression on my own bug: lancedb absence must not be reported as degraded.
+
+    Both measured rows were taken with lancedb absent, so blaming it for the
+    precision gap would attach a real number to a configuration it never described.
+    """
+    hide("lancedb")
+    tier = retrieval_tier.describe_retrieval_tier()
+
+    assert tier["quality_degraded"] is False, "lancedb has no measured effect on the gate"
+    assert "lancedb" in tier["unmeasured_absent"]
+
+    summary = retrieval_tier.tier_summary_line()
+    assert summary.startswith("retrieval tier FULL")
+    assert "no measured effect" in summary
+    assert "0.2 vs 0.36" not in summary, "must not quote a delta lancedb was never measured on"
+
+
+def test_full_tier_reports_real_components() -> None:
+    tier = retrieval_tier.describe_retrieval_tier()
+    if tier["quality_degraded"]:
+        pytest.skip("cross-encoder not installed in this environment")
+
+    assert tier["embedder"] == "BAAI/bge-base-en-v1.5"
+    assert tier["reranker"] == "cross-encoder"
+    assert retrieval_tier.tier_summary_line().startswith("retrieval tier FULL")
+
+
+def test_measured_numbers_are_labelled_by_configuration() -> None:
+    """The constants must name the config they were measured in, not a vague 'tier'."""
+    assert retrieval_tier.MEASURED_WITH_CROSS_ENCODER["precision_at_5"] == 0.36
+    assert retrieval_tier.MEASURED_WITHOUT_CROSS_ENCODER["precision_at_5"] == 0.20
+    assert (
+        retrieval_tier.MEASURED_WITH_CROSS_ENCODER["precision_at_5"]
+        > retrieval_tier.MEASURED_WITHOUT_CROSS_ENCODER["precision_at_5"]
+    )

--- a/tests/test_temporal_trade_graph.py
+++ b/tests/test_temporal_trade_graph.py
@@ -1,0 +1,362 @@
+"""Tests for the temporal trade knowledge graph."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from src.rag.graph.build import _parse_constants, extract_policy_history
+from src.rag.graph.queries import (
+    MIN_COHORT_FOR_RATIOS,
+    Cohort,
+    graph_context,
+    loss_attribution,
+    policy_cohorts,
+)
+from src.rag.graph.temporal_graph import Edge, Node, TemporalGraph
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+
+
+@pytest.fixture
+def graph(tmp_path: Path) -> TemporalGraph:
+    g = TemporalGraph(tmp_path / "graph.sqlite")
+    yield g
+    g.close()
+
+
+# ------------------------------------------------------------------ temporality
+
+
+def test_edge_invisible_outside_validity_window(graph: TemporalGraph) -> None:
+    """A fact must not be visible before it was true or after it stopped being true."""
+    graph.add_many(
+        nodes=[Node("a", "trade", "A"), Node("b", "policy", "B")],
+        edges=[Edge("a", "GOVERNED_BY", "b", valid_from="2026-03-01", valid_to="2026-04-01")],
+    )
+
+    assert list(graph.neighbors("a", as_of="2026-03-15")), "edge should be live mid-window"
+    assert not list(graph.neighbors("a", as_of="2026-02-01")), "edge must not exist before"
+    assert not list(graph.neighbors("a", as_of="2026-05-01")), "edge must not exist after"
+    assert list(graph.neighbors("a", as_of=None)), "as_of=None ignores time"
+
+
+def test_open_ended_edge_is_live_after_start(graph: TemporalGraph) -> None:
+    graph.add_many(
+        nodes=[Node("a", "trade", "A"), Node("b", "policy", "B")],
+        edges=[Edge("a", "GOVERNED_BY", "b", valid_from="2026-03-01", valid_to=None)],
+    )
+    assert list(graph.neighbors("a", as_of="2030-01-01"))
+    assert not list(graph.neighbors("a", as_of="2026-01-01"))
+
+
+# --------------------------------------------------------------------- budgets
+
+
+def test_expansion_respects_node_budget(graph: TemporalGraph) -> None:
+    """Dense hubs must not blow the context budget; truncation must be reported."""
+    nodes = [Node("hub", "outcome", "loss")]
+    edges = []
+    for i in range(100):
+        nodes.append(Node(f"t{i}", "trade", f"trade {i}"))
+        edges.append(Edge(f"t{i}", "RESULTED_IN", "hub"))
+    graph.add_many(nodes=nodes, edges=edges)
+
+    sub = graph.expand(["hub"], hops=2, node_budget=10)
+    assert len(sub.nodes) <= 10
+    assert sub.truncated is True, "a budget-capped subgraph must announce it is partial"
+
+    full = graph.expand(["hub"], hops=2, node_budget=500)
+    assert full.truncated is False
+    assert len(full.nodes) == 101
+
+
+def test_graph_context_states_truncation(graph: TemporalGraph) -> None:
+    nodes = [Node("hub", "outcome", "loss")]
+    edges = []
+    for i in range(50):
+        nodes.append(Node(f"t{i}", "trade", f"trade {i}"))
+        edges.append(Edge(f"t{i}", "RESULTED_IN", "hub"))
+    graph.add_many(nodes=nodes, edges=edges)
+
+    text = graph_context(graph, ["hub"], hops=2, node_budget=5)
+    assert "TRUNCATED" in text, "partial context must never read as complete"
+
+
+# ------------------------------------------------------------------- multi-hop
+
+
+def test_paths_finds_policy_to_outcome_chain(graph: TemporalGraph) -> None:
+    """The join vector search cannot make: policy -> trade -> outcome."""
+    graph.add_many(
+        nodes=[
+            Node("policy:SL@2026-03-01", "policy", "SL=1.0"),
+            Node("trade:X", "trade", "X"),
+            Node("outcome:loss", "outcome", "loss"),
+        ],
+        edges=[
+            Edge("trade:X", "GOVERNED_BY", "policy:SL@2026-03-01"),
+            Edge("trade:X", "RESULTED_IN", "outcome:loss"),
+        ],
+    )
+    found = graph.paths("policy:SL@2026-03-01", "outcome:loss", max_hops=3)
+    assert found, "expected a policy->trade->outcome path"
+    assert len(found[0]) == 2
+
+
+# --------------------------------------------------------------- sample honesty
+
+
+def test_ratios_withheld_below_minimum_sample() -> None:
+    """Small-sample win rate / profit factor must be withheld, not rounded into truth."""
+    cohort = Cohort(key="k", label="k", valid_from=None, valid_to=None)
+    for i in range(5):
+        cohort.trade_ids.append(f"t{i}")
+        cohort.wins += 1
+        cohort.gross_profit += 10.0
+
+    metrics = cohort.metrics()
+    assert metrics["n"] == 5
+    assert metrics["win_rate"] is None
+    assert metrics["profit_factor"] is None
+    assert metrics["sufficient_sample"] is False
+    assert metrics["expectancy"] == 10.0, "expectancy is a mean and is always reportable"
+
+
+def test_ratios_reported_at_sufficient_sample() -> None:
+    cohort = Cohort(key="k", label="k", valid_from=None, valid_to=None)
+    for i in range(MIN_COHORT_FOR_RATIOS):
+        cohort.trade_ids.append(f"t{i}")
+        if i % 2 == 0:
+            cohort.wins += 1
+            cohort.gross_profit += 10.0
+        else:
+            cohort.losses += 1
+            cohort.gross_loss += 5.0
+
+    metrics = cohort.metrics()
+    assert metrics["sufficient_sample"] is True
+    assert metrics["win_rate"] == pytest.approx(0.5, abs=0.02)
+    assert metrics["profit_factor"] == pytest.approx(2.0, abs=0.01)
+
+
+def test_exit_reason_is_never_inferred(graph: TemporalGraph) -> None:
+    """A missing exit reason stays `unrecorded` -- it is not guessed from the P/L sign."""
+    graph.add_many(
+        nodes=[
+            Node(
+                "trade:A",
+                "trade",
+                "A",
+                attrs={"realized_pnl": -300.0, "outcome": "loss", "exit_reason": None},
+            ),
+            Node(
+                "trade:B",
+                "trade",
+                "B",
+                attrs={"realized_pnl": 50.0, "outcome": "win", "exit_reason": "profit_target"},
+            ),
+        ]
+    )
+    report = loss_attribution(graph)
+    reasons = {row["exit_reason"]: row for row in report["by_exit_reason"]}
+
+    assert "unrecorded" in reasons
+    assert reasons["unrecorded"]["n"] == 1
+    assert "stop_loss" not in reasons, "a loss must not be relabelled as a stop-loss exit"
+    assert report["exit_reason_coverage"] == pytest.approx(0.5)
+
+
+# ------------------------------------------------- policy history (regression)
+
+
+def _init_repo(root: Path, revisions: list[str]) -> None:
+    """Create a throwaway git repo whose constants file changes across commits."""
+    subprocess.run(["git", "init", "-q"], cwd=root, check=True)
+    subprocess.run(["git", "config", "user.email", "t@t.t"], cwd=root, check=True)
+    subprocess.run(["git", "config", "user.name", "t"], cwd=root, check=True)
+    target = root / "src" / "core" / "trading_constants.py"
+    target.parent.mkdir(parents=True, exist_ok=True)
+    for i, body in enumerate(revisions):
+        target.write_text(body)
+        subprocess.run(["git", "add", "-A"], cwd=root, check=True)
+        subprocess.run(
+            ["git", "commit", "-q", "-m", f"rev{i}", f"--date=2026-0{i + 1}-01T12:00:00"],
+            cwd=root,
+            check=True,
+            env={
+                "PATH": "/usr/bin:/bin:/usr/local/bin:/opt/homebrew/bin",
+                "GIT_COMMITTER_DATE": f"2026-0{i + 1}-01T12:00:00",
+                "HOME": str(root),
+            },
+        )
+
+
+def test_policy_window_closes_when_value_stops_being_a_literal(tmp_path: Path) -> None:
+    """Regression: a constant that starts delegating must END its window, not coast.
+
+    Before this was fixed, the refactor that replaced a literal with a profile lookup
+    left the last-known literal open forever, silently attributing every later trade to
+    a value that was no longer in force.
+    """
+    _init_repo(
+        tmp_path,
+        [
+            "IRON_CONDOR_STOP_LOSS_MULTIPLIER: float = 1.0\n",
+            "IRON_CONDOR_STOP_LOSS_MULTIPLIER: float = 2.0\n",
+            "IRON_CONDOR_STOP_LOSS_MULTIPLIER: float = PROFILE.stop_loss_pct\n",
+        ],
+    )
+
+    history = extract_policy_history(tmp_path)
+    windows = [w for w in history.windows if w.name == "IRON_CONDOR_STOP_LOSS_MULTIPLIER"]
+
+    assert [w.value for w in windows] == [1.0, 2.0]
+    assert all(w.valid_to is not None for w in windows), (
+        "no window may stay open once the value stops being resolvable"
+    )
+    assert [s.name for s in history.indeterminate] == ["IRON_CONDOR_STOP_LOSS_MULTIPLIER"]
+
+
+def test_parse_constants_separates_literals_from_delegations() -> None:
+    resolved, unresolved = _parse_constants(
+        "MAX_POSITIONS: int = 8\n"
+        "MAX_DAILY_STRUCTURES: int = PROFILE.max_daily_structures\n"
+        "UNRELATED_NAME: int = 3\n"
+    )
+    assert resolved == {"MAX_POSITIONS": 8}
+    assert unresolved == {"MAX_DAILY_STRUCTURES"}
+
+
+def test_journal_rows_never_enter_metrics(graph: TemporalGraph) -> None:
+    """Regression: entry-journal rows were counted as closed trades.
+
+    They can still be open, they carry no `realized_pnl`, and data-integrity.md is
+    explicit that unmatched orders are never trades. Counting them inflated
+    `spy_put_credit` to n=3 when the paired ledger held n=1 -- overstating progress
+    toward the n>=30 live-capital gate, the one direction this must never fail.
+    """
+    graph.add_many(
+        nodes=[
+            Node(
+                "trade:LEDGER",
+                "trade",
+                "paired close",
+                attrs={
+                    "realized_pnl": 17.0,
+                    "outcome": "win",
+                    "strategy": "spy_put_credit",
+                    "evidence_tier": "paired_ledger",
+                },
+            ),
+            Node(
+                "trade:JOURNAL_OPEN",
+                "trade",
+                "still open",
+                attrs={
+                    "realized_pnl": 0.0,
+                    "outcome": "unknown",
+                    "strategy": "spy_put_credit",
+                    "evidence_tier": "journal",
+                    "status": "exit_pending",
+                },
+            ),
+        ]
+    )
+    report = loss_attribution(graph)
+
+    assert report["total_trades"] == 1, "journal row must not be counted as a trade"
+    assert report["excluded_non_scorable"] == {"journal": 1}, "exclusions must be reported"
+    by_strategy = {r["strategy"]: r for r in report["by_strategy"]}
+    assert by_strategy["spy_put_credit"]["n"] == 1
+    assert by_strategy["spy_put_credit"]["expectancy"] == 17.0
+
+
+def test_policy_cohorts_exclude_journal_rows(graph: TemporalGraph) -> None:
+    graph.add_many(
+        nodes=[
+            Node(
+                "policy:P@2026-03-01",
+                "policy",
+                "P=1.0",
+                attrs={"name": "P", "value": 1.0},
+            ),
+            Node(
+                "trade:J",
+                "trade",
+                "journal",
+                attrs={
+                    "realized_pnl": 0.0,
+                    "outcome": "unknown",
+                    "strategy": "spy_put_credit",
+                    "evidence_tier": "journal",
+                },
+            ),
+        ],
+        edges=[Edge("trade:J", "GOVERNED_BY", "policy:P@2026-03-01")],
+    )
+    assert policy_cohorts(graph, "P") == [], "a journal row cannot form a cohort"
+
+
+def test_stale_sources_detects_newer_ledger(tmp_path: Path) -> None:
+    """A graph older than its source ledger must be reported, never answered silently."""
+    import importlib.util
+
+    script = PROJECT_ROOT / "scripts" / "trade_graph.py"
+    spec = importlib.util.spec_from_file_location("trade_graph_cli", script)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+    db = tmp_path / "graph.sqlite"
+    db.write_text("")
+    ledger = tmp_path / "trades.json"
+    ledger.write_text("{}")
+
+    # Ledger written after the graph -> stale.
+    os.utime(db, (1_700_000_000, 1_700_000_000))
+    os.utime(ledger, (1_700_000_500, 1_700_000_500))
+    assert module.stale_sources(db, [ledger]) == [str(ledger)]
+
+    # Graph rebuilt after the ledger -> fresh.
+    os.utime(db, (1_700_001_000, 1_700_001_000))
+    assert module.stale_sources(db, [ledger]) == []
+
+    # A source that does not exist cannot make the graph stale.
+    assert module.stale_sources(db, [tmp_path / "absent.json"]) == []
+
+
+def test_policy_cohorts_excludes_indeterminate_period(graph: TemporalGraph) -> None:
+    """Trades with no GOVERNED_BY edge must not land in any cohort."""
+    graph.add_many(
+        nodes=[
+            Node(
+                "policy:SL@2026-03-01",
+                "policy",
+                "SL=1.0",
+                attrs={"name": "SL", "value": 1.0},
+                valid_from="2026-03-01",
+                valid_to="2026-04-08",
+            ),
+            Node(
+                "trade:attributed",
+                "trade",
+                "in window",
+                attrs={"realized_pnl": -100.0, "outcome": "loss", "strategy": "iron_condor"},
+            ),
+            Node(
+                "trade:orphan",
+                "trade",
+                "after refactor",
+                attrs={"realized_pnl": -999.0, "outcome": "loss", "strategy": "iron_condor"},
+            ),
+        ],
+        edges=[Edge("trade:attributed", "GOVERNED_BY", "policy:SL@2026-03-01")],
+    )
+
+    cohorts = policy_cohorts(graph, "SL")
+    assert len(cohorts) == 1
+    assert cohorts[0]["n"] == 1
+    assert cohorts[0]["realized_pnl"] == -100.0, "unattributable trade must be excluded"


### PR DESCRIPTION
## Temporal trade graph, plus a class of provenance defect found while building it

A bitemporal knowledge graph over the system's own causal history. Risk-constant
validity windows are recovered from the git history of `trading_constants.py`, so a
March trade joins March's rules rather than today's.

Every defect below was silent before this branch:

| Defect | Impact |
| --- | --- |
| `add_lesson()` never re-indexed the pipeline | Lessons written to disk were unretrievable |
| `query()` returned rows without setting `last_source` | CLI reported `source: "none"` beside real results |
| Journal rows counted as closed trades | Active-strategy sample read n=3 when the paired ledger held n=1 |
| Eval harness scored `LessonsSearch` | A retriever the app never calls, published as a CI gate |
| Cross-encoder reloaded per construction | ~3-4s on every pipeline instantiation |

The third is the serious one: it overstated progress toward the `n>=30` gate on live
capital. An error that inflates readiness to deploy money is worse than one that delays it.

## Measured, production retriever, same golden set

```
precision@5  0.2000 -> 0.3600
recall@5     0.3083 -> 0.5750
MRR          0.5000 -> 0.7250
```

The gain came from installing the already-declared `[rag]` extra. The pipeline had been
running its weakest tier because those components ship as an optional extra, and nothing
reported the degradation. `src/rag/retrieval_tier.py` now names the active tier.

## Known gaps, stated rather than hidden

- The golden set has **zero queries covering the active strategy and three covering the
  killed one**, so the 0.40 precision gate scores a retired strategy. Tuning against it
  would optimise for iron condors.
- Exit reasons are missing on 154 of 164 closes, so the killed cohort's losses are
  permanently unattributable. `scripts/check_exit_reason_coverage.py` blocks recurrence.
- **This branch was developed on a base 25 commits behind main and will conflict with the
  RAG work already merged there.** That is deliberate: the conflict belongs in a reviewable
  diff, not resolved blind in a terminal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NpoFEQ1XYAV9XvXpCpPq7q
