### PR TITLE
docs(AGENT-568): add SECURITY.md for GitHub security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,34 @@
+# Security Policy
+
+## Report a vulnerability privately
+
+Use [GitHub private vulnerability reporting](https://github.com/IgorGanapolsky/trading/security/advisories/new)
+for security issues. Do not open a public GitHub Issue for an unpatched
+vulnerability, leaked credentials, or exploit details.
+
+Include the affected path and commit, reproducible steps, expected impact, and
+the least-sensitive evidence needed to reproduce. Do not paste live API keys,
+broker tokens, or account numbers.
+
+## Scope
+
+This repository is a paper-first SPY options validation platform.
+
+In scope:
+
+- Credential handling (`get_alpaca_credentials()`, env/Keychain adapters)
+- Broker order/risk gates and kill-switch files
+- GitHub Actions secrets and workflow permissions
+- Dependency and CodeQL findings on `main`
+
+Out of scope:
+
+- Paper-account P/L, strategy expectancy, or cohort sample-size debates
+- Asking to remove `data/TRADING_HALTED` or to submit live capital
+
+`main` is the only supported branch. Older revisions are fixed by upgrading.
+
+## Research safety
+
+Use the paper Alpaca account only. Do not submit live orders, persist access
+after testing, or publish exploit details before a fix is available.


### PR DESCRIPTION
# Pull request

## Work item

- Linear issue: AGENT-568
- Agent: grok
- Base SHA: 1f8c01265acdaa1d1ac4422f3786026da7a5ec76
- Branch/worktree: `fix/AGENT-568-security-md` / `.worktrees/agent-568-security-md`
- Files or systems claimed: `SECURITY.md`
- Coordination legacy reason: n/a

## Change

- Scope: GitHub Security overview showed Security policy Disabled and Scorecard SecurityPolicyID alert #831. Add a public SECURITY.md that routes reports to private advisories.
- Deleted surfaces and recovery impact: none
- Out of scope: Dependabot GHSA-xrqw-3rrv-vx5w is PR #4463; occupancy freeze is AGENT-566 / #4471

## Verification

- [x] Targeted tests
- [ ] `make check`
- [ ] RAG read/write round trip when RAG changes
- [ ] Orchestration smoke test when orchestration changes
- [ ] `TRADING_ENV=paper make dry-run` when operational paths change
- [ ] CI green on this exact head SHA d7a14f819d6a06d61ca517115e475bebea354fc8

## Evidence boundaries

- Test result: docs-only SECURITY.md
- CI run: pending this PR after coordination checkbox fix
- Protected-system result: no halt flags touched
- Broker/order/fill impact: none unless explicitly evidenced here

## Coordination

- [x] Linear issue and vault claim updated
- [x] No overlapping active claim or worktree
- [ ] Claim will be marked done or released after merge