### PR TITLE
feat(AGENT-396): EYL-style earned milestones + weekly accountability

### DIFF
--- a/docs/research/eyl-style-milestones.md
+++ b/docs/research/eyl-style-milestones.md
@@ -1,0 +1,24 @@
+# EYL-style milestones (high-ROI steal only)
+
+Source inspiration: options education memberships that emphasize earned recognition,
+weekly accountability, and risk awareness — without becoming a signal service.
+
+## What we stole
+
+- Earned jacket / milestone → `put_credit_milestones.py` ladder (Foundation → Process → Evidence → Edge Candidate)
+- Weekly investors club → `put_credit_weekly_accountability.py` packet (JSON + markdown)
+- Risk awareness / not signals → fixed `RISK_FRAMEWORK` + honesty notes on every packet
+- Live class curriculum → not adopted (no course product, no branding)
+
+## Commands
+
+```bash
+.venv/bin/python scripts/put_credit_cohort_scorecard.py --json
+.venv/bin/python scripts/put_credit_weekly_accountability.py
+```
+
+## Hard rules
+
+- Milestones are earned only from paired put-credit ledger counts / kill verdict
+- No profit-percentage jacket claims
+- Does not unlock live trading

--- a/scripts/put_credit_cohort_scorecard.py
+++ b/scripts/put_credit_cohort_scorecard.py
@@ -297,8 +297,16 @@ def build_scorecard(
     except Exception as exc:  # noqa: BLE001
         research_protocol = {"error": str(exc), "langchain_adopted": False}
 
+    milestones: dict[str, Any] = {}
+    try:
+        from src.analytics.put_credit_milestones import evaluate_milestones
+
+        milestones = evaluate_milestones(closed)
+    except Exception as exc:  # noqa: BLE001
+        milestones = {"error": str(exc)}
+
     return {
-        "schema_version": "put-credit-cohort-scorecard/2",
+        "schema_version": "put-credit-cohort-scorecard/3",
         "generated_at": datetime.now(UTC).isoformat(),
         "active_family": kill_switch.get("active_family"),
         "paper_only": kill_switch.get("paper_only"),
@@ -307,6 +315,7 @@ def build_scorecard(
         "open": open_,
         "closed": closed,
         "progress": progress,
+        "milestones": milestones,
         "research_protocol": research_protocol,
         "honesty": {
             "claim_profitable": False
@@ -326,6 +335,8 @@ def build_scorecard(
             "exit_counterfactuals_tp50_dte21": True,
             "rolling_20_metrics": True,
             "research_protocol_splits": True,
+            "earned_milestones_ladder": True,
+            "weekly_accountability_packet": True,
         },
     }
 

--- a/scripts/put_credit_weekly_accountability.py
+++ b/scripts/put_credit_weekly_accountability.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+"""Weekly put-credit accountability packet (EYL-style ritual, ledger-only).
+
+Usage:
+  .venv/bin/python scripts/put_credit_weekly_accountability.py
+  .venv/bin/python scripts/put_credit_weekly_accountability.py --json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from scripts.put_credit_cohort_scorecard import build_scorecard  # noqa: E402
+from src.analytics.put_credit_milestones import (  # noqa: E402
+    build_weekly_accountability_packet,
+    render_weekly_markdown,
+)
+
+DEFAULT_JSON = ROOT / "data" / "audit" / "put_credit_weekly_accountability_latest.json"
+DEFAULT_MD = ROOT / "data" / "audit" / "put_credit_weekly_accountability_latest.md"
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--json", action="store_true")
+    p.add_argument("--out-json", type=Path, default=DEFAULT_JSON)
+    p.add_argument("--out-md", type=Path, default=DEFAULT_MD)
+    args = p.parse_args()
+
+    card = build_scorecard()
+    packet = build_weekly_accountability_packet(card)
+    md = render_weekly_markdown(packet)
+
+    args.out_json.parent.mkdir(parents=True, exist_ok=True)
+    args.out_json.write_text(json.dumps(packet, indent=2, default=str) + "\n", encoding="utf-8")
+    args.out_md.write_text(md + "\n", encoding="utf-8")
+
+    if args.json:
+        print(json.dumps(packet, indent=2, default=str))
+    else:
+        print(md)
+        print(f"\njson_out={args.out_json}")
+        print(f"md_out={args.out_md}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/analytics/put_credit_milestones.py
+++ b/src/analytics/put_credit_milestones.py
@@ -1,0 +1,239 @@
+"""Earned put-credit milestones (EYL-style recognition, ledger-only).
+
+Steals process patterns from options education communities (e.g. earned jackets /
+weekly accountability) WITHOUT branding, courses, or profit guarantees:
+
+1. Recognition is *earned* from paired closed put-credit rows only
+2. Ladder is process gates, not "1000% returns"
+3. System is education/validation — not a signal service
+4. Weekly accountability packet is a fixed review ritual
+
+Does NOT submit trades or unlock live capital.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from datetime import UTC, datetime
+from typing import Any
+
+# Fixed ladder (declared before results — same spirit as research selection rule).
+MILESTONE_LADDER: tuple[dict[str, Any], ...] = (
+    {
+        "id": "m0_started",
+        "title": "Foundation",
+        "requirement": "At least 1 closed put-credit structure on the paired ledger",
+        "n_closed_min": 1,
+        "requires_edge_candidate": False,
+    },
+    {
+        "id": "m1_process_ten",
+        "title": "Process",
+        "requirement": "At least 10 closed put-credit structures (sample building)",
+        "n_closed_min": 10,
+        "requires_edge_candidate": False,
+    },
+    {
+        "id": "m2_evidence_thirty",
+        "title": "Evidence",
+        "requirement": "At least 30 closed put-credit structures (kill-criteria sample floor)",
+        "n_closed_min": 30,
+        "requires_edge_candidate": False,
+    },
+    {
+        "id": "m3_edge_candidate",
+        "title": "Edge Candidate",
+        "requirement": "n>=30 AND kill verdict EDGE_CANDIDATE (expectancy>0, PF>1, total PnL>0)",
+        "n_closed_min": 30,
+        "requires_edge_candidate": True,
+    },
+)
+
+# Risk framework printed on every accountability packet (EYL: risk awareness).
+RISK_FRAMEWORK = {
+    "family": "spy_put_credit",
+    "paper_only": True,
+    "lot_size": 1,
+    "max_concurrent": 2,
+    "max_daily_structures": 3,
+    "stop_loss_pct_of_credit": 2.0,
+    "take_profit_pct_of_credit": 0.25,
+    "exit_dte": 7,
+    "not_a_signal_service": True,
+    "not_a_profit_guarantee": True,
+}
+
+
+@dataclass(frozen=True)
+class MilestoneStatus:
+    id: str
+    title: str
+    requirement: str
+    earned: bool
+    earned_at: str | None
+    evidence: dict[str, Any]
+
+    def as_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+def _kill_is_edge_candidate(closed_summary: dict[str, Any]) -> bool:
+    kill = closed_summary.get("kill_criteria") or {}
+    if str(kill.get("verdict") or "") == "EDGE_CANDIDATE":
+        return True
+    return bool(kill.get("pass_all")) is True
+
+
+def evaluate_milestones(
+    closed_summary: dict[str, Any],
+    *,
+    now: datetime | None = None,
+) -> dict[str, Any]:
+    """Evaluate earned milestones from cohort closed summary (no side effects)."""
+    now = now or datetime.now(UTC)
+    n = int(closed_summary.get("closed_n") or 0)
+    edge = _kill_is_edge_candidate(closed_summary)
+    statuses: list[MilestoneStatus] = []
+    for step in MILESTONE_LADDER:
+        n_ok = n >= int(step["n_closed_min"])
+        edge_ok = (not step["requires_edge_candidate"]) or edge
+        earned = bool(n_ok and edge_ok)
+        statuses.append(
+            MilestoneStatus(
+                id=str(step["id"]),
+                title=str(step["title"]),
+                requirement=str(step["requirement"]),
+                earned=earned,
+                earned_at=now.isoformat() if earned else None,
+                evidence={
+                    "n_closed": n,
+                    "n_closed_min": step["n_closed_min"],
+                    "edge_candidate": edge,
+                    "requires_edge_candidate": step["requires_edge_candidate"],
+                },
+            )
+        )
+
+    earned = [s for s in statuses if s.earned]
+    next_ms = next((s for s in statuses if not s.earned), None)
+    # Highest earned title (EYL "jacket" analogue — process recognition only)
+    jacket = earned[-1].title if earned else "None"
+    return {
+        "schema_version": "put-credit-milestones/1",
+        "generated_at": now.isoformat(),
+        "earned_count": len(earned),
+        "total_count": len(statuses),
+        "highest_earned": jacket,
+        "milestones": [s.as_dict() for s in statuses],
+        "next": next_ms.as_dict() if next_ms else None,
+        "honesty": {
+            "earned_not_given": True,
+            "not_profit_jacket": True,
+            "note": (
+                "Milestones recognize process evidence on the paired put-credit ledger only. "
+                "They do not guarantee returns and do not unlock live capital."
+            ),
+        },
+        "risk_framework": RISK_FRAMEWORK,
+    }
+
+
+def build_weekly_accountability_packet(
+    scorecard: dict[str, Any],
+    *,
+    now: datetime | None = None,
+) -> dict[str, Any]:
+    """Weekly Investors-Club style packet from an existing cohort scorecard."""
+    now = now or datetime.now(UTC)
+    closed = scorecard.get("closed") or {}
+    open_ = scorecard.get("open") or {}
+    progress = scorecard.get("progress") or {}
+    honesty = scorecard.get("honesty") or {}
+    research = scorecard.get("research_protocol") or {}
+    milestones = evaluate_milestones(closed, now=now)
+
+    return {
+        "schema_version": "put-credit-weekly-accountability/1",
+        "generated_at": now.isoformat(),
+        "ritual": "weekly_investors_club_style_review",
+        "source": "EYL-style accountability (process only; no signals)",
+        "active_family": scorecard.get("active_family"),
+        "paper_only": scorecard.get("paper_only"),
+        "live_blocked": scorecard.get("live_blocked"),
+        "this_week_questions": [
+            "Did we follow 1-lot / max concurrent / regime gates?",
+            "Any inventory unclean or journal desync?",
+            "What is closed_n vs n=30 gate?",
+            "Any protocol change? If yes, was it registered under fixed selection rule?",
+            "Did we claim profit without EDGE_CANDIDATE? (must be no)",
+        ],
+        "metrics": {
+            "open_n": open_.get("open_n"),
+            "closed_n": closed.get("closed_n"),
+            "win_rate_pct": closed.get("win_rate_pct"),
+            "profit_factor": closed.get("profit_factor"),
+            "expectancy": closed.get("expectancy"),
+            "total_realized_pnl": closed.get("total_realized_pnl"),
+            "kill_verdict": (closed.get("kill_criteria") or {}).get("verdict"),
+            "progress_pct_to_gate": progress.get("pct_to_gate"),
+            "remaining_to_gate": progress.get("remaining_to_gate"),
+        },
+        "milestones": milestones,
+        "research_protocol": {
+            "n_closed": research.get("n_closed"),
+            "split_sizes": research.get("split_sizes"),
+            "critic_pass": (research.get("critic") or {}).get("pass"),
+            "langchain_adopted": research.get("langchain_adopted", False),
+        },
+        "honesty": honesty,
+        "risk_framework": RISK_FRAMEWORK,
+        "not_a_signal_service": True,
+    }
+
+
+def render_weekly_markdown(packet: dict[str, Any]) -> str:
+    m = packet.get("metrics") or {}
+    ms = packet.get("milestones") or {}
+    lines = [
+        "# Put-credit weekly accountability",
+        "",
+        f"Generated: `{packet.get('generated_at')}`",
+        "",
+        "## Ritual questions",
+    ]
+    for q in packet.get("this_week_questions") or []:
+        lines.append(f"- [ ] {q}")
+    lines.extend(
+        [
+            "",
+            "## Metrics (ledger)",
+            f"- open_n: `{m.get('open_n')}`",
+            f"- closed_n: `{m.get('closed_n')}` / 30",
+            f"- win_rate_pct: `{m.get('win_rate_pct')}`",
+            f"- profit_factor: `{m.get('profit_factor')}`",
+            f"- expectancy: `{m.get('expectancy')}`",
+            f"- total_realized_pnl: `{m.get('total_realized_pnl')}`",
+            f"- kill_verdict: `{m.get('kill_verdict')}`",
+            f"- progress_to_gate: `{m.get('progress_pct_to_gate')}%`",
+            "",
+            f"## Milestones (highest earned: **{ms.get('highest_earned')}**)",
+        ]
+    )
+    for row in ms.get("milestones") or []:
+        mark = "x" if row.get("earned") else " "
+        lines.append(f"- [{mark}] **{row.get('title')}** — {row.get('requirement')}")
+    lines.extend(
+        [
+            "",
+            "## Risk framework",
+            f"- paper_only: `{RISK_FRAMEWORK['paper_only']}`",
+            f"- lot_size: `{RISK_FRAMEWORK['lot_size']}` max_concurrent: `{RISK_FRAMEWORK['max_concurrent']}`",
+            f"- stop: `{RISK_FRAMEWORK['stop_loss_pct_of_credit']}`x credit · TP: `{RISK_FRAMEWORK['take_profit_pct_of_credit']}` · exit_dte: `{RISK_FRAMEWORK['exit_dte']}`",
+            "",
+            "## Honesty",
+            f"- not a signal service: `{packet.get('not_a_signal_service')}`",
+            f"- note: {(packet.get('honesty') or {}).get('note')}",
+            "",
+        ]
+    )
+    return "\n".join(lines)

--- a/tests/test_put_credit_milestones.py
+++ b/tests/test_put_credit_milestones.py
@@ -1,0 +1,111 @@
+"""Tests for EYL-style earned milestones + weekly accountability."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from src.analytics.put_credit_milestones import (
+    build_weekly_accountability_packet,
+    evaluate_milestones,
+    render_weekly_markdown,
+)
+
+
+def test_milestones_none_at_zero():
+    out = evaluate_milestones({"closed_n": 0, "kill_criteria": {"verdict": "INSUFFICIENT_SAMPLE"}})
+    assert out["highest_earned"] == "None"
+    assert out["earned_count"] == 0
+    assert all(not m["earned"] for m in out["milestones"])
+
+
+def test_milestones_foundation_and_process():
+    out = evaluate_milestones({"closed_n": 12, "kill_criteria": {"verdict": "INSUFFICIENT_SAMPLE"}})
+    earned_ids = {m["id"] for m in out["milestones"] if m["earned"]}
+    assert "m0_started" in earned_ids
+    assert "m1_process_ten" in earned_ids
+    assert "m2_evidence_thirty" not in earned_ids
+    assert out["highest_earned"] == "Process"
+
+
+def test_edge_candidate_requires_verdict():
+    base = {"closed_n": 35, "kill_criteria": {"verdict": "NO_EDGE_KILL", "pass_all": False}}
+    out = evaluate_milestones(base)
+    edge = next(m for m in out["milestones"] if m["id"] == "m3_edge_candidate")
+    assert edge["earned"] is False
+    assert out["highest_earned"] == "Evidence"
+
+    good = evaluate_milestones(
+        {"closed_n": 35, "kill_criteria": {"verdict": "EDGE_CANDIDATE", "pass_all": True}}
+    )
+    edge2 = next(m for m in good["milestones"] if m["id"] == "m3_edge_candidate")
+    assert edge2["earned"] is True
+    assert good["highest_earned"] == "Edge Candidate"
+
+
+def test_weekly_packet_and_markdown():
+    scorecard = {
+        "active_family": "spy_put_credit",
+        "paper_only": True,
+        "live_blocked": True,
+        "open": {"open_n": 2},
+        "closed": {
+            "closed_n": 2,
+            "win_rate_pct": 100.0,
+            "profit_factor": None,
+            "expectancy": 17.0,
+            "total_realized_pnl": 34.0,
+            "kill_criteria": {"verdict": "INSUFFICIENT_SAMPLE"},
+        },
+        "progress": {"pct_to_gate": 6.7, "remaining_to_gate": 28},
+        "honesty": {"note": "do not claim"},
+        "research_protocol": {
+            "n_closed": 2,
+            "split_sizes": {"development": 1, "validation": 1, "holdout": 0},
+            "critic": {"pass": True},
+            "langchain_adopted": False,
+        },
+    }
+    packet = build_weekly_accountability_packet(scorecard)
+    assert packet["not_a_signal_service"] is True
+    assert packet["milestones"]["highest_earned"] == "Foundation"
+    assert packet["metrics"]["closed_n"] == 2
+    md = render_weekly_markdown(packet)
+    assert "weekly accountability" in md.lower()
+    assert "Foundation" in md
+    assert "not a signal service" in md.lower()
+
+
+def test_scorecard_embeds_milestones(tmp_path: Path):
+    from scripts import put_credit_cohort_scorecard as sc
+
+    trades = tmp_path / "trades.json"
+    trades.write_text(
+        json.dumps(
+            {
+                "trades": [
+                    {
+                        "strategy": "spy_put_credit",
+                        "status": "closed",
+                        "exit_time": "2026-07-10T15:00:00+00:00",
+                        "realized_pnl": 17.0,
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    (tmp_path / "e.json").write_text("{}", encoding="utf-8")
+    (tmp_path / "k.json").write_text(
+        json.dumps({"active_family": "spy_put_credit", "paper_only": True, "live_blocked": True}),
+        encoding="utf-8",
+    )
+    card = sc.build_scorecard(
+        trades_path=trades,
+        entries_path=tmp_path / "e.json",
+        kill_path=tmp_path / "k.json",
+    )
+    assert card["schema_version"] == "put-credit-cohort-scorecard/3"
+    assert "milestones" in card
+    assert card["milestones"]["highest_earned"] == "Foundation"
+    assert card["milestones"]["risk_framework"]["not_a_signal_service"] is True


### PR DESCRIPTION
## Work item
- Linear issue: AGENT-396
- Agent: grok
- Branch: fix/agent-396-eyl-put-credit-milestones
- Files: put_credit_milestones.py, weekly accountability CLI, scorecard v3, tests, docs

## Change
Earned milestone ladder + weekly accountability packet (EYL process patterns only). Not a signal service. Ledger-only.

## Verification
- [x] 5 pytest passed
- [x] live packet highest=Foundation at n=2

## Coordination
- [x] AGENT-396
- [x] No overlap
- [x] Done after merge