### PR TITLE
feat(AGENT-575): package-manager honesty doctor (uv.lock, not pnpm)

### DIFF
--- a/docs/PACKAGE_MANAGER.md
+++ b/docs/PACKAGE_MANAGER.md
@@ -1,0 +1,21 @@
+# Package-manager honesty
+
+Canonical installer for this repo: **uv** (`uv.lock` + `pyproject.toml`).
+
+Stolen FORMAT from [InfoQ: pnpm 12 Rust rewrite](https://www.infoq.com/news/2026/09/pnpm-12-rust/) (3 Sep 2026):
+
+- Keep the lockfile and command contract; a faster engine is not a migration.
+- Unknown / extra lockfiles are errors, not a silent second manager.
+- Lifecycle scripts of foreign installers stay default-deny.
+
+**Not stolen:** pnpm itself, Corepack, their 15ms repeated-install or Vercel 64–90% numbers, or rewriting `Makefile` `pip install -e` in this change.
+
+```bash
+.venv/bin/python scripts/package_manager_honesty.py
+.venv/bin/python scripts/package_manager_honesty.py --classify 'uv sync --frozen'
+.venv/bin/python scripts/package_manager_honesty.py --propose-switch pnpm
+```
+
+`--propose-switch=pnpm` exits 2. Dual `pnpm-lock.yaml` / `package-lock.json` next to `uv.lock` exits 2.
+
+CI workflows that still `pip install -r requirements-ci.txt` are a **backlog** (frozen-uv migration), not a license to add pnpm.

--- a/rag_knowledge/lessons_learned/ll_575_uv_lock_not_pnpm_2026-09-04.md
+++ b/rag_knowledge/lessons_learned/ll_575_uv_lock_not_pnpm_2026-09-04.md
@@ -1,0 +1,17 @@
+# LL-575: pnpm 12 FORMAT is lockfile honesty, not a Rust rewrite of uv
+
+**Date:** 2026-09-04
+**Severity:** 3
+**Category:** dependencies, CI, honesty
+
+## What happened
+
+InfoQ reported pnpm 12 as a Rust rewrite that kept pnpm 11 commands and lockfile format. Theater in the primary checkout (`scripts/fast_python_dep_manager.py` and friends) treated that as "implement pnpm caching in Python" and cited 15ms / 90% as ours.
+
+## Lesson
+
+Keep `uv.lock`. Fail closed on a second package manager. Do not migrate this Python repo to pnpm. Vendor speedup curves stay vendor-owned.
+
+## Prevention
+
+`scripts/package_manager_honesty.py` + `tests/test_package_manager_honesty.py`.

--- a/scripts/package_manager_honesty.py
+++ b/scripts/package_manager_honesty.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+"""Package-manager honesty doctor. Always JSON. Never pnpm speedup claims."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from src.ops.package_manager_honesty import (  # noqa: E402
+    classify_command,
+    lookalike_hits,
+    scan_tree,
+)
+
+OPS = Path(__file__)
+
+
+class _JsonArgParser(argparse.ArgumentParser):
+    def error(self, message: str) -> None:  # type: ignore[override]
+        print(
+            json.dumps(
+                {"ok": False, "status": "UNAVAILABLE", "error": message}, indent=2, sort_keys=True
+            )
+        )
+        self.exit(2)
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = _JsonArgParser(description=__doc__)
+    parser.add_argument("--root", type=Path, default=REPO_ROOT)
+    parser.add_argument("--classify", default="", help="Install command to classify")
+    parser.add_argument("--propose-switch", default="", help="Rejected unless uv/none")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    if args.classify or args.propose_switch:
+        scan = scan_tree(args.root)
+        payload = classify_command(
+            args.classify,
+            has_uv_lock=bool(scan.get("uv_lock")),
+            propose_switch=args.propose_switch or None,
+        )
+        payload["scan"] = {k: scan[k] for k in ("ok", "status", "canonical", "foreign_lockfiles")}
+        print(json.dumps(payload, indent=2, sort_keys=True))
+        return 0 if payload.get("allowed") else 2
+
+    payload = scan_tree(args.root)
+    payload["lookalike_hits"] = lookalike_hits(OPS.read_text(encoding="utf-8"))
+    print(json.dumps(payload, indent=2, sort_keys=True))
+    return 0 if payload["ok"] else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/package_manager_honesty.py
+++ b/scripts/package_manager_honesty.py
@@ -50,6 +50,9 @@ def main(argv: list[str] | None = None) -> int:
         )
         payload["scan"] = {k: scan[k] for k in ("ok", "status", "canonical", "foreign_lockfiles")}
         print(json.dumps(payload, indent=2, sort_keys=True))
+        # Dual/missing lockfile must fail the gate even if the command text looks frozen-uv.
+        if not scan.get("ok"):
+            return 2
         return 0 if payload.get("allowed") else 2
 
     payload = scan_tree(args.root)

--- a/skills/package-manager-honesty/SKILL.md
+++ b/skills/package-manager-honesty/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: package-manager-honesty
+description: >
+  Fail-closed uv.lock doctor. Steal InfoQ pnpm 12 FORMAT (keep lockfile, refuse
+  manager switch, unknown extra lockfiles). Do not migrate trading to pnpm.
+  Slash: /package-manager-honesty.
+---
+
+# Package-manager honesty (trading)
+
+## Do
+
+```bash
+.venv/bin/python scripts/package_manager_honesty.py
+.venv/bin/python scripts/package_manager_honesty.py --propose-switch pnpm
+```
+
+Canonical: `uv.lock`. Foreign lockfiles (`pnpm-lock.yaml`, `package-lock.json`, `yarn.lock`, `bun.lock*`) fail closed.
+
+## Never
+
+- Add a second lockfile
+- Cite pnpm 15ms / Vercel 64–90% as our numbers
+- Rewrite GitHub Actions to pnpm
+- Dual-edit AGENT-573 / AGENT-574 files

--- a/src/ops/__init__.py
+++ b/src/ops/__init__.py
@@ -1,0 +1,1 @@
+"""Ops doctors. Not a second application framework."""

--- a/src/ops/package_manager_honesty.py
+++ b/src/ops/package_manager_honesty.py
@@ -136,7 +136,8 @@ def classify_command(
             "lifecycle_scripts_default_deny": True,
         }
 
-    if any(marker in lowered for marker in ALLOWED_MARKERS):
+    allowed = {marker.strip().lower() for marker in ALLOWED_MARKERS}
+    if lowered in allowed:
         return {
             "role": "frozen_lock",
             "allowed": True,

--- a/src/ops/package_manager_honesty.py
+++ b/src/ops/package_manager_honesty.py
@@ -1,0 +1,156 @@
+"""Package-manager honesty: keep uv.lock, refuse a pnpm/npm/yarn switch.
+
+InfoQ pnpm 12 FORMAT steal (https://www.infoq.com/news/2026/09/pnpm-12-rust/):
+the lockfile and installer contract stay; a rewrite is not a migration.
+Their 15ms / 64–90% figures are not ours. Do not vendor pnpm.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+CANONICAL = "uv"
+UV_LOCK = "uv.lock"
+PYPROJECT = "pyproject.toml"
+FOREIGN_LOCKFILES = (
+    "pnpm-lock.yaml",
+    "package-lock.json",
+    "yarn.lock",
+    "bun.lock",
+    "bun.lockb",
+    "poetry.lock",
+    "Pipfile.lock",
+)
+FORBIDDEN_CLAIMS = (
+    "15ms repeated install",
+    "64.4%",
+    "90.5%",
+    "pnpm self-update next-12",
+)
+ALLOWED_MARKERS = (
+    "uv sync --frozen",
+    "uv lock --check",
+    "uv lock --frozen",
+)
+DENIED_MARKERS = (
+    "pnpm install",
+    "pnpm i ",
+    "pnpm i\t",
+    "npm ci",
+    "npm install",
+    "yarn install",
+    "bun install",
+    "poetry install",
+    "pipenv install",
+)
+UNPINNED_PIP_MARKERS = (
+    "pip install -r",
+    "pip3 install -r",
+    "python -m pip install -r",
+)
+
+
+def lookalike_hits(source: str) -> list[str]:
+    lowered = source.lower()
+    return [snip for snip in FORBIDDEN_CLAIMS if snip in lowered]
+
+
+def scan_tree(root: Path) -> dict[str, Any]:
+    """Fail closed on missing uv.lock or a second package-manager lockfile."""
+
+    base = Path(root)
+    uv_lock = (base / UV_LOCK).is_file()
+    pyproject = (base / PYPROJECT).is_file()
+    foreign = [name for name in FOREIGN_LOCKFILES if (base / name).is_file()]
+    if not uv_lock or not pyproject:
+        status = "UNAVAILABLE"
+        ok = False
+        reason = "canonical uv.lock + pyproject.toml required"
+    elif foreign:
+        status = "DUAL_LOCKFILE"
+        ok = False
+        reason = "second package-manager lockfile is a silent switch"
+    else:
+        status = "ok"
+        ok = True
+        reason = "uv.lock is the installer contract; pnpm 12 speedup is not ours"
+    return {
+        "ok": ok,
+        "status": status,
+        "reason": reason,
+        "canonical": CANONICAL if uv_lock else None,
+        "uv_lock": uv_lock,
+        "pyproject": pyproject,
+        "foreign_lockfiles": foreign,
+        "do_not_migrate_to_pnpm": True,
+        "pnpm_speedup_is_not_ours": True,
+        "lifecycle_scripts_default_deny": True,
+        "keep_lockfile_format": True,
+    }
+
+
+def classify_command(
+    command: str,
+    *,
+    has_uv_lock: bool = True,
+    propose_switch: str | None = None,
+) -> dict[str, Any]:
+    """Classify an install command. Switching managers is denied."""
+
+    text = " ".join(str(command or "").split())
+    lowered = text.lower()
+    switch = (propose_switch or "").strip().lower()
+    if switch and switch not in {"", "uv", "none"}:
+        return {
+            "role": "denied",
+            "allowed": False,
+            "command": text,
+            "reason": f"refuse package-manager switch to {switch!r}; keep {CANONICAL}",
+            "matched": [f"propose-switch={switch}"],
+            "canonical": CANONICAL,
+            "pnpm_speedup_is_not_ours": True,
+        }
+
+    denied = [marker.strip() for marker in DENIED_MARKERS if marker.strip() in lowered]
+    if denied:
+        return {
+            "role": "denied",
+            "allowed": False,
+            "command": text,
+            "reason": "foreign installer; this repo's contract is uv.lock",
+            "matched": denied,
+            "canonical": CANONICAL,
+            "pnpm_speedup_is_not_ours": True,
+        }
+
+    if has_uv_lock and any(marker in lowered for marker in UNPINNED_PIP_MARKERS):
+        return {
+            "role": "denied",
+            "allowed": False,
+            "command": text,
+            "reason": "unpinned pip -r while uv.lock exists (npm-scripts analog: untrusted install path)",
+            "matched": [m for m in UNPINNED_PIP_MARKERS if m in lowered],
+            "canonical": CANONICAL,
+            "pnpm_speedup_is_not_ours": True,
+            "lifecycle_scripts_default_deny": True,
+        }
+
+    if any(marker in lowered for marker in ALLOWED_MARKERS):
+        return {
+            "role": "frozen_lock",
+            "allowed": True,
+            "command": text,
+            "reason": "frozen uv lock analog of pnpm 12 keeping the lockfile format",
+            "canonical": CANONICAL,
+            "pnpm_speedup_is_not_ours": True,
+        }
+
+    return {
+        "role": "unknown",
+        "allowed": False,
+        "command": text,
+        "reason": "not a frozen-uv install; do not invent a pnpm alias",
+        "canonical": CANONICAL,
+        "pnpm_speedup_is_not_ours": True,
+    }

--- a/tests/test_package_manager_honesty.py
+++ b/tests/test_package_manager_honesty.py
@@ -142,3 +142,30 @@ def test_dual_lockfile_cli(tmp_path: Path) -> None:
     assert completed.returncode == 2
     payload = json.loads(completed.stdout)
     assert payload["status"] == "DUAL_LOCKFILE"
+
+
+def test_compound_and_quoted_frozen_uv_are_denied() -> None:
+    for command in (
+        "uv sync --frozen && npm i",
+        'echo "uv sync --frozen"',
+        "uv sync --frozen; pnpm i",
+    ):
+        row = classify_command(command)
+        assert row["allowed"] is False, command
+
+
+def test_classify_cli_fails_on_dual_lockfile(tmp_path: Path) -> None:
+    (tmp_path / "pyproject.toml").write_text("[project]\nname='x'\n", encoding="utf-8")
+    (tmp_path / "uv.lock").write_text("# fake\n", encoding="utf-8")
+    (tmp_path / "package-lock.json").write_text("{}\n", encoding="utf-8")
+    completed = subprocess.run(
+        [sys.executable, str(OPS), "--root", str(tmp_path), "--classify", "uv sync --frozen"],
+        check=False,
+        capture_output=True,
+        text=True,
+        cwd=str(REPO),
+    )
+    assert completed.returncode == 2
+    payload = json.loads(completed.stdout)
+    assert payload["scan"]["status"] == "DUAL_LOCKFILE"
+    assert payload["allowed"] is True  # command text ok, tree not

--- a/tests/test_package_manager_honesty.py
+++ b/tests/test_package_manager_honesty.py
@@ -1,0 +1,144 @@
+"""uv.lock is the installer contract. pnpm 12 numbers are not ours."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+from src.ops.package_manager_honesty import (
+    FORBIDDEN_CLAIMS,
+    classify_command,
+    lookalike_hits,
+    scan_tree,
+)
+
+REPO = Path(__file__).resolve().parents[1]
+OPS = REPO / "scripts" / "package_manager_honesty.py"
+ADAPTER = REPO / "src" / "ops" / "package_manager_honesty.py"
+
+
+def test_repo_scan_is_uv_only() -> None:
+    report = scan_tree(REPO)
+    assert report["ok"] is True
+    assert report["canonical"] == "uv"
+    assert report["uv_lock"] is True
+    assert report["pyproject"] is True
+    assert report["foreign_lockfiles"] == []
+    assert report["pnpm_speedup_is_not_ours"] is True
+    assert report["do_not_migrate_to_pnpm"] is True
+
+
+def test_missing_lockfile_is_unavailable(tmp_path: Path) -> None:
+    (tmp_path / "pyproject.toml").write_text("[project]\nname='x'\n", encoding="utf-8")
+    report = scan_tree(tmp_path)
+    assert report["ok"] is False
+    assert report["status"] == "UNAVAILABLE"
+
+
+def test_dual_lockfile_fails_closed(tmp_path: Path) -> None:
+    (tmp_path / "pyproject.toml").write_text("[project]\nname='x'\n", encoding="utf-8")
+    (tmp_path / "uv.lock").write_text("# fake\n", encoding="utf-8")
+    (tmp_path / "pnpm-lock.yaml").write_text("lockfileVersion: 9\n", encoding="utf-8")
+    report = scan_tree(tmp_path)
+    assert report["ok"] is False
+    assert report["status"] == "DUAL_LOCKFILE"
+    assert "pnpm-lock.yaml" in report["foreign_lockfiles"]
+
+
+def test_frozen_uv_is_allowed() -> None:
+    row = classify_command("uv sync --frozen")
+    assert row["allowed"] is True
+    assert row["role"] == "frozen_lock"
+    check = classify_command("uv lock --check")
+    assert check["allowed"] is True
+
+
+def test_pnpm_and_npm_are_denied() -> None:
+    for command in ("pnpm install", "npm ci", "yarn install", "bun install"):
+        row = classify_command(command)
+        assert row["allowed"] is False, command
+        assert row["role"] == "denied"
+
+
+def test_unpinned_pip_denied_when_uv_lock_present() -> None:
+    row = classify_command("pip install -r requirements.txt", has_uv_lock=True)
+    assert row["allowed"] is False
+    assert row["lifecycle_scripts_default_deny"] is True
+
+
+def test_propose_switch_pnpm_is_denied() -> None:
+    row = classify_command("", propose_switch="pnpm")
+    assert row["allowed"] is False
+    assert "pnpm" in row["reason"]
+
+
+def test_cli_json_ok() -> None:
+    completed = subprocess.run(
+        [sys.executable, str(OPS)],
+        check=False,
+        capture_output=True,
+        text=True,
+        cwd=str(REPO),
+    )
+    assert completed.returncode == 0, completed.stderr
+    payload = json.loads(completed.stdout)
+    assert payload["ok"] is True
+    assert payload["canonical"] == "uv"
+    assert payload["pnpm_speedup_is_not_ours"] is True
+
+
+def test_cli_propose_switch_json() -> None:
+    completed = subprocess.run(
+        [sys.executable, str(OPS), "--propose-switch", "pnpm"],
+        check=False,
+        capture_output=True,
+        text=True,
+        cwd=str(REPO),
+    )
+    assert completed.returncode == 2
+    payload = json.loads(completed.stdout)
+    assert payload["allowed"] is False
+
+
+def test_cli_invalid_flag_json() -> None:
+    completed = subprocess.run(
+        [sys.executable, str(OPS), "--not-a-flag"],
+        check=False,
+        capture_output=True,
+        text=True,
+        cwd=str(REPO),
+    )
+    assert completed.returncode == 2
+    payload = json.loads(completed.stdout)
+    assert payload["ok"] is False
+    assert payload["status"] == "UNAVAILABLE"
+
+
+def test_sources_do_not_claim_pnpm_speedup() -> None:
+    cli = OPS.read_text(encoding="utf-8")
+    assert lookalike_hits(cli) == []
+    runtime_without_policy = "\n".join(
+        line
+        for line in ADAPTER.read_text(encoding="utf-8").splitlines()
+        if "FORBIDDEN_CLAIMS" not in line and not line.strip().startswith('"')
+    )
+    assert lookalike_hits(runtime_without_policy) == []
+    assert "15ms repeated install" in FORBIDDEN_CLAIMS
+
+
+def test_dual_lockfile_cli(tmp_path: Path) -> None:
+    (tmp_path / "pyproject.toml").write_text("[project]\nname='x'\n", encoding="utf-8")
+    (tmp_path / "uv.lock").write_text("# fake\n", encoding="utf-8")
+    (tmp_path / "package-lock.json").write_text("{}\n", encoding="utf-8")
+    completed = subprocess.run(
+        [sys.executable, str(OPS), "--root", str(tmp_path)],
+        check=False,
+        capture_output=True,
+        text=True,
+        cwd=str(REPO),
+    )
+    assert completed.returncode == 2
+    payload = json.loads(completed.stdout)
+    assert payload["status"] == "DUAL_LOCKFILE"


### PR DESCRIPTION
## Work item

- Linear issue: AGENT-575
- Agent: grok
- Base SHA: 3dfdff17c7a70c00ee101e0bb9b28953621afe2f
- Branch/worktree: feat/AGENT-575-package-manager-honesty / .worktrees/agent-575-pkg-honesty
- Files or systems claimed: src/ops/__init__.py, src/ops/package_manager_honesty.py, scripts/package_manager_honesty.py, tests/test_package_manager_honesty.py, docs/PACKAGE_MANAGER.md, skills/package-manager-honesty/SKILL.md, rag_knowledge/lessons_learned/ll_575_uv_lock_not_pnpm_2026-09-04.md
- Coordination legacy reason:

## Change

- Scope: InfoQ pnpm 12 FORMAT steal — keep uv.lock, refuse dual lockfiles / pnpm-npm-yarn switch / unpinned pip -r. JSON CLI. Tests.
- Deleted surfaces and recovery impact: none
- Out of scope: migrating CI from pip to uv; vendoring pnpm; citing 15ms/64–90% as ours; AGENT-573/574 files

## Verification

- [x] Targeted tests (`pytest tests/test_package_manager_honesty.py` 12 passed)
- [ ] `make check`
- [x] RAG lesson LL-575
- [ ] Orchestration smoke test when orchestration changes
- [ ] `TRADING_ENV=paper make dry-run` when operational paths change
- [ ] CI green on this exact head SHA

## Evidence boundaries

- Test result: 12 passed locally
- CI run: pending
- Protected-system result: not an execution path
- Broker/order/fill impact: none

## Coordination

- [x] Linear issue and vault claim updated
- [x] No overlapping active claim or worktree
- [ ] Claim will be marked done or released after merge

