### PR TITLE
fix(AGENT-566): unblock paper put-credit factory stalls

### DIFF
--- a/.github/workflows/put-credit-validation.yml
+++ b/.github/workflows/put-credit-validation.yml
@@ -22,12 +22,12 @@ concurrency:
   cancel-in-progress: false
 
 env:
-  # Paper validation floor (hard). Research preferred short-premium IVR remains 30;
-  # lean-premium entries are soft-flagged for stratified edge analysis.
-  # Evidence 2026-08-04..10: IVR proxy 8–29 blocked every 11:00 ET entry attempt.
-  # Paper validation floor only — research preferred remains 30 for edge claims.
-  # 10 froze entries for multi-day stretches when VIX percentile sat just under 10.
-  PUT_CREDIT_MIN_IVR: "5"
+  # Paper validation hard floor is VIX (crash veto), not IVR percentile.
+  # Research preferred short-premium IVR remains 30 for *edge claims*;
+  # lean-premium entries are soft-flagged and stratified later.
+  # Evidence 2026-08-04..10: IVR 8–29 blocked every 11:00 ET attempt.
+  # Evidence 2026-09-03: IVR 4.9 < min 5.0 froze the book while VIX was 14.61.
+  PUT_CREDIT_MIN_IVR: "0"
   PUT_CREDIT_RESEARCH_IVR: "30"
   PUT_CREDIT_MAX_VIX: "30"
 

--- a/rag_knowledge/lessons_learned/ll_pcs_factory_ghost_concurrent_and_ivr_floor_2026-09-03.md
+++ b/rag_knowledge/lessons_learned/ll_pcs_factory_ghost_concurrent_and_ivr_floor_2026-09-03.md
@@ -1,0 +1,32 @@
+# LL-566: Put-credit factory stalled on ghost concurrent + IVR paper floor
+
+**Date**: 2026-09-03
+**Severity**: HIGH (4)
+**Category**: Validation cadence / evidence honesty
+
+## What Happened
+
+Weekday `put-credit-validation.yml` was green while no new paper structures opened
+for 13 trading days. North Star income stayed 0%.
+
+1. 11:00 ET 2026-09-03 (run 33770724955): broker `pcs_legs=0` after a profit-target
+   exit, then `Concurrent put credits 2/2`. Journal still had `status=open` rows,
+   one with `exit_reason=broker_reconcile_flat`.
+2. 13:00 ET (run 33782397616): book flat, then `IV rank proxy 4.9 < min 5.0`
+   while VIX was 14.61 (under the crash veto of 30).
+3. `data/audit/grpo_quarantine_status.json` said 35 outcomes / 100% WR /
+   UNQUARANTINED because a unit test persisted to the repo path. Health check
+   correctly reported GRPO quarantined at 1/30 put-credit rows.
+
+## Lesson
+
+Green cron ≠ an entry. Concurrent occupancy is the live broker book, not the
+journal. Paper IVR percentile is a stratification label, not a freeze. Test
+fixtures must not write production audit files.
+
+## Prevention
+
+- `_is_active_entry` treats terminal exit reasons / `exit_filled_at` as inactive.
+- `evaluate_entry_limits(..., broker_open_structures=0)` cannot report 2/2.
+- `PUT_CREDIT_MIN_IVR=0`; research preferred IVR 30 remains a soft flag.
+- `GRPOUnquarantineGate(persist=False)` by default.

--- a/scripts/spy_put_credit.py
+++ b/scripts/spy_put_credit.py
@@ -41,6 +41,17 @@ CLOSED_ENTRY_STATES = {
     "rejected",
     "expired",
 }
+# Journal rows can stay status=open after the broker is already flat.
+# AGENT-566: 2026-09-03 11:00 ET run counted 2/2 concurrent while pcs_legs=0
+# because one "open" row had exit_reason=broker_reconcile_flat.
+TERMINAL_EXIT_REASONS = {
+    "broker_reconcile_flat",
+    "profit_target",
+    "stop_loss",
+    "time_exit",
+    "dte_exit",
+    "expired",
+}
 EASTERN = ZoneInfo("America/New_York")
 
 
