### PR TITLE
feat(AGENT-364): continuous arXiv paper ingestion for DS/ML/Agentic RAG

### DIFF
--- a/.github/workflows/arxiv-paper-ingest.yml
+++ b/.github/workflows/arxiv-paper-ingest.yml
@@ -1,0 +1,115 @@
+name: ArXiv Paper Ingestion (DS/ML/RAG)
+
+# Continuous research feed: pull trading/RL/RAG papers from arXiv into the
+# DocumentIngestionPipeline and curated rag_knowledge/research/arxiv corpus.
+# Never submits trades. Research-only.
+
+on:
+  schedule:
+    # Daily 07:15 UTC (~03:15 ET) — before pre-market, after overnight arXiv batch
+    - cron: 15 7 * * *
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: arxiv-paper-ingest
+  cancel-in-progress: false
+
+jobs:
+  ingest:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Set up Python
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
+        with:
+          python-version: "3.11"
+          cache: pip
+
+      - name: Install minimal dependencies
+        run: |
+          python -m pip install --upgrade pip
+          if [ -f requirements-minimal.txt ]; then
+            pip install -r requirements-minimal.txt
+          fi
+          pip install -e . --no-deps 2>/dev/null || true
+
+      - name: Run arXiv continuous ingestion
+        id: ingest
+        env:
+          PYTHONPATH: ${{ github.workspace }}
+        run: |
+          set -euo pipefail
+          MAX_RESULTS=20
+          MIN_REL=0.18
+          ARGS=(--max-results "$MAX_RESULTS" --min-relevance "$MIN_REL" --json --rebuild-index)
+          python scripts/arxiv_paper_ingestion.py "${ARGS[@]}" | tee /tmp/arxiv_ingest.json
+          python - <<'PY'
+          import json
+          from pathlib import Path
+          p = Path("/tmp/arxiv_ingest.json")
+          text = p.read_text(encoding="utf-8")
+          start = text.rfind("{")
+          data = json.loads(text[start:]) if start >= 0 else {}
+          print(f"status={data.get('status')}")
+          print(f"ingested={data.get('ingested', 0)}")
+          print(f"promoted={data.get('promoted', 0)}")
+          Path("data/runtime").mkdir(parents=True, exist_ok=True)
+          status = Path("data/runtime/arxiv_ingestion_latest.json")
+          if not status.exists() and data:
+              status.write_text(json.dumps(data, indent=2), encoding="utf-8")
+          PY
+
+      - name: Upload status artifact
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: arxiv-ingest-status
+          path: |
+            data/runtime/arxiv_ingestion_latest.json
+            data/audit/arxiv_ingestion_manifest.json
+          if-no-files-found: warn
+
+      - name: Open PR for newly curated research papers
+        if: success()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          mkdir -p rag_knowledge/research/arxiv
+          if git status --porcelain rag_knowledge/research/arxiv data/runtime/arxiv_ingestion_latest.json 2>/dev/null | grep -q .; then
+            BRANCH="chore/arxiv-ingest-${GITHUB_RUN_ID}"
+            git switch -c "$BRANCH"
+            git add rag_knowledge/research/arxiv || true
+            if git ls-files --error-unmatch data/runtime/arxiv_ingestion_latest.json >/dev/null 2>&1; then
+              git add data/runtime/arxiv_ingestion_latest.json
+            fi
+            if git diff --cached --quiet; then
+              echo "No curated papers to commit"
+              exit 0
+            fi
+            git commit -m "chore(rag): curated arXiv research papers [auto AGENT-364]"
+            git push -u origin "$BRANCH"
+            PR_BODY="Automated arXiv research ingestion from run ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}.
+
+          Source: https://arxiv.org/
+          Scope: DS / ML / Agentic RAG only — no trade submission.
+          Issue: AGENT-364
+          "
+            gh pr create \
+              --base main \
+              --head "$BRANCH" \
+              --title "chore(rag): curated arXiv research papers" \
+              --body "$PR_BODY" || echo "::warning::PR create failed; branch pushed: $BRANCH"
+          else
+            echo "No curated research changes"
+          fi

--- a/.gitignore
+++ b/.gitignore
@@ -124,6 +124,10 @@ data/options_signals/
 data/post_market_analysis/
 data/reports/
 data/research/
+
+# Generated arXiv paper store (curated promotions live under rag_knowledge/research/)
+data/arxiv/
+logs/arxiv_ingest*.log
 data/revenue/
 data/screenshots/
 data/sentiment/
@@ -174,3 +178,4 @@ ralph_output.txt
 population_log*.txt
 wiki/
 graphify-out/
+data/runtime/arxiv_ingestion_latest.json

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ VENV_PYTHON := $(VENV)/bin/python
 TRADING_ENV ?= paper
 export TRADING_ENV
 
-.PHONY: setup lint ruff format test coverage audit security health skill-check coordination-check coordination-audit coordination-preflight check dry-run hygiene graph-rag-check rag-aplus-check
+.PHONY: setup lint ruff format test coverage audit security health skill-check coordination-check coordination-audit coordination-preflight check dry-run hygiene graph-rag-check rag-aplus-check arxiv-ingest arxiv-ingest-status
 
 setup:
 	$(PYTHON) -m venv $(VENV)
@@ -68,3 +68,11 @@ dry-run: health
 
 hygiene:
 	scripts/worktree_hygiene.sh --prune
+
+
+# Continuous arXiv research ingestion (DS / ML / Agentic RAG) — AGENT-364
+arxiv-ingest:
+	PYTHONPATH=. $(VENV_PYTHON) scripts/arxiv_paper_ingestion.py --max-results 15 --rebuild-index
+
+arxiv-ingest-status:
+	PYTHONPATH=. $(VENV_PYTHON) scripts/arxiv_paper_ingestion.py --status

