### PR TITLE
fix(put-credit): re-open cancelled journals when broker legs live

### DIFF
--- a/scripts/spy_put_credit.py
+++ b/scripts/spy_put_credit.py
@@ -436,7 +436,12 @@ def _entry_has_open_broker_legs(entry: dict[str, Any], positions: dict[str, Any]
 
 
 def reconcile_put_credit_entries(client: Any, *, dry_run: bool = False) -> dict[str, Any]:
-    """Recover missing PCS journals from our filled paper BPS parent orders."""
+    """Recover missing PCS journals and re-sync cancelled vs open broker legs.
+
+    1. Recover filled paper BPS parent orders that never got a durable journal.
+    2. Re-open journal rows marked cancelled/closed when both legs are still live.
+    3. Close ghost open rows that no longer have either leg (no freehand orders).
+    """
 
     from alpaca.trading.enums import QueryOrderStatus
     from alpaca.trading.requests import GetOrdersRequest
@@ -467,6 +472,10 @@ def reconcile_put_credit_entries(client: Any, *, dry_run: bool = False) -> dict[
         "invalid_filled_orders": 0,
         "recovered": 0,
         "would_recover": 0,
+        "reopened": 0,
+        "would_reopen": 0,
+        "ghost_closed": 0,
+        "would_ghost_close": 0,
         "broken": 0,
         "details": [],
     }
@@ -484,6 +493,66 @@ def reconcile_put_credit_entries(client: Any, *, dry_run: bool = False) -> dict[
         order_id = str(getattr(order, "id", "") or "")
         if order_id in existing_order_ids:
             report["existing"] += 1
+            # If journal is cancelled/closed but this filled order still has legs,
+            # re-open and refresh strikes/signature from the broker order (fixes
+            # mislabeled strike journals).
+            for key, existing in list(entries.items()):
+                if not isinstance(existing, dict):
+                    continue
+                if str(existing.get("order_id") or "") != order_id:
+                    continue
+                try:
+                    _, recovered = _recovered_put_credit_entry(order)
+                except ValueError:
+                    break
+                if not _entry_has_open_broker_legs(recovered, positions):
+                    break
+                status = str(existing.get("status") or "open").strip().lower()
+                needs_reopen = status in CLOSED_ENTRY_STATES
+                needs_strike_fix = existing.get("strikes") != recovered.get("strikes")
+                if not needs_reopen and not needs_strike_fix:
+                    break
+                if dry_run:
+                    report["would_reopen"] += 1
+                    report["details"].append(
+                        {
+                            "key": key,
+                            "order_id": order_id,
+                            "status": "would_reopen_from_order",
+                            "was": status,
+                            "strikes": recovered.get("strikes"),
+                        }
+                    )
+                    break
+                existing["status"] = "open"
+                existing["strikes"] = recovered["strikes"]
+                existing["signature"] = recovered.get("signature") or existing.get("signature")
+                existing["expiry"] = recovered.get("expiry") or existing.get("expiry")
+                if recovered.get("credit") is not None:
+                    existing["credit"] = recovered["credit"]
+                    existing["credit_source"] = recovered.get("credit_source") or "broker_fill"
+                existing["reconciliation_reason"] = "reopened_from_filled_order_legs"
+                existing["reopened_at"] = datetime.now(UTC).isoformat()
+                for ghost_key in (
+                    "exit_filled_at",
+                    "exit_reason",
+                    "exit_order_id",
+                    "exit_pending_at",
+                    "last_error",
+                ):
+                    existing.pop(ghost_key, None)
+                changed = True
+                report["reopened"] += 1
+                report["details"].append(
+                    {
+                        "key": key,
+                        "order_id": order_id,
+                        "status": "reopened_from_order",
+                        "was": status,
+                        "strikes": existing["strikes"],
+                    }
+                )
+                break
             continue
         try:
             key, entry = _recovered_put_credit_entry(order)
@@ -506,6 +575,80 @@ def reconcile_put_credit_entries(client: Any, *, dry_run: bool = False) -> dict[
         changed = True
         report["recovered"] += 1
         report["details"].append({"order_id": order_id, "key": key, "status": "recovered"})
+
+    # Re-open cancelled/closed journals that still match live broker legs.
+    for key, entry in list(entries.items()):
+        if not isinstance(entry, dict):
+            continue
+        status = str(entry.get("status") or "open").strip().lower()
+        if status not in CLOSED_ENTRY_STATES:
+            continue
+        if not _entry_has_open_broker_legs(entry, positions):
+            continue
+        if dry_run:
+            report["would_reopen"] += 1
+            report["details"].append({"key": key, "status": "would_reopen", "was": status})
+            continue
+        entry["status"] = "open"
+        entry["reconciliation_reason"] = "reopened_broker_legs_present"
+        entry["reopened_at"] = datetime.now(UTC).isoformat()
+        for ghost_key in (
+            "exit_filled_at",
+            "exit_reason",
+            "exit_order_id",
+            "exit_pending_at",
+            "last_error",
+        ):
+            entry.pop(ghost_key, None)
+        changed = True
+        report["reopened"] += 1
+        report["details"].append({"key": key, "status": "reopened", "was": status})
+
+    # Close ghost active rows with no legs (status open/broken/entry_pending flat).
+    for key, entry in list(entries.items()):
+        if not isinstance(entry, dict) or not _is_active_entry(entry):
+            continue
+        if _entry_has_open_broker_legs(entry, positions):
+            # Still active with full structure.
+            continue
+        # Skip partial/broken structures — manage-exits owns orphan handling.
+        try:
+            expiry = _expiry_yymmdd(entry)
+            strikes = entry.get("strikes") or {}
+            short_symbol = _option_symbol(expiry, float(strikes["short_put"]))
+            long_symbol = _option_symbol(expiry, float(strikes["long_put"]))
+        except (KeyError, TypeError, ValueError):
+            continue
+        short_pos = positions.get(short_symbol)
+        long_pos = positions.get(long_symbol)
+        if short_pos is not None or long_pos is not None:
+            continue
+        entry_status = _entry_order_status(client, entry)
+        if any(state in entry_status for state in ("NEW", "ACCEPT", "PENDING", "HELD")):
+            continue
+        if dry_run:
+            report["would_ghost_close"] += 1
+            report["details"].append(
+                {
+                    "key": key,
+                    "status": "would_ghost_close",
+                    "entry_order_status": entry_status,
+                }
+            )
+            continue
+        entry["status"] = "closed"
+        entry["reconciliation_reason"] = "broker_flat_ghost_open"
+        entry["exit_filled_at"] = entry.get("exit_filled_at") or datetime.now(UTC).isoformat()
+        entry["exit_reason"] = entry.get("exit_reason") or "broker_reconcile_flat"
+        changed = True
+        report["ghost_closed"] += 1
+        report["details"].append(
+            {
+                "key": key,
+                "status": "ghost_closed",
+                "entry_order_status": entry_status,
+            }
+        )
 
     if changed:
         _save_entries(entries)

--- a/tests/test_active_strategy.py
+++ b/tests/test_active_strategy.py
@@ -467,6 +467,131 @@ def test_malformed_historical_put_credit_does_not_block_exit_workflow(tmp_path, 
     assert report["recovered"] == 0
 
 
+def test_reconcile_reopens_cancelled_when_broker_legs_present(tmp_path, monkeypatch):
+    from scripts import spy_put_credit as pcs
+
+    entries_path = tmp_path / "put_credit_entries.json"
+    entries_path.write_text(
+        json.dumps(
+            {
+                "PCS_cancel": {
+                    "status": "cancelled",
+                    "order_id": "ord-live",
+                    "quantity": 1,
+                    "expiry": "2026-09-25",
+                    "strikes": {"short_put": 746.0, "long_put": 741.0},
+                    "credit": 0.62,
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(pcs, "ENTRIES_FILE", entries_path)
+    client = MagicMock()
+    client.get_orders.return_value = []
+    client.get_all_positions.return_value = [
+        SimpleNamespace(symbol="SPY260925P00741000", qty="1"),
+        SimpleNamespace(symbol="SPY260925P00746000", qty="-1"),
+    ]
+
+    report = pcs.reconcile_put_credit_entries(client)
+
+    assert report["reopened"] == 1
+    saved = json.loads(entries_path.read_text(encoding="utf-8"))
+    assert saved["PCS_cancel"]["status"] == "open"
+    assert saved["PCS_cancel"]["reconciliation_reason"] == "reopened_broker_legs_present"
+
+
+def test_reconcile_reopens_and_corrects_strikes_from_filled_order(tmp_path, monkeypatch):
+    from scripts import spy_put_credit as pcs
+
+    entries_path = tmp_path / "put_credit_entries.json"
+    entries_path.write_text(
+        json.dumps(
+            {
+                "PCS_wrong": {
+                    "status": "cancelled",
+                    "order_id": "818b7a94-239e-4579-bf33-e6aab40ff847",
+                    "quantity": 1,
+                    "expiry": "2026-09-25",
+                    # Mislabeled vs broker fill (real was 735/740).
+                    "strikes": {"short_put": 742.0, "long_put": 737.0},
+                    "signature": "SPY_2026-09-25_P737-742",
+                    "credit": 0.51,
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(pcs, "ENTRIES_FILE", entries_path)
+    monkeypatch.setattr(pcs, "AUDIT_DIR", tmp_path / "audit")
+    order = SimpleNamespace(
+        id="818b7a94-239e-4579-bf33-e6aab40ff847",
+        client_order_id="IC-OPEN-BPS--1786986801253838000003",
+        status="FILLED",
+        qty="1",
+        filled_qty="1",
+        filled_avg_price="-0.51",
+        limit_price="-0.65",
+        submitted_at=datetime.fromisoformat("2026-08-17T17:13:25+00:00"),
+        filled_at=datetime.fromisoformat("2026-08-17T17:13:33+00:00"),
+        legs=[
+            SimpleNamespace(symbol="SPY260925P00735000", side="BUY", filled_avg_price="3.88"),
+            SimpleNamespace(symbol="SPY260925P00740000", side="SELL", filled_avg_price="4.39"),
+        ],
+    )
+    client = MagicMock()
+    client.get_orders.return_value = [order]
+    client.get_all_positions.return_value = [
+        SimpleNamespace(symbol="SPY260925P00735000", qty="1"),
+        SimpleNamespace(symbol="SPY260925P00740000", qty="-1"),
+    ]
+
+    report = pcs.reconcile_put_credit_entries(client)
+
+    assert report["reopened"] == 1
+    saved = json.loads(entries_path.read_text(encoding="utf-8"))
+    entry = saved["PCS_wrong"]
+    assert entry["status"] == "open"
+    assert entry["strikes"] == {"short_put": 740.0, "long_put": 735.0}
+    assert entry["signature"] == "SPY_2026-09-25_P735-740"
+
+
+def test_reconcile_ghost_closes_open_without_legs(tmp_path, monkeypatch):
+
+    from scripts import spy_put_credit as pcs
+
+    entries_path = tmp_path / "put_credit_entries.json"
+    entries_path.write_text(
+        json.dumps(
+            {
+                "PCS_ghost": {
+                    "status": "open",
+                    "order_id": "ord-gone",
+                    "quantity": 1,
+                    "expiry": "2026-09-25",
+                    "strikes": {"short_put": 742.0, "long_put": 737.0},
+                    "credit": 0.65,
+                    "exit_filled_at": "2026-08-17T16:58:24+00:00",
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(pcs, "ENTRIES_FILE", entries_path)
+    client = MagicMock()
+    client.get_orders.return_value = []
+    client.get_all_positions.return_value = []
+    client.get_order_by_id.side_effect = Exception("order not found")
+
+    report = pcs.reconcile_put_credit_entries(client)
+
+    assert report["ghost_closed"] == 1
+    saved = json.loads(entries_path.read_text(encoding="utf-8"))
+    assert saved["PCS_ghost"]["status"] == "closed"
+    assert saved["PCS_ghost"]["reconciliation_reason"] == "broker_flat_ghost_open"
+
+
 def test_put_credit_entry_builds_supported_bull_put_order_id(tmp_path, monkeypatch):
     from scripts import spy_put_credit as pcs
     from src.utils.order_intent import parse_client_order_id


### PR DESCRIPTION
# Pull request

## Work item

- Linear issue: AGENT-392
- Agent: grok
- Base SHA: 590aeea9cf4c2a3c034de0983861bbca24db7e0f
- Branch/worktree: fix/agent-pcs-journal-reopen (.worktrees/agent-pcs-journal-reopen)
- Files or systems claimed: scripts/spy_put_credit.py, tests/test_active_strategy.py
- Coordination legacy reason: n/a

## Change

- Scope: Journal/broker desync fix — re-open cancelled PCS journals with live legs; correct mislabeled strikes from filled order; ghost-close open rows with no legs.
- Out of scope: freehand closes, live capital

## Verification

- [x] pytest tests/test_active_strategy.py -k reconcile (6 passed)
- [x] ruff clean

## Coordination

- [x] Linear issue and vault claim updated
- [x] No overlapping active claim or worktree
- [x] Claim will be marked done or released after merge