### PR TITLE
fix(AGENT-590): pin paper identity to PA3C5AG0CECQ

### DIFF
--- a/scripts/sync_alpaca_state.py
+++ b/scripts/sync_alpaca_state.py
@@ -116,6 +116,27 @@ def _derive_trade_summary_from_fills(trade_history: object, *, now: datetime | N
     }
 
 
+def _paper_account_number(executor: object) -> str | None:
+    """Resolve paper account_number from snapshot or a live broker get_account()."""
+    snapshot = getattr(executor, "account_snapshot", None) or {}
+    if isinstance(snapshot, dict):
+        number = snapshot.get("account_number")
+        if number:
+            return str(number)
+    trader = getattr(executor, "trader", None)
+    account = None
+    if trader is not None and hasattr(trader, "get_account"):
+        account = trader.get_account()
+    elif trader is not None and hasattr(trader, "trading_client"):
+        account = trader.trading_client.get_account()
+    if account is None:
+        return None
+    number = getattr(account, "account_number", None)
+    if isinstance(number, str) and number.strip():
+        return number.strip()
+    return None
+
+
 def sync_from_alpaca() -> dict | None:
     """
     Sync account state from Alpaca.
@@ -238,7 +259,7 @@ def sync_from_alpaca() -> dict | None:
             "trades_loaded": len(trade_history),
             "daily_change": round(daily_change, 2),
             "mode": "paper",
-            "account_number": snapshot.get("account_number"),
+            "account_number": _paper_account_number(executor),
             "synced_at": datetime.now().isoformat(),
         }
         logger.info(f"✅ PAPER account synced: ${executor.account_equity:,.2f}")

--- a/scripts/sync_alpaca_state.py
+++ b/scripts/sync_alpaca_state.py
@@ -226,10 +226,11 @@ def sync_from_alpaca() -> dict | None:
         except Exception as e:
             logger.warning(f"⚠️ Could not fetch PAPER trade history: {e}")
 
+        snapshot = executor.account_snapshot or {}
         result["paper"] = {
             "equity": executor.account_equity,
-            "cash": executor.account_snapshot.get("cash", 0),
-            "buying_power": executor.account_snapshot.get("buying_power", 0),
+            "cash": snapshot.get("cash", 0),
+            "buying_power": snapshot.get("buying_power", 0),
             "last_equity": last_equity,
             "positions": positions,
             "positions_count": len(positions),
@@ -237,12 +238,30 @@ def sync_from_alpaca() -> dict | None:
             "trades_loaded": len(trade_history),
             "daily_change": round(daily_change, 2),
             "mode": "paper",
+            "account_number": snapshot.get("account_number"),
             "synced_at": datetime.now().isoformat(),
         }
         logger.info(f"✅ PAPER account synced: ${executor.account_equity:,.2f}")
 
     except Exception as e:
         logger.error(f"❌ Failed to sync PAPER account: {e}")
+
+    paper_book = result.get("paper")
+    if isinstance(paper_book, dict):
+        from src.core.paper_account_identity import (
+            PaperAccountIdentityError,
+            assert_broker_is_validation_paper,
+        )
+
+        try:
+            paper_book["account_number"] = assert_broker_is_validation_paper(
+                paper_book.get("account_number"),
+                equity=paper_book.get("equity"),
+            )
+        except PaperAccountIdentityError as exc:
+            logger.error("Refusing to write system_state.json: %s", exc)
+            result["paper"] = None
+            raise AlpacaSyncError(str(exc)) from exc
 
     # ========== SYNC LIVE (BROKERAGE) ACCOUNT ==========
     # LL-281: Dashboard was showing PAPER data for LIVE account because we never fetched LIVE
@@ -336,6 +355,28 @@ def update_system_state(alpaca_data: dict | None) -> None:
             if mode == "simulated":
                 raise AlpacaSyncError(f"REFUSING to update with SIMULATED data! mode='{mode}'")
 
+            from src.core.paper_account_identity import (
+                PaperAccountIdentityError,
+                assert_broker_is_validation_paper,
+                paper_identity_block_reason,
+            )
+
+            incoming_number = paper_data.get("account_number")
+            try:
+                if incoming_number:
+                    paper_data["account_number"] = assert_broker_is_validation_paper(
+                        incoming_number,
+                        equity=paper_data.get("equity"),
+                    )
+                else:
+                    fingerprint_reason = paper_identity_block_reason(
+                        state={"paper_account": {"equity": paper_data.get("equity")}}
+                    )
+                    if fingerprint_reason:
+                        raise AlpacaSyncError(fingerprint_reason)
+            except PaperAccountIdentityError as exc:
+                raise AlpacaSyncError(str(exc)) from exc
+
             # Update account section (primary account = PAPER for R&D)
             state.setdefault("account", {})
             state["account"]["current_equity"] = paper_data.get("equity", 0)
@@ -369,6 +410,7 @@ def update_system_state(alpaca_data: dict | None) -> None:
                 else 0
             )
             state["paper_account"]["daily_change"] = paper_data.get("daily_change", 0.0)
+            state["paper_account"]["account_number"] = paper_data.get("account_number")
 
             # Update meta
             state["meta"]["last_sync"] = paper_data.get("synced_at") or now_iso

--- a/skills/alpaca-browseros-auth/SKILL.md
+++ b/skills/alpaca-browseros-auth/SKILL.md
@@ -33,8 +33,11 @@ The helper scripts never print secret values.
 In BrowserOS Neo, open Alpaca and confirm all of the following before touching API credentials:
 
 - The banner explicitly says **Paper Trading**.
+- The account switcher is on **PA3C5AG0CECQ** (validation paper, ~$94,181.95, SPY 261016 put credit).
+- Do **not** bind Keychain to `PA3PYE08C9MN` ($30k) or `PA36N5ZP8S40` ($5k). Those books do not count toward n=30.
+- Live brokerage `979807421` is blocked. Never copy live keys into the paper Keychain slots.
 - Record the paper account identifier and visible equity as non-secret evidence.
-- Do not infer that this is the repository's expected account. The API verification below decides that.
+- Do not infer that this is the repository's expected account. The API verification below decides that. `scripts/sync_alpaca_state.py` refuses to write `data/system_state.json` unless the broker `account_number` is `PA3C5AG0CECQ`.
 
 ### 2. Open Alpaca API keys
 

--- a/src/core/paper_account_identity.py
+++ b/src/core/paper_account_identity.py
@@ -112,12 +112,28 @@ def paper_identity_block_reason(
     return None
 
 
+def default_system_state_path() -> Path:
+    """Canonical ledger path written by scripts/sync_alpaca_state.py."""
+    return Path(__file__).resolve().parents[2] / "data" / "system_state.json"
+
+
 def load_system_state(path: Path | None = None) -> dict[str, Any] | None:
-    state_path = path or Path("data/system_state.json")
+    """Load system_state.json.
+
+    Returns None only when the file is absent (unit tests, empty trees).
+    Read or JSON failures raise PaperAccountIdentityError so callers fail closed.
+    """
+    state_path = path or default_system_state_path()
     if not state_path.exists():
         return None
     try:
         raw = json.loads(state_path.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError):
-        return None
-    return raw if isinstance(raw, dict) else None
+    except (OSError, json.JSONDecodeError) as exc:
+        raise PaperAccountIdentityError(
+            f"system_state unreadable at {state_path}: {exc}"
+        ) from exc
+    if not isinstance(raw, dict):
+        raise PaperAccountIdentityError(
+            f"system_state is not an object at {state_path}"
+        )
+    return raw

--- a/src/core/paper_account_identity.py
+++ b/src/core/paper_account_identity.py
@@ -129,11 +129,7 @@ def load_system_state(path: Path | None = None) -> dict[str, Any] | None:
     try:
         raw = json.loads(state_path.read_text(encoding="utf-8"))
     except (OSError, json.JSONDecodeError) as exc:
-        raise PaperAccountIdentityError(
-            f"system_state unreadable at {state_path}: {exc}"
-        ) from exc
+        raise PaperAccountIdentityError(f"system_state unreadable at {state_path}: {exc}") from exc
     if not isinstance(raw, dict):
-        raise PaperAccountIdentityError(
-            f"system_state is not an object at {state_path}"
-        )
+        raise PaperAccountIdentityError(f"system_state is not an object at {state_path}")
     return raw

--- a/src/core/paper_account_identity.py
+++ b/src/core/paper_account_identity.py
@@ -1,0 +1,123 @@
+"""Pin the validation paper book so the $30k/$5k accounts cannot count toward n=30.
+
+The BrowserOS account switcher (2026-09-07) showed three paper books plus live:
+
+- PA3C5AG0CECQ — validation paper (~$94,181.95, SPY 261016 put credit)
+- PA3PYE08C9MN — $30k paper (does not count toward the cohort)
+- PA36N5ZP8S40 — $5k paper (deprecated)
+- 979807421 — live brokerage (blocked)
+
+Entries on the wrong paper account must not update the validation ledger or
+open new risk. This module never logs credentials.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+VALIDATION_PAPER_ACCOUNT_NUMBER = "PA3C5AG0CECQ"
+FORBIDDEN_PAPER_ACCOUNTS: dict[str, str] = {
+    "PA3PYE08C9MN": "30k_paper_not_validation",
+    "PA36N5ZP8S40": "5k_paper_not_validation",
+    "979807421": "live_brokerage_blocked",
+}
+
+# Equity band that fingerprints the $30k paper book when account_number is absent.
+_THIRTY_K_EQUITY_MIN = 20_000.0
+_THIRTY_K_EQUITY_MAX = 40_000.0
+
+
+class PaperAccountIdentityError(RuntimeError):
+    """Broker or ledger identity is not the validation paper account."""
+
+
+def normalize_account_number(value: object) -> str:
+    return str(value or "").strip().upper()
+
+
+def assert_broker_is_validation_paper(
+    account_number: object,
+    *,
+    equity: object = None,
+) -> str:
+    """Require the live broker snapshot to be the validation paper account."""
+    number = normalize_account_number(account_number)
+    if not number:
+        raise PaperAccountIdentityError(
+            "PAPER identity missing: broker snapshot has no account_number. "
+            f"Refusing to treat this session as {VALIDATION_PAPER_ACCOUNT_NUMBER}."
+        )
+    if number == VALIDATION_PAPER_ACCOUNT_NUMBER:
+        return number
+    label = FORBIDDEN_PAPER_ACCOUNTS.get(number, "unknown_account")
+    equity_txt = ""
+    try:
+        if equity is not None:
+            equity_txt = f" equity={float(equity):.2f}"
+    except (TypeError, ValueError):
+        equity_txt = ""
+    raise PaperAccountIdentityError(
+        f"WRONG_PAPER_ACCOUNT {number} ({label}){equity_txt}; "
+        f"expected {VALIDATION_PAPER_ACCOUNT_NUMBER}. "
+        "Entries on this book do not count toward n=30."
+    )
+
+
+def paper_identity_block_reason(
+    *,
+    broker_account_number: object = None,
+    state: dict[str, Any] | None = None,
+) -> str | None:
+    """Return a gateway block reason, or None when identity is unspecified or valid.
+
+    Live broker account_number wins. Ledger paper_account.account_number is next.
+    A $30k equity fingerprint on the ledger blocks even when the number is missing.
+    Missing both (unit tests, empty tmp trees) is unspecified and does not block.
+    """
+    broker_number = normalize_account_number(broker_account_number)
+    if broker_number:
+        if broker_number == VALIDATION_PAPER_ACCOUNT_NUMBER:
+            return None
+        label = FORBIDDEN_PAPER_ACCOUNTS.get(broker_number, "unknown_account")
+        return (
+            f"WRONG_PAPER_ACCOUNT {broker_number} ({label}); "
+            f"expected {VALIDATION_PAPER_ACCOUNT_NUMBER}"
+        )
+
+    paper = state.get("paper_account") if isinstance(state, dict) else None
+    if not isinstance(paper, dict) or not paper:
+        return None
+
+    ledger_number = normalize_account_number(paper.get("account_number"))
+    if ledger_number:
+        if ledger_number == VALIDATION_PAPER_ACCOUNT_NUMBER:
+            return None
+        label = FORBIDDEN_PAPER_ACCOUNTS.get(ledger_number, "unknown_account")
+        return (
+            f"WRONG_PAPER_ACCOUNT {ledger_number} ({label}); "
+            f"expected {VALIDATION_PAPER_ACCOUNT_NUMBER}"
+        )
+
+    try:
+        equity = float(paper.get("equity") or paper.get("current_equity") or 0)
+    except (TypeError, ValueError):
+        equity = 0.0
+    if _THIRTY_K_EQUITY_MIN <= equity <= _THIRTY_K_EQUITY_MAX:
+        return (
+            f"WRONG_PAPER_ACCOUNT equity={equity:.2f} matches the $30k book fingerprint; "
+            f"expected {VALIDATION_PAPER_ACCOUNT_NUMBER}"
+        )
+    return None
+
+
+def load_system_state(path: Path | None = None) -> dict[str, Any] | None:
+    state_path = path or Path("data/system_state.json")
+    if not state_path.exists():
+        return None
+    try:
+        raw = json.loads(state_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    return raw if isinstance(raw, dict) else None

--- a/src/execution/alpaca_executor.py
+++ b/src/execution/alpaca_executor.py
@@ -191,9 +191,9 @@ class AlpacaExecutor:
             try:
                 # Try to get account info - this MUST work
                 if hasattr(self.trader, "get_account_info"):
-                    self.account_snapshot = self.trader.get_account_info()
+                    self.account_snapshot = self.trader.get_account_info() or {}
                 elif hasattr(self.trader, "get_account"):
-                    # Direct TradingClient fallback
+                    # Direct TradingClient fallback (MultiBroker.alpaca)
                     account = self.trader.get_account()
                     self.account_snapshot = {
                         "equity": float(account.equity),
@@ -202,9 +202,23 @@ class AlpacaExecutor:
                         "portfolio_value": float(account.portfolio_value),
                         # Needed for accurate daily P/L (used by sync_alpaca_state + dashboards).
                         "last_equity": float(getattr(account, "last_equity", 0.0) or 0.0),
+                        "account_number": getattr(account, "account_number", None),
                     }
                 else:
                     raise RuntimeError("Trader has no get_account_info or get_account method!")
+
+                if isinstance(self.account_snapshot, dict) and not self.account_snapshot.get(
+                    "account_number"
+                ):
+                    account = None
+                    if hasattr(self.trader, "get_account"):
+                        account = self.trader.get_account()
+                    elif hasattr(self.trader, "trading_client"):
+                        account = self.trader.trading_client.get_account()
+                    if account is not None:
+                        number = getattr(account, "account_number", None)
+                        if isinstance(number, str) and number.strip():
+                            self.account_snapshot["account_number"] = number.strip()
 
                 # Get positions
                 if hasattr(self.trader, "get_positions"):

--- a/src/risk/trade_gateway.py
+++ b/src/risk/trade_gateway.py
@@ -120,6 +120,10 @@ class RejectionReason(Enum):
         "Open option inventory is unclean (lot/orphan/journal mismatch) — "
         "reconcile broker book before new entries"
     )