@@ -83,6 +94,21 @@ def _inventory_ok(client: Any | None = None) -> bool:
     return True
 
 
+def _broker_open_pcs_structures(client: Any | None = None) -> int | None:
+    """Count live put-credit structures from broker legs (2 legs each). None if unverified."""
+
+    try:
+        from scripts.residual_ic_manager import manage_residual_ics
+
+        broker = client or _get_paper_client()
+        result = manage_residual_ics(broker, dry_run=True)
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("Could not count broker PCS structures: %s", exc)
+        return None
+    excluded = result.get("pcs_inventory_excluded") or {}
+    return max(0, len(excluded) // 2)
+
+
 def _get_paper_client():
     from src.utils.alpaca_client import get_alpaca_credentials
 
@@ -111,7 +137,13 @@ def _save_entries(entries: dict[str, dict[str, Any]]) -> None:
 
 
 def _is_active_entry(entry: dict[str, Any]) -> bool:
-    return str(entry.get("status") or "open").strip().lower() not in CLOSED_ENTRY_STATES
+    status = str(entry.get("status") or "open").strip().lower()
+    if status in CLOSED_ENTRY_STATES:
+        return False
+    reason = str(entry.get("exit_reason") or "").strip().lower()
+    if reason in TERMINAL_EXIT_REASONS:
+        return False
+    return not entry.get("exit_filled_at")
 
 
 def _parse_timestamp(value: Any) -> datetime | None:
@@ -132,12 +164,21 @@ def evaluate_entry_limits(
     *,
     candidate_signature: str | None = None,
     now: datetime | None = None,
+    broker_open_structures: int | None = None,
 ) -> dict[str, Any]:
-    """Enforce one new structure/day, concurrency, and signature uniqueness."""
+    """Enforce daily cap, concurrency, and signature uniqueness.
+
+    Concurrent occupancy is the live book, not ghost journal rows. When the
+    broker reports 0 put-credit structures, journal leftovers cannot fill the
+    2/2 slot (AGENT-566, 2026-09-03).
+    """
 
     profile = _load_profile()
     current = (now or datetime.now(UTC)).astimezone(EASTERN)
     active = {key: entry for key, entry in entries.items() if _is_active_entry(entry)}
+    occupancy = len(active)
+    if broker_open_structures is not None:
+        occupancy = min(occupancy, max(0, int(broker_open_structures)))
     today_count = 0
     for entry in entries.values():
         entry_dt = _parse_timestamp(entry.get("entry_time"))
@@ -145,8 +186,8 @@ def evaluate_entry_limits(
             today_count += 1
 
     blockers: list[str] = []
-    if len(active) >= profile.max_concurrent_positions:
-        blockers.append(f"Concurrent put credits {len(active)}/{profile.max_concurrent_positions}.")
+    if occupancy >= profile.max_concurrent_positions:
+        blockers.append(f"Concurrent put credits {occupancy}/{profile.max_concurrent_positions}.")
     if today_count >= profile.max_daily_structures:
         blockers.append(f"Daily put-credit limit {today_count}/{profile.max_daily_structures}.")
     if candidate_signature and any(
@@ -157,7 +198,9 @@ def evaluate_entry_limits(
     return {
         "allowed": not blockers,
         "blockers": blockers,
-        "active_count": len(active),
+        "active_count": occupancy,
+        "journal_active_count": len(active),
+        "broker_open_structures": broker_open_structures,
         "today_count": today_count,
         "max_concurrent": profile.max_concurrent_positions,
         "max_daily": profile.max_daily_structures,
@@ -1442,7 +1485,8 @@ def main() -> int:
     if not _inventory_ok():
         return 2
 
-    limit_report = evaluate_entry_limits(_load_entries())
+    broker_n = _broker_open_pcs_structures()
+    limit_report = evaluate_entry_limits(_load_entries(), broker_open_structures=broker_n)
     if not limit_report["allowed"]:
         logger.error("PUT-CREDIT ENTRY LIMIT: %s", " | ".join(limit_report["blockers"]))
         print(json.dumps(limit_report, indent=2))
@@ -1507,7 +1551,11 @@ def main() -> int:
         return 1
 
     signature = f"SPY_{opp['expiry']}_P{int(opp['long_put'])}-{int(opp['short_put'])}"
-    limit_report = evaluate_entry_limits(_load_entries(), candidate_signature=signature)
+    limit_report = evaluate_entry_limits(
+        _load_entries(),
+        candidate_signature=signature,
+        broker_open_structures=broker_n,
+    )
     if not limit_report["allowed"]:
         logger.error("PUT-CREDIT ENTRY LIMIT: %s", " | ".join(limit_report["blockers"]))
         print(json.dumps(limit_report, indent=2))
@@ -1568,7 +1616,11 @@ def main() -> int:
                 )
                 return 2
             opp["regime"] = regime_snap2.as_dict()
-            limit_report = evaluate_entry_limits(_load_entries(), candidate_signature=signature)
+            limit_report = evaluate_entry_limits(
+                _load_entries(),
+                candidate_signature=signature,
+                broker_open_structures=_broker_open_pcs_structures(client),
+            )
             if not limit_report["allowed"]:
                 logger.error(
                     "PUT-CREDIT ENTRY LIMIT after lock: %s",

--- a/src/ml/grpo_unquarantine_gate.py
+++ b/src/ml/grpo_unquarantine_gate.py
@@ -32,9 +32,18 @@ class GRPOQuarantineStatus:
 class GRPOUnquarantineGate:
     """Manages ML model quarantine state based on verified trade cohorts."""
 
-    def __init__(self, required_outcomes: int = 30, min_win_rate_pct: float = 75.0):
+    def __init__(
+        self,
+        required_outcomes: int = 30,
+        min_win_rate_pct: float = 75.0,
+        *,
+        status_file: Path | None = None,
+        persist: bool = False,
+    ):
         self.required_outcomes = required_outcomes
         self.min_win_rate_pct = min_win_rate_pct
+        self.status_file = status_file or STATUS_FILE
+        self.persist = persist
 
     def check_status(
         self, cohort_outcomes: list[dict[str, Any]] | None = None
@@ -43,13 +52,15 @@ class GRPOUnquarantineGate:
         count = len(outcomes)
 
         if count == 0:
-            return GRPOQuarantineStatus(
+            status = GRPOQuarantineStatus(
                 total_verified_outcomes=0,
                 required_outcomes=self.required_outcomes,
                 win_rate_pct=0.0,
                 is_quarantined=True,
                 status_message=f"Quarantined: 0/{self.required_outcomes} verified outcomes logged",
             )
+            self._maybe_persist(status)
+            return status
 
         wins = sum(1 for o in outcomes if o.get("profit_usd", 0.0) > 0.0 or o.get("won", False))
         win_rate = round((wins / count) * 100.0, 2)
@@ -65,9 +76,15 @@ class GRPOUnquarantineGate:
         )
 
         if is_quarantined:
-            msg = f"Quarantined: {count}/{self.required_outcomes} verified outcomes (Win Rate: {win_rate}%)"
+            msg = (
+                f"Quarantined: {count}/{self.required_outcomes} verified outcomes "
+                f"(Win Rate: {win_rate}%)"
+            )
         else:
-            msg = f"UNQUARANTINED: {count} verified outcomes pass safety thresholds (Win Rate: {win_rate}%)"
+            msg = (
+                f"UNQUARANTINED: {count} verified outcomes pass safety thresholds "
+                f"(Win Rate: {win_rate}%)"
+            )
 
         status = GRPOQuarantineStatus(
             total_verified_outcomes=count,
@@ -76,9 +93,12 @@ class GRPOUnquarantineGate:
             is_quarantined=is_quarantined,
             status_message=msg,
         )
-
-        STATUS_FILE.parent.mkdir(parents=True, exist_ok=True)
-        with STATUS_FILE.open("w", encoding="utf-8") as h:
-            json.dump(asdict(status), h, indent=2)
-
+        self._maybe_persist(status)
         return status
+
+    def _maybe_persist(self, status: GRPOQuarantineStatus) -> None:
+        if not self.persist:
+            return
+        self.status_file.parent.mkdir(parents=True, exist_ok=True)
+        with self.status_file.open("w", encoding="utf-8") as handle:
+            json.dump(asdict(status), handle, indent=2)

--- a/src/risk/put_credit_regime.py
+++ b/src/risk/put_credit_regime.py
@@ -135,9 +135,10 @@ def capture_regime_snapshot(spy_price: float | None = None) -> RegimeSnapshot:
         try:
             from src.options.vix_monitor import VIXMonitor
 
-            pct = float(VIXMonitor().get_vix_percentile(252))
-            ivr = pct
-            ivr_method = "vix_percentile_252"
+            pct = VIXMonitor().get_vix_percentile(252, default=None)
+            if pct is not None:
+                ivr = float(pct)
+                ivr_method = "vix_percentile_252"
         except Exception as exc:  # noqa: BLE001
             errors.append(f"vix_percentile:{exc}")
 
@@ -198,11 +199,13 @@ def evaluate_regime_gate(
 
     if ivr is None:
         msg = "IV rank proxy unavailable for regime gate"
-        if fail_closed_on_missing:
+        # Paper floor 0: VIX is the hard crash veto; missing IVR is a soft flag
+        # so n→30 is not frozen on a percentile gap (AGENT-566).
+        if fail_closed_on_missing and float(min_iv_rank) > 0:
             blockers.append(msg)
         else:
             soft.append(msg)
-    elif float(ivr) < float(min_iv_rank):
+    elif float(min_iv_rank) > 0 and float(ivr) < float(min_iv_rank):
         blockers.append(
             f"IV rank proxy {float(ivr):.1f} < min {float(min_iv_rank):.1f} (short-premium filter)"
         )

--- a/tests/test_active_strategy.py
+++ b/tests/test_active_strategy.py
@@ -666,6 +666,35 @@ def test_put_credit_entry_limits_enforce_daily_concurrent_and_signature():
     assert any("Concurrent" in blocker for blocker in report["blockers"])
 
 
+def test_put_credit_ghost_journal_is_not_concurrent_occupancy():
+    """AGENT-566: status=open + broker_reconcile_flat must not fill the 2/2 slot."""
+    from scripts import spy_put_credit as pcs
+
+    now = datetime(2026, 9, 3, 15, 9, tzinfo=UTC)
+    entries = {
+        "PCS_flat": {
+            "status": "open",
+            "exit_reason": "broker_reconcile_flat",
+            "entry_time": "2026-08-11T15:23:00+00:00",
+            "signature": "SPY_2026-09-25_P737-742",
+        },
+        "PCS_open": {
+            "status": "open",
+            "entry_time": "2026-08-17T17:13:25+00:00",
+            "signature": "SPY_2026-09-25_P735-740",
+        },
+    }
+    report = pcs.evaluate_entry_limits(entries, now=now)
+    assert report["journal_active_count"] == 1
+    assert report["active_count"] == 1
+    assert report["allowed"] is True
+
+    flat_book = pcs.evaluate_entry_limits(entries, now=now, broker_open_structures=0)
+    assert flat_book["active_count"] == 0
+    assert flat_book["allowed"] is True
+    assert flat_book["broker_open_structures"] == 0
+
+
 def test_put_credit_exit_rules_cover_profit_stop_hold_and_dte():
     from scripts import spy_put_credit as pcs
 

--- a/tests/test_grpo_unquarantine_gate.py
+++ b/tests/test_grpo_unquarantine_gate.py
@@ -11,8 +11,13 @@ def test_grpo_quarantine_default():
     assert "Quarantined" in status.status_message
 
 
-def test_grpo_unquarantine_transition():
-    gate = GRPOUnquarantineGate(required_outcomes=30, min_win_rate_pct=75.0)
+def test_grpo_unquarantine_transition(tmp_path):
+    gate = GRPOUnquarantineGate(
+        required_outcomes=30,
+        min_win_rate_pct=75.0,
+        status_file=tmp_path / "grpo_quarantine_status.json",
+        persist=False,
+    )
     # Generate 35 winning outcomes
     outcomes = [{"profit_usd": 50.0, "behavior_prob": 0.8} for _ in range(35)]
     status = gate.check_status(outcomes)
@@ -21,6 +26,7 @@ def test_grpo_unquarantine_transition():
     assert status.total_verified_outcomes == 35
     assert status.win_rate_pct == 100.0
     assert "UNQUARANTINED" in status.status_message
+    assert not (tmp_path / "grpo_quarantine_status.json").exists()
 
 
 def test_llm_gateway_status():

--- a/tests/test_put_credit_regime.py
+++ b/tests/test_put_credit_regime.py
@@ -57,6 +57,14 @@ def test_regime_still_blocks_below_paper_floor():
     assert any("IV rank" in b for b in gate["blockers"])
 
 
+def test_regime_paper_floor_zero_soft_flags_low_ivr():
+    """AGENT-566: paper MIN_IVR=0 must not freeze on VIX-percentile 4.9 when VIX=14.61."""
+    gate = evaluate_regime_gate(_snap(vix=14.61, iv_rank_proxy=4.9), min_iv_rank=0.0)
+    assert gate["allowed"] is True
+    assert gate["blockers"] == []
+    assert any("research preferred" in f for f in gate["soft_flags"])
+
+
 def test_regime_missing_vix_fail_closed():
     gate = evaluate_regime_gate(_snap(vix=None), fail_closed_on_missing=True)
     assert gate["allowed"] is False


### PR DESCRIPTION
# Pull request

## Work item

- Linear issue: AGENT-566
- Agent: grok
- Base SHA: 583bd07935e95ed35b096c57299ebcd84530c6d7
- Branch/worktree: `fix/AGENT-566-pcs-factory-unblock` / `.worktrees/agent-566-pcs-factory`
- Files or systems claimed: `scripts/spy_put_credit.py`, `.github/workflows/put-credit-validation.yml`, `src/risk/put_credit_regime.py`, `src/ml/grpo_unquarantine_gate.py`, `tests/test_active_strategy.py`, `tests/test_put_credit_regime.py`, `tests/test_grpo_unquarantine_gate.py`, `rag_knowledge/lessons_learned`
- Coordination legacy reason: n/a — new work with Linear claim + isolated worktree

## Change

- Scope: Paper validation factory was green while opening zero new structures. Two false gates: (1) journal `status=open` + `exit_reason=broker_reconcile_flat` counted as 2/2 concurrent while broker `pcs_legs=0` (2026-09-03 run 33770724955); (2) IVR percentile 4.9 < paper floor 5.0 while VIX was 14.61 (run 33782397616). Concurrent occupancy now follows live PCS structures; paper `PUT_CREDIT_MIN_IVR=0` with research 30 as a soft flag; GRPO quarantine tests no longer persist a fake 35-win audit file.
- Deleted surfaces and recovery impact: none
- Out of scope: live capital, IC revival, claiming put-credit edge (n=3)

## Verification

- [x] Targeted tests: 18 passed (`test_put_credit_ghost_journal_is_not_concurrent_occupancy`, regime paper-floor-zero, GRPO persist=false)
- [ ] `make check` (worktree has no local `.venv`; CI on this head)
- [x] RAG lesson added (not a retriever change)
- [ ] Orchestration smoke test when orchestration changes
- [ ] `TRADING_ENV=paper make dry-run` when operational paths change
- [ ] CI green on this exact head SHA

## Evidence boundaries

- Test result: 18 passed locally via primary `.venv` with `PYTHONPATH` = this worktree
- CI run: pending this PR
- Protected-system result: no halt flags touched
- Broker/order/fill impact: none in this PR (entry path gates only; next scheduled paper run can submit if inventory is clean)

## Coordination

- [x] Linear issue and vault claim updated
- [x] No overlapping active claim or worktree
- [ ] Claim will be marked done or released after merge


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Entry limits now reflect live broker positions, preventing closed or reconciled trades from incorrectly blocking new entries.
  - Missing or low IV-rank data no longer blocks paper entries when the configured minimum is zero; it is reported as a research preference instead.
  - VIX percentile fallback handling now avoids treating unavailable data as a valid value.

- **Improvements**
  - Quarantine status files are no longer written automatically unless persistence is explicitly enabled.
  - Added regression coverage for broker reconciliation, IV-rank handling, and quarantine status behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->