### PR TITLE
feat(AGENT-589): Polars-2 fail-fast ledger schema/height/ID checks

### DIFF
--- a/scripts/strict_ledger_schema.py
+++ b/scripts/strict_ledger_schema.py
@@ -30,10 +30,16 @@ REQUIRED_TRADE_FIELDS = (
     "realized_pnl",
 )
 NUMERIC_TRADE_FIELDS = ("realized_pnl", "quantity")
+IDENTITY_TRADE_FIELDS = ("id",)
 
 
 def _load_trades(path: Path) -> dict:
-    payload = json.loads(path.read_text(encoding="utf-8"))
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except OSError as exc:
+        raise SchemaError(f"cannot read trades ledger: {exc}") from exc
+    except json.JSONDecodeError as exc:
+        raise SchemaError(f"trades.json is not valid JSON: {exc}") from exc
     if not isinstance(payload, dict):
         raise SchemaError("trades.json root must be an object")
     return payload
@@ -65,6 +71,7 @@ def main(argv: list[str] | None = None) -> int:
             rows,
             required=REQUIRED_TRADE_FIELDS,
             numeric_fields=NUMERIC_TRADE_FIELDS,
+            identity_fields=IDENTITY_TRADE_FIELDS,
             max_rows=args.max_rows,
         )
         stats = payload.get("stats") if isinstance(payload.get("stats"), dict) else {}

