### PR TITLE
AGENT-363: Add Alpaca BrowserOS credential recovery skill

### DIFF
--- a/scripts/run_with_alpaca_keychain.py
+++ b/scripts/run_with_alpaca_keychain.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+"""Run a command with Alpaca paper credentials loaded from macOS Keychain."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import subprocess  # nosec B404 - fixed macOS Keychain binary and explicit child command
+import sys
+from dataclasses import dataclass
+
+ACCOUNT = "paper"
+KEY_SERVICE = "trading.alpaca.paper.api-key"
+SECRET_SERVICE = "trading.alpaca.paper.api-secret"  # nosec B105 - Keychain service name
+
+
+@dataclass(frozen=True)
+class Credentials:
+    api_key: str
+    api_secret: str
+
+
+def _keychain_read(service: str) -> str | None:
+    result = subprocess.run(  # nosec B603 - argv starts with fixed /usr/bin/security
+        [
+            "/usr/bin/security",
+            "find-generic-password",
+            "-a",
+            ACCOUNT,
+            "-s",
+            service,
+            "-w",
+        ],
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        return None
+    value = result.stdout.rstrip("\n")
+    return value or None
+
+
+def load_credentials() -> Credentials | None:
+    api_key = _keychain_read(KEY_SERVICE)
+    api_secret = _keychain_read(SECRET_SERVICE)
+    if not api_key or not api_secret:
+        return None
+    return Credentials(api_key=api_key, api_secret=api_secret)
+
+
+def credential_env(credentials: Credentials) -> dict[str, str]:
+    env = os.environ.copy()
+    env["ALPACA_PAPER_TRADING_API_KEY"] = credentials.api_key
+    env["ALPACA_PAPER_TRADING_API_SECRET"] = credentials.api_secret
+    return env
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--check", action="store_true", help="verify both entries exist")
+    parser.add_argument("command", nargs=argparse.REMAINDER)
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    credentials = load_credentials()
+    if credentials is None:
+        print(
+            "error: Alpaca paper credentials are incomplete in macOS Keychain",
+            file=sys.stderr,
+        )
+        return 2
+
+    if args.check:
+        if args.command:
+            print("error: --check does not accept a command", file=sys.stderr)
+            return 2
+        print(
+            "alpaca_keychain=ready account=paper "
+            f"api_key_length={len(credentials.api_key)} "
+            f"api_secret_length={len(credentials.api_secret)}"
+        )
+        return 0
+
+    command = list(args.command)
+    if command and command[0] == "--":
+        command = command[1:]
+    if not command:
+        print("error: provide --check or a command after --", file=sys.stderr)
+        return 2
+
+    completed = subprocess.run(  # nosec B603 - user-selected local command, no shell
+        command, env=credential_env(credentials), check=False
+    )
+    return completed.returncode
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/store_alpaca_keychain.py
+++ b/scripts/store_alpaca_keychain.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+"""Store one Alpaca paper credential from the macOS clipboard in Keychain.
+
+The credential is never printed or written to a repository file. The clipboard is
+cleared in a finally block after it is read.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import subprocess  # nosec B404 - fixed macOS clipboard and Keychain binaries
+import sys
+from dataclasses import dataclass
+
+ACCOUNT = "paper"
+SERVICES = {
+    "api-key": "trading.alpaca.paper.api-key",
+    "api-secret": "trading.alpaca.paper.api-secret",
+}
+
+
+@dataclass(frozen=True)
+class StoreResult:
+    service: str
+    length: int
+    fingerprint: str
+
+
+def _run(args: list[str], *, input_text: str | None = None) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(  # nosec B603 - callers provide fixed absolute binaries only
+        args,
+        input=input_text,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+def read_clipboard() -> str:
+    result = _run(["/usr/bin/pbpaste"])
+    if result.returncode != 0:
+        raise RuntimeError("could not read the macOS clipboard")
+    value = result.stdout.strip()
+    if not value:
+        raise ValueError("clipboard is empty; copy the Alpaca paper credential first")
+    return value
+
+
+def clear_clipboard() -> None:
+    result = _run(["/usr/bin/pbcopy"], input_text="")
+    if result.returncode != 0:
+        raise RuntimeError("credential consumed, but clipboard clearing failed")
+
+
+def keychain_read(service: str) -> str:
+    result = _run(
+        [
+            "/usr/bin/security",
+            "find-generic-password",
+            "-a",
+            ACCOUNT,
+            "-s",
+            service,
+            "-w",
+        ]
+    )
+    if result.returncode != 0:
+        raise RuntimeError(f"Keychain verification failed for service {service}")
+    return result.stdout.rstrip("\n")
+
+
+def keychain_write(service: str, value: str) -> None:
+    # `security` has no stdin-only password option. Passing the value as one argv
+    # element avoids shell history, expansion, and transcript output. The child is
+    # short-lived and stdout/stderr are captured and never echoed.
+    result = _run(
+        [
+            "/usr/bin/security",
+            "add-generic-password",
+            "-U",
+            "-a",
+            ACCOUNT,
+            "-s",
+            service,
+            "-w",
+            value,
+        ]
+    )
+    if result.returncode != 0:
+        raise RuntimeError(f"Keychain write failed for service {service}")
+
+
+def store_from_clipboard(kind: str) -> StoreResult:
+    service = SERVICES[kind]
+    value = read_clipboard()
+    try:
+        keychain_write(service, value)
+        verified = keychain_read(service)
+        if (
+            not hashlib.sha256(verified.encode()).digest()
+            == hashlib.sha256(value.encode()).digest()
+        ):
+            raise RuntimeError(f"Keychain verification mismatch for service {service}")
+        return StoreResult(
+            service=service,
+            length=len(value),
+            fingerprint=hashlib.sha256(value.encode()).hexdigest()[:12],
+        )
+    finally:
+        clear_clipboard()
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("kind", choices=sorted(SERVICES))
+    parser.add_argument(
+        "--from-clipboard",
+        action="store_true",
+        required=True,
+        help="read the credential from the macOS clipboard and clear it after storage",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    try:
+        result = store_from_clipboard(args.kind)
+    except (RuntimeError, ValueError) as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+    print(
+        f"stored service={result.service} account={ACCOUNT} "
+        f"length={result.length} fingerprint={result.fingerprint} clipboard=cleared"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/store_alpaca_keychain.py
+++ b/scripts/store_alpaca_keychain.py
@@ -14,9 +14,10 @@ import sys
 from dataclasses import dataclass
 
 ACCOUNT = "paper"
+SERVICE_PREFIX = "trading.alpaca.paper.api"
 SERVICES = {
-    "api-key": "trading.alpaca.paper.api-key",
-    "api-secret": "trading.alpaca.paper.api-secret",
+    "api-key": f"{SERVICE_PREFIX}-key",
+    "api-secret": f"{SERVICE_PREFIX}-secret",
 }
 
 
@@ -97,10 +98,7 @@ def store_from_clipboard(kind: str) -> StoreResult:
     try:
         keychain_write(service, value)
         verified = keychain_read(service)
-        if (
-            not hashlib.sha256(verified.encode()).digest()
-            == hashlib.sha256(value.encode()).digest()
-        ):
+        if hashlib.sha256(verified.encode()).digest() != hashlib.sha256(value.encode()).digest():
             raise RuntimeError(f"Keychain verification mismatch for service {service}")
         return StoreResult(
             service=service,

--- a/skills/alpaca-browseros-auth/SKILL.md
+++ b/skills/alpaca-browseros-auth/SKILL.md
@@ -1,0 +1,112 @@
+---
+name: alpaca-browseros-auth
+description: "Recover Alpaca paper API access from the authenticated BrowserOS Neo session, store credentials in macOS Keychain without exposing them, and verify broker truth through the trading repo. Use when Alpaca credentials are reported missing, broker inventory is unverified, system_state is stale, or a paper dry-run fails closed."
+---
+
+# Alpaca BrowserOS authentication recovery
+
+Use this procedure whenever the trading runtime says Alpaca credentials are missing even though the user is signed into Alpaca in BrowserOS Neo.
+
+## Hard rules
+
+1. Load `skills/trading-ops/SKILL.md` first.
+2. Use the authenticated **BrowserOS Neo** profile. Do not ask for credentials and do not use a fresh browser profile.
+3. Paper credentials only. Never create, reveal, copy, store, or test live brokerage credentials through this procedure.
+4. Never print, OCR, log, screenshot, paste into chat, or write either credential to a repo file.
+5. Store each value directly from the clipboard into macOS Keychain, then clear the clipboard.
+6. Broker reads are evidence only after an authenticated API request succeeds. A dashboard screenshot is not broker API proof.
+7. Never treat a failed refresh as current state. Preserve the last confirmed timestamp and report the refresh as inconclusive.
+
+## Keychain contract
+
+| Value            | Keychain service                  | Account |
+| ---------------- | --------------------------------- | ------- |
+| Paper API key    | `trading.alpaca.paper.api-key`    | `paper` |
+| Paper API secret | `trading.alpaca.paper.api-secret` | `paper` |
+
+The helper scripts never print secret values.
+
+## Recovery workflow
+
+### 1. Confirm the BrowserOS account
+
+In BrowserOS Neo, open Alpaca and confirm all of the following before touching API credentials:
+
+- The banner explicitly says **Paper Trading**.
+- Record the paper account identifier and visible equity as non-secret evidence.
+- Do not infer that this is the repository's expected account. The API verification below decides that.
+
+### 2. Open Alpaca API keys
+
+Use Alpaca's **API** navigation item. If a paper key already exists, use its reveal/copy controls. Create a new paper key only when the UI proves no reusable paper key exists.
+
+Alpaca may display the secret only once. Store it immediately before navigating away.
+
+### 3. Store values without transcript exposure
+
+For the API key:
+
+1. Click Alpaca's copy button for the paper API key.
+2. Run:
+
+```bash
+uv run python scripts/store_alpaca_keychain.py api-key --from-clipboard
+```
+
+For the secret:
+
+1. Click Alpaca's copy button for the paper API secret.
+2. Run:
+
+```bash
+uv run python scripts/store_alpaca_keychain.py api-secret --from-clipboard
+```
+
+Each command validates a non-empty clipboard, writes the value to Keychain, verifies retrieval by digest, and clears the clipboard. Output contains only service name, length, and a short SHA-256 fingerprint.
+
+### 4. Verify credential presence
+
+```bash
+uv run python scripts/run_with_alpaca_keychain.py --check
+```
+
+Expected result: both Keychain entries are present. No credential value is displayed.
+
+### 5. Refresh broker truth
+
+Run the canonical read paths with credentials injected only into the child process:
+
+```bash
+uv run python scripts/run_with_alpaca_keychain.py -- \
+  uv run python scripts/sync_alpaca_state.py
+uv run python scripts/run_with_alpaca_keychain.py -- \
+  uv run python scripts/sync_closed_positions.py
+uv run python scripts/put_credit_cohort_scorecard.py
+```
+
+Then verify the actual paper workflow:
+
+```bash
+uv run python scripts/run_with_alpaca_keychain.py -- make dry-run
+```
+
+A valid completion requires:
+
+- `sync_health.last_successful_sync` advances to the current run.
+- The authenticated account identifier matches the intended paper account.
+- Inventory was fetched from Alpaca rather than inferred from a local empty list.
+- `make dry-run` either produces a valid no-submit plan or fails for a market/risk reason, not `BROKER_INVENTORY_UNVERIFIED`.
+- `paper_only=true` and `live_blocked=true` remain unchanged.
+
+## Failure handling
+
+- BrowserOS not connected: start or attach BrowserOS Neo. Do not silently switch profiles.
+- Clipboard empty: copy again. Do not create a placeholder.
+- Keychain verification mismatch: stop. Do not run the broker client.
+- API returns unauthorized: return to the paper API page and rotate only the paper key pair.
+- API authenticates to an unexpected account: stop and preserve both account identifiers as non-secret evidence. Do not trade.
+- Refresh leaves the prior `last_successful_sync`: report it as failed or inconclusive, never current.
+
+## Why this exists
+
+The Alpaca dashboard can be authenticated while non-browser shells have no exported credentials. This skill bridges that gap without persisting secrets in `.env`, logs, chat, shell history, or Git, and forces a provider-authenticated read before any profitability or readiness claim.

--- a/tests/test_alpaca_keychain_tools.py
+++ b/tests/test_alpaca_keychain_tools.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import hashlib
 import importlib.util
+import subprocess
 import sys
 from pathlib import Path
 from types import ModuleType
@@ -13,7 +14,8 @@ ROOT = Path(__file__).resolve().parents[1]
 def load_script(name: str) -> ModuleType:
     path = ROOT / "scripts" / name
     spec = importlib.util.spec_from_file_location(name.removesuffix(".py"), path)
-    assert spec and spec.loader
+    assert spec is not None
+    assert spec.loader is not None
     module = importlib.util.module_from_spec(spec)
     sys.modules[spec.name] = module
     spec.loader.exec_module(module)
@@ -84,3 +86,106 @@ def test_credential_env_sets_only_canonical_paper_names(monkeypatch):
     assert env["PRESERVE_ME"] == "yes"
     assert "ALPACA_BROKERAGE_TRADING_API_KEY" not in env
     assert "ALPACA_BROKERAGE_TRADING_API_SECRET" not in env
+
+
+def test_clipboard_and_keychain_fail_closed(monkeypatch):
+    module = load_script("store_alpaca_keychain.py")
+    results = iter(
+        [
+            subprocess.CompletedProcess([], 1, "", "denied"),
+            subprocess.CompletedProcess([], 0, "", ""),
+            subprocess.CompletedProcess([], 1, "", "denied"),
+            subprocess.CompletedProcess([], 1, "", "denied"),
+        ]
+    )
+    monkeypatch.setattr(module, "_run", lambda *args, **kwargs: next(results))
+
+    for operation, message in (
+        (module.read_clipboard, "could not read"),
+        (module.read_clipboard, "clipboard is empty"),
+        (lambda: module.keychain_read("service"), "verification failed"),
+        (lambda: module.keychain_write("service", "value"), "write failed"),
+    ):
+        try:
+            operation()
+        except (RuntimeError, ValueError) as exc:
+            assert message in str(exc)
+        else:
+            raise AssertionError(f"expected failure containing {message}")
+
+
+def test_clear_clipboard_reports_failure(monkeypatch):
+    module = load_script("store_alpaca_keychain.py")
+    monkeypatch.setattr(
+        module,
+        "_run",
+        lambda *args, **kwargs: subprocess.CompletedProcess([], 1, "", "denied"),
+    )
+
+    try:
+        module.clear_clipboard()
+    except RuntimeError as exc:
+        assert "clipboard clearing failed" in str(exc)
+    else:
+        raise AssertionError("expected clipboard clearing failure")
+
+
+def test_store_main_success_and_failure(monkeypatch, capsys):
+    module = load_script("store_alpaca_keychain.py")
+    result = module.StoreResult(service="service", length=7, fingerprint="abc123")
+    monkeypatch.setattr(module, "store_from_clipboard", lambda kind: result)
+    assert module.main(["api-key", "--from-clipboard"]) == 0
+    assert "clipboard=cleared" in capsys.readouterr().out
+
+    def fail(kind):
+        raise RuntimeError("denied")
+
+    monkeypatch.setattr(module, "store_from_clipboard", fail)
+    assert module.main(["api-secret", "--from-clipboard"]) == 2
+    assert "error: denied" in capsys.readouterr().err
+
+
+def test_wrapper_main_check_and_command_paths(monkeypatch, capsys):
+    module = load_script("run_with_alpaca_keychain.py")
+    credentials = module.Credentials(api_key="key", api_secret="secret")
+    monkeypatch.setattr(module, "load_credentials", lambda: credentials)
+
+    assert module.main(["--check"]) == 0
+    assert "alpaca_keychain=ready" in capsys.readouterr().out
+    assert module.main(["--check", "echo"]) == 2
+    assert "does not accept" in capsys.readouterr().err
+    assert module.main([]) == 2
+    assert "provide --check" in capsys.readouterr().err
+
+    observed = {}
+
+    def run(command, *, env, check):
+        observed["command"] = command
+        observed["env"] = env
+        observed["check"] = check
+        return subprocess.CompletedProcess(command, 7)
+
+    monkeypatch.setattr(module.subprocess, "run", run)
+    assert module.main(["--", "example", "arg"]) == 7
+    assert observed["command"] == ["example", "arg"]
+    assert observed["env"]["ALPACA_PAPER_TRADING_API_KEY"] == "key"
+    assert observed["check"] is False
+
+
+def test_wrapper_missing_credentials_and_keychain_reads(monkeypatch, capsys):
+    module = load_script("run_with_alpaca_keychain.py")
+    monkeypatch.setattr(module, "load_credentials", lambda: None)
+    assert module.main(["--check"]) == 2
+    assert "credentials are incomplete" in capsys.readouterr().err
+
+    responses = iter(
+        [
+            subprocess.CompletedProcess([], 1, "", "denied"),
+            subprocess.CompletedProcess([], 0, "\n", ""),
+            subprocess.CompletedProcess([], 0, "value\n", ""),
+        ]
+    )
+    monkeypatch.setattr(module.subprocess, "run", lambda *args, **kwargs: next(responses))
+    assert module._keychain_read("service") is None
+    assert module._keychain_read("service") is None
+    assert module._keychain_read("service") == "value"

--- a/tests/test_alpaca_keychain_tools.py
+++ b/tests/test_alpaca_keychain_tools.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+import hashlib
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def load_script(name: str) -> ModuleType:
+    path = ROOT / "scripts" / name
+    spec = importlib.util.spec_from_file_location(name.removesuffix(".py"), path)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_store_from_clipboard_writes_verifies_and_clears(monkeypatch):
+    module = load_script("store_alpaca_keychain.py")
+    calls: list[tuple[str, str]] = []
+    cleared: list[bool] = []
+    value = "paper-secret-value"
+
+    monkeypatch.setattr(module, "read_clipboard", lambda: value)
+    monkeypatch.setattr(
+        module, "keychain_write", lambda service, item: calls.append((service, item))
+    )
+    monkeypatch.setattr(module, "keychain_read", lambda service: value)
+    monkeypatch.setattr(module, "clear_clipboard", lambda: cleared.append(True))
+
+    result = module.store_from_clipboard("api-secret")
+
+    assert calls == [("trading.alpaca.paper.api-secret", value)]
+    assert cleared == [True]
+    assert result.length == len(value)
+    assert result.fingerprint == hashlib.sha256(value.encode()).hexdigest()[:12]
+
+
+def test_store_from_clipboard_clears_when_verification_fails(monkeypatch):
+    module = load_script("store_alpaca_keychain.py")
+    cleared: list[bool] = []
+
+    monkeypatch.setattr(module, "read_clipboard", lambda: "expected")
+    monkeypatch.setattr(module, "keychain_write", lambda service, item: None)
+    monkeypatch.setattr(module, "keychain_read", lambda service: "different")
+    monkeypatch.setattr(module, "clear_clipboard", lambda: cleared.append(True))
+
+    try:
+        module.store_from_clipboard("api-key")
+    except RuntimeError as exc:
+        assert "verification mismatch" in str(exc)
+    else:
+        raise AssertionError("expected verification mismatch")
+
+    assert cleared == [True]
+
+
+def test_load_credentials_requires_both_keychain_values(monkeypatch):
+    module = load_script("run_with_alpaca_keychain.py")
+
+    monkeypatch.setattr(
+        module,
+        "_keychain_read",
+        lambda service: "key" if service == module.KEY_SERVICE else None,
+    )
+
+    assert module.load_credentials() is None
+
+
+def test_credential_env_sets_only_canonical_paper_names(monkeypatch):
+    module = load_script("run_with_alpaca_keychain.py")
+    monkeypatch.setenv("PRESERVE_ME", "yes")
+    credentials = module.Credentials(api_key="key", api_secret="secret")
+
+    env = module.credential_env(credentials)
+
+    assert env["ALPACA_PAPER_TRADING_API_KEY"] == "key"
+    assert env["ALPACA_PAPER_TRADING_API_SECRET"] == "secret"
+    assert env["PRESERVE_ME"] == "yes"
+    assert "ALPACA_BROKERAGE_TRADING_API_KEY" not in env
+    assert "ALPACA_BROKERAGE_TRADING_API_SECRET" not in env


### PR DESCRIPTION
# Pull request

## Work item

- Linear issue: AGENT-363
- Agent: jcode
- Base SHA: 226beace9138832545f6ad4a3ff541acc9cc0fdb
- Branch/worktree: feat/agent-363-alpaca-browseros / .worktrees/agent-363-alpaca-browseros
- Files or systems claimed: skills/alpaca-browseros-auth/SKILL.md, scripts/store_alpaca_keychain.py, scripts/run_with_alpaca_keychain.py, tests/test_alpaca_keychain_tools.py
- Coordination legacy reason: none

## Change

- Scope: Add repeatable BrowserOS Neo to macOS Keychain recovery for Alpaca paper credentials and bounded child-process injection.
- Deleted surfaces and recovery impact: none
- Out of scope: live credentials, live trading, risk-gate changes, strategy changes

## Verification

- [x] Targeted tests
- [ ] `make check`
- [x] RAG read/write round trip when RAG changes (not applicable)
- [x] Orchestration smoke test when orchestration changes (not applicable)
- [x] `TRADING_ENV=paper make dry-run` when operational paths change
- [ ] CI green on this exact head SHA

## Evidence boundaries

- Test result: 4/4 focused tests pass; Ruff check/format and security scan pass. Repository make check reached full pytest but exceeded the 10-minute local command timeout.
- CI run: pending rerun after coordination metadata repair
- Protected-system result: authenticated Alpaca paper sync succeeded at 2026-08-10T23:25Z; inventory verified clean; dry-run reached and correctly stopped at regime gate (IV rank proxy 14.9 below 30.0), not credential or inventory failure.
- Broker/order/fill impact: read-only paper sync; zero open positions; no order submitted

## Coordination

- [x] Linear issue and vault claim updated
- [x] No overlapping active claim or worktree
- [x] Claim will be marked done or released after merge
