### PR TITLE
feat(AGENT-395): wire put-credit research protocol into scorecard + CI

### DIFF
--- a/.github/workflows/put-credit-validation.yml
+++ b/.github/workflows/put-credit-validation.yml
@@ -194,6 +194,21 @@ jobs:
         run: |
           python3 scripts/spy_put_credit.py --status
 
+      # Handbook high-ROI: deterministic research protocol smoke (no broker, no orders).
+      - name: Put-credit research protocol smoke
+        if: always()
+        env:
+          PYTHONPATH: ${{ github.workspace }}
+        run: |
+          python3 scripts/put_credit_research_protocol.py --baseline --critic-audit
+          python3 scripts/put_credit_cohort_scorecard.py --json | python3 -c "
+          import json,sys
+          card=json.load(sys.stdin)
+          rp=card.get('research_protocol') or {}
+          assert 'validation' in rp or 'error' in rp, rp
+          print('research_protocol_ok', rp.get('n_closed'), rp.get('critic',{}).get('pass'))
+          "
+
       - name: Commit trade data
         if: >-
           always() &&

--- a/docs/research/put-credit-research-protocol.md
+++ b/docs/research/put-credit-research-protocol.md
@@ -18,7 +18,14 @@ Source inspiration: freeCodeCamp Multi-Agent Trading Research System with LangCh
 .venv/bin/python scripts/put_credit_research_protocol.py --compare-preferred-ivr
 .venv/bin/python scripts/put_credit_research_protocol.py --freeze-baseline
 .venv/bin/python scripts/put_credit_research_protocol.py --unlock-holdout