--- a/scripts/strict_ledger_schema.py
+++ b/scripts/strict_ledger_schema.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+"""Agent-facing ledger schema preflight (Polars 2 collect_schema analog).
+
+Validates trades.json structure without computing edge claims.
+Exit 0 when schema-ok; exit 2 on SchemaError/ShapeError/LosslessCoercionError.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from src.utils.strict_tabular import (  # noqa: E402
+    LosslessCoercionError,
+    SchemaError,
+    ShapeError,
+    collect_row_schema,
+    parse_optional_strict_int,
+)
+
+
+REQUIRED_TRADE_FIELDS = (
+    "id",
+    "status",
+    "realized_pnl",
+)
+NUMERIC_TRADE_FIELDS = ("realized_pnl", "quantity")
+
+
+def _load_trades(path: Path) -> dict:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise SchemaError("trades.json root must be an object")
+    return payload
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--trades",
+        type=Path,
+        default=ROOT / "data" / "trades.json",
+        help="Path to trades.json",
+    )
+    parser.add_argument(
+        "--max-rows",
+        type=int,
+        default=None,
+        help="Optional row cap for schema scan (default: all)",
+    )
+    parser.add_argument("--json", action="store_true", help="Emit JSON report")
+    args = parser.parse_args(argv)
+
+    try:
+        payload = _load_trades(args.trades)
+        rows = payload.get("trades")
+        if not isinstance(rows, list):
+            raise SchemaError("trades.json missing list field 'trades'")
+        schema = collect_row_schema(
+            rows,
+            required=REQUIRED_TRADE_FIELDS,
+            numeric_fields=NUMERIC_TRADE_FIELDS,
+            max_rows=args.max_rows,
+        )
+        stats = payload.get("stats") if isinstance(payload.get("stats"), dict) else {}
+        stats_counts = {
+            "closed_trades": parse_optional_strict_int(
+                stats.get("closed_trades"), field="stats.closed_trades"
+            ),
+            "unpaired_order_count": parse_optional_strict_int(
+                stats.get("unpaired_order_count"), field="stats.unpaired_order_count"
+            ),
+        }
+        report = {
+            "ok": True,
+            "path": str(args.trades),
+            "schema": schema,
+            "stats_counts": stats_counts,
+            "steal": "polars-2-fail-fast-schema-height-id",
+        }
+    except (SchemaError, ShapeError, LosslessCoercionError) as exc:
+        report = {
+            "ok": False,
+            "path": str(args.trades),
+            "error": str(exc),
+            "error_type": type(exc).__name__,
+            "steal": "polars-2-fail-fast-schema-height-id",
+        }
+        if args.json:
+            print(json.dumps(report, indent=2, sort_keys=True))
+        else:
+            print(f"STRICT_LEDGER_SCHEMA_FAIL: {exc}", file=sys.stderr)
+        return 2
+
+    if args.json:
+        print(json.dumps(report, indent=2, sort_keys=True))
+    else:
+        print(
+            f"STRICT_LEDGER_SCHEMA_OK rows={schema['inspected_rows']} "
+            f"closed_trades={stats_counts['closed_trades']}"
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/strict_ledger_schema.py
+++ b/scripts/strict_ledger_schema.py
@@ -24,7 +24,6 @@ from src.utils.strict_tabular import (  # noqa: E402
     parse_optional_strict_int,
 )
 
-
 REQUIRED_TRADE_FIELDS = (
     "id",
     "status",

--- a/src/analytics/trade_evidence.py
+++ b/src/analytics/trade_evidence.py
@@ -21,6 +21,11 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any
 
+from src.utils.strict_tabular import (
+    LosslessCoercionError,
+    parse_optional_strict_int,
+)
+
 STRATEGY_ALIASES = {
     "bull_put": "spy_put_credit",
     "bull_put_credit": "spy_put_credit",
@@ -331,9 +336,19 @@ def build_trade_evidence(
         verified_rows.append(normalized)
 
     stats = payload.get("stats", {}) if isinstance(payload.get("stats"), dict) else {}
-    unpaired_count = int(_as_float(stats.get("unpaired_order_count")) or 0)
+    # Polars-2 steal: refuse silent float→int coercion for ledger counts (AGENT-589).
+    try:
+        unpaired_count = parse_optional_strict_int(
+            stats.get("unpaired_order_count"), field="stats.unpaired_order_count"
+        ) or 0
+        reported_closed = parse_optional_strict_int(
+            stats.get("closed_trades"), field="stats.closed_trades"
+        ) or 0
+    except LosslessCoercionError as exc:
+        issues.append(f"lossy_stats_count_coercion:{exc}")
+        unpaired_count = 0
+        reported_closed = 0
     unpaired_cash = float(_as_float(stats.get("unpaired_realized_pnl")) or 0.0)
-    reported_closed = int(_as_float(stats.get("closed_trades")) or 0)
     reported_total = _as_float(stats.get("total_realized_pnl", stats.get("total_pnl")))
 
     physical_metrics = _metrics(

--- a/src/analytics/trade_evidence.py
+++ b/src/analytics/trade_evidence.py
@@ -338,12 +338,15 @@ def build_trade_evidence(
     stats = payload.get("stats", {}) if isinstance(payload.get("stats"), dict) else {}
     # Polars-2 steal: refuse silent float→int coercion for ledger counts (AGENT-589).
     try:
-        unpaired_count = parse_optional_strict_int(
-            stats.get("unpaired_order_count"), field="stats.unpaired_order_count"
-        ) or 0
-        reported_closed = parse_optional_strict_int(
-            stats.get("closed_trades"), field="stats.closed_trades"
-        ) or 0
+        unpaired_count = (
+            parse_optional_strict_int(
+                stats.get("unpaired_order_count"), field="stats.unpaired_order_count"
+            )
+            or 0
+        )
+        reported_closed = (
+            parse_optional_strict_int(stats.get("closed_trades"), field="stats.closed_trades") or 0
+        )
     except LosslessCoercionError as exc:
         issues.append(f"lossy_stats_count_coercion:{exc}")
         unpaired_count = 0

--- a/src/utils/strict_tabular.py
+++ b/src/utils/strict_tabular.py
@@ -57,11 +57,21 @@ def strict_horizontal_zip(
     return [{key: values[i][row] for i, key in enumerate(keys)} for row in range(height)]
 
 
-def parse_strict_int(value: Any, *, field: str) -> int:
+def _is_ascii_decimal(text: str) -> bool:
+    """True only for optional leading '-' plus ASCII digits 0-9."""
+    if not text:
+        return False
+    body = text[1:] if text.startswith("-") else text
+    return bool(body) and all("0" <= ch <= "9" for ch in body)
+
+
+def parse_strict_int(value: Any, *, field: str, allow_negative: bool = False) -> int:
     """Parse a whole-number count/ID without float64 round-trip."""
     if isinstance(value, bool):
         raise LosslessCoercionError(f"{field}: bool is not a count/id")
     if isinstance(value, int):
+        if value < 0 and not allow_negative:
+            raise LosslessCoercionError(f"{field}: refuse negative count {value}")
         return value
     if isinstance(value, float):
         if not value.is_integer():
@@ -81,21 +91,45 @@ def parse_strict_int(value: Any, *, field: str) -> int:
         text = value.strip()
         if not text or text.lower() in {"none", "null", "nan"}:
             raise LosslessCoercionError(f"{field}: empty/null string is not a count/id")
-        if text.isdigit() or (text.startswith("-") and text[1:].isdigit()):
-            return int(text)
-        raise LosslessCoercionError(f"{field}: refuse non-digit string count/id {value!r}")
+        if not _is_ascii_decimal(text):
+            raise LosslessCoercionError(f"{field}: refuse non-digit string count/id {value!r}")
+        try:
+            parsed = int(text)
+        except ValueError as exc:  # pragma: no cover - ASCII guard should prevent this
+            raise LosslessCoercionError(
+                f"{field}: refuse non-digit string count/id {value!r}"
+            ) from exc
+        if parsed < 0 and not allow_negative:
+            raise LosslessCoercionError(f"{field}: refuse negative count {parsed}")
+        return parsed
     if value is None:
         raise LosslessCoercionError(f"{field}: None is not a count/id")
     raise LosslessCoercionError(f"{field}: unsupported count/id type {type(value).__name__}")
 
 
-def parse_optional_strict_int(value: Any, *, field: str) -> int | None:
+def parse_optional_strict_int(
+    value: Any, *, field: str, allow_negative: bool = False
+) -> int | None:
     """Like parse_strict_int but maps missing/empty to None."""
     if value is None:
         return None
     if isinstance(value, str) and not value.strip():
         return None
-    return parse_strict_int(value, field=field)
+    return parse_strict_int(value, field=field, allow_negative=allow_negative)
+
+
+def assert_identity_value(value: Any, *, field: str = "id") -> str:
+    """Accept string/int identity values; refuse floats."""
+    if isinstance(value, float):
+        raise LosslessCoercionError(
+            f"{field}: refuse float identity {value!r}; use a string or int id"
+        )
+    if isinstance(value, bool) or value is None:
+        raise LosslessCoercionError(f"{field}: invalid identity type {type(value).__name__}")
+    text = str(value).strip()
+    if not text:
+        raise LosslessCoercionError(f"{field}: empty id")
+    return text
 
 
 def assert_id_equality(left: Any, right: Any, *, field: str = "id") -> str:
@@ -119,6 +153,7 @@ def collect_row_schema(
     *,
     required: Sequence[str],
     numeric_fields: Sequence[str] = (),
+    identity_fields: Sequence[str] = (),
     max_rows: int | None = None,
 ) -> dict[str, Any]:
     """Resolve schema/types without computing metrics (collect_schema analog).
