### PR TITLE
docs(rag): LL-585 tip CI reattach note after Dependabot cascade

### DIFF
--- a/rag_knowledge/lessons_learned/ll_585_dependabot_automerge_run_all_tests_and_vault_nff_2026-09-08.md
+++ b/rag_knowledge/lessons_learned/ll_585_dependabot_automerge_run_all_tests_and_vault_nff_2026-09-08.md
@@ -15,3 +15,4 @@ PR hygiene after Scorecard/Dependabot batch. #4505 merged (29a2bb059). #4500-#45
 - Hygiene completion phrase gated on Dependabot MERGED (or required-fail evidence) + tip required checks + vault push + dry-run/health evidence.
 - Scorecard residuals are not GitHub Issues (never_opens_github_issues).
 - Before writing ll_NNN_*.md, list existing NNN on main.
+7. Tip push CI may be absent after rapid Dependabot squash lands; reattach with a docs PR if required checks are missing on tip.


### PR DESCRIPTION
# Pull request

## Work item

- Linear issue: AGENT-592
- Agent: grok
- Base SHA: 8fe0d34aae7045eb10ed4454abe10778f996d36f
- Branch/worktree: docs/agent-592-tip-ci-reattach / GitHub Contents API
- Files or systems claimed: rag_knowledge/lessons_learned/ll_585_dependabot_automerge_run_all_tests_and_vault_nff_2026-09-08.md
- Coordination legacy reason:

## Change

- Scope: One-line LL-585 prevention note + reattach tip main required CI after Dependabot squash cascade left tip without push CI.
- Deleted surfaces and recovery impact: none
- Out of scope: no trading code

## Security Impact Assessment

- [x] Low security impact

Security considerations:
- Does this change affect credential handling? No
- Does this change modify access controls? No
- Have secrets been properly handled without hardcoding? Yes
- Are any API tokens being added, modified, or removed? No

## Verification

- [x] Targeted tests
- [ ] make check
- [x] No hardcoded secrets or credentials have been added

## Evidence boundaries

- Test result: docs-only
- CI run: pending tip reattach
- Protected-system result: n/a
- Broker/order/fill impact: none

## Coordination

- [x] Linear issue and vault claim updated
- [x] No overlapping active claim or worktree
- [ ] Claim will be marked done or released after merge

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a prevention rule covering missing tip-push CI checks after rapid Dependabot squash merges.
  * Documents reattaching required checks through a documentation pull request when they are absent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->