### PR TITLE
fix(AGENT-567): keep Mercury trading-readonly token alive

### DIFF
--- a/.github/workflows/mercury-readonly-heartbeat.yml
+++ b/.github/workflows/mercury-readonly-heartbeat.yml
@@ -1,0 +1,53 @@
+name: Mercury Read-Only Heartbeat
+
+# Keep the Max Smith KDP LLC trading-readonly API token alive (Mercury deletes
+# unused tokens after 45 days; emailed 2026-09-02 after 38 idle days).
+# GET /accounts only. Never ACH. Mercury cash is not Alpaca buying power.
+
+on:
+  schedule:
+    # Every 3 days at 11:17 UTC — well inside the 45-day unused window.
+    - cron: 17 11 */3 * *
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: mercury-readonly-heartbeat
+  cancel-in-progress: false
+
+jobs:
+  heartbeat:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
+        with:
+          python-version: "3.11"
+          cache: pip
+
+      - name: Install deps
+        run: pip install requests
+
+      - name: GET /accounts (read-only token keep-alive)
+        env:
+          MERCURY_API_TOKEN: ${{ secrets.MERCURY_API_TOKEN }}
+        run: |
+          if [ -z "${MERCURY_API_TOKEN}" ]; then
+            echo "::error::MERCURY_API_TOKEN GitHub secret is empty. Store the trading-readonly token so Mercury does not delete it."
+            exit 1
+          fi
+          python3 scripts/mercury_cli.py heartbeat --json
+          python3 -c "
+          import json
+          from pathlib import Path
+          p = Path('data/audit/mercury_readonly_heartbeat.json')
+          receipt = json.loads(p.read_text())
+          assert receipt['ok'] is True
+          assert receipt['read_only'] is True
+          assert receipt['capital_boundary']['not_alpaca_buying_power'] is True
+          print('heartbeat_ok accounts', receipt['account_count'])
+          "

--- a/.github/workflows/mercury-readonly-heartbeat.yml
+++ b/.github/workflows/mercury-readonly-heartbeat.yml
@@ -49,5 +49,5 @@ jobs:
           assert receipt['ok'] is True
           assert receipt['read_only'] is True
           assert receipt['capital_boundary']['not_alpaca_buying_power'] is True
-          print('heartbeat_ok accounts', receipt['account_count'])
+          print('heartbeat_ok')
           "

--- a/rag_knowledge/lessons_learned/ll_mercury_readonly_token_unused_2026-09-03.md
+++ b/rag_knowledge/lessons_learned/ll_mercury_readonly_token_unused_2026-09-03.md
@@ -10,7 +10,7 @@ Mercury emailed 2026-09-02 that Max Smith KDP LLC API token nickname
 `trading-readonly` will be deleted in 7 days after 38 days with no API
 activity. `~/.resume_secrets/mercury.json` was missing. The trading GitHub
 repo had no `MERCURY_API_TOKEN` secret. No scheduled GET heartbeat existed.
-`autonomous-money-cycle.yml` runs a paper Mercury income *simulation* and
+`autonomous-money-cycle.yml` runs a paper Mercury income _simulation_ and
 never calls the real bank API.
 
 Official keep-alive is GET `https://api.mercury.com/api/v1/accounts`.