@@ -128,9 +163,11 @@ def collect_row_schema(
     """
     required_set = list(required)
     numeric_set = list(numeric_fields)
+    identity_set = list(identity_fields)
     inspected = 0
     missing: dict[str, int] = {name: 0 for name in required_set}
     bad_numeric: dict[str, int] = {name: 0 for name in numeric_set}
+    bad_identity: dict[str, int] = {name: 0 for name in identity_set}
     field_types: dict[str, set[str]] = {}
 
     for row in rows:
@@ -154,6 +191,13 @@ def collect_row_schema(
                     float(value)
                 except ValueError:
                     bad_numeric[name] += 1
+        for name in identity_set:
+            if name not in row or row.get(name) in (None, ""):
+                continue
+            try:
+                assert_identity_value(row.get(name), field=name)
+            except LosslessCoercionError:
+                bad_identity[name] += 1
         if max_rows is not None and inspected >= max_rows:
             break
 
@@ -164,14 +208,19 @@ def collect_row_schema(
     for name, count in bad_numeric.items():
         if count:
             issues.append(f"non_numeric:{name}:{count}/{inspected}")
+    for name, count in bad_identity.items():
+        if count:
+            issues.append(f"lossy_identity:{name}:{count}/{inspected}")
 
     report = {
         "inspected_rows": inspected,
         "required": required_set,
         "numeric_fields": numeric_set,
+        "identity_fields": identity_set,
         "field_types": {key: sorted(values) for key, values in sorted(field_types.items())},
         "missing_required_counts": {k: v for k, v in missing.items() if v},
         "non_numeric_counts": {k: v for k, v in bad_numeric.items() if v},
+        "lossy_identity_counts": {k: v for k, v in bad_identity.items() if v},
         "issues": issues,
         "ok": not issues,
     }

--- a/src/utils/strict_tabular.py
+++ b/src/utils/strict_tabular.py
@@ -1,0 +1,180 @@
+"""Fail-fast tabular helpers inspired by Polars 2.0 defaults.
+
+Steal from https://pola.rs/posts/announcing-polars-2/ (mechanics only):
+
+* streaming/lazy-style schema collect before materializing expensive work
+* strict height checks (no silent horizontal pad with null)
+* refuse silent lossy ID/count coercion through float64
+
+No Polars dependency — pure Python for the trading ledger path.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Iterable, Mapping, Sequence
+
+
+class ShapeError(ValueError):
+    """Row-count / shape mismatch (Polars 2 strict concat class)."""
+
+
+class LosslessCoercionError(ValueError):
+    """Lossy type coercion refused (Polars 2 is_in / float-id class)."""
+
+
+class SchemaError(ValueError):
+    """Schema-level mismatch caught before materializing metrics."""
+
+
+def assert_equal_heights(
+    *tables: Sequence[Any],
+    labels: Sequence[str] | None = None,
+    context: str = "strict_horizontal",
+) -> int:
+    """Require equal lengths; raise ShapeError instead of padding with null."""
+    if not tables:
+        return 0
+    heights = [len(table) for table in tables]
+    if len(set(heights)) == 1:
+        return heights[0]
+    names = list(labels) if labels is not None else [f"col_{i}" for i in range(len(tables))]
+    detail = ", ".join(f"{name}={height}" for name, height in zip(names, heights, strict=True))
+    raise ShapeError(
+        f"cannot concat/zip with different heights in strict mode ({context}): {detail}; "
+        "opt in to padding only with an explicit horizontal_extend path"
+    )
+
+
+def strict_horizontal_zip(
+    columns: Mapping[str, Sequence[Any]],
+    *,
+    context: str = "strict_horizontal",
+) -> list[dict[str, Any]]:
+    """Zip named columns into row dicts only when all heights match."""
+    keys = list(columns.keys())
+    values = [columns[key] for key in keys]
+    height = assert_equal_heights(*values, labels=keys, context=context)
+    return [{key: values[i][row] for i, key in enumerate(keys)} for row in range(height)]
+
+
+def parse_strict_int(value: Any, *, field: str) -> int:
+    """Parse a whole-number count/ID without float64 round-trip."""
+    if isinstance(value, bool):
+        raise LosslessCoercionError(f"{field}: bool is not a count/id")
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float):
+        if not value.is_integer():
+            raise LosslessCoercionError(
+                f"{field}: refuse lossy float→int coercion for non-integer {value!r}"
+            )
+        # Still refuse large floats that cannot be represented exactly in float64 mantissa.
+        as_int = int(value)
+        if abs(as_int) > (2**53) or float(as_int) != value:
+            raise LosslessCoercionError(
+                f"{field}: refuse float id/count {value!r} outside exact float64 integer range"
+            )
+        raise LosslessCoercionError(
+            f"{field}: refuse float→int coercion for count/id {value!r}; pass an int or digit string"
+        )
+    if isinstance(value, str):
+        text = value.strip()
+        if not text or text.lower() in {"none", "null", "nan"}:
+            raise LosslessCoercionError(f"{field}: empty/null string is not a count/id")
+        if text.isdigit() or (text.startswith("-") and text[1:].isdigit()):
+            return int(text)
+        raise LosslessCoercionError(f"{field}: refuse non-digit string count/id {value!r}")
+    if value is None:
+        raise LosslessCoercionError(f"{field}: None is not a count/id")
+    raise LosslessCoercionError(f"{field}: unsupported count/id type {type(value).__name__}")
+
+
+def parse_optional_strict_int(value: Any, *, field: str) -> int | None:
+    """Like parse_strict_int but maps missing/empty to None."""
+    if value is None:
+        return None
+    if isinstance(value, str) and not value.strip():
+        return None
+    return parse_strict_int(value, field=field)
+
+
+def assert_id_equality(left: Any, right: Any, *, field: str = "id") -> str:
+    """Compare identifiers as strings; never via float equality."""
+    if isinstance(left, float) or isinstance(right, float):
+        raise LosslessCoercionError(
+            f"{field}: refuse float identity comparison "
+            f"({left!r} vs {right!r}); cast explicitly if intentional"
+        )
+    left_s = str(left).strip()
+    right_s = str(right).strip()
+    if not left_s or not right_s:
+        raise LosslessCoercionError(f"{field}: empty id")
+    if left_s != right_s:
+        raise LosslessCoercionError(f"{field}: mismatch {left_s!r} != {right_s!r}")
+    return left_s
+
+
+def collect_row_schema(
+    rows: Iterable[Mapping[str, Any]],
+    *,
+    required: Sequence[str],
+    numeric_fields: Sequence[str] = (),
+    max_rows: int | None = None,
+) -> dict[str, Any]:
+    """Resolve schema/types without computing metrics (collect_schema analog).
+
+    Returns a compact report. Raises SchemaError when required fields are absent
+    on any inspected row or numeric fields are non-numeric.
+    """
+    required_set = list(required)
+    numeric_set = list(numeric_fields)
+    inspected = 0
+    missing: dict[str, int] = {name: 0 for name in required_set}
+    bad_numeric: dict[str, int] = {name: 0 for name in numeric_set}
+    field_types: dict[str, set[str]] = {}
+
+    for row in rows:
+        if not isinstance(row, Mapping):
+            raise SchemaError(f"row {inspected}: expected mapping, got {type(row).__name__}")
+        inspected += 1
+        for key, value in row.items():
+            field_types.setdefault(str(key), set()).add(type(value).__name__)
+        for name in required_set:
+            if name not in row or row.get(name) in (None, ""):
+                missing[name] += 1
+        for name in numeric_set:
+            if name not in row or row.get(name) in (None, ""):
+                continue
+            value = row.get(name)
+            if isinstance(value, bool) or not isinstance(value, (int, float, str)):
+                bad_numeric[name] += 1
+                continue
+            if isinstance(value, str):
+                try:
+                    float(value)
+                except ValueError:
+                    bad_numeric[name] += 1
+        if max_rows is not None and inspected >= max_rows:
+            break
+
+    issues: list[str] = []
+    for name, count in missing.items():
+        if count:
+            issues.append(f"missing_required:{name}:{count}/{inspected}")
+    for name, count in bad_numeric.items():
+        if count:
+            issues.append(f"non_numeric:{name}:{count}/{inspected}")
+
+    report = {
+        "inspected_rows": inspected,
+        "required": required_set,
+        "numeric_fields": numeric_set,
+        "field_types": {key: sorted(values) for key, values in sorted(field_types.items())},
+        "missing_required_counts": {k: v for k, v in missing.items() if v},
+        "non_numeric_counts": {k: v for k, v in bad_numeric.items() if v},
+        "issues": issues,
+        "ok": not issues,
+    }
+    if issues:
+        raise SchemaError("; ".join(issues))
+    return report

