### PR TITLE
fix(AGENT-587): Keychain paper aliases + put-credit fill assumptions

### DIFF
--- a/scripts/spy_put_credit.py
+++ b/scripts/spy_put_credit.py
@@ -1131,12 +1131,24 @@ def _scan_put_credit_candidates(
         est_credit = round(short_bid - long_ask, 2)
         if est_credit <= 0:
             continue
+        short_ask = _as_float(short.get("ask"))
+        long_bid = _as_float(long_option.get("bid")) if long_option else None
+        mid_credit = None
+        if short_ask is not None and long_bid is not None:
+            short_mid = (short_bid + short_ask) / 2.0
+            long_mid = (long_bid + long_ask) / 2.0
+            mid_credit = round(short_mid - long_mid, 2)
         row = {
             "expiry": expiry,
             "short_put": short_strike,
             "long_put": long_strike,
             "put_wing": float(profile.wing_width),
             "est_credit": est_credit,
+            "short_bid": short_bid,
+            "long_ask": long_ask,
+            "natural_credit": est_credit,
+            "mid_credit": mid_credit,
+            "pricing_method": "natural",
             "put_delta": put_delta,
             "method": "live_delta_band_scan",
             "quantity": profile.max_contracts_per_trade,
@@ -1215,14 +1227,18 @@ def find_put_credit_opportunity(spy_price: float) -> dict | None:
     pool.sort(key=lambda r: (-float(r["est_credit"]), r["delta_distance"]))
     opp = pool[0]
     opp.pop("delta_distance", None)
+    mid = opp.get("mid_credit")
+    mid_txt = f"${mid:.2f}" if isinstance(mid, (int, float)) else "n/a"
     logger.info(
-        "Opportunity: SPY put credit short=%.0f long=%.0f credit=$%.2f delta=%.3f exp=%s "
-        "(scanned %d band-qualified, %d min-credit-qualified)",
+        "Opportunity: SPY put credit short=%.0f long=%.0f natural=$%.2f mid=%s "
+        "delta=%.3f exp=%s pricing=%s (scanned %d band-qualified, %d min-credit-qualified)",
         opp["short_put"],
         opp["long_put"],
         opp["est_credit"],
+        mid_txt,
         opp["put_delta"],
         opp["expiry"],
+        opp.get("pricing_method") or "natural",
         len(candidates),
         len(qualified),
     )

--- a/src/utils/alpaca_client.py
+++ b/src/utils/alpaca_client.py
@@ -110,22 +110,51 @@ def _keychain_generic_password(service: str, account: str = "hermes-fleet") -> O
         return None
 
 
+# Canonical paper Keychain aliases used by scripts/store_alpaca_keychain.py and
+# scripts/run_with_alpaca_keychain.py. Checked after env-named hermes-fleet services.
+_PAPER_KEYCHAIN_ALIASES: tuple[tuple[str, tuple[tuple[str, str], ...]], ...] = (
+    (
+        "ALPACA_PAPER_TRADING_API_KEY",
+        (
+            ("ALPACA_PAPER_TRADING_API_KEY", "hermes-fleet"),
+            ("trading.alpaca.paper.api-key", "paper"),
+        ),
+    ),
+    (
+        "ALPACA_PAPER_TRADING_API_SECRET",
+        (
+            ("ALPACA_PAPER_TRADING_API_SECRET", "hermes-fleet"),
+            ("trading.alpaca.paper.api-secret", "paper"),
+        ),
+    ),
+    (
+        "ALPACA_API_KEY",
+        (("ALPACA_API_KEY", "hermes-fleet"),),
+    ),
+    (
+        "ALPACA_SECRET_KEY",
+        (("ALPACA_SECRET_KEY", "hermes-fleet"),),
+    ),
+)
+
+
 def _bootstrap_env_from_keychain() -> None:
-    """Fill missing paper Alpaca env vars from Keychain (local Mac operator path)."""
-    pairs = (
-        ("ALPACA_PAPER_TRADING_API_KEY", "ALPACA_PAPER_TRADING_API_KEY"),
-        ("ALPACA_PAPER_TRADING_API_SECRET", "ALPACA_PAPER_TRADING_API_SECRET"),
-        ("ALPACA_API_KEY", "ALPACA_API_KEY"),
-        ("ALPACA_SECRET_KEY", "ALPACA_SECRET_KEY"),
-    )
+    """Fill missing paper Alpaca env vars from Keychain (local Mac operator path).
+
+    Tries hermes-fleet services matching env var names first, then the canonical
+    `trading.alpaca.paper.api-*` / account `paper` aliases used by the store/run
+    wrappers. Never logs secret values.
+    """
     loaded = 0
-    for env_name, service in pairs:
+    for env_name, lookups in _PAPER_KEYCHAIN_ALIASES:
         if os.getenv(env_name):
             continue
-        value = _keychain_generic_password(service)
-        if value:
-            os.environ[env_name] = value
-            loaded += 1
+        for service, account in lookups:
+            value = _keychain_generic_password(service, account=account)
+            if value:
+                os.environ[env_name] = value
+                loaded += 1
+                break
     if loaded:
         logger.info("Loaded %s Alpaca credential(s) from Keychain (values not logged)", loaded)
 
@@ -137,7 +166,8 @@ def get_alpaca_credentials() -> tuple[Optional[str], Optional[str]]:
     Priority order (first found wins) - UPDATED Jan 30, 2026:
     1. ALPACA_PAPER_TRADING_API_KEY / SECRET ($100K account - PRIMARY)
     2. ALPACA_API_KEY / ALPACA_SECRET_KEY (workflow fallback)
-    3. macOS Keychain services with the same names (account hermes-fleet)
+    3. macOS Keychain: hermes-fleet env-named services, then
+       trading.alpaca.paper.api-key|secret (account paper)
 
     NOTE: The $5K/$30K accounts are deprecated. Use $100K account only.
     $100K account = No PDT restrictions, faster path to North Star.

--- a/tests/test_active_strategy.py
+++ b/tests/test_active_strategy.py
@@ -171,6 +171,11 @@ def test_find_put_credit_scans_chain_once_and_uses_put_side_only(monkeypatch):
     assert opp["short_put"] == 700.0
     assert opp["long_put"] == 695.0
     assert opp["est_credit"] == 0.80
+    assert opp["natural_credit"] == 0.80
+    assert opp["short_bid"] == 1.20
+    assert opp["long_ask"] == 0.40
+    assert opp["pricing_method"] == "natural"
+    assert opp["mid_credit"] == 0.85  # (1.20+1.25)/2 - (0.35+0.40)/2
     assert opp["method"] == "live_delta_band_scan"
     assert "short_call" not in opp
     provider.get_options_chain_with_greeks.assert_called_once_with(

--- a/tests/test_alpaca_client_keychain_aliases.py
+++ b/tests/test_alpaca_client_keychain_aliases.py
@@ -1,0 +1,63 @@
+"""Keychain alias bootstrap for Alpaca paper credentials (AGENT-587)."""
+
+from __future__ import annotations
+
+import src.utils.alpaca_client as alpaca_client
+
+
+def test_bootstrap_prefers_trading_paper_alias_when_hermes_fleet_missing(monkeypatch):
+    monkeypatch.delenv("ALPACA_PAPER_TRADING_API_KEY", raising=False)
+    monkeypatch.delenv("ALPACA_PAPER_TRADING_API_SECRET", raising=False)
+    monkeypatch.delenv("ALPACA_API_KEY", raising=False)
+    monkeypatch.delenv("ALPACA_SECRET_KEY", raising=False)
+
+    def fake_keychain(service: str, account: str = "hermes-fleet"):
+        if service == "trading.alpaca.paper.api-key" and account == "paper":
+            return "PAPERKEY123"
+        if service == "trading.alpaca.paper.api-secret" and account == "paper":
+            return "PAPERSECRET456"
+        return None
+
+    monkeypatch.setattr(alpaca_client, "_keychain_generic_password", fake_keychain)
+    alpaca_client._bootstrap_env_from_keychain()
+
+    assert alpaca_client.os.environ["ALPACA_PAPER_TRADING_API_KEY"] == "PAPERKEY123"
+    assert alpaca_client.os.environ["ALPACA_PAPER_TRADING_API_SECRET"] == "PAPERSECRET456"
+
+
+def test_bootstrap_prefers_hermes_fleet_env_named_services(monkeypatch):
+    monkeypatch.delenv("ALPACA_PAPER_TRADING_API_KEY", raising=False)
+    monkeypatch.delenv("ALPACA_PAPER_TRADING_API_SECRET", raising=False)
+
+    def fake_keychain(service: str, account: str = "hermes-fleet"):
+        if service == "ALPACA_PAPER_TRADING_API_KEY" and account == "hermes-fleet":
+            return "HERMESKEY"
+        if service == "ALPACA_PAPER_TRADING_API_SECRET" and account == "hermes-fleet":
+            return "HERMESSECRET"
+        if service.startswith("trading.alpaca.paper"):
+            return "SHOULD_NOT_USE"
+        return None
+
+    monkeypatch.setattr(alpaca_client, "_keychain_generic_password", fake_keychain)
+    alpaca_client._bootstrap_env_from_keychain()
+
+    assert alpaca_client.os.environ["ALPACA_PAPER_TRADING_API_KEY"] == "HERMESKEY"
+    assert alpaca_client.os.environ["ALPACA_PAPER_TRADING_API_SECRET"] == "HERMESSECRET"
+
+
+def test_bootstrap_skips_when_env_already_set(monkeypatch):
+    monkeypatch.setenv("ALPACA_PAPER_TRADING_API_KEY", "ENVKEY")
+    monkeypatch.setenv("ALPACA_PAPER_TRADING_API_SECRET", "ENVSECRET")
+    calls: list[tuple[str, str]] = []
+
+    def fake_keychain(service: str, account: str = "hermes-fleet"):
+        calls.append((service, account))
+        return "IGNORED"
+
+    monkeypatch.setattr(alpaca_client, "_keychain_generic_password", fake_keychain)
+    alpaca_client._bootstrap_env_from_keychain()
+
+    assert alpaca_client.os.environ["ALPACA_PAPER_TRADING_API_KEY"] == "ENVKEY"
+    assert alpaca_client.os.environ["ALPACA_PAPER_TRADING_API_SECRET"] == "ENVSECRET"
+    # Only fallback env names (ALPACA_API_KEY / SECRET) may still be probed.
+    assert all(not s.startswith("trading.alpaca.paper") for s, _ in calls)


### PR DESCRIPTION
# Pull request

## Work item

- Linear issue: AGENT-587
- Agent: grok
- Base SHA: 5550581e7aa35de32e886bd01fd9daaa4b8fbb19
- Branch/worktree: agent/AGENT-587-keychain-fill-assumptions / .worktrees/agent-587-keychain-fill-assumptions
- Files or systems claimed: src/utils/alpaca_client.py, scripts/spy_put_credit.py, tests/test_alpaca_client_keychain_aliases.py, tests/test_active_strategy.py
- Coordination legacy reason:

## Change

- Scope: Bootstrap Alpaca paper env from Keychain aliases trading.alpaca.paper.api-key|secret (account paper) when hermes-fleet env-named services are missing. Persist fill-assumption audit fields on put-credit candidates (short_bid, long_ask, natural_credit, mid_credit, pricing_method=natural).
- Deleted surfaces and recovery impact: none
- Out of scope: syncing data/system_state.json from Keychain paper keys; journaling the $30K Keychain paper book's unjournaled 260925 legs into the $94K validation cohort.

## Security Impact Assessment

- [x] No security impact
- [ ] Low security impact
- [ ] Medium security impact
- [ ] High security impact

Security considerations:
- Does this change affect credential handling? yes — Keychain lookup aliases only; secrets never logged
- Does this change modify access controls? no
- Does this change introduce new dependencies? no
- Does this change modify workflow permissions? no
- Have secrets been properly handled without hardcoding? yes

## Verification

- [x] Targeted tests: pytest tests/test_alpaca_client_keychain_aliases.py tests/test_active_strategy.py (46 passed)
- [ ] make check
- [ ] RAG read/write round trip when RAG changes
- [ ] Orchestration smoke test when orchestration changes
- [ ] TRADING_ENV=paper make dry-run when operational paths change
- [ ] CI green on this PR
- [x] Security implications have been considered and addressed
- [x] Dependencies have been reviewed for security vulnerabilities
- [x] No hardcoded secrets or credentials have been added

## Evidence boundaries

- Test result: 46 passed locally
- CI run: pending after coordination body fix
- Protected-system result: no strategy kill-switch or risk-constant change
- Broker/order/fill impact: none; dry-run pricing fields only; do not sync ledger from mismatched Keychain paper account

## Coordination

- [x] Linear issue and vault claim updated
- [x] No overlapping active claim or worktree
- [ ] Claim will be marked done or released after merge