--- a/rag_knowledge/lessons_learned/ll_mercury_readonly_token_unused_2026-09-03.md
+++ b/rag_knowledge/lessons_learned/ll_mercury_readonly_token_unused_2026-09-03.md
@@ -1,0 +1,35 @@
+# LL-567: Mercury trading-readonly token unused 38 days
+
+**Date**: 2026-09-03
+**Severity**: HIGH (4)
+**Category**: Investing cash-truth / credential hygiene
+
+## What Happened
+
+Mercury emailed 2026-09-02 that Max Smith KDP LLC API token nickname
+`trading-readonly` will be deleted in 7 days after 38 days with no API
+activity. `~/.resume_secrets/mercury.json` was missing. The trading GitHub
+repo had no `MERCURY_API_TOKEN` secret. No scheduled GET heartbeat existed.
+`autonomous-money-cycle.yml` runs a paper Mercury income *simulation* and
+never calls the real bank API.
+
+Official keep-alive is GET `https://api.mercury.com/api/v1/accounts`.
+Dashboard login for minting/copying the token is passkey + Android TOTP
+(SM-S931U1). The token value is not retrievable after creation.
+
+## Lesson
+
+Read-only Mercury is the LLC investing cash ledger. Alpaca paper equity is a
+different account. A token that is never GET-called is deleted. Live ACH
+must stay behind `MERCURY_LIVE_TRANSFERS_ENABLED=1`. Do not treat Mercury
+cash as Alpaca buying power.
+
+## Prevention
+
+- `scripts/mercury_cli.py heartbeat` issues GET `/accounts` and writes a
+  masked receipt that asserts `not_alpaca_buying_power`.
+- `.github/workflows/mercury-readonly-heartbeat.yml` every 3 days (fail-closed
+  if `secrets.MERCURY_API_TOKEN` is empty).
+- Token resolution: env, then Keychain `hermes-fleet`/`MERCURY_API_TOKEN`,
+  then the chmod 600 vault file.
+- Tests freeze the official `api.mercury.com` host and GET-only workflow.

--- a/rag_knowledge/lessons_learned/ll_mercury_readonly_token_unused_2026-09-03.md
+++ b/rag_knowledge/lessons_learned/ll_mercury_readonly_token_unused_2026-09-03.md
@@ -27,9 +27,11 @@ cash as Alpaca buying power.
 ## Prevention
 
 - `scripts/mercury_cli.py heartbeat` issues GET `/accounts` and writes a
-  masked receipt that asserts `not_alpaca_buying_power`.
+  masked receipt that asserts `not_alpaca_buying_power`. Heartbeat stdout
+  (including `--json` for Actions) omits cash and account counts; those stay
+  in the gitignored local receipt only.
 - `.github/workflows/mercury-readonly-heartbeat.yml` every 3 days (fail-closed
-  if `secrets.MERCURY_API_TOKEN` is empty).
+  if `secrets.MERCURY_API_TOKEN` is empty). The job prints `heartbeat_ok` only.
 - Token resolution: env, then Keychain `hermes-fleet`/`MERCURY_API_TOKEN`,
   then the chmod 600 vault file.
 - Tests freeze the official `api.mercury.com` host and GET-only workflow.

--- a/scripts/mercury_cli.py
+++ b/scripts/mercury_cli.py
@@ -107,14 +107,24 @@ def cmd_heartbeat(client: MercuryReadOnlyClient, args: argparse.Namespace) -> No
     }
     args.receipt_path.parent.mkdir(parents=True, exist_ok=True)
     args.receipt_path.write_text(json.dumps(receipt, indent=2) + "\n", encoding="utf-8")
+    # CI/Actions stdout must not include cash or account metadata (Greptile P1).
+    public = {
+        "generated_at": receipt["generated_at"],
+        "ok": True,
+        "read_only": True,
+        "keep_alive": True,
+        "token_nickname": receipt["token_nickname"],
+        "keep_alive_path": "/accounts",
+        "capital_boundary": receipt["capital_boundary"],
+        "note": receipt["note"],
+        "receipt_written": True,
+    }
     if args.json:
-        print(json.dumps(receipt, indent=2))
+        print(json.dumps(public, indent=2))
         return
     print(
-        "✅ Mercury read-only heartbeat: "
-        f"{receipt['account_count']} accounts, "
-        f"${receipt['total_available_usd']:,.2f} available "
-        f"(not Alpaca) -> {args.receipt_path}"
+        "✅ Mercury read-only heartbeat ok (not Alpaca; cash stays off stdout) "
+        f"-> {args.receipt_path}"
     )
 
 

