### PR TITLE
fix(ci): allowlist arXiv ingest manifests in repository hygiene audit

### DIFF
--- a/scripts/audit_repository_hygiene.py
+++ b/scripts/audit_repository_hygiene.py
@@ -28,6 +28,18 @@ FORBIDDEN_PREFIXES = (
     "node_modules/",
     "reports/",
 )
+# Deliberately persisted state that lives under a FORBIDDEN_PREFIXES directory.
+# These two manifests are dedupe / version state for the arXiv research ingest:
+# .github/workflows/arxiv-paper-ingestion.yml force-adds them on every scheduled run,
+# and src/research/arxiv_collector.py + src/rag/document_ingestion_pipeline.py read
+# them back to avoid re-ingesting papers. Untracking them (see LL-4426) only breaks
+# main again on the next scheduled ingest, so they are allowlisted here instead.
+ALLOWED_GENERATED_PATHS = frozenset(
+    {
+        "data/audit/arxiv_ingestion_manifest.json",
+        "data/audit/ingestion_version_manifest.json",
+    }
+)
 FORBIDDEN_NAMES = {".coverage", ".DS_Store", "coverage.json", "coverage.xml", "pytest.ini"}
 BINARY_SUFFIXES = {
     ".avif",
@@ -112,7 +124,9 @@ def scan(repo: Path) -> dict:
         data = path.read_bytes()
         total_lines += physical_line_count(data)
         suffix_counts[path.suffix.lower() or "[no suffix]"] += 1
-        if any(relative.startswith(prefix) for prefix in FORBIDDEN_PREFIXES):
+        if relative not in ALLOWED_GENERATED_PATHS and any(
+            relative.startswith(prefix) for prefix in FORBIDDEN_PREFIXES
+        ):
             findings.append(
                 Finding("error", "generated-path", relative, "tracked generated output")
             )


### PR DESCRIPTION
## Problem

The required check **Run All Tests** is failing on `main` and on all 8 open Dependabot PRs (#4433, #4435-#4441). The job dies at step **Run test runner**, in `scripts/audit_repository_hygiene.py --check`, which exits 1 on two errors:

```
data/audit/arxiv_ingestion_manifest.json    generated-path / tracked generated output
data/audit/ingestion_version_manifest.json  generated-path / tracked generated output
```

pytest never executes, so no PR in this repo can get real test evidence.

Proof it is pre-existing on `main`, not caused by any PR: run 32769721909, job `Run All Tests`, commit `0f3f23be`, same two paths, same exit code 1.

> Note: more recent `main` runs show CI green only because the `Run All Tests` job path-filters to the **Skip full test suite** step for data-only auto-commits. The gate is not actually passing there, it is being skipped.

## Root cause

Two parts of the repo disagree, in a loop:

- `.github/workflows/arxiv-paper-ingestion.yml` **force-adds** both manifests to `main` on every scheduled run (`git add -f`). They are the dedupe / version state read back by `src/research/arxiv_collector.py` (`ARXIV_MANIFEST_FILE`) and `src/rag/document_ingestion_pipeline.py` (`MANIFEST_FILE`).
- `scripts/audit_repository_hygiene.py` lists `data/audit/` in `FORBIDDEN_PREFIXES` and errors on any tracked file underneath it.

`LL-4426` records a previous session untracking the two files to turn `main` green. That fix cannot hold: the next scheduled ingest force-adds them straight back and `main` breaks again. Untracking also discards the ingest dedupe state, which would cause papers to be re-ingested.

## Fix

Allowlist exactly these two deliberate paths via a new `ALLOWED_GENERATED_PATHS` frozenset. Every other path under `data/audit/`, and every other forbidden prefix, still errors as before.

## Verification

- Audit on this branch: `errors=0 warnings=0` over 1438 files (previously `errors=2`).
- `pytest tests/test_repo_hygiene.py tests/test_repository_hygiene_audit.py` -> **5 passed**, including `test_repository_hygiene_audit_has_no_errors`.

Once this lands, the 8 Dependabot PRs already have auto-merge armed and should land on their own after a rebase / re-run.

No branch protection, ruleset, or required check was modified.

Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TLjSrfAchoR4BqHg9YJB8b