+.venv/bin/python scripts/put_credit_research_protocol.py --critic-audit
+.venv/bin/python scripts/put_credit_cohort_scorecard.py --json  # includes research_protocol
 ```
+
+## Wired surfaces
+
+- Cohort scorecard schema v2 embeds `research_protocol` + deterministic critic
+- `put-credit-validation.yml` runs baseline + critic smoke (no broker)
 
 ## Hard boundaries
 

--- a/scripts/put_credit_cohort_scorecard.py
+++ b/scripts/put_credit_cohort_scorecard.py
@@ -285,8 +285,20 @@ def build_scorecard(
         "pct_to_gate": round(min(100.0, closed["closed_n"] / KILL_N * 100.0), 1),
     }
 
+    research_protocol: dict[str, Any] = {}
+    try:
+        from src.research.put_credit_research_protocol import (
+            research_critic_audit,
+            scorecard_research_section,
+        )
+
+        research_protocol = scorecard_research_section(trades)
+        research_protocol["critic"] = research_critic_audit(trades_payload=trades)
+    except Exception as exc:  # noqa: BLE001
+        research_protocol = {"error": str(exc), "langchain_adopted": False}
+
     return {
-        "schema_version": "put-credit-cohort-scorecard/1",
+        "schema_version": "put-credit-cohort-scorecard/2",
         "generated_at": datetime.now(UTC).isoformat(),
         "active_family": kill_switch.get("active_family"),
         "paper_only": kill_switch.get("paper_only"),
@@ -295,6 +307,7 @@ def build_scorecard(
         "open": open_,
         "closed": closed,
         "progress": progress,
+        "research_protocol": research_protocol,
         "honesty": {
             "claim_profitable": False
             if closed["closed_n"] < KILL_N
@@ -308,10 +321,11 @@ def build_scorecard(
             ),
         },
         "process_upgrades": {
-            "regime_gate": "IVR>=30 and VIX<=30 hard; SPY 200-DMA soft-flag",
+            "regime_gate": "paper MIN_IVR via PUT_CREDIT_MIN_IVR (default 5 in CI); research preferred 30; VIX<=30 hard",
             "entry_regime_logging": True,
             "exit_counterfactuals_tp50_dte21": True,
             "rolling_20_metrics": True,
+            "research_protocol_splits": True,
         },
     }
 

--- a/scripts/put_credit_research_protocol.py
+++ b/scripts/put_credit_research_protocol.py
@@ -26,6 +26,7 @@ from src.research.put_credit_research_protocol import (  # noqa: E402
     extract_closed_put_credit_pnls,
     freeze_champion,
     metrics_from_pnls,
+    research_critic_audit,
     run_baseline_snapshot,
     split_dev_val_holdout,
     unlock_holdout_once,
@@ -53,6 +54,11 @@ def main() -> int:
     )
     p.add_argument("--freeze-baseline", action="store_true")
     p.add_argument("--unlock-holdout", action="store_true")
+    p.add_argument(
+        "--critic-audit",
+        action="store_true",
+        help="Deterministic research critic (no LLM); exit 1 on hard failures",
+    )
     p.add_argument("--json", action="store_true")
     args = p.parse_args()
 
@@ -60,7 +66,12 @@ def main() -> int:
     out: dict = {}
 
     if args.baseline or not any(
-        [args.compare_preferred_ivr, args.freeze_baseline, args.unlock_holdout]
+        [
+            args.compare_preferred_ivr,
+            args.freeze_baseline,
+            args.unlock_holdout,
+            args.critic_audit,
+        ]
     ):
         out["baseline"] = run_baseline_snapshot(trades, args.research_dir)
 
@@ -103,8 +114,18 @@ def main() -> int:
             args.research_dir, extract_closed_put_credit_pnls(trades)
         )
 
+    if args.critic_audit:
+        champ = Path(args.research_dir) / "champion.json"
+        out["critic"] = research_critic_audit(
+            trades_payload=trades,
+            decision=out.get("compare") if isinstance(out.get("compare"), dict) else None,
+            champion_path=champ if champ.is_file() else None,
+        )
+
     text = json.dumps(out, indent=2, default=str)
     print(text)
+    if args.critic_audit and not out.get("critic", {}).get("pass", True):
+        return 1
     return 0
 
 

--- a/src/research/put_credit_research_protocol.py
+++ b/src/research/put_credit_research_protocol.py
@@ -450,3 +450,104 @@ def _filter_pnls_for_params(trades_payload: Any, params: dict[str, Any]) -> list
         if pnl is not None:
             pnls.append(float(pnl))
     return pnls
+
+
+def scorecard_research_section(trades_payload: Any) -> dict[str, Any]:
+    """Read-only research view for cohort scorecard (no registry writes)."""
+    timed = extract_closed_put_credit_pnls(trades_payload)
+    evaluation = evaluate_splits(timed)
+    n = evaluation["n_closed"]
+    return {
+        "handbook_roi": "deterministic_eval_fixed_selection_holdout",
+        "langchain_adopted": False,
+        "selection_rule_fixed": True,
+        "n_closed": n,
+        "split_sizes": evaluation["split_sizes"],
+        "development": evaluation["development"],
+        "validation": evaluation["validation"],
+        "holdout": evaluation["holdout"],
+        "full_sample": evaluation["full_sample"],
+        "honesty": {
+            "edge_claim_allowed": False if n < 30 else None,
+            "holdout_usable_for_selection": False,
+            "note": (
+                "Research splits are for protocol comparison only. Live remains blocked "
+                "until kill_criteria EDGE_CANDIDATE on the full put-credit cohort."
+            ),
+        },
+    }
+
+
+def research_critic_audit(
+    *,
+    trades_payload: Any,
+    decision: dict[str, Any] | None = None,
+    champion_path: Path | None = None,
+    kill_n: int = 30,
+) -> dict[str, Any]:
+    """Deterministic research critic (handbook critic role — no LLM).
+
+    Fails closed on:
+    - decisions that reference holdout metrics for promotion
+    - champion freeze claiming live readiness
+    - edge/profit claims when closed n < kill_n
+    """
+    findings: list[dict[str, str]] = []
+    timed = extract_closed_put_credit_pnls(trades_payload)
+    n = len(timed)
+
+    if decision:
+        if decision.get("used_holdout_for_selection") is True:
+            findings.append(
+                {
+                    "severity": "error",
+                    "code": "holdout_used_for_selection",
+                    "message": "Holdout metrics must not drive champion selection",
+                }
+            )
+        if decision.get("claim_profitable") is True and n < kill_n:
+            findings.append(
+                {
+                    "severity": "error",
+                    "code": "premature_edge_claim",
+                    "message": f"Edge claim with n={n} < {kill_n}",
+                }
+            )
+
+    if champion_path and Path(champion_path).is_file():
+        champ = json.loads(Path(champion_path).read_text(encoding="utf-8"))
+        if champ.get("live_trading") is True:
+            findings.append(
+                {
+                    "severity": "error",
+                    "code": "freeze_claims_live",
+                    "message": "Champion freeze must keep live_trading=false",
+                }
+            )
+        if champ.get("claim_profitable") is True and n < kill_n:
+            findings.append(
+                {
+                    "severity": "error",
+                    "code": "freeze_claims_profit",
+                    "message": "Champion freeze must not claim profitability before n gate",
+                }
+            )
+
+    # Soft warnings
+    if n < kill_n:
+        findings.append(
+            {
+                "severity": "info",
+                "code": "insufficient_sample",
+                "message": f"Closed put-credit n={n}; research only, no edge claim",
+            }
+        )
+
+    errors = [f for f in findings if f["severity"] == "error"]
+    return {
+        "role": "research_critic",
+        "pass": len(errors) == 0,
+        "n_closed": n,
+        "findings": findings,
+        "errors": len(errors),
+    }

--- a/tests/test_put_credit_research_protocol.py
+++ b/tests/test_put_credit_research_protocol.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
 import pytest
@@ -102,6 +103,60 @@ def test_freeze_then_holdout_once(tmp_path: Path):
     assert "holdout" in report
     with pytest.raises(RuntimeError, match="already evaluated"):
         unlock_holdout_once(tmp_path, timed)
+
+
+def test_research_critic_flags_holdout_selection():
+    from src.research.put_credit_research_protocol import research_critic_audit
+
+    trades = {"trades": []}
+    bad = research_critic_audit(
+        trades_payload=trades,
+        decision={"event": "decision", "used_holdout_for_selection": True},
+    )
+    assert bad["pass"] is False
+    assert any(f["code"] == "holdout_used_for_selection" for f in bad["findings"])
+
+    good = research_critic_audit(
+        trades_payload=trades,
+        decision={"event": "decision", "used_holdout_for_selection": False},
+    )
+    assert good["pass"] is True
+
+
+def test_scorecard_includes_research_protocol(tmp_path: Path, monkeypatch):
+    from scripts import put_credit_cohort_scorecard as sc
+
+    trades_path = tmp_path / "trades.json"
+    trades_path.write_text(
+        json.dumps(
+            {
+                "trades": [
+                    {
+                        "strategy": "spy_put_credit",
+                        "status": "closed",
+                        "exit_time": "2026-07-10T15:00:00+00:00",
+                        "realized_pnl": 17.0,
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    entries_path = tmp_path / "entries.json"
+    entries_path.write_text("{}", encoding="utf-8")
+    kill_path = tmp_path / "kill.json"
+    kill_path.write_text(
+        json.dumps({"active_family": "spy_put_credit", "paper_only": True, "live_blocked": True}),
+        encoding="utf-8",
+    )
+    card = sc.build_scorecard(
+        trades_path=trades_path, entries_path=entries_path, kill_path=kill_path
+    )
+    assert card["schema_version"] == "put-credit-cohort-scorecard/2"
+    rp = card["research_protocol"]
+    assert rp.get("langchain_adopted") is False
+    assert "validation" in rp
+    assert rp.get("critic", {}).get("pass") is True
 
 
 def test_compare_preferred_ivr_records_decision(tmp_path: Path):


### PR DESCRIPTION
# Pull request

## Work item

- Linear issue: AGENT-395
- Agent: grok
- Base SHA: '"84647cecee1d617e6bdca3a49acf406473149ba8"'
- Branch/worktree: fix/agent-395-research-protocol-wire
- Files or systems claimed: src/research/put_credit_research_protocol.py; scripts/put_credit_cohort_scorecard.py; scripts/put_credit_research_protocol.py; tests/test_put_credit_research_protocol.py; .github/workflows/put-credit-validation.yml; docs/research/put-credit-research-protocol.md
- Coordination legacy reason: n/a

## Change

- Wire handbook high-ROI research protocol into cohort scorecard (schema v2)
- Deterministic research critic (no LLM)
- CI smoke: baseline + critic on put-credit-validation workflow
- Tests: 10 passed

## Verification

- [x] pytest tests/test_put_credit_research_protocol.py (10 passed)
- [x] scorecard includes research_protocol; critic pass on n=2 sample
- Head: '"cde62b4c4fbf2416a093b38454a39349a24803cf"'
- [ ] CI green

## Coordination

- [x] Linear AGENT-395
- [x] No overlapping claim
- [x] Claim done after merge