--- a/tests/test_strict_tabular.py
+++ b/tests/test_strict_tabular.py
@@ -1,0 +1,117 @@
+"""Tests for Polars-2 inspired fail-fast tabular helpers (AGENT-589)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from src.utils.strict_tabular import (
+    LosslessCoercionError,
+    SchemaError,
+    ShapeError,
+    assert_equal_heights,
+    assert_id_equality,
+    collect_row_schema,
+    parse_optional_strict_int,
+    parse_strict_int,
+    strict_horizontal_zip,
+)
+
+
+def test_assert_equal_heights_ok():
+    assert assert_equal_heights([1, 2], ["a", "b"], labels=("n", "s")) == 2
+
+
+def test_assert_equal_heights_raises_instead_of_padding():
+    with pytest.raises(ShapeError, match="different heights"):
+        assert_equal_heights([1, 2, 3], [1, 2], labels=("left", "right"))
+
+
+def test_strict_horizontal_zip_ok():
+    rows = strict_horizontal_zip({"day": [1, 2], "count": [10, 20]})
+    assert rows == [{"day": 1, "count": 10}, {"day": 2, "count": 20}]
+
+
+def test_strict_horizontal_zip_refuses_silent_pad():
+    with pytest.raises(ShapeError):
+        strict_horizontal_zip({"day": [1, 2, 3], "flagged": [1, 0]})
+
+
+def test_parse_strict_int_accepts_int_and_digit_string():
+    assert parse_strict_int(12, field="n") == 12
+    assert parse_strict_int("7", field="n") == 7
+    assert parse_optional_strict_int(None, field="n") is None
+
+
+def test_parse_strict_int_refuses_float_coercion():
+    with pytest.raises(LosslessCoercionError, match="refuse float"):
+        parse_strict_int(3.0, field="closed_trades")
+    with pytest.raises(LosslessCoercionError, match="non-integer"):
+        parse_strict_int(1.5, field="closed_trades")
+
+
+def test_assert_id_equality_string_safe():
+    assert assert_id_equality("9007199254740993", "9007199254740993") == "9007199254740993"
+    with pytest.raises(LosslessCoercionError, match="float identity"):
+        assert_id_equality(9007199254740993.0, 9007199254740992.0)
+
+
+def test_collect_row_schema_ok_and_fail():
+    rows = [
+        {"id": "a", "status": "closed", "realized_pnl": 1.0},
+        {"id": "b", "status": "closed", "realized_pnl": -2.0},
+    ]
+    report = collect_row_schema(
+        rows, required=("id", "status", "realized_pnl"), numeric_fields=("realized_pnl",)
+    )
+    assert report["ok"] is True
+    assert report["inspected_rows"] == 2
+
+    with pytest.raises(SchemaError, match="missing_required:id"):
+        collect_row_schema(
+            [{"status": "closed", "realized_pnl": 1}],
+            required=("id", "status"),
+        )
+
+
+def test_trade_evidence_flags_lossy_stats_count():
+    from src.analytics import trade_evidence as te
+
+    payload = {
+        "trades": [
+            {
+                "id": "t1",
+                "status": "closed",
+                "realized_pnl": 10.0,
+                "strategy_family": "spy_put_credit",
+                "quantity": 1,
+                "put_delta": -0.15,
+                "exit_reason": "profit_target",
+                "strikes": {"short_put": 100, "long_put": 95},
+            }
+        ],
+        "stats": {
+            # Float count would previously coerce silently via int(_as_float(...)).
+            "closed_trades": 1.0,
+            "unpaired_order_count": 0,
+            "total_realized_pnl": 10.0,
+        },
+    }
+    evidence = te.build_trade_evidence(payload, strategy_family="spy_put_credit")
+    assert any("lossy_stats_count_coercion" in issue for issue in evidence.issues)
+
+
+def test_strict_ledger_schema_cli_ok(tmp_path: Path):
+    from scripts import strict_ledger_schema as cli
+
+    payload = {
+        "trades": [
+            {"id": "a", "status": "closed", "realized_pnl": 1.25, "quantity": 1},
+        ],
+        "stats": {"closed_trades": 1, "unpaired_order_count": 0},
+    }
+    path = tmp_path / "trades.json"
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    assert cli.main(["--trades", str(path), "--json"]) == 0

--- a/tests/test_strict_tabular.py
+++ b/tests/test_strict_tabular.py
@@ -52,6 +52,22 @@ def test_parse_strict_int_refuses_float_coercion():
         parse_strict_int(1.5, field="closed_trades")
 
 
+def test_parse_strict_int_refuses_negative_and_unicode_digits():
+    with pytest.raises(LosslessCoercionError, match="negative"):
+        parse_strict_int(-1, field="closed_trades")
+    with pytest.raises(LosslessCoercionError, match="non-digit"):
+        parse_strict_int("²", field="closed_trades")
+
+
+def test_collect_row_schema_rejects_float_identity():
+    with pytest.raises(SchemaError, match="lossy_identity:id"):
+        collect_row_schema(
+            [{"id": 9007199254740992.0, "status": "closed", "realized_pnl": 1.0}],
+            required=("id", "status", "realized_pnl"),
+            identity_fields=("id",),
+        )
+
+
 def test_assert_id_equality_string_safe():
     assert assert_id_equality("9007199254740993", "9007199254740993") == "9007199254740993"
     with pytest.raises(LosslessCoercionError, match="float identity"):


### PR DESCRIPTION
# Pull request

## Work item

- Linear issue: AGENT-589
- Agent: grok
- Base SHA: 3f7698e3019994f28c5e253f94cd10f7325e29bc
- Branch/worktree: agent/AGENT-589-polars2-strict-ledger / .worktrees/agent-589-polars2-strict-ledger
- Files or systems claimed: src/utils/strict_tabular.py, src/analytics/trade_evidence.py, scripts/strict_ledger_schema.py, tests/test_strict_tabular.py
- Coordination legacy reason:

## Change

- Scope: Steal Polars 2.0 fail-fast mechanics (strict height, refuse float→int count/id coercion, collect_schema-style preflight) into pure-Python ledger helpers. Wire stats count parsing in trade_evidence. Add scripts/strict_ledger_schema.py for agent preflight.
- Deleted surfaces and recovery impact: none
- Out of scope: adopting polars==2.0rc1; promoting untracked ai_options_trading/ Polars theater into the active path; streaming engine migration.

## Security Impact Assessment

- [x] No security impact
- [ ] Low security impact
- [ ] Medium security impact
- [ ] High security impact

Security considerations:
- Does this change affect credential handling? no
- Does this change modify access controls? no
- Does this change introduce new dependencies? no
- Does this change modify workflow permissions? no
- Have secrets been properly handled without hardcoding? yes

## Verification

- [x] Targeted tests: pytest tests/test_strict_tabular.py tests/test_trade_evidence.py tests/unit/test_loss_forensics.py (24 passed)
- [x] scripts/strict_ledger_schema.py against data/trades.json → STRICT_LEDGER_SCHEMA_OK rows=164
- [ ] make check
- [ ] RAG read/write round trip when RAG changes
- [ ] Orchestration smoke test when orchestration changes
- [ ] TRADING_ENV=paper make dry-run when operational paths change
- [ ] CI green on this PR
- [x] Security implications have been considered and addressed
- [x] Dependencies have been reviewed for security vulnerabilities
- [x] No hardcoded secrets or credentials have been added

## Evidence boundaries

- Test result: 24 passed locally
- CI run: pending
- Protected-system result: no kill-switch / risk-constant change
- Broker/order/fill impact: none

## Coordination

- [x] Linear issue and vault claim updated
- [x] No overlapping active claim or worktree
- [ ] Claim will be marked done or released after merge

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added strict validation for trade ledger structure, required fields, numeric values, identifiers, and summary counts.
  * Added a command-line schema checker that reports validation results and failures.
  * Added safeguards against data loss when converting numeric values.

* **Bug Fixes**
  * Trade evidence now flags lossy summary-count conversions instead of silently coercing values.
  * Mismatched tabular column lengths now fail clearly rather than producing incomplete results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->