+    WRONG_PAPER_ACCOUNT = (
+        "Broker/ledger paper identity is not the validation account PA3C5AG0CECQ — "
+        "entries on the $30k/$5k books do not count toward n=30"
+    )
     BEHAVIORAL_GUARD_BLOCKED = "Behavioral guard blocked trade (FOMO/cooling/blacklist)"
 
 
@@ -897,6 +901,49 @@ class TradeGateway:
                 or (request.side.lower() == "sell" and existing_qty > 0)
             )
             if not is_reducing:
+                try:
+                    from src.core.paper_account_identity import (
+                        load_system_state,
+                        paper_identity_block_reason,
+                    )
+
+                    snapshot = getattr(self.executor, "account_snapshot", None)
+                    broker_number = None
+                    if isinstance(snapshot, dict):
+                        broker_number = snapshot.get("account_number")
+                    identity_reason = paper_identity_block_reason(
+                        broker_account_number=broker_number,
+                        state=load_system_state(),
+                    )
+                    if identity_reason:
+                        logger.error("🚨 WRONG PAPER ACCOUNT: %s", identity_reason)
+                        return GatewayDecision(
+                            approved=False,
+                            request=request,
+                            rejection_reasons=[RejectionReason.WRONG_PAPER_ACCOUNT],
+                            risk_score=1.0,
+                            metadata={
+                                "circuit_breaker": "WRONG_PAPER_ACCOUNT",
+                                "block_reasons": [identity_reason],
+                                "action": (
+                                    "Bind Keychain trading.alpaca.paper.* to "
+                                    "PA3C5AG0CECQ before new validation entries"
+                                ),
+                            },
+                        )
+                except Exception as ident_exc:  # noqa: BLE001 — fail closed on identity errors
+                    logger.error("🚨 Paper identity check failed closed: %s", ident_exc)
+                    return GatewayDecision(
+                        approved=False,
+                        request=request,
+                        rejection_reasons=[RejectionReason.WRONG_PAPER_ACCOUNT],
+                        risk_score=1.0,
+                        metadata={
+                            "circuit_breaker": "WRONG_PAPER_ACCOUNT",
+                            "error": str(ident_exc),
+                        },
+                    )
+
                 try:
                     from src.risk.open_inventory_audit import audit_open_inventory
 