--- a/docs/ARXIV_INGESTION.md
+++ b/docs/ARXIV_INGESTION.md
@@ -1,0 +1,86 @@
+# Continuous arXiv Paper Ingestion (DS / ML / Agentic RAG)
+
+**Issue:** AGENT-364  
+**Source:** [https://arxiv.org/](https://arxiv.org/) via `https://export.arxiv.org/api/query`  
+**Scope:** Research only — never submits trades, never re-opens killed IC entries.
+
+## Purpose
+
+Continuously discover quantitative finance, options, risk, GRPO/RL, multi-agent, and
+financial RAG papers, grade them for relevance to this lab, and feed accepted
+documents into:
+
+1. **Local paper store** — `data/arxiv/*.md` (generated, gitignored)
+2. **DocumentIngestionPipeline** — versioned chunks + SHA256 dedupe
+3. **Curated RAG corpus** — high-relevance only → `rag_knowledge/research/arxiv/`
+4. **Operator status** — `data/runtime/arxiv_ingestion_latest.json`
+5. **Durable manifest** — `data/audit/arxiv_ingestion_manifest.json` (gitignored)
+
+## Operator commands
+
+```bash
+# One-shot continuous pull
+make arxiv-ingest
+
+# Status of last run
+make arxiv-ingest-status
+# or
+.venv/bin/python scripts/arxiv_paper_ingestion.py --status
+
+# Custom query
+.venv/bin/python scripts/arxiv_paper_ingestion.py \
+  --query "put credit spread options" --max-results 20 --json
+
+# Local continuous job (every 6 hours via launchd)
+bash scripts/setup_arxiv_ingest_launchagent.sh install
+bash scripts/setup_arxiv_ingest_launchagent.sh status
+bash scripts/setup_arxiv_ingest_launchagent.sh run-once
+```
+
+## GitHub Actions
+
+Workflow: `.github/workflows/arxiv-paper-ingest.yml`
+
+- **Schedule:** daily 07:15 UTC
+- **Manual:** Actions → ArXiv Paper Ingestion → Run workflow
+- Promoted curated markdown may open an auto PR under `chore/arxiv-ingest-*`
+
+## Relevance gate
+
+Composite score (0..1):
+
+- Faithfulness / answer relevance / groundedness vs trading+RAG context (lexical metrics)
+- Domain boost for tokens such as `option`, `GRPO`, `SPY`, `microstructure`, `RAG`, …
+
+Defaults:
+
+| Gate    | Threshold | Effect                                     |
+| ------- | --------- | ------------------------------------------ |
+| Ingest  | ≥ 0.18    | Write `data/arxiv/` + pipeline chunks      |
+| Promote | ≥ 0.28    | Also write `rag_knowledge/research/arxiv/` |
+
+Low-signal papers are recorded only as skip counts (not RAG pollution).
+
+## Data Science / ML hooks
+
+- **DS:** status JSON + manifest for coverage/recency dashboards
+- **ML:** curated abstracts as optional GRPO/research context (not training labels for edge claims)
+- **Agentic RAG:** `build_rag_query_index` / `vectorize_rag_knowledge` pick up
+  `rag_knowledge/research/**` after `--rebuild-index`
+
+## Hard rules
+
+- Paper mode only; no broker order paths
+- Papers ≠ evidence of expectancy or profit
+- Do not promote arXiv content into paired trade metrics or kill-criteria math
+- Deduplicate by `arxiv_id` in the manifest
+
+## Code map
+
+| Path                                              | Role                              |
+| ------------------------------------------------- | --------------------------------- |
+| `src/research/arxiv_collector.py`                 | API fetch, score, ingest, promote |
+| `scripts/arxiv_paper_ingestion.py`                | CLI                               |
+| `scripts/setup_arxiv_ingest_launchagent.sh`       | local continuous install          |
+| `ops/launchd/com.igor.trading-arxiv-ingest.plist` | launchd template                  |
+| `tests/test_arxiv_collector.py`                   | unit tests (mocked network)       |

--- a/docs/README.md
+++ b/docs/README.md
@@ -20,6 +20,7 @@ Operator and design docs for the trading lab.
 | [research/](./research/)                                           | Edge audits and deep dives                 |
 | [RAG_11_STAGES_SPECIFICATION.md](./RAG_11_STAGES_SPECIFICATION.md) | RAG pipeline stages                        |
 | [GRAPH_RAG.md](./GRAPH_RAG.md)                                     | Temporal Graph RAG (strategy/lesson/trade) |
+| [ARXIV_INGESTION.md](./ARXIV_INGESTION.md)                         | Continuous arXiv → DS/ML/Agentic RAG job   |
 | [EXTENSIONS.md](./EXTENSIONS.md)                                   | Optional provider boundary                 |
 
 ## Pitch / archive (not operating truth)

--- a/ops/launchd/com.igor.trading-arxiv-ingest.plist
+++ b/ops/launchd/com.igor.trading-arxiv-ingest.plist
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>com.igor.trading-arxiv-ingest</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>__REPO_ROOT__/.venv/bin/python</string>
+    <string>__REPO_ROOT__/scripts/arxiv_paper_ingestion.py</string>
+    <string>--max-results</string>
+    <string>15</string>
+    <string>--rebuild-index</string>
+    <string>--json</string>
+  </array>
+  <key>WorkingDirectory</key>
+  <string>__REPO_ROOT__</string>
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>PYTHONPATH</key>
+    <string>__REPO_ROOT__</string>
+    <key>TRADING_ENV</key>
+    <string>paper</string>
+  </dict>
+  <!-- Every 6 hours -->
+  <key>StartInterval</key>
+  <integer>21600</integer>
+  <key>RunAtLoad</key>
+  <true/>
+  <key>ProcessType</key>
+  <string>Background</string>
+  <key>LowPriorityIO</key>
+  <true/>
+  <key>StandardOutPath</key>
+  <string>__REPO_ROOT__/logs/arxiv_ingest.out.log</string>
+  <key>StandardErrorPath</key>
+  <string>__REPO_ROOT__/logs/arxiv_ingest.err.log</string>
+</dict>
+</plist>

--- a/scripts/arxiv_paper_ingestion.py
+++ b/scripts/arxiv_paper_ingestion.py
@@ -1,0 +1,198 @@
+#!/usr/bin/env python3
+"""Continuous arXiv research paper ingestion CLI.
+
+Fetches papers from https://arxiv.org via the public API, grades relevance for
+this lab's DS/ML/Agentic RAG stack, dedupes, ingests through
+DocumentIngestionPipeline, and promotes high-signal papers into
+``rag_knowledge/research/arxiv/``.
+
+Examples::
+
+    python scripts/arxiv_paper_ingestion.py
+    python scripts/arxiv_paper_ingestion.py --max-results 20 --json
+    python scripts/arxiv_paper_ingestion.py --query "put credit spread options"
+    python scripts/arxiv_paper_ingestion.py --status
+    python scripts/arxiv_paper_ingestion.py --rebuild-index
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import subprocess  # nosec B404 — rebuild index only via fixed local script path
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from src.research.arxiv_collector import (  # noqa: E402
+    DEFAULT_MIN_RELEVANCE,
+    DEFAULT_PROMOTE_RELEVANCE,
+    ArxivCollector,
+)
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s - %(levelname)s - %(message)s",
+)
+logger = logging.getLogger("arxiv_paper_ingestion")
+
+
+def _print_human(report) -> None:
+    d = report.to_dict() if hasattr(report, "to_dict") else report
+    print("\n============================================================")
+    print("ARXIV RESEARCH PAPER INGESTION SUMMARY")
+    print("============================================================")
+    print(f"Status                 : {d.get('status')}")
+    print(f"Fetched                : {d.get('fetched')}")
+    print(f"New Ingested           : {d.get('ingested')}")
+    print(f"Skipped (duplicate)    : {d.get('skipped_duplicate')}")
+    print(f"Skipped (low relevance): {d.get('skipped_low_relevance')}")
+    print(f"Promoted to curated    : {d.get('promoted')}")
+    print(f"Manifest total         : {d.get('total_manifest_papers')}")
+    print(f"Min relevance          : {d.get('min_relevance')}")
+    print(f"Duration (ms)          : {d.get('duration_ms')}")
+    if d.get("errors"):
+        print("Errors:")
+        for err in d["errors"][:10]:
+            print(f"  - {err}")
+    print("------------------------------------------------------------")
+    for paper in d.get("papers") or []:
+        print(f"• [{paper.get('arxiv_id')}] {paper.get('title')}")
+        print(
+            f"  Relevance: {paper.get('relevance_score')} | "
+            f"Chunks: {paper.get('chunks_created')} | "
+            f"Promoted: {paper.get('promoted')}"
+        )
+        if paper.get("file_path"):
+            print(f"  Saved to: {paper['file_path']}")
+    print("============================================================\n")
+
+
+def _rebuild_indexes() -> int:
+    """Best-effort rebuild of dependency-free RAG query index."""
+    build = ROOT / "scripts" / "build_rag_query_index.py"
+    if not build.is_file():
+        logger.warning("build_rag_query_index.py not found; skip rebuild")
+        return 0
+    cmd = [sys.executable, str(build)]
+    logger.info("Rebuilding RAG query index: %s", " ".join(cmd))
+    proc = subprocess.run(cmd, cwd=str(ROOT), check=False)  # nosec B603
+    return int(proc.returncode)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Continuously fetch and ingest research papers from arXiv into RAG."
+    )
+    parser.add_argument(
+        "--query",
+        type=str,
+        default=None,
+        help="Optional search query override (e.g. 'reinforcement learning trading')",
+    )
+    parser.add_argument(
+        "--max-results",
+        type=int,
+        default=15,
+        help="Maximum papers to fetch from arXiv API (1-50)",
+    )
+    parser.add_argument(
+        "--min-relevance",
+        type=float,
+        default=DEFAULT_MIN_RELEVANCE,
+        help=f"Minimum composite relevance to ingest (default {DEFAULT_MIN_RELEVANCE})",
+    )
+    parser.add_argument(
+        "--promote-relevance",
+        type=float,
+        default=DEFAULT_PROMOTE_RELEVANCE,
+        help=(
+            "Minimum relevance to promote into rag_knowledge/research/arxiv "
+            f"(default {DEFAULT_PROMOTE_RELEVANCE})"
+        ),
+    )
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help="Re-ingest even if arxiv_id already in manifest",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Output ingestion results as JSON",
+    )
+    parser.add_argument(
+        "--status",
+        action="store_true",
+        help="Print last run status artifact and exit",
+    )
+    parser.add_argument(
+        "--rebuild-index",
+        action="store_true",
+        help="After successful ingest, rebuild data/rag/lessons_query.json",
+    )
+    parser.add_argument(
+        "-v",
+        "--verbose",
+        action="store_true",
+        help="Debug logging",
+    )
+    args = parser.parse_args(argv)
+
+    if args.verbose:
+        logging.getLogger().setLevel(logging.DEBUG)
+
+    collector = ArxivCollector(
+        min_relevance=args.min_relevance,
+        promote_relevance=args.promote_relevance,
+    )
+
+    if args.status:
+        status_path = collector.status_file
+        if not status_path.exists():
+            payload = {
+                "status": "NO_STATUS",
+                "message": f"No status file at {status_path}",
+                "total_manifest_papers": collector.manifest.get("total_ingested", 0),
+                "last_run_utc": collector.manifest.get("last_run_utc", ""),
+            }
+        else:
+            payload = json.loads(status_path.read_text(encoding="utf-8"))
+        if args.json:
+            print(json.dumps(payload, indent=2))
+        else:
+            print(json.dumps(payload, indent=2))
+        return 0
+
+    logger.info("Running continuous arXiv paper ingestion job...")
+    report = collector.run_continuous_ingestion(
+        query=args.query,
+        max_results=args.max_results,
+        force=args.force,
+    )
+
+    if args.rebuild_index and report.ingested > 0:
+        rc = _rebuild_indexes()
+        if rc != 0:
+            report.status = "PARTIAL" if report.status == "OK" else report.status
+            report.errors.append(f"rebuild_index_exit={rc}")
+            collector._write_status(report)
+
+    if args.json:
+        print(json.dumps(report.to_dict(), indent=2))
+    else:
+        _print_human(report)
+
+    if report.status == "ERROR":
+        return 2
+    if report.status == "EMPTY_OR_API_ERROR":
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/setup_arxiv_ingest_launchagent.sh
+++ b/scripts/setup_arxiv_ingest_launchagent.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# Install / remove / status the local continuous arXiv ingestion LaunchAgent.
+# AGENT-364 — research-only; never submits trades.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+LABEL="com.igor.trading-arxiv-ingest"
+TEMPLATE="${REPO_ROOT}/ops/launchd/${LABEL}.plist"
+DEST="${HOME}/Library/LaunchAgents/${LABEL}.plist"
+LOG_DIR="${REPO_ROOT}/logs"
+
+usage() {
+	cat <<EOF
+Usage: $0 {install|remove|status|run-once}
+
+  install   Write LaunchAgent plist and load it (every 6h + RunAtLoad)
+  remove    Unload and delete the LaunchAgent
+  status    Show launchctl state + last status JSON if present
+  run-once  Execute one ingestion job in the foreground
+EOF
+}
+
+_uid() {
+	id -u
+}
+
+render_plist() {
+	local python_bin="${REPO_ROOT}/.venv/bin/python"
+	if [[ ! -x ${python_bin} ]]; then
+		python_bin="$(command -v python3)"
+	fi
+	mkdir -p "$(dirname "${DEST}")" "${LOG_DIR}"
+	# Substitute repo root and ensure python path is absolute
+	sed -e "s|__REPO_ROOT__|${REPO_ROOT}|g" "${TEMPLATE}" |
+		sed -e "s|${REPO_ROOT}/.venv/bin/python|${python_bin}|g" >"${DEST}"
+}
+
+cmd_install() {
+	render_plist
+	local uid
+	uid="$(_uid)"
+	launchctl bootout "gui/${uid}/${LABEL}" 2>/dev/null || true
+	launchctl bootstrap "gui/${uid}" "${DEST}"
+	launchctl enable "gui/${uid}/${LABEL}" 2>/dev/null || true
+	echo "Installed and loaded: ${DEST}"
+	echo "Logs: ${LOG_DIR}/arxiv_ingest.out.log"
+	echo "Status: ${REPO_ROOT}/data/runtime/arxiv_ingestion_latest.json"
+}
+
+cmd_remove() {
+	local uid
+	uid="$(_uid)"
+	launchctl bootout "gui/${uid}/${LABEL}" 2>/dev/null || true
+	rm -f "${DEST}"
+	echo "Removed ${LABEL}"
+}
+
+cmd_status() {
+	local uid
+	uid="$(_uid)"
+	launchctl print "gui/${uid}/${LABEL}" 2>/dev/null || echo "LaunchAgent not loaded"
+	if [[ -f ${REPO_ROOT}/data/runtime/arxiv_ingestion_latest.json ]]; then
+		echo "--- last status ---"
+		cat "${REPO_ROOT}/data/runtime/arxiv_ingestion_latest.json"
+	else
+		echo "No status file yet"
+	fi
+}
+
+cmd_run_once() {
+	local python_bin="${REPO_ROOT}/.venv/bin/python"
+	if [[ ! -x ${python_bin} ]]; then
+		python_bin="$(command -v python3)"
+	fi
+	cd "${REPO_ROOT}"
+	PYTHONPATH="${REPO_ROOT}" "${python_bin}" scripts/arxiv_paper_ingestion.py \
+		--max-results 15 --rebuild-index --json
+}
+
+main() {
+	local action="${1-}"
+	case ${action} in
+	install) cmd_install ;;
+	remove) cmd_remove ;;
+	status) cmd_status ;;
+	run-once) cmd_run_once ;;
+	*)
+		usage
+		exit 1
+		;;
+	esac
+}
+
+main "$@"

--- a/scripts/vectorize_rag_knowledge.py
+++ b/scripts/vectorize_rag_knowledge.py
@@ -36,6 +36,7 @@ CONTENT_SOURCES = {
     "trainings": RAG_KNOWLEDGE / "trainings",
     "newsletters": RAG_KNOWLEDGE / "newsletters",
     "lessons_learned": RAG_KNOWLEDGE / "lessons_learned",
+    "research": RAG_KNOWLEDGE / "research",
     "books": RAG_KNOWLEDGE / "books",
 }
 

--- a/skills/trading-ops/SKILL.md
+++ b/skills/trading-ops/SKILL.md
@@ -67,6 +67,10 @@ python scripts/graph_rag_query.py --query "why is iron condor killed?" --graph-o
 # Hard gate: rebuild + 5 golden multi-hop assertions (CI offline-evals + make check)
 python scripts/verify_graph_rag.py
 make graph-rag-check
+# Continuous arXiv research feed (DS / ML / Agentic RAG) — never submits trades
+make arxiv-ingest
+make arxiv-ingest-status
+# Local continuous job (every 6h): bash scripts/setup_arxiv_ingest_launchagent.sh install
 ```
 
 Inventory unclean (`exit 2`) → **no new risk**.

--- a/src/research/__init__.py
+++ b/src/research/__init__.py
@@ -4,9 +4,11 @@ Research module for trading system.
 Contains:
 - messy_document_parser: multi-format cascade (PDF/HTML/text + quality gate)
 - docling_parser: IBM Docling integration for parsing financial documents
+- arxiv_collector: continuous arXiv paper ingestion for DS/ML/Agentic RAG
 - research_agent: Perplexity-powered weekend research agent
 """
 
+from src.research.arxiv_collector import ArxivCollector, ArxivPaper, IngestionRunReport
 from src.research.docling_parser import (
     DoclingDocument,
     DoclingFinancialParser,
@@ -23,9 +25,12 @@ from src.research.messy_document_parser import (
 )
 
 __all__ = [
+    "ArxivCollector",
+    "ArxivPaper",
     "DoclingDocument",
     "DoclingFinancialParser",
     "FinancialMetrics",
+    "IngestionRunReport",
     "ParsedDocument",
     "ParsedSection",
     "ParsedTable",

--- a/src/research/arxiv_collector.py
+++ b/src/research/arxiv_collector.py
@@ -1,0 +1,714 @@
+"""ArXiv research paper collector for DS / ML / Agentic RAG.
+
+Fetches papers from the public arXiv API (https://arxiv.org / export.arxiv.org),
+grades them for relevance to this lab (SPY put-credit validation, risk gates,
+GRPO/RL, financial RAG), deduplicates via a durable manifest, and ingests
+accepted papers through ``DocumentIngestionPipeline``.
+
+High-relevance papers are also promoted into ``rag_knowledge/research/arxiv/``
+so ``build_rag_query_index`` / ``vectorize_rag_knowledge`` can index them.
+
+This module never submits orders.
+"""
+
+from __future__ import annotations
+
+import datetime
+import json
+import logging
+import re
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+import xml.etree.ElementTree as ET  # nosec B405 — arXiv Atom API XML only
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any
+
+from src.rag.document_ingestion_pipeline import DocumentIngestionPipeline
+
+logger = logging.getLogger(__name__)
+
+_TOKEN_RE = re.compile(r"[a-z0-9]+")
+_STOP = {
+    "the",
+    "a",
+    "an",
+    "and",
+    "or",
+    "but",
+    "in",
+    "on",
+    "at",
+    "to",
+    "for",
+    "of",
+    "with",
+    "is",
+    "are",
+    "was",
+    "were",
+    "be",
+    "been",
+    "it",
+    "its",
+    "that",
+    "this",
+    "these",
+    "those",
+    "we",
+    "you",
+    "i",
+    "as",
+    "by",
+    "from",
+    "into",
+    "about",
+    "than",
+    "our",
+    "their",
+}
+
+
+def _tokens(text: str) -> set[str]:
+    return {
+        t
+        for t in _TOKEN_RE.findall(text.lower())
+        if len(t) > 2 and t not in _STOP
+    }
+
+
+def _lexical_overlap(a: str, b: str) -> float:
+    ta, tb = _tokens(a), _tokens(b)
+    if not ta or not tb:
+        return 0.0
+    return len(ta & tb) / max(len(ta), 1)
+
+ROOT = Path(__file__).resolve().parents[2]
+ARXIV_DATA_DIR = ROOT / "data" / "arxiv"
+ARXIV_MANIFEST_FILE = ROOT / "data" / "audit" / "arxiv_ingestion_manifest.json"
+ARXIV_STATUS_FILE = ROOT / "data" / "runtime" / "arxiv_ingestion_latest.json"
+ARXIV_CURATED_DIR = ROOT / "rag_knowledge" / "research" / "arxiv"
+
+# Categories that map to trading / ML / RAG research.
+DEFAULT_CATEGORIES = [
+    "q-fin.TR",  # Trading and Market Microstructure
+    "q-fin.PM",  # Portfolio Management
+    "q-fin.RM",  # Risk Management
+    "q-fin.CP",  # Computational Finance
+    "q-fin.ST",  # Statistical Finance
+    "cs.AI",  # Artificial Intelligence / Multi-Agent
+    "cs.LG",  # Machine Learning / RL / GRPO
+    "cs.CL",  # Language models / RAG
+    "cs.MA",  # Multi-agent systems
+]
+
+# Keyword phrases used both for API search and domain scoring.
+DEFAULT_KEYWORDS = [
+    "options trading",
+    "credit spread",
+    "put credit",
+    "iron condor",
+    "market microstructure",
+    "order book",
+    "reinforcement learning trading",
+    "GRPO",
+    "portfolio optimization",
+    "risk management options",
+    "financial RAG",
+    "retrieval augmented generation finance",
+    "agentic trading",
+    "quantitative trading",
+]
+
+# Tokens that strongly signal applicability to this repository.
+DOMAIN_BOOST_TERMS = {
+    "option": 0.08,
+    "options": 0.08,
+    "spy": 0.10,
+    "credit": 0.06,
+    "spread": 0.05,
+    "put": 0.04,
+    "iron": 0.04,
+    "condor": 0.06,
+    "microstructure": 0.07,
+    "orderbook": 0.06,
+    "grpo": 0.10,
+    "ppo": 0.05,
+    "reinforcement": 0.06,
+    "trading": 0.05,
+    "portfolio": 0.04,
+    "risk": 0.03,
+    "rag": 0.07,
+    "retrieval": 0.05,
+    "agentic": 0.06,
+    "llm": 0.03,
+    "market": 0.02,
+    "volatility": 0.05,
+    "delta": 0.04,
+    "greeks": 0.05,
+    "hedge": 0.04,
+}
+
+# Minimum composite relevance to ingest into RAG (0..1).
+DEFAULT_MIN_RELEVANCE = 0.18
+# Minimum composite relevance to promote into curated rag_knowledge/.
+DEFAULT_PROMOTE_RELEVANCE = 0.28
+
+ARXIV_API = "https://export.arxiv.org/api/query"
+USER_AGENT = "IgorTradingLab-ArxivIngest/1.0 (research; paper-only RAG; contact: local)"
+
+
+@dataclass
+class ArxivPaper:
+    arxiv_id: str
+    title: str
+    authors: list[str]
+    published: str
+    updated: str
+    summary: str
+    categories: list[str]
+    abs_url: str
+    pdf_url: str
+    relevance_score: float = 0.0
+    faithfulness_score: float = 0.0
+    groundedness_score: float = 0.0
+    domain_boost: float = 0.0
+    answer_relevance: float = 0.0
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass
+class IngestionRunReport:
+    """Structured summary for operators / DS / ML."""
+
+    status: str
+    fetched: int = 0
+    ingested: int = 0
+    skipped_duplicate: int = 0
+    skipped_low_relevance: int = 0
+    promoted: int = 0
+    errors: list[str] = field(default_factory=list)
+    papers: list[dict[str, Any]] = field(default_factory=list)
+    query: str | None = None
+    max_results: int = 0
+    min_relevance: float = 0.0
+    promote_relevance: float = 0.0
+    total_manifest_papers: int = 0
+    started_utc: str = ""
+    finished_utc: str = ""
+    duration_ms: float = 0.0
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+class ArxivCollector:
+    """Collect papers from arXiv and ingest into RAG + curated research corpus."""
+
+    def __init__(
+        self,
+        output_dir: Path | None = None,
+        manifest_file: Path | None = None,
+        status_file: Path | None = None,
+        curated_dir: Path | None = None,
+        *,
+        min_relevance: float = DEFAULT_MIN_RELEVANCE,
+        promote_relevance: float = DEFAULT_PROMOTE_RELEVANCE,
+        pipeline: DocumentIngestionPipeline | None = None,
+    ) -> None:
+        self.output_dir = output_dir or ARXIV_DATA_DIR
+        self.output_dir.mkdir(parents=True, exist_ok=True)
+        self.manifest_file = manifest_file or ARXIV_MANIFEST_FILE
+        self.status_file = status_file or ARXIV_STATUS_FILE
+        self.curated_dir = curated_dir or ARXIV_CURATED_DIR
+        self.min_relevance = float(min_relevance)
+        self.promote_relevance = float(promote_relevance)
+        self.manifest = self._load_manifest()
+        self.ingestion_pipeline = pipeline or DocumentIngestionPipeline()
+
+    def _load_manifest(self) -> dict[str, Any]:
+        if self.manifest_file.exists():
+            try:
+                with self.manifest_file.open("r", encoding="utf-8") as f:
+                    data = json.load(f)
+                if isinstance(data, dict) and "papers" in data:
+                    return data
+            except Exception as e:  # noqa: BLE001 — corrupt local cache is non-fatal
+                logger.warning("Failed to load arXiv manifest: %s", e)
+        return {
+            "papers": {},
+            "total_ingested": 0,
+            "last_run_utc": "",
+            "runs": [],
+        }
+
+    def _save_manifest(self) -> None:
+        self.manifest_file.parent.mkdir(parents=True, exist_ok=True)
+        with self.manifest_file.open("w", encoding="utf-8") as f:
+            json.dump(self.manifest, f, indent=2, sort_keys=True)
+
+    def _write_status(self, report: IngestionRunReport) -> None:
+        self.status_file.parent.mkdir(parents=True, exist_ok=True)
+        payload = report.to_dict()
+        payload["schema_version"] = 1
+        payload["source"] = "arxiv"
+        payload["api"] = ARXIV_API
+        with self.status_file.open("w", encoding="utf-8") as f:
+            json.dump(payload, f, indent=2)
+
+    def build_search_query(
+        self,
+        query: str | None = None,
+        categories: list[str] | None = None,
+        keywords: list[str] | None = None,
+    ) -> str:
+        """Build an arXiv API search_query string."""
+        cats = categories or DEFAULT_CATEGORIES
+        # Keep category clause compact — arXiv rejects extremely long queries.
+        cat_query = " OR ".join(f"cat:{c}" for c in cats[:8])
+
+        if query:
+            # Free-text override still constrained to our category set.
+            return f"all:({query}) AND ({cat_query})"
+
+        kws = keywords or DEFAULT_KEYWORDS
+        # Use a rotating subset of keywords so continuous runs stay diverse.
+        day_index = datetime.datetime.now(datetime.UTC).timetuple().tm_yday
+        window = 4
+        start = (day_index * window) % max(len(kws), 1)
+        selected = [kws[(start + i) % len(kws)] for i in range(min(window, len(kws)))]
+        kw_query = " OR ".join(f'all:"{kw}"' for kw in selected)
+        return f"({kw_query}) AND ({cat_query})"
+
+    def fetch_papers(
+        self,
+        query: str | None = None,
+        categories: list[str] | None = None,
+        keywords: list[str] | None = None,
+        max_results: int = 15,
+        *,
+        search_query: str | None = None,
+    ) -> list[ArxivPaper]:
+        """Fetch papers from the arXiv Atom API."""
+        sq = search_query or self.build_search_query(
+            query=query, categories=categories, keywords=keywords
+        )
+        params = {
+            "search_query": sq,
+            "start": 0,
+            "max_results": max(1, min(int(max_results), 50)),
+            "sortBy": "submittedDate",
+            "sortOrder": "descending",
+        }
+        url = f"{ARXIV_API}?{urllib.parse.urlencode(params)}"
+        if not url.startswith("https://export.arxiv.org/"):
+            logger.error("Refusing non-arXiv URL: %s", url[:80])
+            return []
+        logger.info("Querying arXiv API: %s", url)
+
+        xml_data = self._http_get_with_retry(url)
+        if xml_data is None:
+            return []
+        return self._parse_arxiv_atom(xml_data)
+
+    def _http_get_with_retry(self, url: str, *, attempts: int = 5) -> bytes | None:
+        """GET with backoff for arXiv 429 / transient network errors."""
+        if not url.startswith("https://export.arxiv.org/"):
+            logger.error("Refusing non-arXiv URL")
+            return None
+        delay = 3.0
+        last_err: Exception | None = None
+        for attempt in range(1, attempts + 1):
+            try:
+                # Fixed https host export.arxiv.org only (no user-controlled schemes).
+                req = urllib.request.Request(url, headers={"User-Agent": USER_AGENT})
+                with urllib.request.urlopen(req, timeout=45) as resp:  # nosec B310
+                    return resp.read()
+            except urllib.error.HTTPError as e:
+                last_err = e
+                if e.code == 429:
+                    retry_after = e.headers.get("Retry-After") if e.headers else None
+                    wait = float(retry_after) if retry_after and str(retry_after).isdigit() else delay
+                    logger.warning(
+                        "arXiv rate limited (429) attempt %d/%d; sleeping %.1fs",
+                        attempt,
+                        attempts,
+                        wait,
+                    )
+                    time.sleep(wait)
+                    delay = min(delay * 2, 60.0)
+                    continue
+                logger.error("arXiv API HTTP %s: %s", e.code, e)
+                return None
+            except (urllib.error.URLError, TimeoutError, OSError) as e:
+                last_err = e
+                logger.warning(
+                    "arXiv API request failed attempt %d/%d: %s",
+                    attempt,
+                    attempts,
+                    e,
+                )
+                time.sleep(delay)
+                delay = min(delay * 2, 60.0)
+        logger.error("arXiv API request failed after %d attempts: %s", attempts, last_err)
+        return None
+
+    def _parse_arxiv_atom(self, xml_bytes: bytes) -> list[ArxivPaper]:
+        papers: list[ArxivPaper] = []
+        ns = {
+            "atom": "http://www.w3.org/2005/Atom",
+            "arxiv": "http://arxiv.org/schemas/atom",
+        }
+        try:
+            root = ET.fromstring(xml_bytes)  # nosec B314 — arXiv Atom feed only
+        except ET.ParseError as e:
+            logger.error("Failed to parse arXiv XML response: %s", e)
+            return []
+
+        for entry in root.findall("atom:entry", ns):
+            id_text = entry.findtext("atom:id", default="", namespaces=ns) or ""
+            arxiv_id = id_text.split("/abs/")[-1] if "/abs/" in id_text else id_text
+            arxiv_id = arxiv_id.strip()
+            if not arxiv_id:
+                continue
+
+            title = entry.findtext("atom:title", default="", namespaces=ns) or ""
+            title = re.sub(r"\s+", " ", title).strip()
+
+            summary = entry.findtext("atom:summary", default="", namespaces=ns) or ""
+            summary = re.sub(r"\s+", " ", summary).strip()
+
+            published = entry.findtext("atom:published", default="", namespaces=ns) or ""
+            updated = entry.findtext("atom:updated", default="", namespaces=ns) or ""
+
+            authors = [
+                (author.findtext("atom:name", default="", namespaces=ns) or "").strip()
+                for author in entry.findall("atom:author", ns)
+            ]
+            authors = [a for a in authors if a]
+
+            categories = [
+                cat.attrib.get("term", "")
+                for cat in entry.findall("atom:category", ns)
+                if cat.attrib.get("term")
+            ]
+
+            abs_url = id_text or f"https://arxiv.org/abs/{arxiv_id}"
+            pdf_url = ""
+            for link in entry.findall("atom:link", ns):
+                if link.attrib.get("title") == "pdf":
+                    pdf_url = link.attrib.get("href", "")
+                    break
+            if not pdf_url:
+                pdf_url = f"https://arxiv.org/pdf/{arxiv_id}.pdf"
+            # Prefer https
+            abs_url = abs_url.replace("http://", "https://")
+            pdf_url = pdf_url.replace("http://", "https://")
+
+            papers.append(
+                ArxivPaper(
+                    arxiv_id=arxiv_id,
+                    title=title,
+                    authors=authors,
+                    published=published,
+                    updated=updated,
+                    summary=summary,
+                    categories=categories,
+                    abs_url=abs_url,
+                    pdf_url=pdf_url,
+                )
+            )
+
+        return papers
+
+    def _domain_boost(self, paper: ArxivPaper) -> float:
+        text = f"{paper.title} {paper.summary} {' '.join(paper.categories)}".lower()
+        # Normalize compound tokens
+        text = text.replace("order book", "orderbook").replace("iron condor", "iron condor")
+        boost = 0.0
+        for term, weight in DOMAIN_BOOST_TERMS.items():
+            if term in text:
+                boost += weight
+        # Soft cap so keyword stuffing cannot dominate.
+        return min(boost, 0.45)
+
+    def evaluate_paper_relevance(self, paper: ArxivPaper) -> ArxivPaper:
+        """Grade paper relevance for this trading lab's DS/ML/RAG stack.
+
+        Dependency-free lexical scoring (no optional embedding/LLM judges) so
+        CI and LaunchAgent runs stay deterministic and offline-safe.
+        """
+        context = (
+            "Paper-first SPY put credit spreads defined-risk options credit spreads. "
+            "Group Relative Policy Optimization GRPO reinforcement learning for trading. "
+            "Market microstructure order books statistical finance risk management. "
+            "Agentic RAG temporal graph RAG faithfulness groundedness evaluation. "
+            "Kill criteria expectancy profit factor inventory hygiene no naked options."
+        )
+        question = (
+            "quantitative options trading risk-controlled credit spreads "
+            "GRPO RL policy learning financial RAG agentic retrieval"
+        )
+        answer = f"{paper.title}. {paper.summary}"
+
+        # Groundedness ≈ answer tokens supported by lab context
+        groundedness = _lexical_overlap(answer, context)
+        # Faithfulness proxy: fraction of context-overlapping answer tokens
+        # (symmetric overlap favors papers that speak the lab's language)
+        faithfulness = _lexical_overlap(context, answer)
+        # Answer relevance: does the paper address the research question tokens?
+        answer_relevance = _lexical_overlap(question, answer)
+
+        paper.faithfulness_score = round(faithfulness, 3)
+        paper.groundedness_score = round(groundedness, 3)
+        paper.answer_relevance = round(answer_relevance, 3)
+        paper.domain_boost = round(self._domain_boost(paper), 3)
+
+        base = (faithfulness * 0.30) + (answer_relevance * 0.35) + (groundedness * 0.15)
+        paper.relevance_score = round(min(1.0, base + paper.domain_boost), 3)
+        return paper
+
+    def _markdown_for_paper(self, paper: ArxivPaper) -> str:
+        authors = ", ".join(paper.authors) if paper.authors else "(unknown)"
+        cats = ", ".join(paper.categories) if paper.categories else "(none)"
+        return f"""# arXiv Paper: {paper.title}
+
+- **arXiv ID**: `{paper.arxiv_id}`
+- **Published**: {paper.published}
+- **Updated**: {paper.updated}
+- **Authors**: {authors}
+- **Categories**: {cats}
+- **URL**: [{paper.abs_url}]({paper.abs_url})
+- **PDF**: [{paper.pdf_url}]({paper.pdf_url})
+- **Source**: continuous arXiv ingestion job (Agentic RAG)
+
+## RAG Quality Scores
+
+- **Relevance Score**: {paper.relevance_score}
+- **Domain Boost**: {paper.domain_boost}
+- **Faithfulness Score**: {paper.faithfulness_score}
+- **Groundedness Score**: {paper.groundedness_score}
+- **Answer Relevance**: {paper.answer_relevance}
+
+## Abstract / Summary
+
+{paper.summary}
+
+## Trading System Applicability
+
+Automatically ingested for Data Science, ML (GRPO/RL), and Agentic RAG research.
+Does **not** authorize live capital, iron-condor re-entry, or profit claims.
+Use only as research context against broker-reconciled evidence and kill criteria.
+"""
+
+    def ingest_paper(
+        self,
+        paper: ArxivPaper,
+        *,
+        force: bool = False,
+    ) -> dict[str, Any]:
+        """Ingest one paper into local markdown + DocumentIngestionPipeline."""
+        paper = self.evaluate_paper_relevance(paper)
+
+        if not force and paper.relevance_score < self.min_relevance:
+            return {
+                "arxiv_id": paper.arxiv_id,
+                "title": paper.title,
+                "relevance_score": paper.relevance_score,
+                "status": "skipped_low_relevance",
+                "chunks_created": 0,
+                "is_duplicate": False,
+                "promoted": False,
+            }
+
+        clean_id = re.sub(r"[^a-zA-Z0-9_.-]", "_", paper.arxiv_id)
+        filename = f"arxiv_{clean_id.replace('.', '_')}.md"
+        file_path = self.output_dir / filename
+        md_content = self._markdown_for_paper(paper)
+        file_path.write_text(md_content, encoding="utf-8")
+
+        doc = self.ingestion_pipeline.ingest_document(file_path, md_content)
+
+        promoted = False
+        curated_path: str | None = None
+        if paper.relevance_score >= self.promote_relevance:
+            promoted = self._promote_to_curated(paper, md_content)
+            if promoted:
+                curated_path = str(self.curated_dir / filename)
+
+        now = datetime.datetime.now(datetime.UTC).isoformat()
+        self.manifest["papers"][paper.arxiv_id] = {
+            "title": paper.title,
+            "published": paper.published,
+            "categories": paper.categories,
+            "relevance_score": paper.relevance_score,
+            "domain_boost": paper.domain_boost,
+            "faithfulness_score": paper.faithfulness_score,
+            "groundedness_score": paper.groundedness_score,
+            "answer_relevance": paper.answer_relevance,
+            "file_path": str(file_path),
+            "curated_path": curated_path,
+            "promoted": promoted,
+            "ingested_at": now,
+            "abs_url": paper.abs_url,
+            "pdf_url": paper.pdf_url,
+        }
+        self.manifest["total_ingested"] = len(self.manifest["papers"])
+        self.manifest["last_run_utc"] = now
+        self._save_manifest()
+
+        logger.info(
+            "Ingested arXiv %s (rel=%.3f promote=%s): %s",
+            paper.arxiv_id,
+            paper.relevance_score,
+            promoted,
+            paper.title[:80],
+        )
+        return {
+            "arxiv_id": paper.arxiv_id,
+            "title": paper.title,
+            "relevance_score": paper.relevance_score,
+            "domain_boost": paper.domain_boost,
+            "file_path": str(file_path),
+            "chunks_created": len(doc.chunks),
+            "is_duplicate": doc.is_duplicate,
+            "promoted": promoted,
+            "curated_path": curated_path,
+            "status": "ingested",
+            "abs_url": paper.abs_url,
+        }
+
+    def _promote_to_curated(self, paper: ArxivPaper, md_content: str) -> bool:
+        """Copy high-relevance papers into rag_knowledge for index rebuilds."""
+        try:
+            self.curated_dir.mkdir(parents=True, exist_ok=True)
+            clean_id = re.sub(r"[^a-zA-Z0-9_.-]", "_", paper.arxiv_id)
+            filename = f"arxiv_{clean_id.replace('.', '_')}.md"
+            target = self.curated_dir / filename
+            # Header note so curated corpus is clearly research-only.
+            header = (
+                "---\n"
+                f"source: arxiv\n"
+                f"arxiv_id: {paper.arxiv_id}\n"
+                f"relevance: {paper.relevance_score}\n"
+                f"kind: research_paper\n"
+                f"strategy_scope: research_only\n"
+                "---\n\n"
+            )
+            target.write_text(header + md_content, encoding="utf-8")
+            return True
+        except OSError as e:
+            logger.warning("Failed to promote arXiv %s: %s", paper.arxiv_id, e)
+            return False
+
+    def run_continuous_ingestion(
+        self,
+        query: str | None = None,
+        max_results: int = 15,
+        *,
+        categories: list[str] | None = None,
+        keywords: list[str] | None = None,
+        force: bool = False,
+    ) -> IngestionRunReport:
+        """Fetch, dedupe, grade, filter, and ingest papers."""
+        started = datetime.datetime.now(datetime.UTC)
+        search_query = self.build_search_query(
+            query=query, categories=categories, keywords=keywords
+        )
+        report = IngestionRunReport(
+            status="OK",
+            query=search_query,
+            max_results=max_results,
+            min_relevance=self.min_relevance,
+            promote_relevance=self.promote_relevance,
+            started_utc=started.isoformat(),
+        )
+
+        papers = self.fetch_papers(
+            query=query,
+            categories=categories,
+            keywords=keywords,
+            max_results=max_results,
+            search_query=search_query,
+        )
+        report.fetched = len(papers)
+
+        if not papers:
+            report.status = "EMPTY_OR_API_ERROR"
+            report.errors.append("No papers returned from arXiv API")
+            finished = datetime.datetime.now(datetime.UTC)
+            report.finished_utc = finished.isoformat()
+            report.duration_ms = (finished - started).total_seconds() * 1000
+            report.total_manifest_papers = len(self.manifest.get("papers", {}))
+            self._write_status(report)
+            self._append_run_summary(report)
+            return report
+
+        for paper in papers:
+            if paper.arxiv_id in self.manifest.get("papers", {}) and not force:
+                logger.info("Paper %s already ingested; skipping.", paper.arxiv_id)
+                report.skipped_duplicate += 1
+                continue
+            try:
+                result = self.ingest_paper(paper, force=force)
+            except Exception as e:  # noqa: BLE001 — keep job alive across bad papers
+                logger.exception("Failed to ingest %s", paper.arxiv_id)
+                report.errors.append(f"{paper.arxiv_id}: {e}")
+                continue
+
+            if result.get("status") == "skipped_low_relevance":
+                report.skipped_low_relevance += 1
+                continue
+
+            report.ingested += 1
+            if result.get("promoted"):
+                report.promoted += 1
+            report.papers.append(result)
+
+        finished = datetime.datetime.now(datetime.UTC)
+        report.finished_utc = finished.isoformat()
+        report.duration_ms = round((finished - started).total_seconds() * 1000, 1)
+        report.total_manifest_papers = len(self.manifest.get("papers", {}))
+        if report.errors and report.ingested == 0:
+            report.status = "ERROR"
+        elif report.errors:
+            report.status = "PARTIAL"
+
+        self._write_status(report)
+        self._append_run_summary(report)
+        logger.info(
+            "arXiv ingestion done: fetched=%d ingested=%d dup=%d low_rel=%d promoted=%d",
+            report.fetched,
+            report.ingested,
+            report.skipped_duplicate,
+            report.skipped_low_relevance,
+            report.promoted,
+        )
+        return report
+
+    def _append_run_summary(self, report: IngestionRunReport) -> None:
+        runs = self.manifest.setdefault("runs", [])
+        if not isinstance(runs, list):
+            runs = []
+            self.manifest["runs"] = runs
+        runs.append(
+            {
+                "finished_utc": report.finished_utc,
+                "status": report.status,
+                "fetched": report.fetched,
+                "ingested": report.ingested,
+                "skipped_duplicate": report.skipped_duplicate,
+                "skipped_low_relevance": report.skipped_low_relevance,
+                "promoted": report.promoted,
+                "errors": report.errors[:5],
+            }
+        )
+        # Bound history so the manifest stays small.
+        if len(runs) > 50:
+            self.manifest["runs"] = runs[-50:]
+        self.manifest["last_run_utc"] = report.finished_utc
+        self._save_manifest()

--- a/tests/test_arxiv_collector.py
+++ b/tests/test_arxiv_collector.py
@@ -1,0 +1,240 @@
+"""Unit tests for continuous arXiv paper ingestion (AGENT-364)."""
+
+from __future__ import annotations
+
+import json
+import urllib.error
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from src.rag.document_ingestion_pipeline import DocumentIngestionPipeline
+from src.research.arxiv_collector import (
+    ArxivCollector,
+    ArxivPaper,
+    DEFAULT_MIN_RELEVANCE,
+)
+
+
+SAMPLE_ATOM_XML = b"""<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom" xmlns:arxiv="http://arxiv.org/schemas/atom">
+  <entry>
+    <id>http://arxiv.org/abs/2608.12345v1</id>
+    <published>2026-08-10T12:00:00Z</published>
+    <updated>2026-08-10T12:00:00Z</updated>
+    <title>Deep Reinforcement Learning for Option Trading under Microstructure Noise</title>
+    <summary>
+      We propose a novel GRPO policy optimization algorithm for option credit spreads
+      and SPY put credit risk management with retrieval-augmented grounding.
+    </summary>
+    <author><name>Jane Doe</name></author>
+    <author><name>John Smith</name></author>
+    <category term="q-fin.TR"/>
+    <category term="cs.AI"/>
+    <link href="http://arxiv.org/abs/2608.12345v1" rel="alternate" type="text/html"/>
+    <link href="http://arxiv.org/pdf/2608.12345v1.pdf" title="pdf" rel="related" type="application/pdf"/>
+  </entry>
+  <entry>
+    <id>http://arxiv.org/abs/2608.00001v1</id>
+    <published>2026-08-09T12:00:00Z</published>
+    <updated>2026-08-09T12:00:00Z</updated>
+    <title>A Taxonomy of Unrelated Computer Vision Benchmarks</title>
+    <summary>We catalog image classification datasets with no finance content.</summary>
+    <author><name>Other Author</name></author>
+    <category term="cs.CV"/>
+    <link href="http://arxiv.org/abs/2608.00001v1" rel="alternate" type="text/html"/>
+    <link href="http://arxiv.org/pdf/2608.00001v1.pdf" title="pdf" rel="related" type="application/pdf"/>
+  </entry>
+</feed>
+"""
+
+
+def _collector(tmp_path: Path, **kwargs) -> ArxivCollector:
+    pipeline = DocumentIngestionPipeline(
+        manifest_file=tmp_path / "data" / "audit" / "ingestion_version_manifest.json",
+    )
+    return ArxivCollector(
+        output_dir=tmp_path / "data" / "arxiv",
+        manifest_file=tmp_path / "data" / "audit" / "arxiv_manifest.json",
+        status_file=tmp_path / "data" / "runtime" / "arxiv_ingestion_latest.json",
+        curated_dir=tmp_path / "rag_knowledge" / "research" / "arxiv",
+        pipeline=pipeline,
+        **kwargs,
+    )
+
+
+def test_arxiv_paper_to_dict():
+    paper = ArxivPaper(
+        arxiv_id="2608.12345v1",
+        title="Test Paper",
+        authors=["Jane Doe"],
+        published="2026-08-10",
+        updated="2026-08-10",
+        summary="Test summary",
+        categories=["q-fin.TR"],
+        abs_url="https://arxiv.org/abs/2608.12345v1",
+        pdf_url="https://arxiv.org/pdf/2608.12345v1.pdf",
+    )
+    d = paper.to_dict()
+    assert d["arxiv_id"] == "2608.12345v1"
+    assert d["title"] == "Test Paper"
+    assert d["authors"] == ["Jane Doe"]
+
+
+def test_parse_arxiv_atom(tmp_path: Path):
+    collector = _collector(tmp_path)
+    papers = collector._parse_arxiv_atom(SAMPLE_ATOM_XML)
+
+    assert len(papers) == 2
+    p = papers[0]
+    assert p.arxiv_id == "2608.12345v1"
+    assert "Option Trading" in p.title
+    assert "Jane Doe" in p.authors
+    assert "q-fin.TR" in p.categories
+    assert p.pdf_url.startswith("https://")
+    assert p.pdf_url.endswith(".pdf")
+
+
+def test_domain_boost_prefers_options_grpo(tmp_path: Path):
+    collector = _collector(tmp_path)
+    relevant = ArxivPaper(
+        arxiv_id="x",
+        title="GRPO for SPY put credit option spreads",
+        authors=[],
+        published="",
+        updated="",
+        summary="order book microstructure and RAG grounded risk",
+        categories=["q-fin.TR"],
+        abs_url="",
+        pdf_url="",
+    )
+    noise = ArxivPaper(
+        arxiv_id="y",
+        title="Image classification taxonomy",
+        authors=[],
+        published="",
+        updated="",
+        summary="computer vision benchmarks",
+        categories=["cs.CV"],
+        abs_url="",
+        pdf_url="",
+    )
+    assert collector._domain_boost(relevant) > collector._domain_boost(noise)
+    assert collector._domain_boost(relevant) >= 0.2
+
+
+def test_ingest_paper_and_promote(tmp_path: Path):
+    collector = _collector(tmp_path, min_relevance=0.0, promote_relevance=0.0)
+    paper = ArxivPaper(
+        arxiv_id="2608.99999v1",
+        title="GRPO Trading Systems for SPY option credit spreads",
+        authors=["Alice Bob"],
+        published="2026-08-10",
+        updated="2026-08-10",
+        summary="GRPO policy optimization for financial options markets and RAG.",
+        categories=["q-fin.TR"],
+        abs_url="https://arxiv.org/abs/2608.99999v1",
+        pdf_url="https://arxiv.org/pdf/2608.99999v1.pdf",
+    )
+
+    res = collector.ingest_paper(paper)
+    assert res["arxiv_id"] == "2608.99999v1"
+    assert res["chunks_created"] > 0
+    assert not res["is_duplicate"]
+    assert Path(res["file_path"]).exists()
+    assert res["promoted"] is True
+    assert Path(res["curated_path"]).exists()
+
+    # Second ingest of same content is duplicate in DocumentIngestionPipeline
+    res2 = collector.ingest_paper(paper)
+    assert res2["is_duplicate"]
+
+
+def test_low_relevance_skipped(tmp_path: Path):
+    collector = _collector(tmp_path, min_relevance=0.99, promote_relevance=1.0)
+    paper = ArxivPaper(
+        arxiv_id="2608.lowrelv1",
+        title="Unrelated CV taxonomy",
+        authors=["X"],
+        published="2026-08-10",
+        updated="2026-08-10",
+        summary="No finance terms at all in this abstract about photography.",
+        categories=["cs.CV"],
+        abs_url="https://arxiv.org/abs/2608.lowrelv1",
+        pdf_url="https://arxiv.org/pdf/2608.lowrelv1.pdf",
+    )
+    res = collector.ingest_paper(paper)
+    assert res["status"] == "skipped_low_relevance"
+    assert paper.arxiv_id not in collector.manifest["papers"]
+
+
+def test_fetch_papers_mocked(tmp_path: Path):
+    collector = _collector(tmp_path)
+
+    mock_resp = MagicMock()
+    mock_resp.read.return_value = SAMPLE_ATOM_XML
+    mock_resp.__enter__.return_value = mock_resp
+
+    with patch("urllib.request.urlopen", return_value=mock_resp):
+        papers = collector.fetch_papers(max_results=2)
+        assert len(papers) == 2
+        assert papers[0].arxiv_id == "2608.12345v1"
+
+
+def test_run_continuous_ingestion_dedupes(tmp_path: Path):
+    collector = _collector(tmp_path, min_relevance=0.0, promote_relevance=0.5)
+
+    mock_resp = MagicMock()
+    mock_resp.read.return_value = SAMPLE_ATOM_XML
+    mock_resp.__enter__.return_value = mock_resp
+
+    with patch("urllib.request.urlopen", return_value=mock_resp):
+        r1 = collector.run_continuous_ingestion(max_results=5)
+        r2 = collector.run_continuous_ingestion(max_results=5)
+
+    assert r1.fetched == 2
+    assert r1.ingested >= 1
+    assert r2.skipped_duplicate >= 1
+    assert collector.status_file.exists()
+    status = json.loads(collector.status_file.read_text(encoding="utf-8"))
+    assert status["schema_version"] == 1
+    assert status["source"] == "arxiv"
+    assert "fetched" in status
+
+
+def test_build_search_query_override(tmp_path: Path):
+    collector = _collector(tmp_path)
+    q = collector.build_search_query(query="put credit spread")
+    assert "put credit spread" in q
+    assert "cat:q-fin.TR" in q
+
+
+def test_default_min_relevance_constant():
+    assert 0.0 < DEFAULT_MIN_RELEVANCE < 0.5
+
+
+def test_http_get_retries_on_429(tmp_path: Path):
+    collector = _collector(tmp_path)
+    call_count = {"n": 0}
+
+    def fake_urlopen(req, timeout=45):  # noqa: ARG001
+        call_count["n"] += 1
+        if call_count["n"] < 3:
+            raise urllib.error.HTTPError(
+                url="https://export.arxiv.org/api/query",
+                code=429,
+                msg="Too Many Requests",
+                hdrs=None,
+                fp=None,
+            )
+        mock_resp = MagicMock()
+        mock_resp.read.return_value = SAMPLE_ATOM_XML
+        mock_resp.__enter__.return_value = mock_resp
+        return mock_resp
+
+    with (
+        patch("urllib.request.urlopen", side_effect=fake_urlopen),
+        patch("src.research.arxiv_collector.time.sleep", return_value=None),
+    ):
+        papers = collector.fetch_papers(max_results=2)
+    assert call_count["n"] == 3
+    assert len(papers) == 2


### PR DESCRIPTION
# Pull request

## Work item

- Linear issue: AGENT-364
- Agent: grok
- Base SHA: 30050f4968fabf800af42bb3d5246c93c8641f1e
- Branch/worktree: feat/AGENT-364-arxiv-paper-ingest @ .worktrees/agent-364-arxiv-ingest
- Files or systems claimed: src/research/arxiv_collector.py, scripts/arxiv_paper_ingestion.py, scripts/setup_arxiv_ingest_launchagent.sh, ops/launchd/com.igor.trading-arxiv-ingest.plist, .github/workflows/arxiv-paper-ingest.yml, tests/test_arxiv_collector.py, Makefile, docs/ARXIV_INGESTION.md, docs/README.md, skills/trading-ops/SKILL.md, scripts/vectorize_rag_knowledge.py, src/research/__init__.py, .gitignore, rag_knowledge/research/arxiv/.gitkeep
- Coordination legacy reason: n/a

## Change

- Scope: Continuous arXiv.org paper ingestion into DocumentIngestionPipeline + Agentic RAG (relevance gates, curated promotion, GHA daily, local LaunchAgent every 6h). Research-only.
- Deleted surfaces and recovery impact: none
- Out of scope: trade submission, IC revival, live capital, profit claims from papers

## Verification

- [x] Targeted tests (`tests/test_arxiv_collector.py` — 10 passed)
- [ ] `make check` (CI on PR)
- [x] RAG read/write round trip when RAG changes (DocumentIngestionPipeline + curated path + vectorize source)
- [ ] Orchestration smoke test when orchestration changes
- [ ] `TRADING_ENV=paper make dry-run` when operational paths change
- [ ] CI green on this exact head SHA

## Evidence boundaries

- Test result: 10/10 unit tests passed locally
- CI run: pending on 56e9f8941b81562b7fc08b9a1d4e4c0c5a049020
- Protected-system result: no trade path changes
- Broker/order/fill impact: none unless explicitly evidenced here

## Coordination

- [x] Linear issue and vault claim updated
- [x] No overlapping active claim or worktree
- [x] Claim will be marked done or released after merge

## Operator

```bash
make arxiv-ingest
make arxiv-ingest-status
bash scripts/setup_arxiv_ingest_launchagent.sh install
```

Docs: `docs/ARXIV_INGESTION.md`