--- a/scripts/mercury_cli.py
+++ b/scripts/mercury_cli.py
@@ -6,6 +6,7 @@ Subcommands:
   transactions   Recent transactions for one account
   sync           Write a masked snapshot to data/mercury_state.json
   health         Exit 0 if the Mercury API is reachable with the vault token
+  heartbeat      GET /accounts to keep trading-readonly alive; write audit receipt
 
 All commands are read-only by construction (MercuryReadOnlyClient is GET-only).
 Money movement stays behind MercuryBankAdapter's MERCURY_LIVE_TRANSFERS_ENABLED
@@ -16,6 +17,7 @@ Examples:
   .venv/bin/python scripts/mercury_cli.py transactions --account savings --limit 10
   .venv/bin/python scripts/mercury_cli.py sync
   .venv/bin/python scripts/mercury_cli.py health
+  .venv/bin/python scripts/mercury_cli.py heartbeat
 """
 
 from __future__ import annotations
@@ -32,6 +34,7 @@ if str(ROOT) not in sys.path:
 from src.adapters.mercury_readonly import MercuryReadOnlyClient  # noqa: E402
 
 DEFAULT_STATE_PATH = ROOT / "data" / "mercury_state.json"
+DEFAULT_HEARTBEAT_PATH = ROOT / "data" / "audit" / "mercury_readonly_heartbeat.json"
 
 
 def cmd_accounts(client: MercuryReadOnlyClient, args: argparse.Namespace) -> None:
@@ -81,6 +84,40 @@ def cmd_health(client: MercuryReadOnlyClient, args: argparse.Namespace) -> None:
     print(f"✅ Mercury API reachable: {len(accounts)} accounts ({active} active)")
 
 
+def cmd_heartbeat(client: MercuryReadOnlyClient, args: argparse.Namespace) -> None:
+    """Ping GET /accounts so Mercury does not delete unused read-only tokens.
+
+    Mercury deletes tokens unused for 45 days and emails 7 days prior
+    (trading-readonly unused 38 days as of 2026-09-02). This call is GET-only.
+    """
+    from datetime import UTC, datetime
+
+    from src.adapters.mercury_readonly import INVESTING_CAPITAL_BOUNDARY
+
+    snapshot = client.snapshot()
+    receipt = {
+        "generated_at": datetime.now(UTC).isoformat(),
+        "ok": True,
+        "read_only": True,
+        "token_nickname": "trading-readonly",
+        "account_count": len(snapshot["accounts"]),
+        "total_available_usd": snapshot["total_available_usd"],
+        "capital_boundary": snapshot.get("capital_boundary") or dict(INVESTING_CAPITAL_BOUNDARY),
+        "note": "Mercury LLC cash is not Alpaca buying power. Live ACH is not enabled.",
+    }
+    args.receipt_path.parent.mkdir(parents=True, exist_ok=True)
+    args.receipt_path.write_text(json.dumps(receipt, indent=2) + "\n", encoding="utf-8")
+    if args.json:
+        print(json.dumps(receipt, indent=2))
+        return
+    print(
+        "✅ Mercury read-only heartbeat: "
+        f"{receipt['account_count']} accounts, "
+        f"${receipt['total_available_usd']:,.2f} available "
+        f"(not Alpaca) -> {args.receipt_path}"
+    )
+
+
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description=__doc__)
     sub = parser.add_subparsers(dest="command", required=True)
@@ -101,6 +138,14 @@ def build_parser() -> argparse.ArgumentParser:
 
     p_health = sub.add_parser("health", help="Exit 0 if Mercury API is reachable")
     p_health.set_defaults(func=cmd_health)
+
+    p_hb = sub.add_parser(
+        "heartbeat",
+        help="GET /accounts to keep trading-readonly token alive",
+    )
+    p_hb.add_argument("--json", action="store_true")
+    p_hb.add_argument("--receipt-path", type=Path, default=DEFAULT_HEARTBEAT_PATH)
+    p_hb.set_defaults(func=cmd_heartbeat)
 
     return parser
 

--- a/scripts/mercury_cli.py
+++ b/scripts/mercury_cli.py
@@ -99,7 +99,7 @@ def cmd_heartbeat(client: MercuryReadOnlyClient, args: argparse.Namespace) -> No
         "generated_at": datetime.now(UTC).isoformat(),
         "ok": True,
         "read_only": True,
-        "token_nickname": "trading-readonly",
+        "token_nickname": "trading-readonly",  # nosec B105 — public nickname, not a secret
         "account_count": len(snapshot["accounts"]),
         "total_available_usd": snapshot["total_available_usd"],
         "capital_boundary": (snapshot.get("capital_boundary") or dict(INVESTING_CAPITAL_BOUNDARY)),

--- a/scripts/mercury_cli.py
+++ b/scripts/mercury_cli.py
@@ -102,7 +102,7 @@ def cmd_heartbeat(client: MercuryReadOnlyClient, args: argparse.Namespace) -> No
         "token_nickname": "trading-readonly",
         "account_count": len(snapshot["accounts"]),
         "total_available_usd": snapshot["total_available_usd"],
-        "capital_boundary": snapshot.get("capital_boundary") or dict(INVESTING_CAPITAL_BOUNDARY),
+        "capital_boundary": (snapshot.get("capital_boundary") or dict(INVESTING_CAPITAL_BOUNDARY)),
         "note": "Mercury LLC cash is not Alpaca buying power. Live ACH is not enabled.",
     }
     args.receipt_path.parent.mkdir(parents=True, exist_ok=True)

--- a/src/adapters/mercury_readonly.py
+++ b/src/adapters/mercury_readonly.py
@@ -27,7 +27,7 @@ from __future__ import annotations
 
 import json
 import os
-import subprocess
+import subprocess  # nosec B404 — Keychain CLI bridge only
 from collections.abc import Callable
 from datetime import UTC, datetime
 from pathlib import Path
@@ -50,8 +50,8 @@ INVESTING_CAPITAL_BOUNDARY = {
     "mercury_is_llc_bank": True,
     "not_alpaca_buying_power": True,
     "live_ach_requires": "MERCURY_LIVE_TRANSFERS_ENABLED=1",
-    "token_scope": "read_only",
-    "token_nickname": "trading-readonly",
+    "token_scope": "read_only",  # nosec B105 — scope label, not a credential
+    "token_nickname": "trading-readonly",  # nosec B105 — public nickname, not a secret
     "official_api_base": "https://api.mercury.com/api/v1",
     "keep_alive_path": "/accounts",
     "unused_deletion_days": 45,
@@ -83,7 +83,7 @@ def _keychain_token() -> str | None:
     """Read MERCURY_API_TOKEN from macOS Keychain. Never logs the secret."""
     for account, service in KEYCHAIN_LOOKUPS:
         try:
-            result = subprocess.run(
+            result = subprocess.run(  # nosec B603 — absolute binary + fixed argv
                 [
                     "/usr/bin/security",
                     "find-generic-password",

--- a/src/adapters/mercury_readonly.py
+++ b/src/adapters/mercury_readonly.py
@@ -9,17 +9,25 @@ hard stop (src/adapters/bank_adapter.py).
 
 Token resolution order:
   1. MERCURY_API_TOKEN environment variable
-  2. Vault file (MERCURY_SECRETS_PATH env override, default
+  2. macOS Keychain (account hermes-fleet, service MERCURY_API_TOKEN)
+  3. Vault file (MERCURY_SECRETS_PATH env override, default
      ~/.resume_secrets/mercury.json) under the "MERCURY_API_TOKEN" or legacy
      "api_token" key
 
 The token value is never logged, printed, or included in any return value.
+
+Mercury LLC cash is not Alpaca buying power. This client is the investing
+cash-truth seam (read-only). Live ACH stays behind MERCURY_LIVE_TRANSFERS_ENABLED=1.
+
+Official keep-alive (docs.mercury.com): GET https://api.mercury.com/api/v1/accounts
+with the token. Unused tokens are deleted after 45 days.
 """
 
 from __future__ import annotations
 
 import json
 import os
