### PR TITLE
fix(AGENT-361): unblock put-credit paper cadence in low-vol regime

### DIFF
--- a/.github/workflows/put-credit-validation.yml
+++ b/.github/workflows/put-credit-validation.yml
@@ -7,9 +7,11 @@ on:
   schedule:
     - cron: 0 15 * * 1-5 # 11:00 AM ET — exit residual IC + put-credit entry attempt
     - cron: 0 16 * * 1-5 # Exit check: 12:00 PM ET
+    - cron: 0 17 * * 1-5 # 1:00 PM ET — second entry attempt (low-vol recheck)
     - cron: 0 18 * * 1-5 # Exit check: 2:00 PM ET
     - cron: 30 19 * * 1-5 # EOD exit: 3:30 PM ET
-  # Manual dispatch is always a dry run. Scheduled jobs retain their bounded paper behavior.
+  # Manual dispatch is dry-run only (Checkov CKV_GHA_7 forbids workflow_dispatch inputs).
+  # Scheduled jobs execute paper entries under the kill switch.
   workflow_dispatch:
 
 permissions:
@@ -18,6 +20,14 @@ permissions:
 concurrency:
   group: ${{ format('state-writer-{0}-{1}', github.repository, github.ref_name || 'main') }}
   cancel-in-progress: false
+
+env:
+  # Paper validation floor (hard). Research preferred short-premium IVR remains 30;
+  # lean-premium entries are soft-flagged for stratified edge analysis.
+  # Evidence 2026-08-04..10: IVR proxy 8–29 blocked every 11:00 ET entry attempt.
+  PUT_CREDIT_MIN_IVR: "10"
+  PUT_CREDIT_RESEARCH_IVR: "30"
+  PUT_CREDIT_MAX_VIX: "30"
 
 jobs:
   run:
@@ -68,7 +78,7 @@ jobs:
             # GitHub can deliver scheduled jobs late. Preserve the intent of the
             # triggering cron expression instead of reclassifying by wall clock.
             case "$SCHEDULE_EXPRESSION" in
-              "0 15 * * 1-5")
+              "0 15 * * 1-5"|"0 17 * * 1-5")
                 MODE="both"
                 RUN_PUT_CREDIT=true
                 ;;
@@ -87,6 +97,7 @@ jobs:
             echo "run_put_credit=$RUN_PUT_CREDIT"
           } >> "$GITHUB_OUTPUT"
           echo "Mode: $MODE, Dry run: $DRY, Put credit: $RUN_PUT_CREDIT"
+          echo "Regime floors: PUT_CREDIT_MIN_IVR=${PUT_CREDIT_MIN_IVR:-unset} RESEARCH=${PUT_CREDIT_RESEARCH_IVR:-unset}"
 
       - name: Reconcile filled put-credit journals
         if: steps.mode.outputs.mode != 'status'

--- a/src/risk/put_credit_regime.py
+++ b/src/risk/put_credit_regime.py
@@ -20,6 +20,11 @@ from typing import Any
 logger = logging.getLogger(__name__)
 
 # Research defaults — keep knobs explicit for audit.
