### PR TITLE
feat(AGENT-571): wire official Graphify-Labs/graphify (graphifyy)

### DIFF
--- a/.graphifyignore
+++ b/.graphifyignore
@@ -1,0 +1,16 @@
+# Extra excludes on top of .gitignore. Graphify merges this file with
+# .gitignore and never re-includes a gitignored path (official contract).
+rag_knowledge/arxiv/
+data/
+models/
+.worktrees/
+coverage/
+artifacts/
+reports/
+logs/
+*.pyc
+__pycache__/
+.venv/
+.go-cache/
+mcp/
+go/adk_trading/vendor/

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ VENV_PYTHON := $(VENV)/bin/python
 TRADING_ENV ?= paper
 export TRADING_ENV
 
-.PHONY: setup lint ruff format test coverage audit security health skill-check coordination-check coordination-audit coordination-preflight check dry-run hygiene graph-rag-check rag-aplus-check gsd-tick gsd-status cohort-scorecard
+.PHONY: setup lint ruff format test coverage audit security health skill-check coordination-check coordination-audit coordination-preflight check dry-run hygiene graph-rag-check graphify-check rag-aplus-check gsd-tick gsd-status cohort-scorecard
 
 setup:
 	$(PYTHON) -m venv $(VENV)
@@ -56,6 +56,10 @@ graph-rag-check:
 	$(VENV_PYTHON) -m pytest tests/test_graph_rag.py -q
 	$(VENV_PYTHON) scripts/verify_graph_rag.py
 
+graphify-check:
+	$(VENV_PYTHON) -m pytest tests/test_graphify_contract.py -q
+	$(VENV_PYTHON) scripts/graphify_ops.py status --json
+
 rag-aplus-check:
 	$(VENV_PYTHON) -m pytest tests/test_rag_aplus_platform.py tests/test_messy_document_parser.py tests/test_retrieve_for_trade.py -q
 	$(VENV_PYTHON) scripts/verify_rag_aplus.py
@@ -67,7 +71,7 @@ arxiv-ingest:
 arxiv-ingest-check:
 	$(VENV_PYTHON) -m pytest tests/test_arxiv_collector.py -q
 
-check: lint audit security skill-check coordination-check graph-rag-check rag-aplus-check test
+check: lint audit security skill-check coordination-check graph-rag-check graphify-check rag-aplus-check test
 
 dry-run: health
 	$(VENV_PYTHON) scripts/spy_put_credit.py --dry-run

--- a/docs/EXTENSIONS.md
+++ b/docs/EXTENSIONS.md
@@ -13,3 +13,5 @@ The host owns configuration and secret lookup, validation, timeouts/retries/circ
 7. Do not create an extension registry until at least two retained adapters need the same lifecycle contract.
 
 This takes the useful part of a plugin architecture—clear ownership and optionality—without introducing a plugin loader the repository does not need.
+
+Official Graphify-Labs/graphify is an optional code-graph adapter (`src/rag/graphify/`, `scripts/graphify_ops.py`). The PyPI package is `graphifyy`; retrieval is `graph.json` via query/path/explain. It must not become a required core import, must not dump into `financial_graph.sqlite`, and must not treat `graph.html` as retrieval. See `docs/GRAPHIFY.md`.