+import subprocess
 from collections.abc import Callable
 from datetime import UTC, datetime
 from pathlib import Path
@@ -31,6 +39,22 @@ DEFAULT_VAULT_PATH = Path.home() / ".resume_secrets" / "mercury.json"
 ACCOUNT_ALIAS_KEYS = {
     "checking": "MERCURY_ACCOUNT_ID",
     "savings": "MERCURY_SAVINGS_ACCOUNT_ID",
+}
+
+KEYCHAIN_LOOKUPS = (
+    ("hermes-fleet", "MERCURY_API_TOKEN"),
+    ("trading-readonly", "mercury.api"),
+)
+
+INVESTING_CAPITAL_BOUNDARY = {
+    "mercury_is_llc_bank": True,
+    "not_alpaca_buying_power": True,
+    "live_ach_requires": "MERCURY_LIVE_TRANSFERS_ENABLED=1",
+    "token_scope": "read_only",
+    "token_nickname": "trading-readonly",
+    "official_api_base": "https://api.mercury.com/api/v1",
+    "keep_alive_path": "/accounts",
+    "unused_deletion_days": 45,
 }
 
 HttpGet = Callable[[str, dict[str, Any], dict[str, str]], dict[str, Any]]
@@ -55,10 +79,41 @@ def _load_vault(secrets_path: Path | None = None) -> dict[str, Any]:
         return {}
 
 
