### PR TITLE
feat(AGENT-579): deterministic JIT task→harness packs

### DIFF
--- a/docs/JIT_HARNESS.md
+++ b/docs/JIT_HARNESS.md
@@ -1,0 +1,44 @@
+# JIT task→harness packs (AGENT-579)
+
+Process steal from [JIT-Agent](https://arxiv.org/abs/2608.25593) (Rohan Paul /
+@rohanpaul_ai summary, 2026-09-02): **a smaller model with the right
+task-specific harness can beat a stronger model** in a fat fixed runtime, with
+lower token/API cost.
+
+We do **not** train or vendor JIT-Agent. We steal the _composable four-module
+harness artifact_ and select packs deterministically for trading ops.
+
+## Four modules
+
+| Module  | Trading mapping                                   |
+| ------- | ------------------------------------------------- |
+| memory  | Ledgers / kill switch / RAG paths to load         |
+| plan    | Ordered operator steps                            |
+| actions | Allowed scripts / make targets                    |
+| skills  | Skill routes (+ hard forbids for live / freehand) |
+
+## Operator
+
+```bash
+.venv/bin/python scripts/jit_harness.py --check-ready
+.venv/bin/python scripts/jit_harness.py "account status"
+.venv/bin/python scripts/jit_harness.py --json "put credit dry-run"
+.venv/bin/python scripts/jit_harness.py "merge ready PRs"
+```
+
+## Task classes
+
+`status` · `dry_run` · `inventory` · `rag_search` · `pr_hygiene` ·
+`residual_ic` · `broker_sync` · `unknown` (fail-closed → status-only)
+
+## Explicit non-goals
+
+- Training a harness-generation model
+- Auto-evolving harness archives from online RL
+- Untracked theater under `scripts/jit_agent_*.py` in dirty checkouts
+- Live order submission paths
+
+## Prevention
+
+`tests/test_jit_harness.py` locks classification, four-module shape, paper-only
+forbids, and CLI readiness so agents cannot silently fall back to a fat pack.

