### PR TITLE
fix(put-credit): reconcile ghost exit_pending + paper IVR floor 5

### DIFF
--- a/.github/workflows/put-credit-validation.yml
+++ b/.github/workflows/put-credit-validation.yml
@@ -25,7 +25,9 @@ env:
   # Paper validation floor (hard). Research preferred short-premium IVR remains 30;
   # lean-premium entries are soft-flagged for stratified edge analysis.
   # Evidence 2026-08-04..10: IVR proxy 8–29 blocked every 11:00 ET entry attempt.
-  PUT_CREDIT_MIN_IVR: "10"
+  # Paper validation floor only — research preferred remains 30 for edge claims.
+  # 10 froze entries for multi-day stretches when VIX percentile sat just under 10.
+  PUT_CREDIT_MIN_IVR: "5"
   PUT_CREDIT_RESEARCH_IVR: "30"
   PUT_CREDIT_MAX_VIX: "30"
 

--- a/scripts/spy_put_credit.py
+++ b/scripts/spy_put_credit.py
@@ -540,6 +540,19 @@ def _confirm_entry_credit(client, entry: dict[str, Any], short_pos: Any, long_po
     return False
 
 
+def _is_order_not_found_error(exc: BaseException) -> bool:
+    """True when broker says the order id does not exist (vs transient API failure)."""
+    text = str(exc).lower()
+    code = getattr(exc, "code", None)
+    if code in (40410000, 404):
+        return True
+    return (
+        "order not found" in text
+        or "40410000" in text
+        or ("not found" in text and "order" in text)
+    )
+
+
 def _pending_exit_is_active(client, entry: dict[str, Any]) -> bool:
     exit_order_id = str(entry.get("exit_order_id") or "")
     if not exit_order_id:
@@ -547,8 +560,14 @@ def _pending_exit_is_active(client, entry: dict[str, Any]) -> bool:
     try:
         order = client.get_order_by_id(exit_order_id)
         status = _order_status_name(getattr(order, "status", ""))
-    except Exception:
+    except Exception as exc:
+        # Transient API failures: keep pending so we do not double-submit closes.
+        # Hard not-found is handled by manage_put_credit_exits with position context.
+        if _is_order_not_found_error(exc):
+            entry["_exit_order_not_found"] = True
+            return False
         return True
+    entry.pop("_exit_order_not_found", None)
     if status == "FILLED":
         entry["status"] = "closed"
         entry["exit_filled_at"] = datetime.now(UTC).isoformat()
@@ -664,11 +683,36 @@ def manage_put_credit_exits(client, *, dry_run: bool = False) -> dict[str, Any]:
             continue
         short_pos = positions.get(short_symbol)
         long_pos = positions.get(long_symbol)
-        if str(entry.get("status")) == "exit_pending" and _pending_exit_is_active(client, entry):
-            changed = True
-            report["pending"] += 1
-            report["details"].append({"key": key, "status": "exit_pending"})
-            continue
+        if str(entry.get("status")) == "exit_pending":
+            still_pending = _pending_exit_is_active(client, entry)
+            if still_pending:
+                changed = True
+                report["pending"] += 1
+                report["details"].append({"key": key, "status": "exit_pending"})
+                continue
+            # Exit order missing/terminal and broker has neither leg: treat as closed.
+            # Covers account resets and filled exits whose order ids are gone from the API.
+            if short_pos is None and long_pos is None:
+                entry["status"] = "closed"
+                entry["exit_filled_at"] = entry.get("exit_filled_at") or datetime.now(
+                    UTC
+                ).isoformat()
+                entry["reconciliation_reason"] = (
+                    "broker_flat_after_exit_pending"
+                    if entry.pop("_exit_order_not_found", None)
+                    else "broker_flat_exit_terminal"
+                )
+                changed = True
+                report["details"].append(
+                    {
+                        "key": key,
+                        "status": "closed_reconciled_flat",
+                        "reason": entry["reconciliation_reason"],
+                    }
+                )
+                continue
+            entry.pop("_exit_order_not_found", None)
+            # Legs still present after a dead exit order: fall through to re-evaluate exit.
         if short_pos is None or long_pos is None:
             entry_status = _entry_order_status(client, entry)
             if (
@@ -690,6 +734,23 @@ def manage_put_credit_exits(client, *, dry_run: bool = False) -> dict[str, Any]:
                 entry["entry_terminal_status"] = entry_status
                 changed = True
                 report["details"].append({"key": key, "status": "entry_rejected"})
+                continue
+            # Flat book + missing entry order on this account: journal is ghost risk, close it.
+            if short_pos is None and long_pos is None and entry_status == "UNKNOWN":
+                entry["status"] = "closed"
+                entry["reconciliation_reason"] = "broker_flat_entry_order_unknown"
+                entry["exit_filled_at"] = entry.get("exit_filled_at") or datetime.now(
+                    UTC
+                ).isoformat()
+                entry["exit_reason"] = entry.get("exit_reason") or "broker_reconcile_flat"
+                changed = True
+                report["details"].append(
+                    {
+                        "key": key,
+                        "status": "closed_reconciled_flat",
+                        "reason": entry["reconciliation_reason"],
+                    }
+                )
                 continue
             entry["status"] = "broken_structure"
             entry["last_error"] = (

--- a/tests/test_active_strategy.py
+++ b/tests/test_active_strategy.py
@@ -873,6 +873,57 @@ def test_put_credit_parsing_and_credit_confirmation_failure_paths(tmp_path, monk
     )
 
 
+
+def test_pending_exit_order_not_found_is_not_active():
+    from scripts import spy_put_credit as pcs
+
+    client = MagicMock()
+    client.get_order_by_id.side_effect = RuntimeError(
+        '{"code":40410000,"message":"order not found for close-1"}'
+    )
+    entry = {"status": "exit_pending", "exit_order_id": "close-1"}
+    assert pcs._pending_exit_is_active(client, entry) is False
+    assert entry.get("_exit_order_not_found") is True
+
+
+def test_manage_exits_reconciles_flat_exit_pending_when_order_missing(tmp_path, monkeypatch):
+    from scripts import spy_put_credit as pcs
+
+    entries_path = tmp_path / "put_credit_entries.json"
+    entries_path.write_text(
+        json.dumps(
+            {
+                "PCS_ghost": {
+                    "status": "exit_pending",
+                    "exit_order_id": "missing-close",
+                    "exit_reason": "profit_target",
+                    "order_id": "missing-entry",
+                    "expiry": "2026-08-28",
+                    "entry_time": datetime.now(UTC).isoformat(),
+                    "credit": 0.65,
+                    "quantity": 1,
+                    "strikes": {"short_put": 712.0, "long_put": 707.0},
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(pcs, "ENTRIES_FILE", entries_path)
+    client = MagicMock()
+    client.get_all_positions.return_value = []
+    client.get_order_by_id.side_effect = RuntimeError(
+        '{"code":40410000,"message":"order not found"}'
+    )
+
+    report = pcs.manage_put_credit_exits(client, dry_run=False)
+    saved = json.loads(entries_path.read_text(encoding="utf-8"))
+    assert saved["PCS_ghost"]["status"] == "closed"
+    assert saved["PCS_ghost"]["reconciliation_reason"] == "broker_flat_after_exit_pending"
+    assert report["details"][0]["status"] == "closed_reconciled_flat"
+    assert report["pending"] == 0
+    assert report["broken"] == 0
+
+
 def test_put_credit_pending_and_entry_status_failure_paths():
     from scripts import spy_put_credit as pcs
 


### PR DESCRIPTION
## Summary
- Fix put-credit exit manager so `exit_pending` journals with missing broker orders and a flat book are closed as reconciled (no infinite ghost opens).
- Distinguish transient order-lookup failures (keep pending) from hard 404/order-not-found.
- Lower paper validation `PUT_CREDIT_MIN_IVR` from 10 → 5 in the scheduled workflow; research preferred IVR remains 30 for edge claims.
- Tests for not-found pending detection and flat-book reconcile.

## Why
North Star path is paper put-credit n≥30. Ghost journals + IVR floor just under 10 were stalling entries while VIX percentile sat ~9.

## Test plan
- [x] `pytest` focused put-credit reconcile tests (5 passed)
- [x] Live paper: opened SPY 2026-09-25 P741/746 1-lot credit **$0.62** fill on account PA3PYE08C9MN; inventory hold via `--manage-exits`
- [ ] CI green on PR

## Evidence (this session)
- Paper equity: **$30,029.37** (not the historical $94k snapshot)
- Live still blocked; IC still killed
- Put-credit closed cohort still **1** closed win (+$17 historical); open **1** new structure (not yet closed)