### PR TITLE
feat(AGENT-577): zg-style local-first 4-route search (hybrid/fts/vector/rg)

### DIFF
--- a/docs/ZG_LOCAL_SEARCH.md
+++ b/docs/ZG_LOCAL_SEARCH.md
@@ -1,0 +1,44 @@
+# zg-style local-first search (AGENT-577)
+
+Process steal from [Qwen zg / zvec-grep](https://github.com/zvec-ai/zvec-grep)
+(MarkTechPost 2026-09-02). **We do not vendor `@zvec/zvec-grep`.** The transferable
+mechanics map onto existing trading RAG rails (`UnifiedSearch`, LanceDB lessons,
+ripgrep, `HybridRAGRetriever` RRF).
+
+## What transferred
+
+| zg mechanic                        | Trading implementation                                             |
+| ---------------------------------- | ------------------------------------------------------------------ |
+| Four routes behind one interface   | `hybrid` / `fts` / `vector` / `rg` in `src/rag/zg_local_search.py` |
+| Default hybrid + RRF fusion        | `HybridRAGRetriever.rrf_merge` + `rrf_merge_multi`                 |
+| Managed ripgrep without an index   | `ZgLocalSearch._run_rg` via system `rg`                            |
+| Compact path:line evidence         | `EvidenceHit.compact_line()` / CLI default output                  |
+| Local-first (no remote embeddings) | Vector route is optional local LanceDB only                        |
+| Wire dead RRF into production      | `LessonsLearnedRAG.query` fuses vector+keyword when both hit       |
+
+## What did **not** transfer
+
+- npm `@zvec/zvec-grep` / Node 22 MCP installer
+- Remote Qwen embedding auth grants
+- Workspace `.zvec-grep/` index format
+- Multimodal / image indexing
+
+## Operator / agent usage
+
+```bash
+# Status
+.venv/bin/python scripts/zg_search.py --check-ready
+
+# Default hybrid (FTS + vector RRF; rg fused for symbol-like queries)
+.venv/bin/python scripts/zg_search.py "put credit stop loss rules"
+.venv/bin/python scripts/zg_search.py --route fts "expectancy kill criteria"
+.venv/bin/python scripts/zg_search.py --route vector "iron condor exit"
+.venv/bin/python scripts/zg_search.py --route rg "TradeGateway"
+.venv/bin/python scripts/zg_search.py --json --limit 5 "UNCLEAN_INVENTORY"
+```
+
+## Prevention
+
+`tests/test_zg_local_search.py` covers RRF overlap preference, injected FTS/vector
+routes, live `rg` route, compact evidence, and `LessonsLearnedRAG` `hybrid_rrf`
+wiring so the retriever cannot silently go unused again.

--- a/scripts/zg_search.py
+++ b/scripts/zg_search.py
@@ -30,18 +30,24 @@ def main(argv: list[str] | None = None) -> int:
         default=SearchRoute.HYBRID.value,
         help="Retrieval route (default: hybrid = FTS+vector RRF, optional rg)",
     )
-    parser.add_argument("--limit", type=int, default=10, help="Max hits")
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=10,
+        help="Max hits (must be >= 0)",
+    )
     parser.add_argument(
         "--json",
         action="store_true",
         help="Emit JSON evidence hits instead of compact lines",
     )