--- a/docs/GRAPHIFY.md
+++ b/docs/GRAPHIFY.md
@@ -1,0 +1,30 @@
+# Graphify (official Graphify-Labs/graphify)
+
+This repository uses **[Graphify-Labs/graphify](https://github.com/Graphify-Labs/graphify)**, not a lookalike.
+
+| Fact         | Value                                                                                   |
+| ------------ | --------------------------------------------------------------------------------------- |
+| PyPI package | `graphifyy` (double-y). Other `graphify*` packages are unaffiliated.                    |
+| CLI          | `graphify`                                                                              |
+| Install      | `uv tool install graphifyy` then `graphify install`                                     |
+| Retrieval    | `graphify query`, `graphify path`, `graphify explain` against `graphify-out/graph.json` |
+| Edge tags    | `EXTRACTED` (in source) / `INFERRED` (resolved) / `AMBIGUOUS`                           |
+| Code extract | local tree-sitter AST, no LLM (`graphify extract . --code-only --no-cluster`)           |
+| HTML         | `graphify-out/graph.html` is visualization only — never retrieval                       |
+| Git          | `graphify-out/` stays gitignored (LL-349). Rebuild locally.                             |
+
+Financial Graph RAG (`src/rag/graph`, SQLite lessons/trades/strategies) is a **different** graph. Do not dump Graphify AST nodes into `financial_graph.sqlite`. Do not clone Cosmos/Gremlin.
+
+```bash
+python scripts/graphify_ops.py status --json
+python scripts/graphify_ops.py extract
+python scripts/graphify_ops.py query "what calls TradeGateway"
+python scripts/graphify_ops.py path plan_put_credit TradeGateway
+python scripts/graphify_ops.py explain TradeGateway
+python scripts/graphify_ops.py fuse "what calls TradeGateway"
+make graphify-check
+```
+
+`.graphifyignore` is merged with `.gitignore` and can only exclude more files.
+
+Graphify AST edges have **no validity window**. Time filters belong on the financial graph, not on AST `imports`/`calls`.

--- a/rag_knowledge/lessons_learned/ll_571_official_graphify_not_sqlite_lookalike_2026-09-04.md
+++ b/rag_knowledge/lessons_learned/ll_571_official_graphify_not_sqlite_lookalike_2026-09-04.md
@@ -1,0 +1,31 @@
+# LL-571: Graphify means Graphify-Labs/graphify, not a SQLite dump
+
+**Date:** 2026-09-04
+
+**Severity:** HIGH (4)
+
+**Category:** retrieval, knowledge graph, official contract
+
+## What happened
+
+Untracked local scripts (`setup_graphify_integration.py`, `integrate_graphify.py`) treated Graphify as `pip install graphify` / `python -m graphify .` and dumped nodes into `financial_graph.sqlite`. That is not [Graphify-Labs/graphify](https://github.com/Graphify-Labs/graphify).
+
+Official contract:
+
+- PyPI package is **`graphifyy`**. CLI is **`graphify`**.
+- Install: `uv tool install graphifyy`.
+- Retrieval: `graphify query|path|explain` against `graphify-out/graph.json`.
+- Edges are `EXTRACTED` / `INFERRED` / `AMBIGUOUS`.
+- `graph.html` is visualization, not retrieval.
+- `graphify-out/` stays gitignored (LL-349).
+- Financial Graph RAG (`src/rag/graph`) stays the trading-domain graph.
+
+## Prevention
+
+- `scripts/graphify_ops.py` + `src/rag/graphify/` wrap the official CLI and graph.json.
+- Tests fail if adapter sources contain `pip install graphify`, `python -m graphify .`, or SQLite `graphify_nodes`.
+- `make graphify-check` is part of `make check`.
+
+## Verification
+
+Run `python scripts/graphify_ops.py status --json` and `pytest tests/test_graphify_contract.py`.

--- a/scripts/graphify_ops.py
+++ b/scripts/graphify_ops.py
@@ -1,0 +1,200 @@
+#!/usr/bin/env python3
+"""Operator CLI for official Graphify-Labs/graphify (PyPI: graphifyy).
+
+This is not a SQLite dump and not a cloned graph-database query language.
+Retrieval is graph.json via query / path / explain. graph.html is visualization only.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from src.rag.graphify.cli import (  # noqa: E402
+    GraphifyCliError,
+    extract_code,
+    graphify_version,
+    install_official,
+    resolve_graphify_bin,
+    run_explain,
+    run_path,
+    run_query,
+)
+from src.rag.graphify.contract import (  # noqa: E402
+    OFFICIAL_CLI_NAME,
+    OFFICIAL_PYPI_PACKAGE,
+    OFFICIAL_REPO,
+)
+from src.rag.graphify.fuse import fuse_hits_with_graph  # noqa: E402
+from src.rag.graphify.graph import (  # noqa: E402
+    default_graph_path,
+    load_code_graph,
+)
+
+
+def _graph_path(repo: Path, explicit: str | None) -> Path:
+    return Path(explicit) if explicit else default_graph_path(repo)
+
+
+def cmd_status(repo: Path, graph: Path) -> dict[str, Any]:
+    binary = resolve_graphify_bin(repo)
+    payload: dict[str, Any] = {
+        "official_package": OFFICIAL_PYPI_PACKAGE,
+        "official_cli": OFFICIAL_CLI_NAME,
+        "official_repo": OFFICIAL_REPO,
+        "binary": str(binary) if binary else None,
+        "version": graphify_version(repo) if binary else "",
+        "graph_json": str(graph),
+        "graph_exists": graph.is_file(),
+        "html_is_not_retrieval": True,
+        "financial_graph_is_separate": True,
+    }
+    if graph.is_file():
+        code_graph = load_code_graph(graph)
+        payload["nodes"] = len(code_graph.nodes)
+        payload["edges"] = len(code_graph.edges)
+        payload["confidence_counts"] = code_graph.confidence_counts()
+        payload["validity_window"] = None
+    return payload
+
+
+def cmd_query(repo: Path, graph: Path, question: str) -> dict[str, Any]:
+    binary = resolve_graphify_bin(repo)
+    if binary is not None and graph.is_file():
+        completed = run_query(question, repo_root=repo, graph=graph)
+        return {
+            "mode": "cli",
+            "returncode": completed.returncode,
+            "stdout": completed.stdout,
+            "stderr": completed.stderr,
+        }
+    code_graph = load_code_graph(graph)
+    return {"mode": "local", **code_graph.query(question)}
+
+
+def cmd_path(repo: Path, graph: Path, start: str, goal: str) -> dict[str, Any]:
+    binary = resolve_graphify_bin(repo)
+    if binary is not None and graph.is_file():
+        completed = run_path(start, goal, repo_root=repo, graph=graph)
+        return {
+            "mode": "cli",
+            "returncode": completed.returncode,
+            "stdout": completed.stdout,
+            "stderr": completed.stderr,
+        }
+    trail = load_code_graph(graph).shortest_path(start, goal)
+    return {"mode": "local", "path": trail}
+
+
+def cmd_explain(repo: Path, graph: Path, node: str) -> dict[str, Any]:
+    binary = resolve_graphify_bin(repo)
+    if binary is not None and graph.is_file():
+        completed = run_explain(node, repo_root=repo, graph=graph)
+        return {
+            "mode": "cli",
+            "returncode": completed.returncode,
+            "stdout": completed.stdout,
+            "stderr": completed.stderr,
+        }
+    return {"mode": "local", "explain": load_code_graph(graph).explain(node)}
+
+
+def cmd_fuse(graph: Path, question: str, hits_json: str | None) -> dict[str, Any]:
+    hits: list[dict[str, Any]] = []
+    if hits_json:
+        loaded = json.loads(Path(hits_json).read_text(encoding="utf-8"))
+        if isinstance(loaded, list):
+            hits = [item for item in loaded if isinstance(item, dict)]
+    else:
+        hits = [{"id": question, "title": question, "file": ""}]
+    code_graph = load_code_graph(graph) if graph.is_file() else None
+    return fuse_hits_with_graph(hits, code_graph)
+
+
+def _common() -> argparse.ArgumentParser:
+    common = argparse.ArgumentParser(add_help=False)
+    common.add_argument("--repo", type=Path, default=_REPO_ROOT)
+    common.add_argument(
+        "--graph", help="path to graph.json (default <repo>/graphify-out/graph.json)"
+    )
+    common.add_argument("--json", action="store_true", dest="as_json")
+    return common
+
+
+def _parser() -> argparse.ArgumentParser:
+    common = _common()
+    parser = argparse.ArgumentParser(description=__doc__)
+    sub = parser.add_subparsers(dest="command", required=True)
+    sub.add_parser("status", parents=[common], help="official CLI + graph.json readiness")
+    sub.add_parser("install", parents=[common], help="uv tool install graphifyy")
+    extract = sub.add_parser(
+        "extract", parents=[common], help="graphify extract --code-only --no-cluster"
+    )
+    extract.add_argument("target", nargs="?", default=".")
+    query = sub.add_parser("query", parents=[common], help="graphify query against graph.json")
+    query.add_argument("question")
+    path_cmd = sub.add_parser("path", parents=[common], help="graphify path A B")
+    path_cmd.add_argument("start")
+    path_cmd.add_argument("goal")
+    explain = sub.add_parser("explain", parents=[common], help="graphify explain NODE")
+    explain.add_argument("node")
+    fuse = sub.add_parser("fuse", parents=[common], help="search hits + 1-2 hop graph traversal")
+    fuse.add_argument("question")
+    fuse.add_argument("--hits", help="JSON list of search hits")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    repo = args.repo.resolve()
+    graph = _graph_path(repo, args.graph)
+    try:
+        if args.command == "status":
+            payload: Any = cmd_status(repo, graph)
+        elif args.command == "install":
+            completed = install_official(repo)
+            payload = {
+                "returncode": completed.returncode,
+                "stdout": completed.stdout,
+                "stderr": completed.stderr,
+                "package": OFFICIAL_PYPI_PACKAGE,
+            }
+        elif args.command == "extract":
+            completed = extract_code(repo, target=args.target)
+            payload = {
+                "returncode": completed.returncode,
+                "stdout": completed.stdout,
+                "stderr": completed.stderr,
+            }
+        elif args.command == "query":
+            payload = cmd_query(repo, graph, args.question)
+        elif args.command == "path":
+            payload = cmd_path(repo, graph, args.start, args.goal)
+        elif args.command == "explain":
+            payload = cmd_explain(repo, graph, args.node)
+        else:
+            payload = cmd_fuse(graph, args.question, args.hits)
+    except (GraphifyCliError, OSError, ValueError, json.JSONDecodeError) as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
+
+    if args.as_json or isinstance(payload, dict):
+        text = (
+            payload if isinstance(payload, str) else json.dumps(payload, indent=2, sort_keys=True)
+        )
+        print(text if isinstance(text, str) else json.dumps(text))
+        if isinstance(payload, dict) and payload.get("returncode") not in (None, 0):
+            return int(payload["returncode"])
+        return 0
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/graphify/SKILL.md
+++ b/skills/graphify/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: graphify
+description: >
+  Official Graphify-Labs/graphify for this trading repo. Query graph.json
+  (query/path/explain), never graph.html, never pip install graphify (wrong
+  package). Package is graphifyy. Slash: /graphify
+---
+
+# Graphify (official)
+
+Upstream: [Graphify-Labs/graphify](https://github.com/Graphify-Labs/graphify)
+
+```bash
+uv tool install graphifyy
+python scripts/graphify_ops.py extract          # code-only AST, no LLM
+graphify query "what calls TradeGateway"
+graphify path "plan_put_credit" "TradeGateway"
+graphify explain "TradeGateway"
+python scripts/graphify_ops.py fuse "what calls TradeGateway"
+```
+
+If `graphify-out/graph.json` exists, answer architecture questions from the graph first. Fuse search hits with 1–2 hop traversal. Do not treat `graph.html` as retrieval. Do not merge into `financial_graph.sqlite`. Details: `docs/GRAPHIFY.md`.

--- a/skills/trading-ops/SKILL.md
+++ b/skills/trading-ops/SKILL.md
@@ -82,6 +82,10 @@ python scripts/graph_rag_query.py --query "why is iron condor killed?" --graph-o
 # Hard gate: rebuild + 5 golden multi-hop assertions (CI offline-evals + make check)
 python scripts/verify_graph_rag.py
 make graph-rag-check
+# Official Graphify-Labs/graphify (package graphifyy; graph.json query/path/explain)
+python scripts/graphify_ops.py status --json
+python scripts/graphify_ops.py query "what calls TradeGateway"
+make graphify-check
 ```
 
 Inventory unclean (`exit 2`) → **no new risk**.

--- a/src/rag/graphify/__init__.py
+++ b/src/rag/graphify/__init__.py
@@ -1,0 +1,26 @@
+"""Official Graphify-Labs/graphify adapter (code graph, not financial Graph RAG).
+
+Package on PyPI is ``graphifyy``. CLI command is ``graphify``. Retrieval is
+``graph.json`` via query/path/explain. ``graph.html`` is visualization only.
+"""
+
+from src.rag.graphify.contract import (
+    CONFIDENCE_AMBIGUOUS,
+    CONFIDENCE_EXTRACTED,
+    CONFIDENCE_INFERRED,
+    VALID_CONFIDENCES,
+    validate_graphify_payload,
+)
+from src.rag.graphify.fuse import fuse_hits_with_graph
+from src.rag.graphify.graph import CodeGraph, load_code_graph
+
+__all__ = [
+    "CONFIDENCE_AMBIGUOUS",
+    "CONFIDENCE_EXTRACTED",
+    "CONFIDENCE_INFERRED",
+    "VALID_CONFIDENCES",
+    "CodeGraph",
+    "fuse_hits_with_graph",
+    "load_code_graph",
+    "validate_graphify_payload",
+]

--- a/src/rag/graphify/cli.py
+++ b/src/rag/graphify/cli.py
@@ -1,0 +1,144 @@
+"""Resolve and invoke the official Graphify CLI (package graphifyy)."""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess  # nosec B404
+from pathlib import Path
+from typing import Sequence
+
+from src.rag.graphify.contract import OFFICIAL_CLI_NAME, OFFICIAL_PYPI_PACKAGE
+
+_HOME = Path.home()
+_CANDIDATES = (
+    _HOME / ".local" / "bin" / OFFICIAL_CLI_NAME,
+    Path("/opt/homebrew/bin") / OFFICIAL_CLI_NAME,
+    Path("/usr/local/bin") / OFFICIAL_CLI_NAME,
+)
+
+
+class GraphifyCliError(RuntimeError):
+    """Official graphify binary missing or command failed."""
+
+
+def resolve_graphify_bin(repo_root: str | Path | None = None) -> Path | None:
+    """Return the official ``graphify`` executable if present."""
+    if repo_root is not None:
+        local = Path(repo_root) / ".graphify-venv" / "bin" / OFFICIAL_CLI_NAME
+        if local.is_file():
+            return local
+    env_bin = os.environ.get("GRAPHIFY_BIN")
+    if env_bin:
+        path = Path(env_bin)
+        if path.is_file():
+            return path
+    for candidate in _CANDIDATES:
+        if candidate.is_file():
+            return candidate
+    which = shutil.which(OFFICIAL_CLI_NAME)
+    return Path(which) if which else None
+
+
+def graphify_version(repo_root: str | Path | None = None) -> str:
+    binary = resolve_graphify_bin(repo_root)
+    if binary is None:
+        return ""
+    completed = _run([str(binary), "--version"], timeout=20)
+    if completed.returncode != 0:
+        return ""
+    return (completed.stdout or completed.stderr).strip()
+
+
+def install_official(repo_root: str | Path | None = None) -> subprocess.CompletedProcess[str]:
+    """Install the official PyPI package ``graphifyy`` via uv tool or pipx."""
+    uv = shutil.which("uv")
+    if uv:
+        return _run([uv, "tool", "install", OFFICIAL_PYPI_PACKAGE], timeout=180)
+    pipx = shutil.which("pipx")
+    if pipx:
+        return _run([pipx, "install", OFFICIAL_PYPI_PACKAGE], timeout=180)
+    raise GraphifyCliError(
+        "Need uv or pipx to install graphifyy "
+        f"(official package {OFFICIAL_PYPI_PACKAGE}; CLI {OFFICIAL_CLI_NAME})"
+    )
+
+
+def extract_code(
+    repo_root: str | Path,
+    *,
+    target: str | Path | None = None,
+) -> subprocess.CompletedProcess[str]:
+    binary = _require_bin(repo_root)
+    path = str(target or repo_root)
+    return _run(
+        [str(binary), "extract", path, "--code-only", "--no-cluster"],
+        cwd=str(repo_root),
+        timeout=600,
+    )
+
+
+def run_query(
+    question: str,
+    *,
+    repo_root: str | Path,
+    graph: str | Path | None = None,
+    budget: int = 2000,
+) -> subprocess.CompletedProcess[str]:
+    binary = _require_bin(repo_root)
+    cmd = [str(binary), "query", question, "--budget", str(budget)]
+    if graph is not None:
+        cmd.extend(["--graph", str(graph)])
+    return _run(cmd, cwd=str(repo_root), timeout=60)
+
+
+def run_path(
+    start: str,
+    goal: str,
+    *,
+    repo_root: str | Path,
+    graph: str | Path | None = None,
+) -> subprocess.CompletedProcess[str]:
+    binary = _require_bin(repo_root)
+    cmd = [str(binary), "path", start, goal]
+    if graph is not None:
+        cmd.extend(["--graph", str(graph)])
+    return _run(cmd, cwd=str(repo_root), timeout=60)
+
+
+def run_explain(
+    node: str,
+    *,
+    repo_root: str | Path,
+    graph: str | Path | None = None,
+) -> subprocess.CompletedProcess[str]:
+    binary = _require_bin(repo_root)
+    cmd = [str(binary), "explain", node]
+    if graph is not None:
+        cmd.extend(["--graph", str(graph)])
+    return _run(cmd, cwd=str(repo_root), timeout=60)
+
+
+def _require_bin(repo_root: str | Path | None) -> Path:
+    binary = resolve_graphify_bin(repo_root)
+    if binary is None:
+        raise GraphifyCliError(
+            "Official graphify CLI not found. Install with: uv tool install graphifyy"
+        )
+    return binary
+
+
+def _run(
+    argv: Sequence[str],
+    *,
+    cwd: str | None = None,
+    timeout: int = 60,
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(  # nosec B603
+        list(argv),
+        cwd=cwd,
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+    )

--- a/src/rag/graphify/contract.py
+++ b/src/rag/graphify/contract.py
@@ -1,0 +1,109 @@
+"""Official Graphify-Labs/graphify graph.json contract.
+
+Mirrors graphify.validate: nodes need id/label/file_type/source_file; edges
+need source/target/relation/confidence/source_file. Confidence is
+EXTRACTED | INFERRED | AMBIGUOUS. Accepts NetworkX ``links`` as an edges alias.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+CONFIDENCE_EXTRACTED = "EXTRACTED"
+CONFIDENCE_INFERRED = "INFERRED"
+CONFIDENCE_AMBIGUOUS = "AMBIGUOUS"
+VALID_CONFIDENCES = frozenset({CONFIDENCE_EXTRACTED, CONFIDENCE_INFERRED, CONFIDENCE_AMBIGUOUS})
+VALID_FILE_TYPES = frozenset({"code", "document", "paper", "image", "rationale", "concept"})
+REQUIRED_NODE_FIELDS = frozenset({"id", "label", "file_type", "source_file"})
+REQUIRED_EDGE_FIELDS = frozenset({"source", "target", "relation", "confidence", "source_file"})
+
+OFFICIAL_PYPI_PACKAGE = "graphifyy"
+OFFICIAL_CLI_NAME = "graphify"
+OFFICIAL_REPO = "https://github.com/Graphify-Labs/graphify"
+WRONG_PIP_PACKAGES = ("graphify",)
+FORBIDDEN_INSTALL_SNIPPETS = (
+    "pip show graphify",
+    "pip install graphify",
+    "pip install git+https://github.com/Graphify-Labs/graphify.git",
+    "python -m graphify .",
+)
+RETRIEVAL_HTML_NAMES = frozenset({"graph.html", "graph_tree.html", "GRAPH_TREE.html"})
+
+
+def edge_list(payload: dict[str, Any]) -> list[dict[str, Any]]:
+    """Return edges from official ``edges`` or NetworkX ``links``."""
+    if "edges" in payload and isinstance(payload["edges"], list):
+        return payload["edges"]
+    links = payload.get("links")
+    return links if isinstance(links, list) else []
+
+
+def validate_graphify_payload(data: object) -> list[str]:
+    """Return schema errors; empty list means the payload matches Graphify."""
+    if not isinstance(data, dict):
+        return ["Extraction must be a JSON object"]
+
+    errors: list[str] = []
+    node_ids: set[str] = set()
+
+    nodes = data.get("nodes")
+    if "nodes" not in data:
+        errors.append("Missing required key 'nodes'")
+    elif not isinstance(nodes, list):
+        errors.append("'nodes' must be a list")
+    else:
+        for i, node in enumerate(nodes):
+            if not isinstance(node, dict):
+                errors.append(f"Node {i} must be an object")
+                continue
+            for field in REQUIRED_NODE_FIELDS:
+                if field not in node:
+                    errors.append(
+                        f"Node {i} (id={node.get('id', '?')!r}) missing required field '{field}'"
+                    )
+            node_id = node.get("id")
+            if isinstance(node_id, str) and node_id:
+                node_ids.add(node_id)
+            file_type = node.get("file_type")
+            if file_type is not None and file_type not in VALID_FILE_TYPES:
+                errors.append(
+                    f"Node {i} (id={node.get('id', '?')!r}) has invalid file_type '{file_type}'"
+                )
+
+    if "edges" not in data and "links" not in data:
+        errors.append("Missing required key 'edges'")
+        return errors
+
+    edges = edge_list(data)
+    if "edges" in data and not isinstance(data.get("edges"), list) and "links" not in data:
+        errors.append("'edges' must be a list")
+        return errors
+
+    for i, edge in enumerate(edges):
+        if not isinstance(edge, dict):
+            errors.append(f"Edge {i} must be an object")
+            continue
+        for field in REQUIRED_EDGE_FIELDS:
+            if field not in edge:
+                errors.append(f"Edge {i} missing required field '{field}'")
+        confidence = edge.get("confidence")
+        if confidence is not None and confidence not in VALID_CONFIDENCES:
+            errors.append(
+                f"Edge {i} has invalid confidence '{confidence}' "
+                f"- must be one of {sorted(VALID_CONFIDENCES)}"
+            )
+        for endpoint in ("source", "target"):
+            val = edge.get(endpoint)
+            if isinstance(val, str) and node_ids and val not in node_ids:
+                errors.append(f"Edge {i} {endpoint} '{val}' does not match any node id")
+
+    return errors
+
+
+def is_html_visualization(path: str) -> bool:
+    """True when a path is Graphify HTML (visualization, never retrieval)."""
+    normalized = path.replace("\\", "/").lower()
+    name = normalized.rsplit("/", 1)[-1]
+    if name in {item.lower() for item in RETRIEVAL_HTML_NAMES}:
+        return True
+    return "graphify-out/" in normalized and name.endswith(".html")

--- a/src/rag/graphify/fuse.py
+++ b/src/rag/graphify/fuse.py
@@ -1,0 +1,105 @@
+"""Always fuse search hits with bounded Graphify traversal (1–2 hops + RRF)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+from src.rag.graphify.contract import is_html_visualization
+from src.rag.graphify.graph import CodeGraph
+
+RRF_K = 60.0
+DEFAULT_HOPS = 2
+
+
+def fuse_hits_with_graph(
+    hits: Sequence[Mapping[str, Any]],
+    graph: CodeGraph | None,
+    *,
+    max_hops: int = DEFAULT_HOPS,
+    top_n: int = 12,
+) -> dict[str, Any]:
+    """Merge lexical/semantic hits with graph neighbors. Never reads HTML."""
+    usable_hits: list[dict[str, Any]] = []
+    dropped_html: list[str] = []
+    for raw in hits:
+        item = dict(raw)
+        path = str(item.get("file") or item.get("path") or item.get("source_file") or "")
+        if path and is_html_visualization(path):
+            dropped_html.append(path)
+            continue
+        usable_hits.append(item)
+
+    if graph is None:
+        return {
+            "graph_used": False,
+            "reason": "graph.json missing",
+            "hits": usable_hits[:top_n],
+            "graph_nodes": [],
+            "graph_edges": [],
+            "dropped_html": dropped_html,
+            "validity_window": None,
+        }
+
+    scores: dict[str, float] = {}
+    records: dict[str, dict[str, Any]] = {}
+
+    def _add(key: str, rank: int, record: dict[str, Any]) -> None:
+        scores[key] = scores.get(key, 0.0) + (1.0 / (RRF_K + rank))
+        records.setdefault(key, record)
+
+    for rank, hit in enumerate(usable_hits, 1):
+        key = str(hit.get("id") or hit.get("file") or hit.get("path") or f"hit_{rank}")
+        _add(f"hit:{key}", rank, {"kind": "search", **hit})
+
+    seeds: list[str] = []
+    for hit in usable_hits:
+        needles = [
+            str(hit.get("id") or ""),
+            str(hit.get("title") or ""),
+            Path(str(hit.get("file") or hit.get("path") or "")).stem,
+            Path(str(hit.get("file") or hit.get("path") or "")).name,
+        ]
+        for needle in needles:
+            if not needle:
+                continue
+            for node in graph.match_nodes(needle):
+                if node.id not in seeds:
+                    seeds.append(node.id)
+
+    graph_edges: list[dict[str, Any]] = []
+    graph_nodes: list[dict[str, Any]] = []
+    seen_nodes: set[str] = set()
+    seen_edges: set[tuple[str, str, str, str]] = set()
+    for seed in seeds:
+        if seed in graph.nodes and seed not in seen_nodes:
+            seen_nodes.add(seed)
+            graph_nodes.append(graph.nodes[seed].to_dict())
+        for rank, edge in enumerate(graph.neighbors(seed, max_hops=max_hops), 1):
+            key = (edge.source, edge.target, edge.relation, edge.confidence)
+            if key not in seen_edges:
+                seen_edges.add(key)
+                graph_edges.append(edge.to_dict())
+            _add(
+                f"edge:{edge.source}:{edge.target}:{edge.relation}",
+                rank,
+                {"kind": "graph", **edge.to_dict()},
+            )
+            for endpoint in (edge.source, edge.target):
+                if endpoint in graph.nodes and endpoint not in seen_nodes:
+                    seen_nodes.add(endpoint)
+                    graph_nodes.append(graph.nodes[endpoint].to_dict())
+
+    ranked = sorted(scores, key=lambda item: scores[item], reverse=True)[:top_n]
+    return {
+        "graph_used": True,
+        "max_hops": max_hops,
+        "hits": usable_hits,
+        "fused": [records[key] | {"rrf": round(scores[key], 6)} for key in ranked],
+        "graph_nodes": graph_nodes,
+        "graph_edges": graph_edges,
+        "dropped_html": dropped_html,
+        "seeds": seeds,
+        "validity_window": None,
+        "note": "Graphify AST edges have no validity window",
+    }

--- a/src/rag/graphify/graph.py
+++ b/src/rag/graphify/graph.py
@@ -1,0 +1,317 @@
+"""Load and traverse official graph.json (stdlib; no NetworkX/Gremlin)."""
+
+from __future__ import annotations
+
+import json
+import re
+from collections import defaultdict, deque
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from src.rag.graphify.contract import edge_list, validate_graphify_payload
+
+_TOKEN_RE = re.compile(r"[a-z0-9_]+", re.IGNORECASE)
+_STOP = frozenset(
+    {
+        "a",
+        "an",
+        "the",
+        "what",
+        "which",
+        "who",
+        "how",
+        "does",
+        "do",
+        "is",
+        "are",
+        "to",
+        "of",
+        "and",
+        "or",
+        "in",
+        "on",
+        "for",
+        "with",
+        "from",
+        "calls",
+        "call",
+        "connect",
+        "connects",
+        "between",
+        "show",
+        "me",
+        "trace",
+    }
+)
+
+
+def _norm(value: str) -> str:
+    return re.sub(r"[^a-z0-9]+", "", value.lower())
+
+
+@dataclass(frozen=True)
+class GraphNode:
+    id: str
+    label: str
+    file_type: str
+    source_file: str
+    source_location: str = ""
+    raw: dict[str, Any] | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "label": self.label,
+            "file_type": self.file_type,
+            "source_file": self.source_file,
+            "source_location": self.source_location,
+        }
+
+
+@dataclass(frozen=True)
+class GraphEdge:
+    source: str
+    target: str
+    relation: str
+    confidence: str
+    source_file: str
+    source_location: str = ""
+    confidence_score: float | None = None
+    context: str = ""
+    raw: dict[str, Any] | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        payload = {
+            "source": self.source,
+            "target": self.target,
+            "relation": self.relation,
+            "confidence": self.confidence,
+            "source_file": self.source_file,
+            "source_location": self.source_location,
+        }
+        if self.confidence_score is not None:
+            payload["confidence_score"] = self.confidence_score
+        if self.context:
+            payload["context"] = self.context
+        return payload
+
+
+class CodeGraph:
+    """Undirected adjacency over official Graphify node-link JSON."""
+
+    def __init__(self, payload: dict[str, Any], *, path: Path | None = None):
+        errors = validate_graphify_payload(payload)
+        if errors:
+            raise ValueError("graph.json is not a Graphify payload:\n" + "\n".join(errors))
+        self.path = path
+        self.payload = payload
+        self.nodes: dict[str, GraphNode] = {}
+        for raw in payload.get("nodes") or []:
+            if not isinstance(raw, dict) or not raw.get("id"):
+                continue
+            node_id = str(raw["id"])
+            self.nodes[node_id] = GraphNode(
+                id=node_id,
+                label=str(raw.get("label") or node_id),
+                file_type=str(raw.get("file_type") or ""),
+                source_file=str(raw.get("source_file") or ""),
+                source_location=str(raw.get("source_location") or ""),
+                raw=raw,
+            )
+        self.edges: list[GraphEdge] = []
+        self._adj: dict[str, list[tuple[str, GraphEdge]]] = defaultdict(list)
+        for raw in edge_list(payload):
+            if not isinstance(raw, dict):
+                continue
+            source = str(raw.get("source") or "")
+            target = str(raw.get("target") or "")
+            if not source or not target:
+                continue
+            score = raw.get("confidence_score")
+            edge = GraphEdge(
+                source=source,
+                target=target,
+                relation=str(raw.get("relation") or ""),
+                confidence=str(raw.get("confidence") or ""),
+                source_file=str(raw.get("source_file") or ""),
+                source_location=str(raw.get("source_location") or ""),
+                confidence_score=float(score) if isinstance(score, (int, float)) else None,
+                context=str(raw.get("context") or ""),
+                raw=raw,
+            )
+            self.edges.append(edge)
+            self._adj[source].append((target, edge))
+            self._adj[target].append((source, edge))
+
+    def confidence_counts(self) -> dict[str, int]:
+        counts: dict[str, int] = {}
+        for edge in self.edges:
+            counts[edge.confidence] = counts.get(edge.confidence, 0) + 1
+        return counts
+
+    def match_nodes(self, needle: str) -> list[GraphNode]:
+        text = needle.strip()
+        if not text:
+            return []
+        exact: list[GraphNode] = []
+        fuzzy: list[GraphNode] = []
+        lowered = text.lower()
+        compact = _norm(text)
+        for node in self.nodes.values():
+            hay = f"{node.id} {node.label} {node.source_file}".lower()
+            if node.id == text or node.label == text:
+                exact.append(node)
+            elif lowered in hay or (compact and compact in _norm(hay)):
+                fuzzy.append(node)
+        return exact or fuzzy
+
+    def neighbors(self, node_id: str, *, max_hops: int = 1) -> list[GraphEdge]:
+        if node_id not in self.nodes or max_hops < 1:
+            return []
+        seen_edges: set[tuple[str, str, str, str]] = set()
+        found: list[GraphEdge] = []
+        frontier = {node_id}
+        visited = {node_id}
+        for _ in range(max_hops):
+            nxt: set[str] = set()
+            for current in frontier:
+                for neighbor, edge in self._adj.get(current, ()):
+                    key = (edge.source, edge.target, edge.relation, edge.confidence)
+                    if key not in seen_edges:
+                        seen_edges.add(key)
+                        found.append(edge)
+                    if neighbor not in visited:
+                        visited.add(neighbor)
+                        nxt.add(neighbor)
+            frontier = nxt
+            if not frontier:
+                break
+        return found
+
+    def shortest_path(self, start: str, goal: str) -> list[dict[str, Any]] | None:
+        start_nodes = self.match_nodes(start)
+        goal_nodes = self.match_nodes(goal)
+        if not start_nodes or not goal_nodes:
+            return None
+        goal_ids = {node.id for node in goal_nodes}
+        origin = start_nodes[0].id
+        if origin in goal_ids:
+            node = self.nodes[origin]
+            return [{"node": node.to_dict(), "via": None}]
+        prev: dict[str, tuple[str, GraphEdge]] = {}
+        queue: deque[str] = deque([origin])
+        seen = {origin}
+        found_id: str | None = None
+        while queue:
+            current = queue.popleft()
+            for neighbor, edge in self._adj.get(current, ()):
+                if neighbor in seen:
+                    continue
+                seen.add(neighbor)
+                prev[neighbor] = (current, edge)
+                if neighbor in goal_ids:
+                    found_id = neighbor
+                    queue.clear()
+                    break
+                queue.append(neighbor)
+        if found_id is None:
+            return None
+        hops: list[tuple[str, GraphEdge | None]] = []
+        cursor = found_id
+        while cursor != origin:
+            parent, edge = prev[cursor]
+            hops.append((cursor, edge))
+            cursor = parent
+        hops.append((origin, None))
+        hops.reverse()
+        trail: list[dict[str, Any]] = []
+        for node_id, edge in hops:
+            trail.append(
+                {
+                    "node": self.nodes[node_id].to_dict(),
+                    "via": edge.to_dict() if edge is not None else None,
+                }
+            )
+        return trail
+
+    def explain(self, needle: str) -> dict[str, Any] | None:
+        matches = self.match_nodes(needle)
+        if not matches:
+            return None
+        node = matches[0]
+        connections = []
+        for neighbor, edge in self._adj.get(node.id, ()):
+            other = self.nodes[neighbor]
+            inbound = edge.target == node.id
+            connections.append(
+                {
+                    "direction": "in" if inbound else "out",
+                    "neighbor": other.to_dict(),
+                    "edge": edge.to_dict(),
+                }
+            )
+        return {
+            "node": node.to_dict(),
+            "degree": len(connections),
+            "connections": connections,
+            "validity_window": None,
+            "note": "Graphify AST edges have no validity window",
+        }
+
+    def query(self, question: str, *, max_hops: int = 2, budget_nodes: int = 24) -> dict[str, Any]:
+        tokens = [tok for tok in _TOKEN_RE.findall(question.lower()) if tok not in _STOP]
+        seeds: list[GraphNode] = []
+        seen: set[str] = set()
+        for token in tokens or _TOKEN_RE.findall(question.lower()):
+            for node in self.match_nodes(token):
+                if node.id not in seen:
+                    seen.add(node.id)
+                    seeds.append(node)
+        if not seeds:
+            for node in self.nodes.values():
+                if question.lower() in f"{node.label} {node.source_file}".lower():
+                    seeds.append(node)
+                    break
+        node_ids: list[str] = []
+        edge_hits: list[GraphEdge] = []
+        for seed in seeds:
+            if seed.id not in node_ids:
+                node_ids.append(seed.id)
+            for edge in self.neighbors(seed.id, max_hops=max_hops):
+                edge_hits.append(edge)
+                for endpoint in (edge.source, edge.target):
+                    if endpoint not in node_ids:
+                        node_ids.append(endpoint)
+        node_ids = node_ids[:budget_nodes]
+        keep = set(node_ids)
+        unique_edges: list[GraphEdge] = []
+        seen_edge: set[tuple[str, str, str, str]] = set()
+        for edge in edge_hits:
+            if edge.source not in keep or edge.target not in keep:
+                continue
+            key = (edge.source, edge.target, edge.relation, edge.confidence)
+            if key in seen_edge:
+                continue
+            seen_edge.add(key)
+            unique_edges.append(edge)
+        return {
+            "question": question,
+            "seeds": [self.nodes[i].to_dict() for i in node_ids if i in {s.id for s in seeds}],
+            "nodes": [self.nodes[i].to_dict() for i in node_ids if i in self.nodes],
+            "edges": [edge.to_dict() for edge in unique_edges],
+            "max_hops": max_hops,
+            "validity_window": None,
+        }
+
+
+def load_code_graph(path: str | Path) -> CodeGraph:
+    graph_path = Path(path)
+    payload = json.loads(graph_path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"{graph_path} is not a JSON object")
+    return CodeGraph(payload, path=graph_path)
+
+
+def default_graph_path(repo_root: str | Path) -> Path:
+    return Path(repo_root) / "graphify-out" / "graph.json"

--- a/tests/fixtures/graphify/corpus/gateway.py
+++ b/tests/fixtures/graphify/corpus/gateway.py
@@ -1,0 +1,6 @@
+"""Trade gateway."""
+
+
+class TradeGateway:
+    def reject_unclean(self) -> None:
+        raise RuntimeError("UNCLEAN_INVENTORY")

--- a/tests/fixtures/graphify/corpus/strategy.py
+++ b/tests/fixtures/graphify/corpus/strategy.py
@@ -1,0 +1,7 @@
+"""SPY put credit entry."""
+
+from gateway import TradeGateway
+
+
+def plan_put_credit() -> None:
+    TradeGateway().reject_unclean()

--- a/tests/fixtures/graphify/graph.json
+++ b/tests/fixtures/graphify/graph.json
@@ -1,0 +1,155 @@
+{
+  "nodes": [
+    {
+      "id": "gateway",
+      "label": "gateway.py",
+      "file_type": "code",
+      "source_file": "gateway.py",
+      "source_location": "L1",
+      "_origin": "ast"
+    },
+    {
+      "id": "gateway_tradegateway",
+      "label": "TradeGateway",
+      "file_type": "code",
+      "source_file": "gateway.py",
+      "source_location": "L3",
+      "_callable": true,
+      "_callable_class": true,
+      "_origin": "ast"
+    },
+    {
+      "id": "gateway_tradegateway_reject_unclean",
+      "label": ".reject_unclean()",
+      "file_type": "code",
+      "source_file": "gateway.py",
+      "source_location": "L4",
+      "_callable": true,
+      "_origin": "ast"
+    },
+    {
+      "id": "strategy",
+      "label": "strategy.py",
+      "file_type": "code",
+      "source_file": "strategy.py",
+      "source_location": "L1",
+      "_origin": "ast"
+    },
+    {
+      "id": "strategy_plan_put_credit",
+      "label": "plan_put_credit()",
+      "file_type": "code",
+      "source_file": "strategy.py",
+      "source_location": "L6",
+      "_callable": true,
+      "_origin": "ast"
+    },
+    {
+      "id": "strategy_rationale_1",
+      "label": "SPY put credit entry.",
+      "file_type": "rationale",
+      "source_file": "strategy.py",
+      "source_location": "L1",
+      "_origin": "ast"
+    }
+  ],
+  "edges": [
+    {
+      "source": "gateway",
+      "target": "gateway_tradegateway",
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "gateway.py",
+      "source_location": "L3",
+      "weight": 1.0,
+      "_origin": "ast"
+    },
+    {
+      "source": "gateway_tradegateway",
+      "target": "gateway_tradegateway_reject_unclean",
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "gateway.py",
+      "source_location": "L4",
+      "weight": 1.0,
+      "_origin": "ast"
+    },
+    {
+      "source": "strategy",
+      "target": "gateway",
+      "relation": "imports_from",
+      "context": "import",
+      "confidence": "EXTRACTED",
+      "source_file": "strategy.py",
+      "source_location": "L3",
+      "weight": 1.0,
+      "_origin": "ast"
+    },
+    {
+      "source": "strategy",
+      "target": "strategy_plan_put_credit",
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "strategy.py",
+      "source_location": "L6",
+      "weight": 1.0,
+      "_origin": "ast"
+    },
+    {
+      "source": "strategy_rationale_1",
+      "target": "strategy",
+      "relation": "rationale_for",
+      "confidence": "EXTRACTED",
+      "source_file": "strategy.py",
+      "source_location": "L1",
+      "weight": 1.0,
+      "_origin": "ast"
+    },
+    {
+      "source": "strategy",
+      "target": "gateway_tradegateway",
+      "relation": "imports",
+      "context": "import",
+      "confidence": "EXTRACTED",
+      "source_file": "strategy.py",
+      "source_location": "L3",
+      "weight": 1.0,
+      "_origin": "ast"
+    },
+    {
+      "source": "strategy_plan_put_credit",
+      "target": "gateway_tradegateway",
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "strategy.py",
+      "source_location": "L7",
+      "weight": 1.0,
+      "_origin": "ast"
+    },
+    {
+      "source": "strategy_plan_put_credit",
+      "target": "gateway_tradegateway",
+      "relation": "uses",
+      "confidence": "INFERRED",
+      "confidence_score": 0.95,
+      "source_file": "strategy.py",
+      "source_location": "L7",
+      "weight": 0.8,
+      "_origin": "ast"
+    },
+    {
+      "source": "strategy_plan_put_credit",
+      "target": "gateway_tradegateway_reject_unclean",
+      "relation": "calls",
+      "confidence": "AMBIGUOUS",
+      "source_file": "strategy.py",
+      "source_location": "L7",
+      "weight": 0.4,
+      "_origin": "fixture"
+    }
+  ],
+  "hyperedges": [],
+  "input_tokens": 0,
+  "output_tokens": 0
+}

--- a/tests/test_graphify_contract.py
+++ b/tests/test_graphify_contract.py
@@ -1,0 +1,115 @@
+"""Official Graphify-Labs/graphify contract: graph.json, not SQLite/HTML."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from src.rag.graphify.cli import resolve_graphify_bin
+from src.rag.graphify.contract import (
+    CONFIDENCE_AMBIGUOUS,
+    CONFIDENCE_EXTRACTED,
+    CONFIDENCE_INFERRED,
+    FORBIDDEN_INSTALL_SNIPPETS,
+    OFFICIAL_PYPI_PACKAGE,
+    is_html_visualization,
+    validate_graphify_payload,
+)
+from src.rag.graphify.fuse import fuse_hits_with_graph
+from src.rag.graphify.graph import load_code_graph
+
+REPO = Path(__file__).resolve().parents[1]
+FIXTURE = REPO / "tests/fixtures/graphify/graph.json"
+OPS = REPO / "scripts/graphify_ops.py"
+ADAPTER_DIR = REPO / "src/rag/graphify"
+
+
+def test_fixture_matches_official_schema() -> None:
+    payload = json.loads(FIXTURE.read_text(encoding="utf-8"))
+    assert validate_graphify_payload(payload) == []
+    graph = load_code_graph(FIXTURE)
+    counts = graph.confidence_counts()
+    assert counts[CONFIDENCE_EXTRACTED] >= 1
+    assert counts[CONFIDENCE_INFERRED] >= 1
+    assert counts[CONFIDENCE_AMBIGUOUS] >= 1
+
+
+def test_path_and_explain_preserve_extracted_vs_inferred() -> None:
+    graph = load_code_graph(FIXTURE)
+    trail = graph.shortest_path("plan_put_credit", "TradeGateway")
+    assert trail is not None
+    assert trail[0]["node"]["label"] == "plan_put_credit()"
+    assert trail[-1]["node"]["label"] == "TradeGateway"
+    via_conf = {hop["via"]["confidence"] for hop in trail if hop["via"]}
+    assert CONFIDENCE_EXTRACTED in via_conf or CONFIDENCE_INFERRED in via_conf
+    explained = graph.explain("TradeGateway")
+    assert explained is not None
+    confs = {item["edge"]["confidence"] for item in explained["connections"]}
+    assert CONFIDENCE_EXTRACTED in confs
+    assert explained["validity_window"] is None
+
+
+def test_query_returns_calls_edge() -> None:
+    result = load_code_graph(FIXTURE).query("what calls TradeGateway")
+    labels = {node["label"] for node in result["nodes"]}
+    assert "TradeGateway" in labels
+    assert "plan_put_credit()" in labels
+    relations = {(edge["relation"], edge["confidence"]) for edge in result["edges"]}
+    assert ("calls", CONFIDENCE_EXTRACTED) in relations
+
+
+def test_fuse_always_traverses_and_skips_html() -> None:
+    graph = load_code_graph(FIXTURE)
+    hits = [
+        {"id": "strategy.py", "title": "put credit", "file": "strategy.py"},
+        {"id": "viz", "title": "pretty graph", "file": "graphify-out/graph.html"},
+    ]
+    fused = fuse_hits_with_graph(hits, graph, max_hops=2)
+    assert fused["graph_used"] is True
+    assert fused["dropped_html"] == ["graphify-out/graph.html"]
+    assert fused["graph_edges"], "retrieval must traverse graph.json, not skip it"
+    assert fused["validity_window"] is None
+    assert any(edge["confidence"] == CONFIDENCE_EXTRACTED for edge in fused["graph_edges"])
+    assert is_html_visualization("graphify-out/graph.html")
+    assert not is_html_visualization("graphify-out/graph.json")
+
+
+def test_ops_and_adapter_do_not_install_wrong_pip_package() -> None:
+    blobs = [
+        OPS.read_text(encoding="utf-8"),
+        (ADAPTER_DIR / "cli.py").read_text(encoding="utf-8"),
+        (ADAPTER_DIR / "__init__.py").read_text(encoding="utf-8"),
+    ]
+    joined = "\n".join(blobs)
+    assert OFFICIAL_PYPI_PACKAGE in joined
+    assert "uv tool install" in joined
+    for snippet in FORBIDDEN_INSTALL_SNIPPETS:
+        assert snippet not in joined
+    assert "financial_graph.sqlite" not in joined
+    assert "CREATE TABLE IF NOT EXISTS graphify_nodes" not in joined
+    assert "gremlin" not in joined.lower()
+
+
+def test_graphify_out_stays_gitignored_and_hygiene_forbidden() -> None:
+    gitignore = (REPO / ".gitignore").read_text(encoding="utf-8")
+    assert "graphify-out/" in gitignore
+    hygiene = (REPO / "scripts/audit_repository_hygiene.py").read_text(encoding="utf-8")
+    assert '"graphify-out/"' in hygiene
+    ignore = (REPO / ".graphifyignore").read_text(encoding="utf-8")
+    assert "rag_knowledge/arxiv/" in ignore
+
+
+def test_status_reports_official_package() -> None:
+    from scripts.graphify_ops import cmd_status, main
+
+    payload = cmd_status(REPO, FIXTURE)
+    assert payload["official_package"] == "graphifyy"
+    assert payload["official_cli"] == "graphify"
+    assert payload["html_is_not_retrieval"] is True
+    assert payload["financial_graph_is_separate"] is True
+    assert payload["confidence_counts"][CONFIDENCE_INFERRED] >= 1
+    binary = resolve_graphify_bin(REPO)
+    if binary is not None:
+        assert payload["binary"]
+        assert "graphify" in payload["version"].lower()
+    assert main(["status", "--graph", str(FIXTURE), "--json"]) == 0


### PR DESCRIPTION
# Pull request

## Work item

- Linear issue: AGENT-571
- Agent: grok
- Base SHA: 7496e8fbabe27a7b1845e666195caec4f9b1b18b
- Branch/worktree: feat/AGENT-571-official-graphify at .worktrees/agent-571-graphify
- Files or systems claimed: src/rag/graphify/, scripts/graphify_ops.py, tests/test_graphify_contract.py, tests/fixtures/graphify/, .graphifyignore, Makefile, docs/GRAPHIFY.md, skills/graphify/, skills/trading-ops/SKILL.md, docs/EXTENSIONS.md, rag_knowledge/lessons_learned/ll_571_official_graphify_not_sqlite_lookalike_2026-09-04.md
- Coordination legacy reason:

## Change

- Scope: Wire official Graphify-Labs/graphify (PyPI graphifyy, CLI graphify) so trading queries graph.json via query/path/explain, fuses search hits with 1-2 hop traversal, and keeps EXTRACTED/INFERRED/AMBIGUOUS tags.
- Deleted surfaces and recovery impact: none
- Out of scope: financial Graph RAG SQLite, committing graphify-out/, Cosmos/Gremlin clones, pip install of the unaffiliated graphify package, live trading, AGENT-570 tech-debt merge

## Verification

- [x] Targeted tests
- [ ] `make check`
- [x] RAG read/write round trip when RAG changes
- [ ] Orchestration smoke test when orchestration changes
- [ ] `TRADING_ENV=paper make dry-run` when operational paths change
- [ ] CI green on this exact head SHA

## Evidence boundaries

- Test result: pytest tests/test_graphify_contract.py 7 passed; official graphify 0.9.53 query/path against fixture graph.json returned EXTRACTED calls edge
- CI run: pending after open
- Protected-system result: not an operational trading change
- Broker/order/fill impact: none unless explicitly evidenced here

## Coordination

- [x] Linear issue and vault claim updated
- [x] No overlapping active claim or worktree
- [ ] Claim will be marked done or released after merge

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional Graphify integration for extracting and exploring code relationships.
  * Added commands for status checks, graph extraction, querying, path discovery, explanations, and combining graph results with search.
  * Added validation for graph data, including node, edge, confidence, and visualization checks.
  * Graph-based results now support bounded relationship traversal and filtering of visualization-only files.

* **Documentation**
  * Added setup, usage, operational guidance, and architecture documentation for Graphify.
  * Added ignore rules to keep generated outputs and unrelated directories out of graph analysis.

* **Tests**
  * Added contract coverage for Graphify installation, graph validation, querying, traversal, result fusion, and repository hygiene.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->