--- a/scripts/jit_harness.py
+++ b/scripts/jit_harness.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+"""CLI: just-in-time trading ops harness packs (deterministic).
+
+Inspired by JIT-Agent (arxiv:2608.25593) — task-adaptive harness, not a fatter model.
+Does not train or call a harness-generation LLM.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from src.ops.jit_harness import (  # noqa: E402
+    estimate_savings_vs_full_context,
+    list_task_classes,
+    select_harness,
+)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Select a task-specific trading harness pack (memory/plan/actions/skills)"
+    )
+    parser.add_argument("prompt", nargs="?", default="", help="Operator task prompt")
+    parser.add_argument("--json", action="store_true", help="Emit JSON pack")
+    parser.add_argument("--list", action="store_true", help="List task classes")
+    parser.add_argument(
+        "--full-budget",
+        type=int,
+        default=12000,
+        help="Assumed fat-harness token budget for savings hint",
+    )
+    parser.add_argument(
+        "--check-ready",
+        action="store_true",
+        help="Print catalog readiness JSON and exit 0",
+    )
+    args = parser.parse_args(argv)
+
+    if args.check_ready or args.list:
+        payload = {
+            "ready": True,
+            "source": "arxiv:2608.25593 process steal (deterministic)",
+            "task_classes": list_task_classes(),
+        }
+        print(json.dumps(payload, indent=2))
+        return 0
+
+    if not (args.prompt or "").strip():
+        parser.error("prompt is required unless --list / --check-ready")
+
+    pack = select_harness(args.prompt)
+    savings = estimate_savings_vs_full_context(pack, full_budget=max(0, args.full_budget))
+
+    if args.json:
+        out = pack.to_dict()
+        out["savings_hint"] = savings
+        out["prompt"] = args.prompt
+        print(json.dumps(out, indent=2))
+    else:
+        print(pack.compact())
+        print(
+            f"\nsavings_hint: ~{savings['saved_pct_hint']}% vs {savings['full_budget']} tok fat pack "
+            f"(pack={savings['pack_budget']})"
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/trading-ops/SKILL.md
+++ b/skills/trading-ops/SKILL.md
@@ -90,6 +90,10 @@ make graphify-check
 python scripts/zg_search.py --check-ready
 python scripts/zg_search.py "put credit stop loss"
 python scripts/zg_search.py --route rg "TradeGateway"
+# JIT task→harness pack (memory/plan/actions/skills) — docs/JIT_HARNESS.md
+python scripts/jit_harness.py --check-ready
+python scripts/jit_harness.py "account status"
+python scripts/jit_harness.py --json "put credit dry-run"
 ```
 
 Inventory unclean (`exit 2`) → **no new risk**.

--- a/src/ops/jit_harness.py
+++ b/src/ops/jit_harness.py
@@ -1,0 +1,399 @@
+"""JIT task→harness packs for trading ops (deterministic).
+
+Process steal from JIT-Agent (arxiv:2608.25593 / Rohan Paul X 2026-09-02):
+a smaller model with the *right task-specific harness* beats a stronger model
+in a fat fixed harness. We do **not** train or vendor JIT-Agent.
+
+Four-module harness artifact (paper protocol, mapped to ops):
+
+* memory  — which ledgers / RAG surfaces to load
+* plan    — ordered operator steps
+* actions — allowed scripts / CLI commands
+* skills  — skill routes to load (and hard forbids)
+
+Selection is keyword/rule based and fail-closed for live execution.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import asdict, dataclass
+from enum import StrEnum
+from typing import Any
+
+
+class TaskClass(StrEnum):
+    STATUS = "status"
+    DRY_RUN = "dry_run"
+    INVENTORY = "inventory"
+    RAG_SEARCH = "rag_search"
+    PR_HYGIENE = "pr_hygiene"
+    RESIDUAL_IC = "residual_ic"
+    BROKER_SYNC = "broker_sync"
+    UNKNOWN = "unknown"
+
+
+@dataclass(frozen=True)
+class HarnessPack:
+    """Composable four-module harness for one task class."""
+
+    task_class: TaskClass
+    memory: tuple[str, ...]
+    plan: tuple[str, ...]
+    actions: tuple[str, ...]
+    skills: tuple[str, ...]
+    forbid: tuple[str, ...]
+    token_budget_hint: int
+    paper_only: bool = True
+    rationale: str = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        d = asdict(self)
+        d["task_class"] = self.task_class.value
+        return d
+
+    def compact(self) -> str:
+        lines = [
+            f"task_class: {self.task_class.value}",
+            f"paper_only: {self.paper_only}",
+            f"token_budget_hint: {self.token_budget_hint}",
+            "memory:",
+            *[f"  - {m}" for m in self.memory],
+            "plan:",
+            *[f"  - {p}" for p in self.plan],
+            "actions:",
+            *[f"  - {a}" for a in self.actions],
+            "skills:",
+            *[f"  - {s}" for s in self.skills],
+            "forbid:",
+            *[f"  - {f}" for f in self.forbid],
+        ]
+        if self.rationale:
+            lines.append(f"rationale: {self.rationale}")
+        return "\n".join(lines)
+
+
+# Shared hard forbids — always included.
+_LIVE_FORBIDS = (
+    "live order submit",
+    "close_position outside guardian",
+    "delete TRADING_HALTED",
+    "force-push main",
+    "hardcode Alpaca credentials",
+)
+
+_PACKS: dict[TaskClass, HarnessPack] = {
+    TaskClass.STATUS: HarnessPack(
+        task_class=TaskClass.STATUS,
+        memory=(
+            "data/system_state.json",
+            "data/runtime/strategy_kill_switch.json",
+            "data/put_credit_entries.json",
+        ),
+        plan=(
+            "Read kill switch active_family + live_blocked",
+            "Run spy_put_credit --status",
+            "Cite equity/positions from system_state.json only",
+        ),
+        actions=(
+            "python scripts/spy_put_credit.py --status",
+            "python scripts/system_health_check.py",
+        ),
+        skills=("trading-ops", "alpaca-paper-trading"),
+        forbid=_LIVE_FORBIDS + ("make dry-run unless asked",),
+        token_budget_hint=2500,
+        rationale="Read-only status; smallest memory surface.",
+    ),
+    TaskClass.DRY_RUN: HarnessPack(
+        task_class=TaskClass.DRY_RUN,
+        memory=(
+            "data/runtime/strategy_kill_switch.json",
+            "data/system_state.json",
+            "data/put_credit_entries.json",
+        ),
+        plan=(
+            "Confirm paper mode / live_blocked",
+            "Audit open inventory (must be clean)",
+            "Plan put-credit with --dry-run (no submit)",
+            "State plan != executed trade",
+        ),
+        actions=(
+            "python scripts/audit_open_inventory.py",
+            "python scripts/spy_put_credit.py --dry-run",
+            "make dry-run",
+        ),
+        skills=("trading-ops", "alpaca-paper-trading"),
+        forbid=_LIVE_FORBIDS + ("omit --dry-run", "claim planned trade as filled"),
+        token_budget_hint=4000,
+        rationale="Paper plan path; inventory gate before risk.",
+    ),
+    TaskClass.INVENTORY: HarnessPack(
+        task_class=TaskClass.INVENTORY,
+        memory=(
+            "data/system_state.json",
+            "data/put_credit_entries.json",
+            ".claude/rules/open-inventory-hygiene.md",
+        ),
+        plan=(
+            "Run open inventory audit",
+            "If exit 2 unclean: block new risk",
+            "Residual IC exits only via residual_ic_manager",
+        ),
+        actions=(
+            "python scripts/audit_open_inventory.py",
+            "python scripts/residual_ic_manager.py --dry-run",
+        ),
+        skills=("trading-ops",),
+        forbid=_LIVE_FORBIDS + ("freehand close legs", "new iron-condor entries"),
+        token_budget_hint=3000,
+        rationale="Inventory hygiene owns unclean-book decisions.",
+    ),
+    TaskClass.RAG_SEARCH: HarnessPack(
+        task_class=TaskClass.RAG_SEARCH,
+        memory=(
+            "rag_knowledge/lessons_learned/",
+            "docs/ZG_LOCAL_SEARCH.md",
+            "data/trades.json (paired only)",
+        ),
+        plan=(
+            "Prefer zg_search four-route local search",
+            "Cite lesson IDs / path:line evidence",
+            "No profitability claim without paired cohort n",
+        ),
+        actions=(
+            "python scripts/zg_search.py --check-ready",
+            'python scripts/zg_search.py "<query>"',
+            'python scripts/zg_search.py --route rg "<symbol>"',
+            'python scripts/graph_rag_query.py --query "<q>" --graph-only',
+        ),
+        skills=("trading-ops", "zg-local-first-search", "fleet-repo-intelligence"),
+        forbid=_LIVE_FORBIDS + ("invent expectancy from 0 trades",),
+        token_budget_hint=3500,
+        rationale="Compact retrieval beats dumping full RAG into context.",
+    ),
+    TaskClass.PR_HYGIENE: HarnessPack(
+        task_class=TaskClass.PR_HYGIENE,
+        memory=(
+            "docs/AGENT_COORDINATION.md",
+            "Handoffs/linear-claims/ (vault)",
+            ".github/pull_request_template.md",
+        ),
+        plan=(
+            "List open PRs + required checks",
+            "Resolve review threads before merge",
+            "Bare Base SHA in PR body",
+            "Merge only when required CI green",
+        ),
+        actions=(
+            "gh pr list --state open",
+            "gh pr checks <N>",
+            "gh pr merge <N> --auto --squash",
+            "make coordination-preflight",
+        ),
+        skills=(
+            "trading-ops",
+            "fleet-pr-hygiene",
+            "trading-pr-base-sha-bare",
+            "three-bus-ship-cycle",
+            "multi-agent-coord",
+        ),
+        forbid=_LIVE_FORBIDS + ("gh pr merge --admin", "force-push"),
+        token_budget_hint=5000,
+        rationale="PR hygiene does not need trade ledgers or strategy code.",
+    ),
+    TaskClass.RESIDUAL_IC: HarnessPack(
+        task_class=TaskClass.RESIDUAL_IC,
+        memory=(
+            "data/runtime/strategy_kill_switch.json",
+            "data/system_state.json",
+            ".claude/rules/kill-criteria.md",
+        ),
+        plan=(
+            "Confirm IC new entries killed",
+            "Dry-run residual_ic_manager only",
+            "Do not revive ic_simple / iron_condor entries",
+        ),
+        actions=("python scripts/residual_ic_manager.py --dry-run",),
+        skills=("trading-ops",),
+        forbid=_LIVE_FORBIDS
+        + (
+            "new iron condor entries",
+            "close outside residual_ic_manager / spy_put_credit manage-exits",
+        ),
+        token_budget_hint=3000,
+        rationale="Exit-only residual inventory path.",
+    ),
+    TaskClass.BROKER_SYNC: HarnessPack(
+        task_class=TaskClass.BROKER_SYNC,
+        memory=("data/system_state.json", "data/trades.json"),
+        plan=(
+            "Refresh broker snapshot",
+            "Refresh paired closed ledger",
+            "Re-read system_state mtime before trading claims",
+        ),
+        actions=(
+            "python scripts/sync_alpaca_state.py",
+            "python scripts/sync_closed_positions.py",
+        ),
+        skills=("trading-ops", "alpaca-paper-trading"),
+        forbid=_LIVE_FORBIDS + ("treat unpaired fills as trades",),
+        token_budget_hint=3000,
+        rationale="Sync mutates local ledgers only; still paper-scoped.",
+    ),
+}
+
+_UNKNOWN = HarnessPack(
+    task_class=TaskClass.UNKNOWN,
+    memory=("skills/trading-ops/SKILL.md", "data/runtime/strategy_kill_switch.json"),
+    plan=(
+        "Rephrase into a known task class",
+        "Default to STATUS read-only until classified",
+    ),
+    actions=("python scripts/spy_put_credit.py --status",),
+    skills=("trading-ops",),
+    forbid=_LIVE_FORBIDS
+    + (
+        "guess live submit",
+        "load full repo into context",
+    ),
+    token_budget_hint=2000,
+    rationale="Fail closed: unknown → status-only until reclassified.",
+)
+
+# Ordered rules: first match wins.
+_RULES: tuple[tuple[TaskClass, tuple[str, ...]], ...] = (
+    (
+        TaskClass.PR_HYGIENE,
+        (
+            r"\bpr\b",
+            r"pull request",
+            r"merge",
+            r"ci\b",
+            r"greptile",
+            r"branch hygiene",
+            r"open prs",
+            r"automerge",
+        ),
+    ),
+    (
+        TaskClass.RESIDUAL_IC,
+        (
+            r"residual.?ic",
+            r"iron.?condor",
+            r"\bic_simple\b",
+            r"exit.?only.?ic",
+        ),
+    ),
+    (
+        TaskClass.INVENTORY,
+        (
+            r"inventory",
+            r"orphan",
+            r"unclean",
+            r"lot.?mismatch",
+            r"audit_open_inventory",
+        ),
+    ),
+    (
+        TaskClass.BROKER_SYNC,
+        (
+            r"sync.?alpaca",
+            r"broker.?sync",
+            r"refresh.?ledger",
+            r"sync_closed",
+            r"system_state",
+        ),
+    ),
+    (
+        TaskClass.DRY_RUN,
+        (
+            r"dry.?run",
+            r"plan.?trade",
+            r"put.?credit.*plan",
+            r"spy_put_credit",
+            r"\bmake dry-run\b",
+        ),
+    ),
+    (
+        TaskClass.RAG_SEARCH,
+        (
+            r"\brag\b",
+            r"lesson",
+            r"zg_search",
+            r"search",
+            r"graph.?rag",
+            r"recall",
+            r"why.*(kill|halt|stop)",
+        ),
+    ),
+    (
+        TaskClass.STATUS,
+        (
+            r"\bstatus\b",
+            r"health",
+            r"equity",
+            r"positions",
+            r"kill.?switch",
+            r"how.*(account|doing)",
+        ),
+    ),
+)
+
+
+def classify_task(prompt: str) -> TaskClass:
+    """Map free-text operator intent to a task class (first match)."""
+    text = (prompt or "").strip().lower()
+    if not text:
+        return TaskClass.UNKNOWN
+    for task_class, patterns in _RULES:
+        for pat in patterns:
+            if re.search(pat, text, flags=re.IGNORECASE):
+                return task_class
+    return TaskClass.UNKNOWN
+
+
+def select_harness(prompt: str) -> HarnessPack:
+    """Just-in-time harness selection for a trading ops prompt."""
+    task_class = classify_task(prompt)
+    if task_class == TaskClass.UNKNOWN:
+        return _UNKNOWN
+    return _PACKS[task_class]
+
+
+def list_task_classes() -> list[dict[str, Any]]:
+    """Catalog for --list / agent discovery."""
+    out: list[dict[str, Any]] = []
+    for tc, pack in _PACKS.items():
+        out.append(
+            {
+                "task_class": tc.value,
+                "token_budget_hint": pack.token_budget_hint,
+                "paper_only": pack.paper_only,
+                "skills": list(pack.skills),
+                "actions_n": len(pack.actions),
+            }
+        )
+    out.append(
+        {
+            "task_class": TaskClass.UNKNOWN.value,
+            "token_budget_hint": _UNKNOWN.token_budget_hint,
+            "paper_only": True,
+            "skills": list(_UNKNOWN.skills),
+            "actions_n": len(_UNKNOWN.actions),
+        }
+    )
+    return out
+
+
+def estimate_savings_vs_full_context(pack: HarnessPack, full_budget: int = 12000) -> dict[str, Any]:
+    """Rough token-budget comparison vs loading a fat fixed harness."""
+    used = pack.token_budget_hint
+    saved = max(0, full_budget - used)
+    pct = round(100.0 * saved / full_budget, 1) if full_budget else 0.0
+    return {
+        "full_budget": full_budget,
+        "pack_budget": used,
+        "saved_tokens_hint": saved,
+        "saved_pct_hint": pct,
+        "note": "Heuristic budget, not measured LLM tokens.",
+    }