+def _keychain_token() -> str | None:
+    """Read MERCURY_API_TOKEN from macOS Keychain. Never logs the secret."""
+    for account, service in KEYCHAIN_LOOKUPS:
+        try:
+            result = subprocess.run(
+                [
+                    "/usr/bin/security",
+                    "find-generic-password",
+                    "-a",
+                    account,
+                    "-s",
+                    service,
+                    "-w",
+                ],
+                capture_output=True,
+                text=True,
+                check=False,
+                timeout=5,
+            )
+        except (OSError, subprocess.TimeoutExpired):
+            continue
+        if result.returncode == 0:
+            token = (result.stdout or "").rstrip("\n")
+            if token:
+                return token
+    return None
+
+
 def resolve_token(secrets_path: Path | None = None) -> str | None:
     token = os.environ.get("MERCURY_API_TOKEN")
     if token:
         return token
+    keychain = _keychain_token()
+    if keychain:
+        return keychain
     vault = _load_vault(secrets_path)
     return vault.get("MERCURY_API_TOKEN") or vault.get("api_token")
 
@@ -178,4 +233,5 @@ class MercuryReadOnlyClient:
             "read_only": True,
             "accounts": accounts,
             "total_available_usd": total,
+            "capital_boundary": dict(INVESTING_CAPITAL_BOUNDARY),
         }

--- a/tests/test_mercury_cli.py
+++ b/tests/test_mercury_cli.py
@@ -97,7 +97,9 @@ class TestCommands:
         assert _run(["health"], _fake_client(ACCOUNTS_RESPONSE), monkeypatch) == 0
         assert "2 accounts" not in capsys.readouterr().out  # exactly one account in fixture
 