+# Preferred short-premium IVR for *edge claims* is still 30 (research 2026-07-24).
+# Paper validation may lower the hard floor via PUT_CREDIT_MIN_IVR so the n→30
+# cohort is not frozen in multi-week low-vol regimes; stratify scorecards by
+# iv_rank_proxy >= RESEARCH_PREFERRED_IVR when claiming edge.
+RESEARCH_PREFERRED_IVR = float(os.environ.get("PUT_CREDIT_RESEARCH_IVR", "30"))
 MIN_IV_RANK = float(os.environ.get("PUT_CREDIT_MIN_IVR", "30"))
 MAX_VIX = float(os.environ.get("PUT_CREDIT_MAX_VIX", "30"))
 REQUIRE_ABOVE_200DMA = os.environ.get("PUT_CREDIT_REQUIRE_200DMA", "0").lower() in {
@@ -201,6 +206,12 @@ def evaluate_regime_gate(
         blockers.append(
             f"IV rank proxy {float(ivr):.1f} < min {float(min_iv_rank):.1f} (short-premium filter)"
         )
+    elif float(ivr) < float(RESEARCH_PREFERRED_IVR):
+        # Allowed under a lowered paper floor, but not "rich premium" for edge claims.
+        soft.append(
+            f"IV rank proxy {float(ivr):.1f} < research preferred "
+            f"{float(RESEARCH_PREFERRED_IVR):.1f} (lean premium; stratify later)"
+        )
 
     if above is False:
         msg = "SPY below 200-day SMA (trend soft-flag)"
@@ -217,6 +228,7 @@ def evaluate_regime_gate(
         "soft_flags": soft,
         "thresholds": {
             "min_iv_rank": min_iv_rank,
+            "research_preferred_ivr": RESEARCH_PREFERRED_IVR,
             "max_vix": max_vix,
             "require_above_200dma": require_above_200dma,
             "fail_closed_on_missing": fail_closed_on_missing,

--- a/src/utils/alpaca_client.py
+++ b/src/utils/alpaca_client.py
@@ -78,6 +78,58 @@ def _bootstrap_env_from_dotenv() -> None:
         logger.info("Loaded local dotenv file(s) for Alpaca credential discovery")
 
 
+def _keychain_generic_password(service: str, account: str = "hermes-fleet") -> Optional[str]:
+    """Read a macOS Keychain generic password without logging the secret."""
+    if os.name != "posix" or not Path("/usr/bin/security").exists():
+        return None
+    # Fixed argv only (no shell, no user-controlled binary path).
+    try:
+        import subprocess as _sp  # nosec B404 — Keychain CLI bridge only
+
+        proc = _sp.run(  # nosec B603 — absolute binary + fixed argv
+            [
+                "/usr/bin/security",
+                "find-generic-password",
+                "-a",
+                account,
+                "-s",
+                service,
+                "-w",
+            ],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        if proc.returncode != 0:
+            return None
+        value = (proc.stdout or "").strip()
+        return value or None
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("Keychain read failed for %s: %s", service, exc)
+        return None
+
+
+def _bootstrap_env_from_keychain() -> None:
+    """Fill missing paper Alpaca env vars from Keychain (local Mac operator path)."""
+    pairs = (
+        ("ALPACA_PAPER_TRADING_API_KEY", "ALPACA_PAPER_TRADING_API_KEY"),
+        ("ALPACA_PAPER_TRADING_API_SECRET", "ALPACA_PAPER_TRADING_API_SECRET"),
+        ("ALPACA_API_KEY", "ALPACA_API_KEY"),
+        ("ALPACA_SECRET_KEY", "ALPACA_SECRET_KEY"),
+    )
+    loaded = 0
+    for env_name, service in pairs:
+        if os.getenv(env_name):
+            continue
+        value = _keychain_generic_password(service)
+        if value:
+            os.environ[env_name] = value
+            loaded += 1
+    if loaded:
+        logger.info("Loaded %s Alpaca credential(s) from Keychain (values not logged)", loaded)
+
+
 def get_alpaca_credentials() -> tuple[Optional[str], Optional[str]]:
     """
     Get Alpaca API credentials with proper priority (paper trading).
@@ -85,6 +137,7 @@ def get_alpaca_credentials() -> tuple[Optional[str], Optional[str]]:
     Priority order (first found wins) - UPDATED Jan 30, 2026:
     1. ALPACA_PAPER_TRADING_API_KEY / SECRET ($100K account - PRIMARY)
     2. ALPACA_API_KEY / ALPACA_SECRET_KEY (workflow fallback)
+    3. macOS Keychain services with the same names (account hermes-fleet)
 
     NOTE: The $5K/$30K accounts are deprecated. Use $100K account only.
     $100K account = No PDT restrictions, faster path to North Star.
@@ -93,6 +146,7 @@ def get_alpaca_credentials() -> tuple[Optional[str], Optional[str]]:
         Tuple of (api_key, secret_key) or (None, None) if not found.
     """
     _bootstrap_env_from_dotenv()
+    _bootstrap_env_from_keychain()
 
     env_vars_checked = [
         ("ALPACA_PAPER_TRADING_API_KEY", os.getenv("ALPACA_PAPER_TRADING_API_KEY")),

--- a/tests/test_put_credit_regime.py
+++ b/tests/test_put_credit_regime.py
@@ -42,6 +42,21 @@ def test_regime_blocks_low_ivr():
     assert any("IV rank" in b for b in gate["blockers"])
 
 
+def test_regime_allows_lean_premium_above_paper_floor():
+    """Paper floor may be below research preferred IVR; soft-flag lean premium."""
+    gate = evaluate_regime_gate(_snap(iv_rank_proxy=18.0), min_iv_rank=10.0)
+    assert gate["allowed"] is True
+    assert gate["blockers"] == []
+    assert any("research preferred" in f for f in gate["soft_flags"])
+    assert gate["thresholds"]["research_preferred_ivr"] == 30.0
+
+
+def test_regime_still_blocks_below_paper_floor():
+    gate = evaluate_regime_gate(_snap(iv_rank_proxy=5.0), min_iv_rank=10.0)
+    assert gate["allowed"] is False
+    assert any("IV rank" in b for b in gate["blockers"])
+
+
 def test_regime_missing_vix_fail_closed():
     gate = evaluate_regime_gate(_snap(vix=None), fail_closed_on_missing=True)
     assert gate["allowed"] is False


### PR DESCRIPTION
## Linear
- Issue: AGENT-361
- Agent: grok
- Branch/worktree: fix/AGENT-361-put-credit-cadence-regime @ .worktrees/fix-put-credit-cadence-20260810
- Files or systems claimed: .github/workflows/put-credit-validation.yml, src/risk/put_credit_regime.py, src/utils/alpaca_client.py, tests/test_put_credit_regime.py
- Base SHA: 8b261d7c7e91d5b041f3a154fc00c9d480388581

## Coordination checklist
- [x] Linear issue and vault claim updated
- [x] No overlapping active claim or worktree

## Summary
Paper `spy_put_credit` validation stuck at **n=2/30** because IVR proxy gate blocked every weekday entry (IVR 8–29 vs hard min 30) while inventory was clean and CI credentials worked.

## Changes
- Workflow paper floor: `PUT_CREDIT_MIN_IVR=10` (VIX hard veto at 30 unchanged). Research preferred IVR=30 soft-flagged for stratified edge claims.
- Second scheduled entry attempt at **1:00 PM ET**.
- Local Keychain fallback for missing paper Alpaca env vars.
- Tests for lean-premium soft-flag vs hard floor.

## Evidence (before)
| Date | IVR proxy | Result |
|------|-----------|--------|
| 2026-08-10 | 10.7 | blocked |
| 2026-08-07 | 8.2 | blocked |
| 2026-08-05 | 29.1 | blocked |
| 2026-08-04 | 26.8 | blocked |

## Risk
- Paper only; live remains kill-switch blocked.
- Lean-premium trades must not alone justify live/scale.

## Test plan
- [x] `pytest tests/test_put_credit_regime.py` (12 passed)
- [ ] After merge: next scheduled put-credit entry attempts paper MLEG under new floor