--- a/tests/test_jit_harness.py
+++ b/tests/test_jit_harness.py
@@ -1,0 +1,85 @@
+"""Tests for deterministic JIT task→harness selection."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+from src.ops.jit_harness import (
+    TaskClass,
+    classify_task,
+    estimate_savings_vs_full_context,
+    list_task_classes,
+    select_harness,
+)
+
+
+def test_classify_status():
+    assert classify_task("what is account status?") == TaskClass.STATUS
+    assert classify_task("show kill switch health") == TaskClass.STATUS
+
+
+def test_classify_dry_run():
+    assert classify_task("run put credit dry-run") == TaskClass.DRY_RUN
+    assert classify_task("make dry-run for today") == TaskClass.DRY_RUN
+
+
+def test_classify_inventory_before_generic_search():
+    assert classify_task("audit open inventory unclean") == TaskClass.INVENTORY
+
+
+def test_classify_pr_hygiene():
+    assert classify_task("merge ready PRs and fix CI") == TaskClass.PR_HYGIENE
+
+
+def test_classify_rag_search():
+    assert classify_task("zg_search put credit stop lessons") == TaskClass.RAG_SEARCH
+
+
+def test_classify_residual_ic():
+    assert classify_task("residual IC exit plan") == TaskClass.RESIDUAL_IC
+
+
+def test_unknown_fail_closed():
+    pack = select_harness("teleport the moon")
+    assert pack.task_class == TaskClass.UNKNOWN
+    assert pack.paper_only is True
+    assert any("live" in f.lower() or "submit" in f.lower() for f in pack.forbid)
+
+
+def test_four_modules_present():
+    pack = select_harness("spy put credit dry-run plan")
+    assert pack.task_class == TaskClass.DRY_RUN
+    assert pack.memory and pack.plan and pack.actions and pack.skills
+    assert "--dry-run" in " ".join(pack.actions)
+    assert any("live" in f.lower() for f in pack.forbid)
+
+
+def test_dry_run_forbids_claiming_fill():
+    pack = select_harness("plan trade with spy_put_credit")
+    assert any("filled" in f or "executed" in f or "claim" in f for f in pack.forbid)
+
+
+def test_savings_hint_positive():
+    pack = select_harness("status")
+    hint = estimate_savings_vs_full_context(pack, full_budget=12000)
+    assert hint["pack_budget"] < hint["full_budget"]
+    assert hint["saved_pct_hint"] > 0
+
+
+def test_list_task_classes_includes_unknown():
+    rows = list_task_classes()
+    ids = {r["task_class"] for r in rows}
+    assert TaskClass.STATUS.value in ids
+    assert TaskClass.UNKNOWN.value in ids
+
+
+def test_cli_json_and_ready():
+    path = Path(__file__).resolve().parents[1] / "scripts" / "jit_harness.py"
+    spec = importlib.util.spec_from_file_location("jit_harness_cli", path)
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+
+    assert mod.main(["--check-ready"]) == 0
+    assert mod.main(["--json", "account status"]) == 0


### PR DESCRIPTION
## Work item

- Linear issue: AGENT-579
- Agent: grok
- Base SHA: a690cfc7932f4b738a14ac41d56e77a72cf965df
- Branch/worktree: feat/agent-579-jit-task-harness / .worktrees/agent-579-jit-task-harness
- Files or systems claimed: src/ops/jit_harness.py, scripts/jit_harness.py, tests/test_jit_harness.py, docs/JIT_HARNESS.md, skills/trading-ops/SKILL.md
- Coordination legacy reason:

## Change

- Scope: Steal JIT-Agent (arxiv 2608.25593 / Rohan Paul) high-ROI mechanic — task-specific four-module harness packs (memory/plan/actions/skills) beat fat fixed runtimes. Deterministic task→pack selector for trading ops. Paper-only forbids; unknown fail-closed. Do not train or vendor JIT-Agent. Do not ship dirty scripts/jit_agent_*.py theater.
- Deleted surfaces and recovery impact: none
- Out of scope: online RL harness evolution, live order submit paths, training a harness-generation model

## Verification

- [x] Targeted tests (`pytest tests/test_jit_harness.py` — 12 passed)
- [ ] `make check`
- [ ] RAG read/write round trip when RAG changes
- [ ] Orchestration smoke test when orchestration changes
- [ ] `TRADING_ENV=paper make dry-run` when operational paths change
- [ ] CI green on this exact head SHA

## Evidence boundaries

- Test result: 12 passed (test_jit_harness); ruff clean
- CLI: `scripts/jit_harness.py --check-ready` ready=true; dry_run pack savings_hint ~66.7% vs 12k fat pack
- CI run: pending
- Protected-system result: n/a (ops harness selector only)
- Broker/order/fill impact: none (paper-only forbids; no submit)

## Coordination

- [x] Linear issue and vault claim updated
- [x] No overlapping active claim or worktree
- [ ] Claim will be marked done or released after merge

Source: https://arxiv.org/abs/2608.25593
X: https://x.com/rohanpaul_ai/status/2095036248918548812
Docs: docs/JIT_HARNESS.md

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added task-specific harness selection for trading operations, including status checks, dry runs, inventory, search, broker sync, and maintenance tasks.
  - Added structured and compact command-line output, readiness checks, task listings, prompt validation, and context-savings estimates.
  - Unknown tasks now fail closed with paper-only safeguards and live-action restrictions.

- **Documentation**
  - Added usage guidance, supported task classes, safety boundaries, and example commands for harness operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->