-    parser.add_argument(
+    fuse_group = parser.add_mutually_exclusive_group()
+    fuse_group.add_argument(
         "--fuse-rg",
         action="store_true",
         help="Force ripgrep into hybrid fusion (default: only for symbol-like queries)",
     )
-    parser.add_argument(
+    fuse_group.add_argument(
         "--no-fuse-rg",
         action="store_true",
         help="Never fuse ripgrep into hybrid",
@@ -72,6 +78,8 @@ def main(argv: list[str] | None = None) -> int:
 
     if not args.query.strip():
         parser.error("query is required unless --check-ready")
+    if args.limit < 0:
+        parser.error("--limit must be >= 0")
 
     fuse_rg: bool | None = None
     if args.fuse_rg:

--- a/scripts/zg_search.py
+++ b/scripts/zg_search.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+"""CLI for zg-style local-first search (hybrid / fts / vector / rg).
+
+Inspired by Qwen zvec-grep (zg): one interface, four routes, compact evidence.
+Does not vendor @zvec/zvec-grep — maps the process onto trading RAG rails.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from src.rag.zg_local_search import SearchRoute, ZgLocalSearch  # noqa: E402
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Local-first search: hybrid (default) | fts | vector | rg"
+    )
+    parser.add_argument("query", nargs="?", default="", help="Search query")
+    parser.add_argument(
+        "--route",
+        choices=[r.value for r in SearchRoute],
+        default=SearchRoute.HYBRID.value,
+        help="Retrieval route (default: hybrid = FTS+vector RRF, optional rg)",
+    )
+    parser.add_argument("--limit", type=int, default=10, help="Max hits")
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit JSON evidence hits instead of compact lines",
+    )
+    parser.add_argument(
+        "--fuse-rg",
+        action="store_true",
+        help="Force ripgrep into hybrid fusion (default: only for symbol-like queries)",
+    )
+    parser.add_argument(
+        "--no-fuse-rg",
+        action="store_true",
+        help="Never fuse ripgrep into hybrid",
+    )
+    parser.add_argument(
+        "--root",
+        type=Path,
+        default=None,
+        help="Workspace root (default: repo root)",
+    )
+    parser.add_argument(
+        "--check-ready",
+        action="store_true",
+        help="Exit 0 if engine imports; print routes (zg status analog)",
+    )
+    args = parser.parse_args(argv)
+
+    if args.check_ready:
+        engine = ZgLocalSearch(root=args.root)
+        payload = {
+            "ready": True,
+            "routes": [r.value for r in SearchRoute],
+            "root": str(engine.root),
+            "rg": engine._rg_bin,  # noqa: SLF001
+        }
+        print(json.dumps(payload, indent=2))
+        return 0
+
+    if not args.query.strip():
+        parser.error("query is required unless --check-ready")
+
+    fuse_rg: bool | None = None
+    if args.fuse_rg:
+        fuse_rg = True
+    elif args.no_fuse_rg:
+        fuse_rg = False
+
+    engine = ZgLocalSearch(root=args.root)
+    hits = engine.search(
+        args.query,
+        route=args.route,
+        limit=args.limit,
+        fuse_rg=fuse_rg,
+    )
+
+    if args.json:
+        print(json.dumps([h.to_dict() for h in hits], indent=2))
+    else:
+        print(engine.format_compact(hits))
+    return 0 if hits or args.route == SearchRoute.VECTOR.value else (0 if hits else 0)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/trading-ops/SKILL.md
+++ b/skills/trading-ops/SKILL.md
@@ -86,6 +86,10 @@ make graph-rag-check
 python scripts/graphify_ops.py status --json
 python scripts/graphify_ops.py query "what calls TradeGateway"
 make graphify-check
+# zg-style local-first search (hybrid|fts|vector|rg) — docs/ZG_LOCAL_SEARCH.md
+python scripts/zg_search.py --check-ready
+python scripts/zg_search.py "put credit stop loss"
+python scripts/zg_search.py --route rg "TradeGateway"
 ```
 
 Inventory unclean (`exit 2`) → **no new risk**.

--- a/src/rag/hybrid_retriever.py
+++ b/src/rag/hybrid_retriever.py
@@ -1,14 +1,16 @@
 """Hybrid RAG Retriever with Reciprocal Rank Fusion (RRF).
 
-Combines Lexical Keyword Search (BM25) and Dense Vector Search (LanceDB)
-using Reciprocal Rank Fusion (RRF) to maximize recall and precision.
+Combines Lexical Keyword Search (BM25/FTS), Dense Vector Search, and optional
+managed ripgrep ranks using Reciprocal Rank Fusion (RRF).
+
+zg (zvec-grep) process steal: one fusion layer for multi-route local search.
 """
 
 from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, Mapping
 
 from src.rag.query_rewriter import RAGQueryRewriter
 from src.rag.rag_reranker import RAGReranker
@@ -24,10 +26,14 @@ class HybridSearchResult:
     vector_rank: int
     bm25_rank: int
     content_snippet: str
+    rg_rank: int = 999
+    path: str = ""
+    line: int | None = None
+    route: str = "hybrid"
 
 
 class HybridRAGRetriever:
-    """Combines BM25 lexical keyword ranking and vector search via RRF."""
+    """Combines BM25/FTS lexical ranking, vector search, and optional rg via RRF."""
 
     def __init__(self, k_rrf: float = 60.0):
         self.k_rrf = k_rrf
@@ -39,39 +45,126 @@ class HybridRAGRetriever:
         vector_results: list[dict[str, Any]],
         bm25_results: list[dict[str, Any]],
         top_n: int = 5,
+        rg_results: list[dict[str, Any]] | None = None,
     ) -> list[HybridSearchResult]:
-        scores: dict[str, float] = {}
+        """Two/three-list merge kept for existing tests and callers."""
+        out: list[HybridSearchResult] = []
+        v_ranks = {
+            str(item.get("id", item.get("lesson_id", f"vec_{i}"))): i
+            for i, item in enumerate(vector_results, 1)
+        }
+        b_ranks = {
+            str(item.get("id", item.get("lesson_id", f"bm25_{i}"))): i
+            for i, item in enumerate(bm25_results, 1)
+        }
+        r_ranks = {
+            str(item.get("id", item.get("lesson_id", f"rg_{i}"))): i
+            for i, item in enumerate(rg_results or [], 1)
+        }
         items: dict[str, dict[str, Any]] = {}
-        v_ranks: dict[str, int] = {}
-        b_ranks: dict[str, int] = {}
-
+        scores: dict[str, float] = {}
         for rank, item in enumerate(vector_results, 1):
             lid = str(item.get("id", item.get("lesson_id", f"vec_{rank}")))
             scores[lid] = scores.get(lid, 0.0) + (1.0 / (self.k_rrf + rank))
             items[lid] = item
-            v_ranks[lid] = rank
-
         for rank, item in enumerate(bm25_results, 1):
             lid = str(item.get("id", item.get("lesson_id", f"bm25_{rank}")))
             scores[lid] = scores.get(lid, 0.0) + (1.0 / (self.k_rrf + rank))
             if lid not in items:
                 items[lid] = item
-            b_ranks[lid] = rank
+        for rank, item in enumerate(rg_results or [], 1):
+            lid = str(item.get("id", item.get("lesson_id", f"rg_{rank}")))
+            scores[lid] = scores.get(lid, 0.0) + (1.0 / (self.k_rrf + rank))
+            if lid not in items:
+                items[lid] = item
 
         sorted_ids = sorted(scores.keys(), key=lambda x: scores[x], reverse=True)[:top_n]
-        merged: list[HybridSearchResult] = []
-
         for lid in sorted_ids:
             item = items[lid]
-            merged.append(
+            out.append(
                 HybridSearchResult(
                     lesson_id=lid,
                     title=str(item.get("title", "")),
                     rrf_score=round(scores[lid], 6),
                     vector_rank=v_ranks.get(lid, 999),
                     bm25_rank=b_ranks.get(lid, 999),
-                    content_snippet=str(item.get("snippet", item.get("content", "")))[:200],
+                    rg_rank=r_ranks.get(lid, 999),
+                    content_snippet=str(
+                        item.get("snippet", item.get("content", item.get("preview", "")))
+                    )[:200],
+                    path=str(item.get("path") or item.get("file") or ""),
+                    line=item.get("line") if isinstance(item.get("line"), int) else None,
+                    route="hybrid",
                 )
             )
+        return out
 
+    def rrf_merge_multi(
+        self,
+        ranked_lists: Mapping[str, list[dict[str, Any]]],
+        *,
+        top_n: int = 10,
+        weights: Mapping[str, float] | None = None,
+    ) -> list[Any]:
+        """Fuse arbitrary named ranked lists with RRF; returns EvidenceHit when available."""
+        from src.rag.zg_local_search import EvidenceHit
+
+        scores: dict[str, float] = {}
+        items: dict[str, dict[str, Any]] = {}
+        route_hits: dict[str, set[str]] = {}
+
+        for route_name, results in ranked_lists.items():
+            if not results:
+                continue
+            w = 1.0
+            if weights and route_name in weights:
+                w = float(weights[route_name]) or 1.0
+            for rank, item in enumerate(results, 1):
+                lid = str(item.get("id", item.get("lesson_id", f"{route_name}_{rank}")))
+                scores[lid] = scores.get(lid, 0.0) + w / (self.k_rrf + rank)
+                if lid not in items:
+                    items[lid] = dict(item)
+                    items[lid].setdefault("route", route_name)
+                route_hits.setdefault(lid, set()).add(route_name)
+
+        sorted_ids = sorted(scores.keys(), key=lambda x: scores[x], reverse=True)[:top_n]
+        merged: list[EvidenceHit] = []
+        for lid in sorted_ids:
+            item = items[lid]
+            routes = sorted(route_hits.get(lid, set()))
+            route_label = "+".join(routes) if routes else "hybrid"
+            line_raw = item.get("line")
+            line = line_raw if isinstance(line_raw, int) else None
+            merged.append(
+                EvidenceHit(
+                    id=lid,
+                    path=str(item.get("path") or item.get("file") or lid),
+                    line=line,
+                    preview=str(
+                        item.get("preview")
+                        or item.get("snippet")
+                        or item.get("content")
+                        or ""
+                    )[:500],
+                    score=round(scores[lid], 6),
+                    route=route_label,
+                    title=str(item.get("title", "")),
+                    metadata=dict(item.get("metadata") or {}),
+                )
+            )
         return merged
+
+    @staticmethod
+    def format_compact_evidence(results: list[HybridSearchResult]) -> str:
+        """zg-style compact evidence lines for agent context."""
+        if not results:
+            return "(no hits)"
+        lines: list[str] = []
+        for r in results:
+            loc = f"{r.path}:{r.line}" if r.path and r.line else (r.path or r.lesson_id)
+            preview = r.content_snippet.replace("\n", " ").strip()
+            if len(preview) > 160:
+                preview = preview[:157] + "..."
+            title = f" {r.title}" if r.title else ""
+            lines.append(f"[hybrid {r.rrf_score:.4f}] {loc}{title} — {preview}")
+        return "\n".join(lines)

--- a/src/rag/hybrid_retriever.py
+++ b/src/rag/hybrid_retriever.py
@@ -141,10 +141,7 @@ class HybridRAGRetriever:
                     path=str(item.get("path") or item.get("file") or lid),
                     line=line,
                     preview=str(
-                        item.get("preview")
-                        or item.get("snippet")
-                        or item.get("content")
-                        or ""
+                        item.get("preview") or item.get("snippet") or item.get("content") or ""
                     )[:500],
                     score=round(scores[lid], 6),
                     route=route_label,

--- a/src/rag/lessons_learned_rag.py
+++ b/src/rag/lessons_learned_rag.py
@@ -370,17 +370,50 @@ class LessonsLearnedRAG:
                 merged = HybridRAGRetriever().rrf_merge(
                     vector_results, keyword_results, top_n=top_k
                 )
-                by_id = {
-                    str(r.get("id", "")).lower(): r for r in (vector_results + keyword_results)
-                }
+                # Prefer vector row as base so full LanceDB content is not overwritten
+                # by keyword snippets when the same lesson ID appears in both lists.
+                by_id: dict[str, dict] = {}
+                for r in keyword_results + vector_results:
+                    key = str(r.get("id", "")).lower()
+                    if not key:
+                        continue
+                    prev = by_id.get(key)
+                    if prev is None:
+                        by_id[key] = dict(r)
+                        continue
+                    # Keep longer content / higher original score when merging duplicates.
+                    merged_row = dict(prev)
+                    if len(str(r.get("content") or "")) > len(str(prev.get("content") or "")):
+                        merged_row["content"] = r.get("content")
+                        merged_row["snippet"] = r.get("snippet") or merged_row.get("snippet")
+                    try:
+                        if float(r.get("score") or 0) > float(prev.get("score") or 0):
+                            merged_row["score"] = r.get("score")
+                    except (TypeError, ValueError):
+                        pass
+                    by_id[key] = merged_row
+
+                # Normalize RRF ranks into [0, 1] so public `score` stays comparable
+                # to legacy keyword/vector relevance scores.
+                rrf_vals = [float(h.rrf_score) for h in merged] or [0.0]
+                rrf_max = max(rrf_vals) or 1.0
+
                 fused: list[dict] = []
                 for hit in merged:
                     base = dict(by_id.get(hit.lesson_id.lower(), {}))
+                    original = base.get("score")
+                    try:
+                        original_f = float(original) if original is not None else 0.0
+                    except (TypeError, ValueError):
+                        original_f = 0.0
+                    norm_rrf = round(float(hit.rrf_score) / rrf_max, 6)
                     base.update(
                         {
                             "id": hit.lesson_id,
                             "title": hit.title or base.get("title", ""),
-                            "score": hit.rrf_score,
+                            # Keep a normalized relevance score for callers; expose raw RRF too.
+                            "score": max(original_f, norm_rrf),
+                            "rrf_score": hit.rrf_score,
                             "snippet": hit.content_snippet or base.get("snippet", ""),
                             "content": base.get("content") or hit.content_snippet,
                             "rrf": True,

--- a/src/rag/lessons_learned_rag.py
+++ b/src/rag/lessons_learned_rag.py
@@ -406,14 +406,15 @@ class LessonsLearnedRAG:
                         original_f = float(original) if original is not None else 0.0
                     except (TypeError, ValueError):
                         original_f = 0.0
+                    # Public score stays in [0, 1] for fused results (matches query() contract).
                     norm_rrf = round(float(hit.rrf_score) / rrf_max, 6)
                     base.update(
                         {
                             "id": hit.lesson_id,
                             "title": hit.title or base.get("title", ""),
-                            # Keep a normalized relevance score for callers; expose raw RRF too.
-                            "score": max(original_f, norm_rrf),
+                            "score": norm_rrf,
                             "rrf_score": hit.rrf_score,
+                            "source_score": original_f,
                             "snippet": hit.content_snippet or base.get("snippet", ""),
                             "content": base.get("content") or hit.content_snippet,
                             "rrf": True,

--- a/src/rag/lessons_learned_rag.py
+++ b/src/rag/lessons_learned_rag.py
@@ -327,43 +327,81 @@ class LessonsLearnedRAG:
             except Exception as e:
                 logger.warning(f"TradingRAGPipeline query failed: {e} - using legacy search")
 
+        # zg-style hybrid: fuse LanceDB vector + keyword BM25 via RRF when both exist.
+        vector_results: list[dict] = []
         if self.lancedb_rag is not None:
             try:
-                results = self._query_lancedb(query, top_k=top_k)
-                if results:
-                    if severity_filter:
-                        results = [r for r in results if r.get("severity") == severity_filter][
-                            :top_k
-                        ]
-                    self.last_source = "lancedb"
-                    return self._reposition_results(query, results, top_k)
+                vector_results = self._query_lancedb(query, top_k=max(top_k * 3, 15))
+                if severity_filter and vector_results:
+                    vector_results = [
+                        r for r in vector_results if r.get("severity") == severity_filter
+                    ]
             except Exception as e:
                 logger.warning(f"LanceDB query failed: {e} - using keyword fallback")
+                vector_results = []
 
-        # Use LessonsSearch if available
+        keyword_results: list[dict] = []
         if self.search_engine is not None:
             try:
-                results = self.search_engine.search(
-                    query, top_k=top_k, severity_filter=severity_filter
+                kw_raw = self.search_engine.search(
+                    query, top_k=max(top_k * 3, 15), severity_filter=severity_filter
                 )
-                # Convert results to expected format
-                self.last_source = "keyword"
-                formatted = [
+                keyword_results = [
                     {
                         "id": lesson.id,
                         "severity": lesson.severity,
                         "score": score,
                         "snippet": lesson.snippet,
-                        "content": lesson.snippet,  # Use snippet as content
+                        "content": lesson.snippet,
                         "file": lesson.file,
                         "title": lesson.title,
                         "prevention": lesson.prevention,
                     }
-                    for lesson, score in results
+                    for lesson, score in kw_raw
                 ]
-                return self._reposition_results(query, formatted, top_k)
             except Exception as e:
                 logger.warning(f"LessonsSearch failed: {e} - using direct file search")
+                keyword_results = []
+
+        if vector_results and keyword_results:
+            try:
+                from src.rag.hybrid_retriever import HybridRAGRetriever
+
+                merged = HybridRAGRetriever().rrf_merge(
+                    vector_results, keyword_results, top_n=top_k
+                )
+                by_id = {
+                    str(r.get("id", "")).lower(): r for r in (vector_results + keyword_results)
+                }
+                fused: list[dict] = []
+                for hit in merged:
+                    base = dict(by_id.get(hit.lesson_id.lower(), {}))
+                    base.update(
+                        {
+                            "id": hit.lesson_id,
+                            "title": hit.title or base.get("title", ""),
+                            "score": hit.rrf_score,
+                            "snippet": hit.content_snippet or base.get("snippet", ""),
+                            "content": base.get("content") or hit.content_snippet,
+                            "rrf": True,
+                            "vector_rank": hit.vector_rank,
+                            "bm25_rank": hit.bm25_rank,
+                        }
+                    )
+                    fused.append(base)
+                if fused:
+                    self.last_source = "hybrid_rrf"
+                    return self._reposition_results(query, fused, top_k)
+            except Exception as e:
+                logger.warning("Hybrid RRF merge failed: %s — falling back", e)
+
+        if vector_results:
+            self.last_source = "lancedb"
+            return self._reposition_results(query, vector_results[:top_k], top_k)
+
+        if keyword_results:
+            self.last_source = "keyword"
+            return self._reposition_results(query, keyword_results[:top_k], top_k)
 
         # Fallback: keyword-based search
         if not self.lessons:

--- a/src/rag/zg_local_search.py
+++ b/src/rag/zg_local_search.py
@@ -82,13 +82,7 @@ FtsFn = Callable[[str, int], list[dict[str, Any]]]
 
 
 def _normalize_item(item: dict[str, Any], *, default_route: str) -> dict[str, Any]:
-    path = str(
-        item.get("path")
-        or item.get("file")
-        or item.get("source")
-        or item.get("id")
-        or ""
-    )
+    path = str(item.get("path") or item.get("file") or item.get("source") or item.get("id") or "")
     preview = str(item.get("snippet") or item.get("content") or item.get("preview") or "")
     line = item.get("line")
     try:
@@ -236,7 +230,8 @@ class ZgLocalSearch:
         if self._vector_fn is not None:
             try:
                 return [
-                    _normalize_item(x, default_route="vector") for x in self._vector_fn(query, limit)
+                    _normalize_item(x, default_route="vector")
+                    for x in self._vector_fn(query, limit)
                 ]
             except Exception as exc:  # noqa: BLE001
                 logger.warning("vector_fn failed: %s", exc)

--- a/src/rag/zg_local_search.py
+++ b/src/rag/zg_local_search.py
@@ -81,6 +81,28 @@ VectorFn = Callable[[str, int], list[dict[str, Any]]]
 FtsFn = Callable[[str, int], list[dict[str, Any]]]
 
 
+def _canonical_doc_id(raw_id: str) -> str:
+    """Unify lesson:/LL-/path-ish IDs so RRF can fuse cross-route duplicates."""
+    s = (raw_id or "").strip()
+    if not s:
+        return s
+    lower = s.lower()
+    if lower.startswith("lesson:"):
+        s = s.split(":", 1)[1]
+    # Strip common path wrappers for lesson markdown files.
+    if "/" in s and s.lower().endswith(".md"):
+        stem = Path(s).stem
+        # ll_301_foo / LL-301_foo → prefer lesson token when present
+        m = re.search(r"(LL[-_]?\d+)", stem, flags=re.IGNORECASE)
+        if m:
+            return m.group(1).upper().replace("_", "-")
+        return stem
+    m = re.fullmatch(r"(?i)ll[-_]?(\d+)", s)
+    if m:
+        return f"LL-{m.group(1)}"
+    return s
+
+
 def _normalize_item(item: dict[str, Any], *, default_route: str) -> dict[str, Any]:
     path = str(item.get("path") or item.get("file") or item.get("source") or item.get("id") or "")
     preview = str(item.get("snippet") or item.get("content") or item.get("preview") or "")
@@ -94,8 +116,9 @@ def _normalize_item(item: dict[str, Any], *, default_route: str) -> dict[str, An
         score_f = float(score) if score is not None else 0.0
     except (TypeError, ValueError):
         score_f = 0.0
+    raw_id = str(item.get("id") or path or f"{default_route}:{preview[:40]}")
     return {
-        "id": str(item.get("id") or path or f"{default_route}:{preview[:40]}"),
+        "id": _canonical_doc_id(raw_id) or raw_id,
         "path": path,
         "line": line_i,
         "preview": preview[:500],
@@ -301,6 +324,8 @@ class ZgLocalSearch:
         for g in globs or DEFAULT_RG_GLOBS:
             glob_args.extend(["-g", g])
 
+        # --max-count is per-file; keep it small and truncate globally in Python
+        # so a large workspace does not buffer unbounded matches.
         cmd = [
             self._rg_bin,
             "--line-number",
@@ -308,7 +333,7 @@ class ZgLocalSearch:
             "--color",
             "never",
             "--max-count",
-            str(max(1, limit)),
+            "1",
             *glob_args,
             "--",
             pattern,

--- a/src/rag/zg_local_search.py
+++ b/src/rag/zg_local_search.py
@@ -1,0 +1,374 @@
+"""zg-style local-first search: ripgrep + BM25/FTS + vector behind one interface.
+
+Steals the high-ROI mechanics from Qwen/zvec-grep (zg), not the npm package:
+
+* Four routes: ``hybrid`` (default), ``fts``, ``vector``, ``rg``
+* Reciprocal Rank Fusion (RRF) when combining ranked lists
+* Managed ripgrep works without an embedding index
+* Compact path:line evidence for agents (fewer tokens)
+* Local-first: no remote embeddings; vector is optional/offline only
+
+See docs/ZG_LOCAL_SEARCH.md and MarkTechPost 2026-09-02 on zg (zvec-grep).
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+import shutil
+import subprocess  # nosec B404 — managed local ripgrep only; argv list, never shell
+from dataclasses import asdict, dataclass, field
+from enum import StrEnum
+from pathlib import Path
+from typing import Any, Callable, Iterable
+
+from src.rag.hybrid_retriever import HybridRAGRetriever
+from src.rag.query_rewriter import RAGQueryRewriter
+
+logger = logging.getLogger(__name__)
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+
+# Default include globs for managed ripgrep (matched relative to search root).
+# Prefer extension/path fragments — ripgrep does not treat `src/**/*.py` as a
+# rooted path prefix the way shell globs do.
+DEFAULT_RG_GLOBS = (
+    "*.py",
+    "*.md",
+    "*.json",
+    "*.yml",
+    "*.yaml",
+    "!**/.venv/**",
+    "!**/node_modules/**",
+    "!**/.git/**",
+    "!**/__pycache__/**",
+)
+
+
+class SearchRoute(StrEnum):
+    HYBRID = "hybrid"
+    FTS = "fts"
+    VECTOR = "vector"
+    RG = "rg"
+
+
+@dataclass(frozen=True)
+class EvidenceHit:
+    """Compact, source-linked hit suitable for agent context."""
+
+    id: str
+    path: str
+    line: int | None
+    preview: str
+    score: float
+    route: str
+    title: str = ""
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+    def compact_line(self) -> str:
+        loc = f"{self.path}:{self.line}" if self.line else self.path
+        title = f" {self.title}" if self.title else ""
+        preview = self.preview.replace("\n", " ").strip()
+        if len(preview) > 160:
+            preview = preview[:157] + "..."
+        return f"[{self.route} {self.score:.4f}] {loc}{title} — {preview}"
+
+
+VectorFn = Callable[[str, int], list[dict[str, Any]]]
+FtsFn = Callable[[str, int], list[dict[str, Any]]]
+
+
+def _normalize_item(item: dict[str, Any], *, default_route: str) -> dict[str, Any]:
+    path = str(
+        item.get("path")
+        or item.get("file")
+        or item.get("source")
+        or item.get("id")
+        or ""
+    )
+    preview = str(item.get("snippet") or item.get("content") or item.get("preview") or "")
+    line = item.get("line")
+    try:
+        line_i = int(line) if line is not None else None
+    except (TypeError, ValueError):
+        line_i = None
+    score = item.get("score")
+    try:
+        score_f = float(score) if score is not None else 0.0
+    except (TypeError, ValueError):
+        score_f = 0.0
+    return {
+        "id": str(item.get("id") or path or f"{default_route}:{preview[:40]}"),
+        "path": path,
+        "line": line_i,
+        "preview": preview[:500],
+        "score": score_f,
+        "route": str(item.get("route") or default_route),
+        "title": str(item.get("title") or ""),
+        "metadata": dict(item.get("metadata") or {}),
+    }
+
+
+def _looks_like_symbol(query: str) -> bool:
+    """Heuristic: exact identifier / path / regex → prefer rg anchors in hybrid."""
+    q = query.strip()
+    if not q:
+        return False
+    if any(ch in q for ch in ("*", "^", "$", "\\", "/", ".")):
+        # path-ish or regex-ish, but still allow multi-word NL
+        if " " not in q and len(q) <= 80:
+            return True
+    # CamelCase / snake_case / SCREAMING_SNAKE without spaces
+    return " " not in q and bool(re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]{2,}", q))
+
+
+class ZgLocalSearch:
+    """One local-first search layer with four retrieval routes."""
+
+    def __init__(
+        self,
+        *,
+        root: Path | None = None,
+        k_rrf: float = 60.0,
+        fts_fn: FtsFn | None = None,
+        vector_fn: VectorFn | None = None,
+        rg_bin: str | None = None,
+        rewrite_queries: bool = True,
+    ) -> None:
+        self.root = Path(root) if root else PROJECT_ROOT
+        self.retriever = HybridRAGRetriever(k_rrf=k_rrf)
+        self.rewriter = RAGQueryRewriter() if rewrite_queries else None
+        self._fts_fn = fts_fn
+        self._vector_fn = vector_fn
+        self._rg_bin = rg_bin or shutil.which("rg") or "rg"
+
+    def search(
+        self,
+        query: str,
+        *,
+        route: SearchRoute | str = SearchRoute.HYBRID,
+        limit: int = 10,
+        globs: Iterable[str] | None = None,
+        fuse_rg: bool | None = None,
+    ) -> list[EvidenceHit]:
+        q = (query or "").strip()
+        if not q:
+            return []
+
+        if isinstance(route, SearchRoute):
+            route_e = route
+        else:
+            route_e = SearchRoute(str(route).strip().lower())
+        expanded = q
+        if self.rewriter is not None and route_e != SearchRoute.RG:
+            expanded = self.rewriter.rewrite(q).expanded_query
+
+        if route_e == SearchRoute.FTS:
+            return self._to_hits(self._run_fts(expanded, limit), route="fts")[:limit]
+        if route_e == SearchRoute.VECTOR:
+            return self._to_hits(self._run_vector(expanded, limit), route="vector")[:limit]
+        if route_e == SearchRoute.RG:
+            return self._to_hits(self._run_rg(q, limit=limit, globs=globs), route="rg")[:limit]
+
+        # hybrid: FTS + vector (+ optional rg for symbol-like queries)
+        fts = self._run_fts(expanded, max(limit * 3, 15))
+        vec = self._run_vector(expanded, max(limit * 3, 15))
+        include_rg = fuse_rg if fuse_rg is not None else _looks_like_symbol(q)
+        rg_hits = self._run_rg(q, limit=max(limit * 2, 10), globs=globs) if include_rg else []
+
+        merged = self.retriever.rrf_merge_multi(
+            {
+                "fts": fts,
+                "vector": vec,
+                "rg": rg_hits,
+            },
+            top_n=limit,
+        )
+        return merged
+
+    def format_compact(self, hits: list[EvidenceHit]) -> str:
+        if not hits:
+            return "(no hits)"
+        return "\n".join(h.compact_line() for h in hits)
+
+    # --- route runners -------------------------------------------------
+
+    def _run_fts(self, query: str, limit: int) -> list[dict[str, Any]]:
+        if self._fts_fn is not None:
+            try:
+                return [_normalize_item(x, default_route="fts") for x in self._fts_fn(query, limit)]
+            except Exception as exc:  # noqa: BLE001 — route must fail soft
+                logger.warning("fts_fn failed: %s", exc)
+                return []
+        try:
+            from src.rag.unified_search import UnifiedSearch
+
+            search = UnifiedSearch()
+            search.build_index()
+            raw = search.search(query, top_k=limit)
+            out: list[dict[str, Any]] = []
+            for item in raw:
+                out.append(
+                    _normalize_item(
+                        {
+                            "id": item.get("id"),
+                            "path": item.get("id"),
+                            "title": item.get("title"),
+                            "snippet": item.get("snippet") or item.get("content", ""),
+                            "score": item.get("score", 0.0),
+                            "metadata": {
+                                "source_type": item.get("source_type"),
+                                **(item.get("metadata") or {}),
+                            },
+                        },
+                        default_route="fts",
+                    )
+                )
+            return out
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("UnifiedSearch FTS failed: %s", exc)
+            return []
+
+    def _run_vector(self, query: str, limit: int) -> list[dict[str, Any]]:
+        if self._vector_fn is not None:
+            try:
+                return [
+                    _normalize_item(x, default_route="vector") for x in self._vector_fn(query, limit)
+                ]
+            except Exception as exc:  # noqa: BLE001
+                logger.warning("vector_fn failed: %s", exc)
+                return []
+        # Optional local LanceDB / LessonsLearnedRAG — soft fail when unavailable.
+        # Probe lancedb first so we do not pull HF embedding weights on a miss.
+        try:
+            import lancedb  # noqa: F401
+        except ImportError:
+            logger.debug("vector route skipped: lancedb not installed")
+            return []
+        try:
+            from src.rag.lessons_learned_rag import LessonsLearnedRAG
+
+            rag = LessonsLearnedRAG()
+            if getattr(rag, "lancedb_rag", None) is None:
+                return []
+            raw = rag._query_lancedb(query, top_k=limit)  # noqa: SLF001 — local optional path
+            return [
+                _normalize_item(
+                    {
+                        "id": r.get("id"),
+                        "path": r.get("file") or r.get("id"),
+                        "title": r.get("title"),
+                        "snippet": r.get("snippet") or r.get("content", ""),
+                        "score": r.get("score", 0.0),
+                        "metadata": {"severity": r.get("severity")},
+                    },
+                    default_route="vector",
+                )
+                for r in raw
+            ]
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("vector route unavailable: %s", exc)
+            return []
+
+    def _run_rg(
+        self,
+        pattern: str,
+        *,
+        limit: int,
+        globs: Iterable[str] | None = None,
+    ) -> list[dict[str, Any]]:
+        """Managed ripgrep: exhaustive literal/regex, no index required."""
+        rg = self._rg_bin
+        if not shutil.which(rg) and not Path(rg).exists():
+            logger.warning("ripgrep binary not found (%s); rg route empty", rg)
+            return []
+
+        glob_args: list[str] = []
+        for g in globs or DEFAULT_RG_GLOBS:
+            glob_args.extend(["-g", g])
+
+        cmd = [
+            rg,
+            "--line-number",
+            "--no-heading",
+            "--color",
+            "never",
+            "--max-count",
+            str(max(1, limit)),
+            *glob_args,
+            "--",
+            pattern,
+            str(self.root),
+        ]
+        try:
+            # argv list only (no shell); pattern is treated as a search string by rg.
+            proc = subprocess.run(  # nosec B603
+                cmd,
+                capture_output=True,
+                text=True,
+                timeout=20,
+                check=False,
+            )
+        except (OSError, subprocess.TimeoutExpired) as exc:
+            logger.warning("rg failed: %s", exc)
+            return []
+
+        hits: list[dict[str, Any]] = []
+        for raw_line in (proc.stdout or "").splitlines():
+            if len(hits) >= limit:
+                break
+            # path:line:text
+            m = re.match(r"^(.*?):(\d+):(.*)$", raw_line)
+            if not m:
+                continue
+            path_s, line_s, text = m.group(1), m.group(2), m.group(3)
+            try:
+                rel = str(Path(path_s).resolve().relative_to(self.root.resolve()))
+            except ValueError:
+                rel = path_s
+            hits.append(
+                _normalize_item(
+                    {
+                        "id": f"rg:{rel}:{line_s}",
+                        "path": rel,
+                        "line": int(line_s),
+                        "preview": text.strip(),
+                        "score": 1.0 / (len(hits) + 1),
+                        "title": "",
+                    },
+                    default_route="rg",
+                )
+            )
+        return hits
+
+    def _to_hits(self, items: list[dict[str, Any]], *, route: str) -> list[EvidenceHit]:
+        out: list[EvidenceHit] = []
+        for item in items:
+            n = _normalize_item(item, default_route=route)
+            out.append(
+                EvidenceHit(
+                    id=n["id"],
+                    path=n["path"],
+                    line=n["line"],
+                    preview=n["preview"],
+                    score=float(n["score"]),
+                    route=n["route"],
+                    title=n["title"],
+                    metadata=n["metadata"],
+                )
+            )
+        return out
+
+
+def search(
+    query: str,
+    *,
+    route: str = "hybrid",
+    limit: int = 10,
+    root: Path | None = None,
+) -> list[EvidenceHit]:
+    """Module-level convenience wrapper."""
+    return ZgLocalSearch(root=root).search(query, route=route, limit=limit)

--- a/src/rag/zg_local_search.py
+++ b/src/rag/zg_local_search.py
@@ -362,16 +362,16 @@ class ZgLocalSearch:
         globs: Iterable[str] | None,
     ) -> list[dict[str, Any]]:
         """Bounded recursive text scan used when ripgrep is unavailable."""
-        try:
-            regex = re.compile(pattern)
-        except re.error:
-            regex = re.compile(re.escape(pattern))
+        # Literal match by default — avoid catastrophic backtracking on caller patterns.
+        regex = re.compile(re.escape(pattern))
 
-        include_exts = {".py", ".md", ".json", ".yml", ".yaml"}
-        # Honor simple "*.ext" globs when provided.
+        default_exts = {".py", ".md", ".json", ".yml", ".yaml"}
+        include_exts: set[str] = set()
         for g in globs or ():
-            if g.startswith("*.") and len(g) <= 8:
-                include_exts.add(g[1:])
+            if g.startswith("*.") and len(g) <= 10:
+                include_exts.add(g[1:].lower())
+        if not include_exts:
+            include_exts = default_exts
 
         skip_dirs = {".git", ".venv", "node_modules", "__pycache__", ".tox", "dist", "build"}
         hits: list[dict[str, Any]] = []
@@ -389,6 +389,7 @@ class ZgLocalSearch:
                 text = path.read_text(encoding="utf-8", errors="ignore")
             except OSError:
                 continue
+            # Match binary rg --max-count 1: at most one hit per file.
             for i, line in enumerate(text.splitlines(), 1):
                 if not regex.search(line):
                     continue
@@ -409,8 +410,7 @@ class ZgLocalSearch:
                         default_route="rg",
                     )
                 )
