### PR TITLE
feat(AGENT-580): harden JIT harness to Sept 2026 standards

### DIFF
--- a/docs/JIT_HARNESS.md
+++ b/docs/JIT_HARNESS.md
@@ -1,21 +1,30 @@
-# JIT task→harness packs (AGENT-579)
+# JIT task→harness packs (AGENT-579 / AGENT-580)
 
-Process steal from [JIT-Agent](https://arxiv.org/abs/2608.25593) (Rohan Paul /
-@rohanpaul_ai summary, 2026-09-02): **a smaller model with the right
-task-specific harness can beat a stronger model** in a fat fixed runtime, with
-lower token/API cost.
+Process steal from [JIT-Agent](https://arxiv.org/abs/2608.25593) (v2, Sept 2026):
+**harness quality can dominate model quality**. A smaller model with the right
+task-specific harness can beat a stronger model in a fat fixed runtime.
 
-We do **not** train or vendor JIT-Agent. We steal the _composable four-module
-harness artifact_ and select packs deterministically for trading ops.
+We do **not** train or vendor JIT-Agent. We implement a **deterministic**
+task→pack selector aligned to Sept 2026 harness craft.
 
-## Four modules
+## Four modules (JIT protocol → trading)
 
-| Module  | Trading mapping                                   |
-| ------- | ------------------------------------------------- |
-| memory  | Ledgers / kill switch / RAG paths to load         |
-| plan    | Ordered operator steps                            |
-| actions | Allowed scripts / make targets                    |
-| skills  | Skill routes (+ hard forbids for live / freehand) |
+| JIT module | Trading mapping                                    |
+| ---------- | -------------------------------------------------- |
+| memory     | Ledgers / kill switch / RAG paths to load          |
+| planning   | Ordered operator steps (`plan`)                    |
+| action     | Allowed scripts / make targets (`actions`)         |
+| capability | Skills allowlist + forbid denylist (`tool_policy`) |
+
+## Sept 2026 standards we keep
+
+1. **Task-specific packs** beat one fat fixed context dump.
+2. **Minimal skill surface** — in-repo `skills/` only; readiness fails closed.
+3. **Fail-closed capability gates** — paper-only forbids; unknown → status-only.
+4. **Explicit intent conflicts** — e.g. `--status` + `dry-run` → `dry_run` with note.
+5. **Selection receipts** — `logs/jit_harness_receipts.jsonl` for archive/eval
+   (not online RL / not training a harness model).
+6. **Lazy disclosure** — load the pack for the task, not every skill.
 
 ## Operator
 
@@ -23,7 +32,9 @@ harness artifact_ and select packs deterministically for trading ops.
 .venv/bin/python scripts/jit_harness.py --check-ready
 .venv/bin/python scripts/jit_harness.py "account status"
 .venv/bin/python scripts/jit_harness.py --json "put credit dry-run"
-.venv/bin/python scripts/jit_harness.py "merge ready PRs"
+.venv/bin/python scripts/jit_harness.py --receipt "spy_put_credit --status --dry-run"
+.venv/bin/python scripts/jit_harness.py --receipt --record "merge ready PRs"
+.venv/bin/python -m pytest tests/test_jit_harness.py -q
 ```
 
 ## Task classes
@@ -33,12 +44,13 @@ harness artifact_ and select packs deterministically for trading ops.
 
 ## Explicit non-goals
 
-- Training a harness-generation model
-- Auto-evolving harness archives from online RL
-- Untracked theater under `scripts/jit_agent_*.py` in dirty checkouts
+- Training a harness-generation model / vendoring JIT-Agent-27B
+- Auto-evolving harness weights from online RL
+- Untracked theater under `scripts/jit_agent_*.py`
 - Live order submission paths
 
 ## Prevention
 
-`tests/test_jit_harness.py` locks classification, four-module shape, paper-only
-forbids, and CLI readiness so agents cannot silently fall back to a fat pack.
+`tests/test_jit_harness.py` locks classification (incl. flag order + conflicts),
+four-module/capability shape, paper-only forbids, readiness honesty, and receipt
+CLI so agents cannot silently fall back to a fat pack.

--- a/scripts/jit_harness.py
+++ b/scripts/jit_harness.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
 """CLI: just-in-time trading ops harness packs (deterministic).
 
-Inspired by JIT-Agent (arxiv:2608.25593) — task-adaptive harness, not a fatter model.
-Does not train or call a harness-generation LLM.
+Inspired by JIT-Agent (arxiv:2608.25593v2, Sept 2026) — task-adaptive harness,
+not a fatter model. Does not train or call a harness-generation LLM.
 """
 
 from __future__ import annotations
@@ -17,15 +17,17 @@ if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
 from src.ops.jit_harness import (  # noqa: E402
+    append_selection_receipt,
     estimate_savings_vs_full_context,
     readiness_report,
     select_harness,
+    selection_receipt,
 )
 
 
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(
-        description="Select a task-specific trading harness pack (memory/plan/actions/skills)"
+        description=("Select a task-specific trading harness pack (memory/plan/actions/capability)")
     )
     parser.add_argument("prompt", nargs="?", default="", help="Operator task prompt")
     parser.add_argument("--json", action="store_true", help="Emit JSON pack")
@@ -39,7 +41,17 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument(
         "--check-ready",
         action="store_true",
-        help="Print catalog readiness JSON and exit 0",
+        help="Print catalog readiness JSON and exit 0 when ready",
+    )
+    parser.add_argument(
+        "--receipt",
+        action="store_true",
+        help="Emit full selection receipt (conflicts, capability_ok, fingerprint)",
+    )
+    parser.add_argument(
+        "--record",
+        action="store_true",
+        help="Append selection receipt to logs/jit_harness_receipts.jsonl",
     )
     args = parser.parse_args(argv)
 
@@ -50,6 +62,16 @@ def main(argv: list[str] | None = None) -> int:
 
     if not (args.prompt or "").strip():
         parser.error("prompt is required unless --list / --check-ready")
+
+    if args.receipt or args.record:
+        receipt = selection_receipt(
+            args.prompt, repo_root=ROOT, full_budget=max(0, args.full_budget)
+        )
+        if args.record:
+            path = append_selection_receipt(receipt, repo_root=ROOT)
+            receipt["receipt_path"] = str(path)
+        print(json.dumps(receipt, indent=2))
+        return 0 if receipt.get("capability_ok") else 2
 
     pack = select_harness(args.prompt)
     savings = estimate_savings_vs_full_context(pack, full_budget=max(0, args.full_budget))
@@ -62,7 +84,8 @@ def main(argv: list[str] | None = None) -> int:
     else:
         print(pack.compact())
         print(
-            f"\nsavings_hint: ~{savings['saved_pct_hint']}% vs {savings['full_budget']} tok fat pack "
+            f"\nsavings_hint: ~{savings['saved_pct_hint']}% vs "
+            f"{savings['full_budget']} tok fat pack "
             f"(pack={savings['pack_budget']})"
         )
     return 0

--- a/skills/trading-ops/SKILL.md
+++ b/skills/trading-ops/SKILL.md
@@ -94,6 +94,8 @@ python scripts/zg_search.py --route rg "TradeGateway"
 python scripts/jit_harness.py --check-ready
 python scripts/jit_harness.py "account status"
 python scripts/jit_harness.py --json "put credit dry-run"
+python scripts/jit_harness.py --receipt "spy_put_credit --status --dry-run"
+python scripts/jit_harness.py --receipt --record "merge ready PRs"
 ```
 
 Inventory unclean (`exit 2`) → **no new risk**.

--- a/src/ops/jit_harness.py
+++ b/src/ops/jit_harness.py
@@ -1,23 +1,33 @@
 """JIT task→harness packs for trading ops (deterministic).
 
-Process steal from JIT-Agent (arxiv:2608.25593 / Rohan Paul X 2026-09-02):
-a smaller model with the *right task-specific harness* beats a stronger model
-in a fat fixed harness. We do **not** train or vendor JIT-Agent.
+Process steal from JIT-Agent (arxiv:2608.25593v2, Sept 2026): harness quality
+can dominate model quality. We do **not** train or vendor JIT-Agent.
 
-Four-module harness artifact (paper protocol, mapped to ops):
+Four-module artifact (JIT protocol → trading ops):
 
-* memory  — which ledgers / RAG surfaces to load
-* plan    — ordered operator steps
-* actions — allowed scripts / CLI commands
-* skills  — skill routes to load (and hard forbids)
+* memory     — which ledgers / RAG surfaces to load
+* plan       — ordered operator steps (planning)
+* actions    — allowed scripts / CLI commands (action loop)
+* capability — skills allowlist + forbid denylist (tool_policy)
+
+Sept 2026 standards we implement here (not clones):
+
+* Task-specific packs beat fat fixed runtimes
+* Lazy / minimal skill surface (in-repo skills only)
+* Deterministic fail-closed capability gates (paper-only forbids)
+* Selection receipts for archive/eval (logs/, not model training)
+* Explicit intent-conflict resolution in the classifier
 
 Selection is keyword/rule based and fail-closed for live execution.
 """
 
 from __future__ import annotations
 
+import hashlib
+import json
 import re
 from dataclasses import asdict, dataclass
+from datetime import UTC, datetime
 from enum import StrEnum
 from pathlib import Path
 from typing import Any
@@ -51,6 +61,8 @@ class HarnessPack:
     def to_dict(self) -> dict[str, Any]:
         d = asdict(self)
         d["task_class"] = self.task_class.value
+        # JIT-Agent capability/tool_policy module = skills allow + forbid deny
+        d["capability"] = {"skills": list(self.skills), "forbid": list(self.forbid)}
         return d
 
     def compact(self) -> str:
@@ -341,27 +353,139 @@ _RULES: tuple[tuple[TaskClass, tuple[str, ...]], ...] = (
 )
 
 
+@dataclass(frozen=True)
+class ClassificationResult:
+    """Classifier output with explicit conflict notes (Sept 2026 harness honesty)."""
+
+    task_class: TaskClass
+    conflict_note: str = ""
+    matched_intents: tuple[str, ...] = ()
+
+
+def _detect_intents(text: str) -> list[str]:
+    """Lightweight multi-intent detector for conflict resolution."""
+    found: list[str] = []
+    checks = (
+        ("dry_run", r"dry.?run|--dry-run|\bplan.?trade\b"),
+        ("status", r"--status\b|\bstatus\b|\bhealth\b"),
+        ("inventory", r"inventory|unclean|orphan|lot.?mismatch"),
+        ("pr_hygiene", r"\bpr\b|pull request|\bmerge\b|\bci\b|automerge"),
+        ("broker_sync", r"sync.?alpaca|broker.?sync|sync_closed"),
+        ("residual_ic", r"residual.?ic|iron.?condor|\bic_simple\b"),
+        ("rag_search", r"\brag\b|zg_search|\blesson\b|graph.?rag"),
+    )
+    for name, pat in checks:
+        if re.search(pat, text, flags=re.IGNORECASE):
+            found.append(name)
+    return found
+
+
 def classify_task(prompt: str) -> TaskClass:
     """Map free-text operator intent to a task class (first match)."""
+    return classify_with_meta(prompt).task_class
+
+
+def classify_with_meta(prompt: str) -> ClassificationResult:
+    """Classify with conflict notes when multiple intents appear."""
     text = (prompt or "").strip().lower()
     if not text:
-        return TaskClass.UNKNOWN
-    # Explicit --status / status mode beats generic spy_put_credit dry-run match.
-    if re.search(r"--status\b", text) and not re.search(r"dry.?run", text):
-        return TaskClass.STATUS
+        return ClassificationResult(TaskClass.UNKNOWN)
+    intents = tuple(_detect_intents(text))
+    conflict_note = ""
+
+    # Conflict policy (deterministic): dry-run wins over status when both present.
+    # Status alone (incl. --status before/after spy_put_credit) stays read-only.
+    has_dry = "dry_run" in intents
+    has_status = "status" in intents
+    if has_dry and has_status:
+        conflict_note = (
+            "conflict: dry_run+status → selected dry_run "
+            "(plan path includes status reads; status-only pack would omit --dry-run)"
+        )
+        return ClassificationResult(TaskClass.DRY_RUN, conflict_note, intents)
+
+    if re.search(r"--status\b", text) and not has_dry:
+        return ClassificationResult(TaskClass.STATUS, conflict_note, intents)
+
     for task_class, patterns in _RULES:
         for pat in patterns:
             if re.search(pat, text, flags=re.IGNORECASE):
-                return task_class
-    return TaskClass.UNKNOWN
+                return ClassificationResult(task_class, conflict_note, intents)
+    return ClassificationResult(TaskClass.UNKNOWN, conflict_note, intents)
 
 
 def select_harness(prompt: str) -> HarnessPack:
     """Just-in-time harness selection for a trading ops prompt."""
-    task_class = classify_task(prompt)
-    if task_class == TaskClass.UNKNOWN:
+    meta = classify_with_meta(prompt)
+    if meta.task_class == TaskClass.UNKNOWN:
         return _UNKNOWN
-    return _PACKS[task_class]
+    return _PACKS[meta.task_class]
+
+
+def pack_fingerprint(pack: HarnessPack) -> str:
+    """Stable short hash of pack contents for receipts/archive."""
+    payload = json.dumps(pack.to_dict(), sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(payload.encode()).hexdigest()[:16]
+
+
+def missing_action_scripts(pack: HarnessPack, *, repo_root: Path | None = None) -> list[str]:
+    """Return action command scripts that do not exist under repo_root."""
+    root = repo_root or Path(__file__).resolve().parents[2]
+    missing: list[str] = []
+    for action in pack.actions:
+        # Extract first scripts/*.py or make target path when present
+        m = re.search(r"scripts/[\w./-]+\.py", action)
+        if not m:
+            continue
+        rel = m.group(0)
+        if not (root / rel).is_file():
+            missing.append(rel)
+    return missing
+
+
+def selection_receipt(
+    prompt: str,
+    *,
+    repo_root: Path | None = None,
+    full_budget: int = 12000,
+) -> dict[str, Any]:
+    """Full selection artifact: pack + capability + conflicts + savings + fingerprint."""
+    meta = classify_with_meta(prompt)
+    pack = _UNKNOWN if meta.task_class == TaskClass.UNKNOWN else _PACKS[meta.task_class]
+    savings = estimate_savings_vs_full_context(pack, full_budget=full_budget)
+    missing_skills = unresolved_skills(pack, repo_root=repo_root)
+    missing_scripts = missing_action_scripts(pack, repo_root=repo_root)
+    return {
+        "prompt": prompt,
+        "task_class": pack.task_class.value,
+        "matched_intents": list(meta.matched_intents),
+        "conflict_note": meta.conflict_note,
+        "pack": pack.to_dict(),
+        "fingerprint": pack_fingerprint(pack),
+        "savings_hint": savings,
+        "capability_ok": not missing_skills and not missing_scripts,
+        "unresolved_skills": missing_skills,
+        "missing_action_scripts": missing_scripts,
+        "standards": {
+            "source": "arxiv:2608.25593v2 + Sept 2026 harness craft (deterministic)",
+            "modules": ["memory", "plan", "actions", "capability"],
+            "train_jit_agent": False,
+        },
+    }
+
+
+def append_selection_receipt(receipt: dict[str, Any], *, repo_root: Path | None = None) -> Path:
+    """Append one JSONL receipt under logs/ (gitignored archive; not training)."""
+    root = repo_root or Path(__file__).resolve().parents[2]
+    path = root / "logs" / "jit_harness_receipts.jsonl"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    row = {
+        **receipt,
+        "ts": datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ"),
+    }
+    with path.open("a", encoding="utf-8") as fh:
+        fh.write(json.dumps(row, separators=(",", ":")) + "\n")
+    return path
 
 
 def list_task_classes() -> list[dict[str, Any]]:
@@ -426,7 +550,7 @@ def readiness_report(repo_root: Path | None = None) -> dict[str, Any]:
     missing = unresolved_skills(repo_root=repo_root)
     return {
         "ready": not missing,
-        "source": "arxiv:2608.25593 process steal (deterministic)",
+        "source": "arxiv:2608.25593v2 process steal (deterministic, Sept 2026)",
         "task_classes": list_task_classes(),
         "unresolved_skills": missing,
         "skill_roots": [str(p) for p in repo_skill_roots(repo_root)],

--- a/src/ops/jit_harness.py
+++ b/src/ops/jit_harness.py
@@ -363,19 +363,21 @@ class ClassificationResult:
 
 
 def _detect_intents(text: str) -> list[str]:
-    """Lightweight multi-intent detector for conflict resolution."""
+    """Detect intents from the same `_RULES` patterns used for classification."""
     found: list[str] = []
-    checks = (
-        ("dry_run", r"dry.?run|--dry-run|\bplan.?trade\b"),
-        ("status", r"--status\b|\bstatus\b|\bhealth\b"),
-        ("inventory", r"inventory|unclean|orphan|lot.?mismatch"),
-        ("pr_hygiene", r"\bpr\b|pull request|\bmerge\b|\bci\b|automerge"),
-        ("broker_sync", r"sync.?alpaca|broker.?sync|sync_closed"),
-        ("residual_ic", r"residual.?ic|iron.?condor|\bic_simple\b"),
-        ("rag_search", r"\brag\b|zg_search|\blesson\b|graph.?rag"),
+    # Extra dry-run / --status markers used for conflict policy.
+    extras = (
+        ("dry_run", (r"--dry-run",)),
+        ("status", (r"--status\b",)),
     )
-    for name, pat in checks:
-        if re.search(pat, text, flags=re.IGNORECASE):
+    for name, pats in extras:
+        if any(re.search(p, text, flags=re.IGNORECASE) for p in pats):
+            found.append(name)
+    for task_class, patterns in _RULES:
+        name = task_class.value
+        if name in found:
+            continue
+        if any(re.search(p, text, flags=re.IGNORECASE) for p in patterns):
             found.append(name)
     return found
 
@@ -393,19 +395,23 @@ def classify_with_meta(prompt: str) -> ClassificationResult:
     intents = tuple(_detect_intents(text))
     conflict_note = ""
 
-    # Conflict policy (deterministic): dry-run wins over status when both present.
-    # Status alone (incl. --status before/after spy_put_credit) stays read-only.
-    has_dry = "dry_run" in intents
-    has_status = "status" in intents
-    if has_dry and has_status:
+    # Explicit dry-run language (not bare spy_put_credit) vs --status.
+    explicit_dry = bool(re.search(r"dry.?run|--dry-run", text))
+    has_status_flag = bool(re.search(r"--status\b", text))
+    has_status = "status" in intents or has_status_flag
+
+    # --status without explicit dry-run → STATUS even if spy_put_credit is present
+    # (flag may appear before the command name).
+    if has_status_flag and not explicit_dry:
+        return ClassificationResult(TaskClass.STATUS, conflict_note, intents)
+
+    # Conflict policy: explicit dry-run wins over status when both present.
+    if explicit_dry and has_status:
         conflict_note = (
             "conflict: dry_run+status → selected dry_run "
             "(plan path includes status reads; status-only pack would omit --dry-run)"
         )
         return ClassificationResult(TaskClass.DRY_RUN, conflict_note, intents)
-
-    if re.search(r"--status\b", text) and not has_dry:
-        return ClassificationResult(TaskClass.STATUS, conflict_note, intents)
 
     for task_class, patterns in _RULES:
         for pat in patterns:
@@ -420,6 +426,14 @@ def select_harness(prompt: str) -> HarnessPack:
     if meta.task_class == TaskClass.UNKNOWN:
         return _UNKNOWN
     return _PACKS[meta.task_class]
+
+
+_SECRETISH = re.compile(r"(?i)\b(api[_-]?key|secret|token|password|authorization)\b\s*[:=]?\s*\S+")
+
+
+def redact_prompt_for_receipt(prompt: str) -> str:
+    """Strip credential-shaped tokens before writing selection archives."""
+    return _SECRETISH.sub(r"\1=[REDACTED]", prompt or "")
 
 
 def pack_fingerprint(pack: HarnessPack) -> str:
@@ -456,7 +470,7 @@ def selection_receipt(
     missing_skills = unresolved_skills(pack, repo_root=repo_root)
     missing_scripts = missing_action_scripts(pack, repo_root=repo_root)
     return {
-        "prompt": prompt,
+        "prompt": redact_prompt_for_receipt(prompt),
         "task_class": pack.task_class.value,
         "matched_intents": list(meta.matched_intents),
         "conflict_note": meta.conflict_note,
@@ -546,13 +560,21 @@ def unresolved_skills(
 
 
 def readiness_report(repo_root: Path | None = None) -> dict[str, Any]:
-    """Catalog readiness: ready only when every pack skill resolves in-repo."""
+    """Catalog readiness: skills + action scripts must resolve in-repo."""
     missing = unresolved_skills(repo_root=repo_root)
+    missing_scripts: list[str] = []
+    seen: set[str] = set()
+    for pack in [*_PACKS.values(), _UNKNOWN]:
+        for rel in missing_action_scripts(pack, repo_root=repo_root):
+            if rel not in seen:
+                seen.add(rel)
+                missing_scripts.append(rel)
     return {
-        "ready": not missing,
+        "ready": not missing and not missing_scripts,
         "source": "arxiv:2608.25593v2 process steal (deterministic, Sept 2026)",
         "task_classes": list_task_classes(),
         "unresolved_skills": missing,
+        "missing_action_scripts": missing_scripts,
         "skill_roots": [str(p) for p in repo_skill_roots(repo_root)],
     }
 

--- a/tests/test_jit_harness.py
+++ b/tests/test_jit_harness.py
@@ -136,3 +136,23 @@ def test_cli_receipt():
     mod = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(mod)
     assert mod.main(["--receipt", "put credit dry-run"]) == 0
+
+
+def test_rule_only_status_intent_recorded():
+    meta = classify_with_meta("show equity")
+    assert meta.task_class == TaskClass.STATUS
+    assert "status" in meta.matched_intents
+
+
+def test_receipt_redacts_secretish_prompt():
+    root = Path(__file__).resolve().parents[1]
+    receipt = selection_receipt("status api_key=sk-live-ABC123", repo_root=root)
+    assert "sk-live-ABC123" not in receipt["prompt"]
+    assert "REDACTED" in receipt["prompt"]
+
+
+def test_readiness_includes_action_script_field():
+    root = Path(__file__).resolve().parents[1]
+    report = readiness_report(repo_root=root)
+    assert "missing_action_scripts" in report
+    assert report["missing_action_scripts"] == []

--- a/tests/test_jit_harness.py
+++ b/tests/test_jit_harness.py
@@ -8,10 +8,12 @@ from pathlib import Path
 from src.ops.jit_harness import (
     TaskClass,
     classify_task,
+    classify_with_meta,
     estimate_savings_vs_full_context,
     list_task_classes,
     readiness_report,
     select_harness,
+    selection_receipt,
     unresolved_skills,
 )
 
@@ -104,3 +106,33 @@ def test_broker_sync_forbids_live_sync_script():
     assert "sync_alpaca_state.py" not in joined
     assert any("sync_alpaca_state" in f for f in pack.forbid)
     assert pack.skills == ("trading-ops",)
+
+
+def test_status_flag_before_command():
+    assert classify_task("--status spy_put_credit") == TaskClass.STATUS
+
+
+def test_dry_run_wins_status_conflict():
+    meta = classify_with_meta("spy_put_credit --status --dry-run")
+    assert meta.task_class == TaskClass.DRY_RUN
+    assert "conflict" in meta.conflict_note
+    assert "dry_run" in meta.matched_intents and "status" in meta.matched_intents
+
+
+def test_selection_receipt_capability_and_fingerprint():
+    root = Path(__file__).resolve().parents[1]
+    receipt = selection_receipt("account status", repo_root=root)
+    assert receipt["task_class"] == TaskClass.STATUS.value
+    assert receipt["capability_ok"] is True
+    assert receipt["pack"]["capability"]["skills"] == ["trading-ops"]
+    assert len(receipt["fingerprint"]) == 16
+    assert receipt["standards"]["train_jit_agent"] is False
+
+
+def test_cli_receipt():
+    path = Path(__file__).resolve().parents[1] / "scripts" / "jit_harness.py"
+    spec = importlib.util.spec_from_file_location("jit_harness_cli_receipt", path)
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    assert mod.main(["--receipt", "put credit dry-run"]) == 0


### PR DESCRIPTION
## Work item

- Linear issue: AGENT-580
- Agent: grok
- Base SHA: e7f1f9b6954230e93466b50996c572528f6b6849
- Branch/worktree: feat/agent-580-jit-harness-harden / .worktrees/agent-580-jit-harness-harden
- Files or systems claimed: src/ops/jit_harness.py, scripts/jit_harness.py, tests/test_jit_harness.py, docs/JIT_HARNESS.md, skills/trading-ops/SKILL.md
- Coordination legacy reason:

## Change

- Scope: Harden deterministic JIT task→harness packs to Sept 2026 harness standards from deep research (JIT-Agent arxiv 2608.25593v2, OpenAI/Anthropic/Cursor harness craft, OWASP/FINRA/NIST fail-closed). Add capability module (skills+forbid), explicit dry-run/status conflict notes, selection receipts/fingerprints (logs/), action-script existence checks. Do not train/vendor JIT-Agent.
- Deleted surfaces and recovery impact: none
- Out of scope: training harness generator, live broker execute path, cloning Claude/Cursor products

## Verification

- [x] Targeted tests (`pytest tests/test_jit_harness.py` — 18 passed)
- [ ] `make check`
- [ ] CI green on this exact head SHA

## Evidence boundaries

- Test result: 18 passed; ruff clean
- CLI: --check-ready ready=true; --receipt shows conflict dry_run+status → dry_run
- Deep research: interaction_id trun_4255c0bf94f6469594a9a55d7b8c78a3 (/tmp/sept2026-agent-harness-standards.md)
- Broker/order/fill impact: none

## Coordination

- [x] Linear issue and vault claim updated
- [x] No overlapping active claim or worktree
- [ ] Claim will be marked done or released after merge

Docs: docs/JIT_HARNESS.md
Source research: arxiv.org/abs/2608.25593 (v2)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added CLI options to generate detailed task-selection receipts, including conflict status, capability checks, and fingerprints.
  * Added an option to record receipts for later review.
  * Improved task classification when status and dry-run requests conflict.

* **Documentation**
  * Updated harness and trading operations guidance with receipt workflows, revised terminology, readiness behavior, and current standards.

* **Bug Fixes**
  * Standardized flag ordering and conflict handling for more predictable task selection.
  * Clarified readiness command exit behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->