-    def test_heartbeat_writes_receipt_and_does_not_claim_alpaca(self, tmp_path, capsys, monkeypatch):
+    def test_heartbeat_writes_receipt_and_does_not_claim_alpaca(
+        self, tmp_path, capsys, monkeypatch
+    ):
         receipt = tmp_path / "mercury_readonly_heartbeat.json"
         code = _run(
             ["heartbeat", "--receipt-path", str(receipt)],
@@ -126,7 +128,9 @@ class TestCommands:
         payload = json.loads(capsys.readouterr().out)
         assert payload["ok"] is True
         assert payload["read_only"] is True
-        assert payload["capital_boundary"]["live_ach_requires"] == "MERCURY_LIVE_TRANSFERS_ENABLED=1"
+        assert (
+            payload["capital_boundary"]["live_ach_requires"] == "MERCURY_LIVE_TRANSFERS_ENABLED=1"
+        )
         dumped = json.dumps(payload)
         assert "Bearer tok" not in dumped
         assert "secret-token" not in dumped

--- a/tests/test_mercury_cli.py
+++ b/tests/test_mercury_cli.py
@@ -56,6 +56,8 @@ class TestCommands:
         payload = json.loads(capsys.readouterr().out)
         assert payload["read_only"] is True
         assert payload["total_available_usd"] == 10.0
+        assert payload["capital_boundary"]["not_alpaca_buying_power"] is True
+        assert payload["capital_boundary"]["token_nickname"] == "trading-readonly"
 
     def test_transactions_table(self, capsys, monkeypatch):
         code = _run(
@@ -95,6 +97,41 @@ class TestCommands:
         assert _run(["health"], _fake_client(ACCOUNTS_RESPONSE), monkeypatch) == 0
         assert "2 accounts" not in capsys.readouterr().out  # exactly one account in fixture
 
+    def test_heartbeat_writes_receipt_and_does_not_claim_alpaca(self, tmp_path, capsys, monkeypatch):
+        receipt = tmp_path / "mercury_readonly_heartbeat.json"
+        code = _run(
+            ["heartbeat", "--receipt-path", str(receipt)],
+            _fake_client(ACCOUNTS_RESPONSE),
+            monkeypatch,
+        )
+        assert code == 0
+        payload = json.loads(receipt.read_text(encoding="utf-8"))
+        assert payload["ok"] is True
+        assert payload["read_only"] is True
+        assert payload["account_count"] == 1
+        assert payload["capital_boundary"]["not_alpaca_buying_power"] is True
+        out = capsys.readouterr().out
+        assert "not Alpaca" in out
+        assert "123456787725" not in out
+        assert "secret-token" not in out
+
+    def test_heartbeat_json_stdout_masks_and_keeps_ach_off(self, tmp_path, capsys, monkeypatch):
+        receipt = tmp_path / "mercury_readonly_heartbeat.json"
+        code = _run(
+            ["heartbeat", "--json", "--receipt-path", str(receipt)],
+            _fake_client(ACCOUNTS_RESPONSE),
+            monkeypatch,
+        )
+        assert code == 0
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["ok"] is True
+        assert payload["read_only"] is True
+        assert payload["capital_boundary"]["live_ach_requires"] == "MERCURY_LIVE_TRANSFERS_ENABLED=1"
+        dumped = json.dumps(payload)
+        assert "Bearer tok" not in dumped
+        assert "secret-token" not in dumped
+        assert payload.get("token") is None
+
 
 class TestFailurePaths:
     def test_missing_credentials_exits_1(self, capsys, monkeypatch):
@@ -122,3 +159,21 @@ class TestParser:
     def test_requires_subcommand(self):
         with pytest.raises(SystemExit):
             mercury_cli.build_parser().parse_args([])
+
+
+class TestHeartbeatWorkflowContract:
+    """Prevention: the keep-alive job must stay GET-only and must not enable ACH."""
+
+    def test_workflow_is_get_only_and_not_alpaca(self):
+        from pathlib import Path
+
+        root = Path(__file__).resolve().parents[1]
+        text = (root / ".github/workflows/mercury-readonly-heartbeat.yml").read_text(
+            encoding="utf-8"
+        )
+        assert "python3 scripts/mercury_cli.py heartbeat --json" in text
+        assert "cron: 17 11 */3 * *" in text
+        assert "MERCURY_LIVE_TRANSFERS_ENABLED" not in text
+        assert "send_to_broker" not in text
+        assert "not_alpaca_buying_power" in text
+        assert "secrets.MERCURY_API_TOKEN" in text

--- a/tests/test_mercury_cli.py
+++ b/tests/test_mercury_cli.py
@@ -116,6 +116,8 @@ class TestCommands:
         assert "not Alpaca" in out
         assert "123456787725" not in out
         assert "secret-token" not in out
+        assert "$10.00" not in out
+        assert "1 accounts" not in out
 
     def test_heartbeat_json_stdout_masks_and_keeps_ach_off(self, tmp_path, capsys, monkeypatch):
         receipt = tmp_path / "mercury_readonly_heartbeat.json"
@@ -128,6 +130,7 @@ class TestCommands:
         payload = json.loads(capsys.readouterr().out)
         assert payload["ok"] is True
         assert payload["read_only"] is True
+        assert payload["keep_alive"] is True
         assert (
             payload["capital_boundary"]["live_ach_requires"] == "MERCURY_LIVE_TRANSFERS_ENABLED=1"
         )
@@ -135,6 +138,11 @@ class TestCommands:
         assert "Bearer tok" not in dumped
         assert "secret-token" not in dumped
         assert payload.get("token") is None
+        assert "account_count" not in payload
+        assert "total_available_usd" not in payload
+        file_receipt = json.loads(receipt.read_text(encoding="utf-8"))
+        assert file_receipt["account_count"] == 1
+        assert file_receipt["total_available_usd"] == 10.0
 
 
 class TestFailurePaths:
@@ -181,3 +189,6 @@ class TestHeartbeatWorkflowContract:
         assert "send_to_broker" not in text
         assert "not_alpaca_buying_power" in text
         assert "secrets.MERCURY_API_TOKEN" in text
+        assert "print('heartbeat_ok')" in text
+        assert "account_count" not in text
+        assert "total_available_usd" not in text

--- a/tests/test_mercury_readonly.py
+++ b/tests/test_mercury_readonly.py
@@ -12,10 +12,22 @@ from src.adapters.mercury_readonly import (
 
 @pytest.fixture
 def clean_env(monkeypatch, tmp_path):
-    """Isolate tests from the real env vars and the real vault file."""
+    """Isolate tests from the real env vars, Keychain, and vault file."""
     for key in ("MERCURY_API_TOKEN", "MERCURY_ACCOUNT_ID", "MERCURY_SAVINGS_ACCOUNT_ID"):
         monkeypatch.delenv(key, raising=False)
     monkeypatch.setenv("MERCURY_SECRETS_PATH", str(tmp_path / "missing.json"))
+
+    def fake_run(cmd, **kwargs):
+        class Result:
+            returncode = 1
+            stdout = ""
+            stderr = "not found"
+
+        if cmd[:2] == ["/usr/bin/security", "find-generic-password"]:
+            return Result()
+        raise AssertionError(cmd)
+
+    monkeypatch.setattr("src.adapters.mercury_readonly.subprocess.run", fake_run)
     return tmp_path
 
 
@@ -150,6 +162,36 @@ class TestRequests:
         assert snapshot["total_available_usd"] == 15.5
         assert snapshot["read_only"] is True
         assert "generated_at" in snapshot
+        assert snapshot["capital_boundary"]["not_alpaca_buying_power"] is True
+        assert snapshot["capital_boundary"]["token_scope"] == "read_only"
+        assert snapshot["capital_boundary"]["official_api_base"] == "https://api.mercury.com/api/v1"
+        assert snapshot["capital_boundary"]["keep_alive_path"] == "/accounts"
+        assert snapshot["capital_boundary"]["unused_deletion_days"] == 45
+
+    def test_readonly_client_defaults_to_official_host(self):
+        from pathlib import Path
+
+        text = (Path(__file__).resolve().parents[1] / "src/adapters/mercury_readonly.py").read_text(
+            encoding="utf-8"
+        )
+        assert 'os.environ.get("MERCURY_API_BASE_URL", "https://api.mercury.com/api/v1")' in text
+        assert "backend.mercury.com" not in text
+
+
+class TestKeychainResolution:
+    def test_keychain_used_when_env_missing(self, clean_env, monkeypatch):
+        def fake_run(cmd, **kwargs):
+            class Result:
+                returncode = 0
+                stdout = "keychain-token\n"
+                stderr = ""
+
+            if cmd[:2] == ["/usr/bin/security", "find-generic-password"]:
+                return Result()
+            raise AssertionError(cmd)
+
+        monkeypatch.setattr("src.adapters.mercury_readonly.subprocess.run", fake_run)
+        assert resolve_token() == "keychain-token"
 
 
 class TestSummarizers:


### PR DESCRIPTION
# Pull request

## Work item

- Linear issue: AGENT-567
- Agent: grok
- Base SHA: 583bd07935e95ed35b096c57299ebcd84530c6d7
- Branch/worktree: `fix/AGENT-567-mercury-readonly-heartbeat` / `.worktrees/agent-567-mercury`
- Files or systems claimed: `src/adapters/mercury_readonly.py`, `scripts/mercury_cli.py`, `.github/workflows/mercury-readonly-heartbeat.yml`, `tests/test_mercury_readonly.py`, `tests/test_mercury_cli.py`, `rag_knowledge/lessons_learned`
- Coordination legacy reason:

## Change

- Scope: Keep Max Smith KDP LLC Mercury API token nickname `trading-readonly` alive. Mercury deletes unused tokens after 45 days (7-day email 2026-09-02 after 38 idle days). Official keep-alive is GET `https://api.mercury.com/api/v1/accounts`.
- Added GET-only `scripts/mercury_cli.py heartbeat` that writes a masked receipt asserting Mercury LLC cash is **not** Alpaca buying power.
- Added `.github/workflows/mercury-readonly-heartbeat.yml` every 3 days. Fail-closed if `secrets.MERCURY_API_TOKEN` is empty. Never enables ACH.
- Token resolution: env, then Keychain `hermes-fleet`/`MERCURY_API_TOKEN`, then chmod 600 vault.
- Deleted surfaces and recovery impact: none
- Out of scope: live ACH, treating Mercury cash as Alpaca buying power, minting a new dashboard token (2FA/passkey wall; token value is not stored locally)

## Verification

- [x] Targeted tests
- [ ] `make check`
- [x] RAG read/write round trip when RAG changes
- [ ] Orchestration smoke test when orchestration changes
- [ ] `TRADING_ENV=paper make dry-run` when operational paths change
- [ ] CI green on this exact head SHA

Local: `pytest tests/test_mercury_readonly.py tests/test_mercury_cli.py` 28 passed. `ruff check` on touched Python files passed. `python3 scripts/agent_coordination.py preflight` errors=0.

## Evidence boundaries

- Test result: 28 passed (`tests/test_mercury_readonly.py` + `tests/test_mercury_cli.py`)
- CI run: pending after open
- Protected-system result: no broker orders; GET-only Mercury path
- Broker/order/fill impact: none unless explicitly evidenced here
- Live token ping: **not yet**. Token is not in Keychain, vault, or GitHub secrets. Dashboard is passkey + Android TOTP. Workflow will fail-closed until `MERCURY_API_TOKEN` is stored.

## Coordination

- [x] Linear issue and vault claim updated
- [x] No overlapping active claim or worktree
- [x] Claim will be marked done or released after merge

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a read-only Mercury account heartbeat to verify API connectivity and keep the token active.
  - Heartbeat results now provide safe status information and audit receipts while masking sensitive account, token, and balance details.
  - Added clear confirmation that Mercury funds are separate from Alpaca buying power.
  - Added automatic credential lookup through supported secure storage options.
  - Added scheduled and manually triggered monitoring for the read-only connection.

- **Documentation**
  - Documented read-only token maintenance and safeguards around live ACH transfers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->