-                if len(hits) >= limit:
-                    break
+                break
         return hits
 
     def _parse_rg_stdout(self, stdout: str, *, limit: int) -> list[dict[str, Any]]:

--- a/src/rag/zg_local_search.py
+++ b/src/rag/zg_local_search.py
@@ -275,18 +275,34 @@ class ZgLocalSearch:
         limit: int,
         globs: Iterable[str] | None = None,
     ) -> list[dict[str, Any]]:
-        """Managed ripgrep: exhaustive literal/regex, no index required."""
-        rg = self._rg_bin
-        if not shutil.which(rg) and not Path(rg).exists():
-            logger.warning("ripgrep binary not found (%s); rg route empty", rg)
-            return []
+        """Managed ripgrep: exhaustive literal/regex, no index required.
 
+        Falls back to a pure-Python line scan when the ``rg`` binary is absent
+        (GitHub-hosted CI runners often lack ripgrep).
+        """
+        rg = self._rg_bin
+        if shutil.which(rg) or Path(rg).exists():
+            hits = self._run_rg_binary(pattern, limit=limit, globs=globs)
+            if hits:
+                return hits
+            # Binary present but no matches — do not invent hits.
+            return []
+        logger.info("ripgrep binary not found (%s); using Python line-scan fallback", rg)
+        return self._run_rg_python(pattern, limit=limit, globs=globs)
+
+    def _run_rg_binary(
+        self,
+        pattern: str,
+        *,
+        limit: int,
+        globs: Iterable[str] | None,
+    ) -> list[dict[str, Any]]:
         glob_args: list[str] = []
         for g in globs or DEFAULT_RG_GLOBS:
             glob_args.extend(["-g", g])
 
         cmd = [
-            rg,
+            self._rg_bin,
             "--line-number",
             "--no-heading",
             "--color",
@@ -311,11 +327,72 @@ class ZgLocalSearch:
             logger.warning("rg failed: %s", exc)
             return []
 
+        return self._parse_rg_stdout(proc.stdout or "", limit=limit)
+
+    def _run_rg_python(
+        self,
+        pattern: str,
+        *,
+        limit: int,
+        globs: Iterable[str] | None,
+    ) -> list[dict[str, Any]]:
+        """Bounded recursive text scan used when ripgrep is unavailable."""
+        try:
+            regex = re.compile(pattern)
+        except re.error:
+            regex = re.compile(re.escape(pattern))
+
+        include_exts = {".py", ".md", ".json", ".yml", ".yaml"}
+        # Honor simple "*.ext" globs when provided.
+        for g in globs or ():
+            if g.startswith("*.") and len(g) <= 8:
+                include_exts.add(g[1:])
+
+        skip_dirs = {".git", ".venv", "node_modules", "__pycache__", ".tox", "dist", "build"}
         hits: list[dict[str, Any]] = []
-        for raw_line in (proc.stdout or "").splitlines():
+        root = self.root
+        for path in root.rglob("*"):
             if len(hits) >= limit:
                 break
-            # path:line:text
+            if not path.is_file():
+                continue
+            if any(part in skip_dirs for part in path.parts):
+                continue
+            if path.suffix.lower() not in include_exts:
+                continue
+            try:
+                text = path.read_text(encoding="utf-8", errors="ignore")
+            except OSError:
+                continue
+            for i, line in enumerate(text.splitlines(), 1):
+                if not regex.search(line):
+                    continue
+                try:
+                    rel = str(path.resolve().relative_to(root.resolve()))
+                except ValueError:
+                    rel = str(path)
+                hits.append(
+                    _normalize_item(
+                        {
+                            "id": f"rg:{rel}:{i}",
+                            "path": rel,
+                            "line": i,
+                            "preview": line.strip(),
+                            "score": 1.0 / (len(hits) + 1),
+                            "title": "",
+                        },
+                        default_route="rg",
+                    )
+                )
+                if len(hits) >= limit:
+                    break
+        return hits
+
+    def _parse_rg_stdout(self, stdout: str, *, limit: int) -> list[dict[str, Any]]:
+        hits: list[dict[str, Any]] = []
+        for raw_line in stdout.splitlines():
+            if len(hits) >= limit:
+                break
             m = re.match(r"^(.*?):(\d+):(.*)$", raw_line)
             if not m:
                 continue

--- a/tests/test_zg_local_search.py
+++ b/tests/test_zg_local_search.py
@@ -1,0 +1,164 @@
+"""Tests for zg-style local-first four-route search."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from src.rag.hybrid_retriever import HybridRAGRetriever
+from src.rag.zg_local_search import EvidenceHit, SearchRoute, ZgLocalSearch, _looks_like_symbol
+
+
+def test_looks_like_symbol():
+    assert _looks_like_symbol("TradeGateway") is True
+    assert _looks_like_symbol("spy_put_credit") is True
+    assert _looks_like_symbol("IRON_CONDOR_STOP_LOSS_MULTIPLIER") is True
+    assert _looks_like_symbol("where are put credit exits managed") is False
+
+
+def test_rrf_multi_prefers_overlap():
+    retriever = HybridRAGRetriever(k_rrf=60.0)
+    fts = [
+        {"id": "A", "title": "only fts", "snippet": "a"},
+        {"id": "B", "title": "both", "snippet": "b"},
+    ]
+    vec = [
+        {"id": "B", "title": "both", "snippet": "b"},
+        {"id": "C", "title": "only vec", "snippet": "c"},
+    ]
+    merged = retriever.rrf_merge_multi({"fts": fts, "vector": vec}, top_n=3)
+    assert merged[0].id == "B"
+    assert "fts" in merged[0].route and "vector" in merged[0].route
+
+
+def test_rrf_merge_still_works_for_legacy_tests():
+    retriever = HybridRAGRetriever(k_rrf=60.0)
+    vec = [{"id": "LL-323", "title": "Iron Condor Management", "score": 0.95}]
+    bm25 = [
+        {"id": "LL-323", "title": "Iron Condor Management", "score": 12.4},
+        {"id": "LL-268", "title": "Win Rate", "score": 10.1},
+    ]
+    merged = retriever.rrf_merge(vec, bm25, top_n=2)
+    assert merged[0].lesson_id == "LL-323"
+    assert merged[0].vector_rank == 1
+    assert merged[0].bm25_rank == 1
+
+
+def test_zg_hybrid_with_injected_fns(tmp_path: Path):
+    def fts_fn(q: str, limit: int):
+        return [
+            {"id": "fts-1", "path": "rag_knowledge/a.md", "snippet": f"fts {q}", "score": 2.0},
+            {"id": "both", "path": "rag_knowledge/b.md", "snippet": "overlap", "score": 1.5},
+        ][:limit]
+
+    def vector_fn(q: str, limit: int):
+        return [
+            {"id": "both", "path": "rag_knowledge/b.md", "snippet": "overlap", "score": 0.9},
+            {"id": "vec-1", "path": "rag_knowledge/c.md", "snippet": f"vec {q}", "score": 0.8},
+        ][:limit]
+
+    engine = ZgLocalSearch(
+        root=tmp_path,
+        fts_fn=fts_fn,
+        vector_fn=vector_fn,
+        rewrite_queries=False,
+    )
+    hits = engine.search("put credit stop loss", route=SearchRoute.HYBRID, limit=3, fuse_rg=False)
+    assert hits
+    assert hits[0].id == "both"
+    compact = engine.format_compact(hits)
+    assert "both" in compact or "rag_knowledge/b.md" in compact
+    assert "[" in compact
+
+
+def test_zg_fts_and_vector_routes():
+    engine = ZgLocalSearch(
+        fts_fn=lambda q, n: [{"id": "f", "path": "f.md", "snippet": q, "score": 1.0}],
+        vector_fn=lambda q, n: [{"id": "v", "path": "v.md", "snippet": q, "score": 0.5}],
+        rewrite_queries=False,
+    )
+    fts = engine.search("x", route="fts", limit=1)
+    vec = engine.search("x", route="vector", limit=1)
+    assert fts[0].route == "fts" and fts[0].id == "f"
+    assert vec[0].route == "vector" and vec[0].id == "v"
+
+
+def test_zg_rg_route_finds_file(tmp_path: Path):
+    src = tmp_path / "src"
+    src.mkdir()
+    target = src / "sample_marker_mod.py"
+    target.write_text("def unique_zg_marker_fn():\n    return 42\n")
+
+    engine = ZgLocalSearch(root=tmp_path, rewrite_queries=False)
+    hits = engine.search("unique_zg_marker_fn", route=SearchRoute.RG, limit=5, globs=["*.py"])
+    assert hits, "rg route should find the marker"
+    assert hits[0].line == 1
+    assert "sample_marker_mod.py" in hits[0].path
+    assert hits[0].route == "rg"
+
+
+def test_evidence_hit_compact_line():
+    hit = EvidenceHit(
+        id="x",
+        path="src/risk/trade_gateway.py",
+        line=42,
+        preview="class TradeGateway:",
+        score=0.123456,
+        route="rg",
+        title="TradeGateway",
+    )
+    line = hit.compact_line()
+    assert "src/risk/trade_gateway.py:42" in line
+    assert "TradeGateway" in line
+
+
+def test_hybrid_rrf_wiring_in_lessons_learned_rag(monkeypatch):
+    """When both vector and keyword return hits, last_source becomes hybrid_rrf."""
+    from src.rag import lessons_learned_rag as llr
+
+    class FakeLesson:
+        def __init__(self):
+            self.id = "LL-301"
+            self.severity = "HIGH"
+            self.snippet = "IC position management"
+            self.file = "rag_knowledge/lessons_learned/ll_301.md"
+            self.title = "IC Position Management"
+            self.prevention = ""
+
+    class FakeSearch:
+        def search(self, query, top_k=5, severity_filter=None):
+            return [(FakeLesson(), 12.0)]
+
+    class FakeRAG(llr.LessonsLearnedRAG):
+        def __init__(self):
+            # Bypass heavy __init__
+            self._custom_dir = True  # skip defended path
+            self._pipeline = None
+            self.lancedb_rag = object()  # truthy
+            self.search_engine = FakeSearch()
+            self.lessons = []
+            self.last_source = None
+            self.last_retrieve_meta = None
+
+        def _query_lancedb(self, query, top_k=5):
+            return [
+                {
+                    "id": "LL-301",
+                    "title": "IC Position Management",
+                    "score": 0.9,
+                    "snippet": "IC position management",
+                    "content": "IC position management",
+                    "file": "rag_knowledge/lessons_learned/ll_301.md",
+                    "severity": "HIGH",
+                }
+            ]
+
+        def _reposition_results(self, query, results, top_k):
+            return results[:top_k]
+
+    monkeypatch.setenv("TRADING_RAG_DEFENDED", "0")
+    rag = FakeRAG()
+    out = rag.query("iron condor management", top_k=3)
+    assert out
+    assert rag.last_source == "hybrid_rrf"
+    assert out[0]["id"] == "LL-301"
+    assert out[0].get("rrf") is True

--- a/tests/test_zg_local_search.py
+++ b/tests/test_zg_local_search.py
@@ -172,8 +172,9 @@ def test_hybrid_rrf_wiring_in_lessons_learned_rag(monkeypatch):
     assert out[0]["id"] == "LL-301"
     assert out[0].get("rrf") is True
     assert "FULL VECTOR DOCUMENT" in str(out[0].get("content") or "")
-    assert 0.0 <= float(out[0]["score"]) <= 12.0
+    assert 0.0 <= float(out[0]["score"]) <= 1.0
     assert "rrf_score" in out[0]
+    assert float(out[0].get("source_score") or 0) >= 0.0
 
 
 def test_canonical_doc_id_unifies_lesson_prefixes():

--- a/tests/test_zg_local_search.py
+++ b/tests/test_zg_local_search.py
@@ -155,7 +155,7 @@ def test_hybrid_rrf_wiring_in_lessons_learned_rag(monkeypatch):
                     "title": "IC Position Management",
                     "score": 0.9,
                     "snippet": "IC position management",
-                    "content": "IC position management",
+                    "content": "FULL VECTOR DOCUMENT CONTENT FOR LESSON 301 " * 3,
                     "file": "rag_knowledge/lessons_learned/ll_301.md",
                     "severity": "HIGH",
                 }
@@ -171,3 +171,32 @@ def test_hybrid_rrf_wiring_in_lessons_learned_rag(monkeypatch):
     assert rag.last_source == "hybrid_rrf"
     assert out[0]["id"] == "LL-301"
     assert out[0].get("rrf") is True
+    assert "FULL VECTOR DOCUMENT" in str(out[0].get("content") or "")
+    assert 0.0 <= float(out[0]["score"]) <= 12.0
+    assert "rrf_score" in out[0]
+
+
+def test_canonical_doc_id_unifies_lesson_prefixes():
+    from src.rag.zg_local_search import _canonical_doc_id
+
+    assert _canonical_doc_id("lesson:LL-301") == "LL-301"
+    assert _canonical_doc_id("ll_301") == "LL-301"
+    assert _canonical_doc_id("rag_knowledge/lessons_learned/LL-301_foo.md") == "LL-301"
+
+
+def test_cli_rejects_negative_limit():
+    import importlib.util
+    from pathlib import Path
+
+    path = Path(__file__).resolve().parents[1] / "scripts" / "zg_search.py"
+    spec = importlib.util.spec_from_file_location("zg_search_cli", path)
+    assert spec and spec.loader
+    cli = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(cli)
+    try:
+        cli.main(["--limit", "-1", "query"])
+        raised = False
+    except SystemExit as exc:
+        raised = True
+        assert exc.code != 0
+    assert raised

--- a/tests/test_zg_local_search.py
+++ b/tests/test_zg_local_search.py
@@ -88,12 +88,21 @@ def test_zg_rg_route_finds_file(tmp_path: Path):
     target = src / "sample_marker_mod.py"
     target.write_text("def unique_zg_marker_fn():\n    return 42\n")
 
-    engine = ZgLocalSearch(root=tmp_path, rewrite_queries=False)
+    # Force Python fallback so CI runners without ripgrep still pass.
+    engine = ZgLocalSearch(root=tmp_path, rewrite_queries=False, rg_bin="rg-not-installed-for-test")
     hits = engine.search("unique_zg_marker_fn", route=SearchRoute.RG, limit=5, globs=["*.py"])
-    assert hits, "rg route should find the marker"
+    assert hits, "rg route should find the marker via Python fallback"
     assert hits[0].line == 1
     assert "sample_marker_mod.py" in hits[0].path
     assert hits[0].route == "rg"
+
+
+def test_zg_rg_python_fallback_literal(tmp_path: Path):
+    (tmp_path / "note.md").write_text("hello TradeGateway world\n")
+    engine = ZgLocalSearch(root=tmp_path, rewrite_queries=False, rg_bin="/no/such/rg")
+    hits = engine.search("TradeGateway", route="rg", limit=3)
+    assert len(hits) == 1
+    assert hits[0].path.endswith("note.md")
 
 
 def test_evidence_hit_compact_line():


### PR DESCRIPTION
## Work item

- Linear issue: AGENT-577
- Agent: grok
- Base SHA: 6fe97b9c772020c835f128e8c8248035df7061ef
- Branch/worktree: feat/agent-577-zg-local-first-search / .worktrees/agent-577-zg-local-first-search
- Files or systems claimed: src/rag/zg_local_search.py, src/rag/hybrid_retriever.py, src/rag/lessons_learned_rag.py, scripts/zg_search.py, tests/test_zg_local_search.py, docs/ZG_LOCAL_SEARCH.md, skills/trading-ops/SKILL.md
- Coordination legacy reason:

## Change

- Scope: Steal Qwen zg (zvec-grep) high-ROI mechanics onto trading RAG — four routes (hybrid/fts/vector/rg), RRF fusion, managed ripgrep, compact evidence. Wire previously dead HybridRAGRetriever into LessonsLearnedRAG.query when vector+keyword both return hits. Do not vendor @zvec/zvec-grep.
- Deleted surfaces and recovery impact: none
- Out of scope: npm zg install, remote Qwen embeddings, .zvec-grep index format

## Verification

- [x] Targeted tests (`pytest tests/test_zg_local_search.py tests/test_hybrid_retriever.py` — 11 passed)
- [ ] `make check`
- [x] RAG read/write round trip when RAG changes (FTS + rg CLI smoke; hybrid RRF unit wiring)
- [ ] Orchestration smoke test when orchestration changes
- [ ] `TRADING_ENV=paper make dry-run` when operational paths change
- [ ] CI green on this exact head SHA

## Evidence boundaries

- Test result: 11 passed (test_zg_local_search + test_hybrid_retriever); ruff clean
- CLI: `scripts/zg_search.py --check-ready` ready=true; `--route rg TradeGateway` and `--route fts` return compact hits
- CI run: pending
- Protected-system result: n/a (search layer only)
- Broker/order/fill impact: none

## Coordination

- [x] Linear issue and vault claim updated
- [x] No overlapping active claim or worktree
- [ ] Claim will be marked done or released after merge

Source: https://www.marktechpost.com/2026/09/02/qwen-developers-open-sources-zg-zvec-grep-a-local-first-search-layer-unifying-ripgrep-bm25-and-vector-search/
Docs: docs/ZG_LOCAL_SEARCH.md

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added local-first search across hybrid, full-text, vector, and ripgrep routes.
  - Added a command-line search tool with result limits, JSON output, workspace selection, and readiness checks.
  - Improved results by combining sources and showing compact evidence with locations, scores, and previews.
  - Refined lessons-learned retrieval with hybrid ranking and more reliable duplicate-result handling.

- **Documentation**
  - Added local search documentation covering routes, CLI usage, configuration, and examples.
  - Added trading-operations guidance and sample commands.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->