--- a/src/risk/trade_gateway.py
+++ b/src/risk/trade_gateway.py
@@ -903,6 +903,7 @@ class TradeGateway:
             if not is_reducing:
                 try:
                     from src.core.paper_account_identity import (
+                        default_system_state_path,
                         load_system_state,
                         paper_identity_block_reason,
                     )
@@ -913,7 +914,7 @@ class TradeGateway:
                         broker_number = snapshot.get("account_number")
                     identity_reason = paper_identity_block_reason(
                         broker_account_number=broker_number,
-                        state=load_system_state(),
+                        state=load_system_state(default_system_state_path()),
                     )
                     if identity_reason:
                         logger.error("🚨 WRONG PAPER ACCOUNT: %s", identity_reason)

--- a/tests/test_paper_account_identity.py
+++ b/tests/test_paper_account_identity.py
@@ -182,12 +182,32 @@ def test_gateway_allows_unspecified_identity_for_unit_tests(tmp_path, monkeypatc
     assert RejectionReason.WRONG_PAPER_ACCOUNT not in decision.rejection_reasons
 
 
+def test_load_system_state_raises_on_malformed_json(tmp_path) -> None:
+    path = tmp_path / "system_state.json"
+    path.write_text("{not-json", encoding="utf-8")
+    with pytest.raises(PaperAccountIdentityError, match="unreadable"):
+        from src.core.paper_account_identity import load_system_state
+
+        load_system_state(path)
+
+
+def test_load_system_state_none_when_absent(tmp_path) -> None:
+    from src.core.paper_account_identity import load_system_state
+
+    assert load_system_state(tmp_path / "missing.json") is None
+
+
 def test_gateway_rejects_30k_ledger_fingerprint(tmp_path, monkeypatch) -> None:
     data_dir = tmp_path / "data"
     data_dir.mkdir()
-    (data_dir / "system_state.json").write_text(
+    state_path = data_dir / "system_state.json"
+    state_path.write_text(
         json.dumps({"paper_account": {"equity": 30055.2, "cash": 30147.2}}),
         encoding="utf-8",
+    )
+    monkeypatch.setattr(
+        "src.core.paper_account_identity.default_system_state_path",
+        lambda: state_path,
     )
     monkeypatch.chdir(tmp_path)
     monkeypatch.setattr(

--- a/tests/test_paper_account_identity.py
+++ b/tests/test_paper_account_identity.py
@@ -1,0 +1,203 @@
+"""Validation paper account identity pin (AGENT-590)."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock
+
+import pytest
+
+from src.core.paper_account_identity import (
+    VALIDATION_PAPER_ACCOUNT_NUMBER,
+    PaperAccountIdentityError,
+    assert_broker_is_validation_paper,
+    paper_identity_block_reason,
+)
+from src.risk.trade_gateway import RejectionReason, TradeGateway, TradeRequest
+
+
+def test_assert_accepts_validation_account() -> None:
+    assert (
+        assert_broker_is_validation_paper("pa3c5ag0cecq", equity=94181.95)
+        == VALIDATION_PAPER_ACCOUNT_NUMBER
+    )
+
+
+@pytest.mark.parametrize(
+    "number",
+    ["PA3PYE08C9MN", "PA36N5ZP8S40", "979807421", "PAUNKNOWN"],
+)
+def test_assert_rejects_non_validation_accounts(number: str) -> None:
+    with pytest.raises(PaperAccountIdentityError, match="WRONG_PAPER_ACCOUNT"):
+        assert_broker_is_validation_paper(number, equity=30055.2)
+
+
+def test_assert_rejects_missing_account_number() -> None:
+    with pytest.raises(PaperAccountIdentityError, match="identity missing"):
+        assert_broker_is_validation_paper(None, equity=94181.95)
+
+
+def test_block_reason_none_when_unspecified() -> None:
+    assert paper_identity_block_reason() is None
+    assert paper_identity_block_reason(state={}) is None
+    assert paper_identity_block_reason(state={"paper_account": {"equity": 94181.95}}) is None
+
+
+def test_block_reason_30k_equity_fingerprint() -> None:
+    reason = paper_identity_block_reason(state={"paper_account": {"equity": 30055.2}})
+    assert reason is not None
+    assert "30k" in reason
+
+
+def test_block_reason_broker_number_wins_over_ledger() -> None:
+    reason = paper_identity_block_reason(
+        broker_account_number="PA3PYE08C9MN",
+        state={"paper_account": {"account_number": "PA3C5AG0CECQ", "equity": 94181.95}},
+    )
+    assert reason is not None
+    assert "PA3PYE08C9MN" in reason
+
+
+def test_sync_from_alpaca_refuses_30k_broker_book(monkeypatch) -> None:
+    import sys
+    import types
+    from pathlib import Path
+
+    scripts_dir = Path(__file__).resolve().parents[1] / "scripts"
+    sys.path.insert(0, str(scripts_dir))
+    import sync_alpaca_state
+
+    monkeypatch.setattr(
+        "src.utils.alpaca_client.get_alpaca_credentials",
+        lambda: ("paper_key", "paper_secret"),
+    )
+    monkeypatch.delenv("ALPACA_BROKERAGE_TRADING_API_KEY", raising=False)
+    monkeypatch.delenv("ALPACA_BROKERAGE_TRADING_API_SECRET", raising=False)
+
+    class _Executor:
+        def __init__(self, paper=True, allow_simulator=False):  # noqa: ARG002
+            self.trader = None
+            self.account_snapshot = {
+                "cash": 30147.2,
+                "buying_power": 120000.0,
+                "last_equity": 30060.0,
+                "account_number": "PA3PYE08C9MN",
+            }
+            self.account_equity = 30055.2
+
+        def sync_portfolio_state(self) -> None:
+            return None
+
+        def get_positions(self):
+            return []
+
+    fake_executor_mod = types.ModuleType("src.execution.alpaca_executor")
+    fake_executor_mod.AlpacaExecutor = _Executor
+    monkeypatch.setitem(sys.modules, "src.execution.alpaca_executor", fake_executor_mod)
+
+    with pytest.raises(sync_alpaca_state.AlpacaSyncError, match="PA3PYE08C9MN"):
+        sync_alpaca_state.sync_from_alpaca()
+
+
+def test_sync_refuses_to_apply_30k_book(tmp_path, monkeypatch) -> None:
+    import sys
+    from pathlib import Path
+
+    scripts_dir = Path(__file__).resolve().parents[1] / "scripts"
+    sys.path.insert(0, str(scripts_dir))
+    import sync_alpaca_state
+
+    monkeypatch.setattr(sync_alpaca_state, "SYSTEM_STATE_FILE", tmp_path / "system_state.json")
+    (tmp_path / "system_state.json").write_text("{}", encoding="utf-8")
+
+    with pytest.raises(sync_alpaca_state.AlpacaSyncError, match="WRONG_PAPER_ACCOUNT"):
+        sync_alpaca_state.update_system_state(
+            {
+                "paper": {
+                    "mode": "paper",
+                    "account_number": "PA3PYE08C9MN",
+                    "equity": 30055.2,
+                    "cash": 30147.2,
+                    "positions_count": 4,
+                }
+            }
+        )
+
+
+class _Executor:
+    def __init__(self, equity: float = 100_000, snapshot: dict | None = None) -> None:
+        self.account_equity = equity
+        self.account_snapshot = snapshot or {}
+        self._positions: list[dict] = []
+
+    def get_positions(self) -> list[dict]:
+        return self._positions
+
+
+def _option_request() -> TradeRequest:
+    return TradeRequest(
+        symbol="SPY261016P00742000",
+        side="sell",
+        quantity=1,
+        source="test",
+        is_option=True,
+        strategy_type="put_credit",
+        bid_price=5.00,
+        ask_price=5.10,
+        stop_price=10.0,
+        is_spread=True,
+        max_loss=200.0,
+        dte=35,
+    )
+
+
+def test_gateway_rejects_30k_broker_snapshot(monkeypatch) -> None:
+    monkeypatch.setattr(
+        "src.rag.retrieve_for_trade.retrieve_for_trade",
+        lambda *args, **kwargs: MagicMock(lessons=[], meta={}),
+    )
+    gateway = TradeGateway(executor=None, paper=True)
+    gateway.executor = _Executor(
+        equity=30055.2,
+        snapshot={"account_number": "PA3PYE08C9MN", "equity": 30055.2},
+    )
+    gateway._get_total_pl = lambda: 100.0  # type: ignore[method-assign]
+    gateway._get_drawdown = lambda: 0.0  # type: ignore[method-assign]
+    decision = gateway.evaluate(_option_request())
+    assert not decision.approved
+    assert RejectionReason.WRONG_PAPER_ACCOUNT in decision.rejection_reasons
+
+
+def test_gateway_allows_unspecified_identity_for_unit_tests(tmp_path, monkeypatch) -> None:
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(
+        "src.rag.retrieve_for_trade.retrieve_for_trade",
+        lambda *args, **kwargs: MagicMock(lessons=[], meta={}),
+    )
+    gateway = TradeGateway(executor=None, paper=True)
+    gateway.executor = _Executor(equity=100_000)
+    gateway._get_total_pl = lambda: 100.0  # type: ignore[method-assign]
+    gateway._get_drawdown = lambda: 0.0  # type: ignore[method-assign]
+    decision = gateway.evaluate(_option_request())
+    assert RejectionReason.WRONG_PAPER_ACCOUNT not in decision.rejection_reasons
+
+
+def test_gateway_rejects_30k_ledger_fingerprint(tmp_path, monkeypatch) -> None:
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    (data_dir / "system_state.json").write_text(
+        json.dumps({"paper_account": {"equity": 30055.2, "cash": 30147.2}}),
+        encoding="utf-8",
+    )
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(
+        "src.rag.retrieve_for_trade.retrieve_for_trade",
+        lambda *args, **kwargs: MagicMock(lessons=[], meta={}),
+    )
+    gateway = TradeGateway(executor=None, paper=True)
+    gateway.executor = _Executor(equity=100_000)
+    gateway._get_total_pl = lambda: 100.0  # type: ignore[method-assign]
+    gateway._get_drawdown = lambda: 0.0  # type: ignore[method-assign]
+    decision = gateway.evaluate(_option_request())
+    assert not decision.approved
+    assert RejectionReason.WRONG_PAPER_ACCOUNT in decision.rejection_reasons

--- a/tests/test_paper_account_identity.py
+++ b/tests/test_paper_account_identity.py
@@ -58,6 +58,79 @@ def test_block_reason_broker_number_wins_over_ledger() -> None:
     assert "PA3PYE08C9MN" in reason
 
 
+def test_executor_tradingclient_snapshot_includes_account_number() -> None:
+    from types import SimpleNamespace
+
+    from src.execution.alpaca_executor import AlpacaExecutor
+
+    account = SimpleNamespace(
+        equity=94181.95,
+        buying_power=375003.8,
+        cash=94250.95,
+        portfolio_value=94181.95,
+        last_equity=94190.95,
+        account_number="PA3C5AG0CECQ",
+    )
+    executor = AlpacaExecutor.__new__(AlpacaExecutor)
+    executor.simulated = False
+    executor.paper = True
+    executor.trader = SimpleNamespace(get_account=lambda: account, get_all_positions=lambda: [])
+    executor.positions = []
+    executor.account_snapshot = {}
+    executor.sync_portfolio_state()
+    assert executor.account_snapshot["account_number"] == "PA3C5AG0CECQ"
+    assert executor.account_snapshot["equity"] == 94181.95
+
+
+def test_sync_from_alpaca_fills_account_number_from_get_account(monkeypatch) -> None:
+    import sys
+    import types
+    from pathlib import Path
+    from types import SimpleNamespace
+
+    scripts_dir = Path(__file__).resolve().parents[1] / "scripts"
+    sys.path.insert(0, str(scripts_dir))
+    import sync_alpaca_state
+
+    monkeypatch.setattr(
+        "src.utils.alpaca_client.get_alpaca_credentials",
+        lambda: ("paper_key", "paper_secret"),
+    )
+    monkeypatch.delenv("ALPACA_BROKERAGE_TRADING_API_KEY", raising=False)
+    monkeypatch.delenv("ALPACA_BROKERAGE_TRADING_API_SECRET", raising=False)
+
+    class _OrdersClient:
+        def get_orders(self, filter):  # noqa: A002
+            return []
+
+        def get_account(self):
+            return SimpleNamespace(account_number="PA3C5AG0CECQ")
+
+    class _Executor:
+        def __init__(self, paper=True, allow_simulator=False):  # noqa: ARG002
+            self.trader = _OrdersClient()
+            self.account_snapshot = {"cash": 94250.95, "buying_power": 1.0, "last_equity": 94190.0}
+            self.account_equity = 94181.95
+
+        def sync_portfolio_state(self) -> None:
+            return None
+
+        def get_positions(self):
+            return []
+
+    fake_executor_mod = types.ModuleType("src.execution.alpaca_executor")
+    fake_executor_mod.AlpacaExecutor = _Executor
+    monkeypatch.setitem(sys.modules, "src.execution.alpaca_executor", fake_executor_mod)
+    monkeypatch.setattr(
+        "src.utils.alpaca_client.get_alpaca_client",
+        lambda paper=True: _OrdersClient(),
+    )
+
+    result = sync_alpaca_state.sync_from_alpaca()
+    assert result is not None
+    assert result["paper"]["account_number"] == "PA3C5AG0CECQ"
+
+
 def test_sync_from_alpaca_refuses_30k_broker_book(monkeypatch) -> None:
     import sys
     import types

--- a/tests/test_sync_alpaca_trade_history_client.py
+++ b/tests/test_sync_alpaca_trade_history_client.py
@@ -76,7 +76,12 @@ def test_sync_from_alpaca_uses_trader_wrapped_trading_client(
     class _Executor:
         def __init__(self, paper=True, allow_simulator=False):  # noqa: ARG002
             self.trader = _TraderWrapper()
-            self.account_snapshot = {"cash": 1000.0, "buying_power": 2000.0, "last_equity": 950.0}
+            self.account_snapshot = {
+                "cash": 1000.0,
+                "buying_power": 2000.0,
+                "last_equity": 950.0,
+                "account_number": "PA3C5AG0CECQ",
+            }
             self.account_equity = 1000.0
 
         def sync_portfolio_state(self) -> None:
@@ -123,7 +128,12 @@ def test_sync_from_alpaca_falls_back_to_get_alpaca_client_for_orders(
     class _ExecutorNoTrader:
         def __init__(self, paper=True, allow_simulator=False):  # noqa: ARG002
             self.trader = None
-            self.account_snapshot = {"cash": 3000.0, "buying_power": 4000.0, "last_equity": 3050.0}
+            self.account_snapshot = {
+                "cash": 3000.0,
+                "buying_power": 4000.0,
+                "last_equity": 3050.0,
+                "account_number": "PA3C5AG0CECQ",
+            }
             self.account_equity = 3000.0
 
         def sync_portfolio_state(self) -> None:


### PR DESCRIPTION
# Pull request

## Work item

- Linear issue: AGENT-590
- Agent: grok
- Base SHA: 30ace9868774ad565e30fb4fbd76e833401da8d4
- Branch/worktree: fix/agent-590-paper-account-identity / .worktrees/agent-590-paper-identity
- Files or systems claimed: src/core/paper_account_identity.py, scripts/sync_alpaca_state.py, src/risk/trade_gateway.py, tests/test_paper_account_identity.py, tests/test_sync_alpaca_trade_history_client.py, skills/alpaca-browseros-auth/SKILL.md
- Coordination legacy reason:

## Change

- Scope: Pin the validation paper book to PA3C5AG0CECQ. sync_alpaca_state refuses to write data/system_state.json when the broker account is PA3PYE08C9MN (30k) or any other non-validation paper/live account. TradeGateway rejects new risk with WRONG_PAPER_ACCOUNT. Reducing existing legs remains allowed.
- Deleted surfaces and recovery impact: none
- Out of scope: no new put-credit entries; live still blocked

## Security Impact Assessment

- [x] Low security impact

Security considerations:
- Does this change affect credential handling? No values added to the repo. Keychain labels only.
- Does this change modify access controls? Yes: wrong paper account cannot clobber the validation ledger or open new risk.
- Have secrets been properly handled without hardcoding? Yes.
- Are any API tokens being added, modified, or removed? GitHub Actions ALPACA_PAPER_TRADING_API_KEY/SECRET were rotated to the PA3C5AG0CECQ pair via stdin; values are not in this PR.

## Verification

- [x] Targeted tests
- [ ] make check
- [x] No hardcoded secrets or credentials have been added

## Evidence boundaries

- Test result: pytest tests/test_paper_account_identity.py tests/test_sync_alpaca_trade_history_client.py tests/test_sync_alpaca_positions.py — 30 passed
- CI run: pending
- Protected-system result: Keychain probe account_number=PA3C5AG0CECQ equity=94181.95 symbols=SPY261016P00737000,SPY261016P00742000; 30k pair backed up to trading.alpaca.paper30k.*
- Broker/order/fill impact: none; no new orders submitted

## Coordination

- [x] Linear issue and vault claim updated
- [x] No overlapping active claim or worktree
- [ ] Claim will be marked done or released after merge

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Paper account snapshots now display cash, buying power, and account number.
  * Added validation to confirm that broker activity is connected to the designated validation paper account.
  * Added safeguards to prevent opening trades when the account identity cannot be verified.

* **Bug Fixes**
  * Synchronization now stops without updating stored state when the account identity is invalid.
  * Incoming paper account data is validated before being saved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->