### PR TITLE
feat(AGENT-602): Fahmy entry OS — 50-DMA soft flag + predefined-risk checklist

### DIFF
--- a/rag_knowledge/lessons_learned/ll_592_fahmy_entry_os_put_credit_2026-09-10.md
+++ b/rag_knowledge/lessons_learned/ll_592_fahmy_entry_os_put_credit_2026-09-10.md
@@ -1,0 +1,32 @@
+# LL-592: Fahmy episode OS → put-credit rails (not growth stocks)
+
+**Date**: 2026-09-10
+**Severity**: 3
+**Category**: regime / entry process / FORMAT steal
+**Source**: [Investing with IBD / Joe Fahmy](https://www.youtube.com/watch?v=YTqZtOMHZrk)
+
+## What transferred
+
+Episode rule: _Market healthy? Strong fundamentals? Clean technical? Predefined risk?_
+
+Mapped onto **spy_put_credit** only:
+
+1. **Market healthy** — existing IVR/VIX gate + new SPY **50-DMA** soft-flag beside 200-DMA.
+2. **Structure strong** — defined-risk 1-lot bull put vertical with positive credit (not earnings acceleration screens).
+3. **Clean technical** — short delta + DTE inside profile bands.
+4. **Predefined risk** — stop, take-profit, time exit, and size must be written before entry.
+
+Journaled on every plan as `entry_operating_system`. Entry blocked when any answer is no.
+
+## What did NOT transfer
+
+- Multi-name growth watchlists / ~30% YoY earnings screens
+- Equity breakout entries
+- Averaging down
+
+Controlled experiment remains SPY put-credit paper validation.
+
+## Evidence
+
+- AGENT-602 / `src/risk/put_credit_regime.py` + `scripts/spy_put_credit.py`
+- Tests in `tests/test_put_credit_regime.py`

--- a/scripts/spy_put_credit.py
+++ b/scripts/spy_put_credit.py
@@ -1640,10 +1640,17 @@ def main() -> int:
         print(json.dumps({"success": False, "reason": "no_opportunity", "plan_path": str(path)}))
         return 1
 
-    if not entry_os.get("pass") and not args.ignore_regime_gate:
+    # --ignore-regime-gate only bypasses market_healthy=no (regime debug).
+    # Structure / technical / predefined-risk failures still block (CodeRabbit P1).
+    blocking_fails = [
+        failure
+        for failure in (entry_os.get("fails") or [])
+        if failure != "market_healthy=no" or not args.ignore_regime_gate
+    ]
+    if blocking_fails:
         logger.error(
             "PUT-CREDIT ENTRY OS BLOCKED: %s",
-            " | ".join(entry_os.get("fails") or ["os_failed"]),
+            " | ".join(blocking_fails),
         )
         print(
             json.dumps(
@@ -1651,6 +1658,7 @@ def main() -> int:
                     "success": False,
                     "reason": "entry_operating_system_blocked",
                     "entry_operating_system": entry_os,
+                    "blocking_fails": blocking_fails,
                     "plan_path": str(path),
                 },
                 indent=2,

--- a/scripts/spy_put_credit.py
+++ b/scripts/spy_put_credit.py
@@ -1603,12 +1603,62 @@ def main() -> int:
     plan["spy_price"] = spy_price
     plan["regime"] = regime_snap.as_dict()
     plan["regime_gate"] = regime_gate
+
+    # Fahmy FORMAT OS (AGENT-602): market / structure / technical / predefined risk.
+    from src.risk.put_credit_regime import evaluate_entry_operating_system
+
+    risk_plan = None
+    if isinstance(opp, dict):
+        risk_plan = {
+            "entry": {
+                "expiry": opp.get("expiry"),
+                "short_put": opp.get("short_put"),
+                "long_put": opp.get("long_put"),
+                "est_credit": opp.get("est_credit"),
+            },
+            "quantity": plan.get("quantity"),
+            "stop_loss": plan.get("stop_loss_pct"),
+            "take_profit": plan.get("take_profit_pct"),
+            "time_exit": plan.get("exit_dte"),
+        }
+    entry_os = evaluate_entry_operating_system(
+        regime_gate=regime_gate,
+        opportunity=opp if isinstance(opp, dict) else None,
+        risk_plan=risk_plan,
+        min_dte=int(plan.get("min_dte") or 30),
+        max_dte=int(plan.get("max_dte") or 45),
+        min_short_delta=float((plan.get("delta_band") or [0.10, 0.25])[0]),
+        max_short_delta=float((plan.get("delta_band") or [0.10, 0.25])[1]),
+    )
+    plan["entry_operating_system"] = entry_os
+    if isinstance(opp, dict):
+        opp["entry_operating_system"] = entry_os
     path = write_plan(plan)
 
     if opp is None:
         logger.warning("No valid put-credit opportunity right now")
         print(json.dumps({"success": False, "reason": "no_opportunity", "plan_path": str(path)}))
         return 1
+
+    if not entry_os.get("pass") and not args.ignore_regime_gate:
+        logger.error(
+            "PUT-CREDIT ENTRY OS BLOCKED: %s",
+            " | ".join(entry_os.get("fails") or ["os_failed"]),
+        )
+        print(
+            json.dumps(
+                {
+                    "success": False,
+                    "reason": "entry_operating_system_blocked",
+                    "entry_operating_system": entry_os,
+                    "plan_path": str(path),
+                },
+                indent=2,
+                default=str,
+            )
+        )
+        # Dry-run still writes the plan for audit; non-zero so automation does not submit.
+        return 2
 
     signature = f"SPY_{opp['expiry']}_P{int(opp['long_put'])}-{int(opp['short_put'])}"
     limit_report = evaluate_entry_limits(
@@ -1642,6 +1692,7 @@ def main() -> int:
                     "dry_run": True,
                     "opportunity": opp,
                     "regime": regime_gate,
+                    "entry_operating_system": entry_os,
                     "plan_path": str(path),
                 },
                 indent=2,

--- a/src/risk/put_credit_regime.py
+++ b/src/risk/put_credit_regime.py
@@ -1,9 +1,12 @@
 """Regime snapshot and entry gate for spy_put_credit paper validation.
 
-Research-backed minimal filter (Parallel deep research 2026-07-24):
+Research-backed minimal filter (Parallel deep research 2026-07-24)
+plus Fahmy-style market-health OS (FORMAT steal 2026-09-10, AGENT-602):
 - Prefer short premium when IV rank proxy is elevated (IVR >= 30)
 - Hard veto when VIX is extreme (VIX > 30)
-- Optional trend soft-flag: SPY vs 200-day SMA (logged; hard only if enabled)
+- Trend soft-flags: SPY vs 50-day SMA (intermediate) and 200-day SMA (longer-term)
+- Pre-entry OS: market healthy / structure strong / clean setup / predefined risk
+  (growth-stock earnings screens intentionally NOT transferred — SPY put-credit only)
 
 Does NOT claim edge. Live remains blocked by kill switch until cohort gates pass.
 Missing market data fails closed for *new entries* (fail open for pure logging).
@@ -32,6 +35,11 @@ REQUIRE_ABOVE_200DMA = os.environ.get("PUT_CREDIT_REQUIRE_200DMA", "0").lower() 
     "true",
     "yes",
 }
+REQUIRE_ABOVE_50DMA = os.environ.get("PUT_CREDIT_REQUIRE_50DMA", "0").lower() in {
+    "1",
+    "true",
+    "yes",
+}
 # When true, missing IVR/VIX blocks entries. Default true for reliability.
 FAIL_CLOSED_ON_MISSING = os.environ.get("PUT_CREDIT_REGIME_FAIL_CLOSED", "1").lower() in {
     "1",
@@ -51,6 +59,8 @@ class RegimeSnapshot:
     iv_rank_method: str
     spy_sma_200: float | None
     spy_above_200dma: bool | None
+    spy_sma_50: float | None = None
+    spy_above_50dma: bool | None = None
     source_errors: tuple[str, ...] = ()
 
     def as_dict(self) -> dict[str, Any]:
@@ -59,8 +69,10 @@ class RegimeSnapshot:
         return payload
 
 
-def _spy_sma_200(spy_price: float | None) -> tuple[float | None, bool | None, str | None]:
-    """Return (sma200, above, error)."""
+def _spy_sma_levels(
+    spy_price: float | None,
+) -> tuple[float | None, bool | None, float | None, bool | None, str | None]:
+    """Return (sma50, above50, sma200, above200, error)."""
     try:
         from alpaca.data.historical import StockHistoricalDataClient
         from alpaca.data.requests import StockBarsRequest
@@ -70,7 +82,7 @@ def _spy_sma_200(spy_price: float | None) -> tuple[float | None, bool | None, st
 
         key, secret = get_alpaca_credentials()
         if not key:
-            return None, None, "no_alpaca_credentials"
+            return None, None, None, None, "no_alpaca_credentials"
         client = StockHistoricalDataClient(key, secret)
         end = datetime.now(UTC)
         start = end - timedelta(days=400)
@@ -89,16 +101,31 @@ def _spy_sma_200(spy_price: float | None) -> tuple[float | None, bool | None, st
         bars = client.get_stock_bars(req)
         rows = bars.data.get("SPY") if hasattr(bars, "data") else None
         if not rows or len(rows) < 200:
-            return None, None, f"insufficient_spy_bars:{0 if not rows else len(rows)}"
+            return None, None, None, None, f"insufficient_spy_bars:{0 if not rows else len(rows)}"
         closes = [float(b.close) for b in rows if getattr(b, "close", None) is not None]
         if len(closes) < 200:
-            return None, None, f"insufficient_spy_closes:{len(closes)}"
-        sma = sum(closes[-200:]) / 200.0
+            return None, None, None, None, f"insufficient_spy_closes:{len(closes)}"
+        sma200 = sum(closes[-200:]) / 200.0
+        sma50 = sum(closes[-50:]) / 50.0 if len(closes) >= 50 else None
         price = float(spy_price) if spy_price is not None else closes[-1]
-        return round(sma, 4), bool(price >= sma), None
+        above200 = bool(price >= sma200)
+        above50 = bool(price >= sma50) if sma50 is not None else None
+        return (
+            round(sma50, 4) if sma50 is not None else None,
+            above50,
+            round(sma200, 4),
+            above200,
+            None,
+        )
     except Exception as exc:  # noqa: BLE001
-        logger.debug("SPY 200-DMA fetch failed: %s", exc)
-        return None, None, f"spy_sma_error:{exc}"
+        logger.debug("SPY SMA fetch failed: %s", exc)
+        return None, None, None, None, f"spy_sma_error:{exc}"
+
+
+def _spy_sma_200(spy_price: float | None) -> tuple[float | None, bool | None, str | None]:
+    """Backward-compatible wrapper: (sma200, above200, error)."""
+    _s50, _a50, s200, a200, err = _spy_sma_levels(spy_price)
+    return s200, a200, err
 
 
 def capture_regime_snapshot(spy_price: float | None = None) -> RegimeSnapshot:
@@ -142,7 +169,7 @@ def capture_regime_snapshot(spy_price: float | None = None) -> RegimeSnapshot:
         except Exception as exc:  # noqa: BLE001
             errors.append(f"vix_percentile:{exc}")
 
-    sma, above, sma_err = _spy_sma_200(spy_price)
+    sma50, above50, sma200, above200, sma_err = _spy_sma_levels(spy_price)
     if sma_err:
         errors.append(sma_err)
 
@@ -152,8 +179,10 @@ def capture_regime_snapshot(spy_price: float | None = None) -> RegimeSnapshot:
         vix=round(vix, 4) if vix is not None else None,
         iv_rank_proxy=round(ivr, 2) if ivr is not None else None,
         iv_rank_method=ivr_method,
-        spy_sma_200=sma,
-        spy_above_200dma=above,
+        spy_sma_200=sma200,
+        spy_above_200dma=above200,
+        spy_sma_50=sma50,
+        spy_above_50dma=above50,
         source_errors=tuple(errors),
     )
 
@@ -164,6 +193,7 @@ def evaluate_regime_gate(
     min_iv_rank: float = MIN_IV_RANK,
     max_vix: float = MAX_VIX,
     require_above_200dma: bool = REQUIRE_ABOVE_200DMA,
+    require_above_50dma: bool = REQUIRE_ABOVE_50DMA,
     fail_closed_on_missing: bool = FAIL_CLOSED_ON_MISSING,
 ) -> dict[str, Any]:
     """Return {allowed, blockers, soft_flags, snapshot}.
@@ -172,8 +202,9 @@ def evaluate_regime_gate(
     - VIX > max_vix
     - IV rank proxy < min_iv_rank
     - missing VIX or IVR when fail_closed_on_missing
-    Soft flags (never block unless require_above_200dma):
-    - SPY below 200-DMA
+    Soft flags (never block unless require_above_*dma):
+    - SPY below 50-DMA (intermediate health)
+    - SPY below 200-DMA (longer-term health)
     """
 
     if isinstance(snapshot, RegimeSnapshot):
@@ -186,7 +217,8 @@ def evaluate_regime_gate(
 
     vix = snap.get("vix")
     ivr = snap.get("iv_rank_proxy")
-    above = snap.get("spy_above_200dma")
+    above200 = snap.get("spy_above_200dma")
+    above50 = snap.get("spy_above_50dma")
 
     if vix is None:
         msg = "VIX unavailable for regime gate"
@@ -216,13 +248,22 @@ def evaluate_regime_gate(
             f"{float(RESEARCH_PREFERRED_IVR):.1f} (lean premium; stratify later)"
         )
 
-    if above is False:
+    if above50 is False:
+        msg = "SPY below 50-day SMA (intermediate trend soft-flag)"
+        if require_above_50dma:
+            blockers.append(msg)
+        else:
+            soft.append(msg)
+    elif above50 is None:
+        soft.append("SPY 50-DMA unavailable")
+
+    if above200 is False:
         msg = "SPY below 200-day SMA (trend soft-flag)"
         if require_above_200dma:
             blockers.append(msg)
         else:
             soft.append(msg)
-    elif above is None:
+    elif above200 is None:
         soft.append("SPY 200-DMA unavailable")
 
     return {
@@ -234,9 +275,137 @@ def evaluate_regime_gate(
             "research_preferred_ivr": RESEARCH_PREFERRED_IVR,
             "max_vix": max_vix,
             "require_above_200dma": require_above_200dma,
+            "require_above_50dma": require_above_50dma,
             "fail_closed_on_missing": fail_closed_on_missing,
         },
         "snapshot": snap,
+    }
+
+
+def evaluate_entry_operating_system(
+    *,
+    regime_gate: dict[str, Any],
+    opportunity: dict[str, Any] | None,
+    risk_plan: dict[str, Any] | None,
+    min_dte: int = 30,
+    max_dte: int = 45,
+    min_short_delta: float = 0.10,
+    max_short_delta: float = 0.25,
+) -> dict[str, Any]:
+    """Fahmy-style four-question OS mapped onto SPY put-credit (AGENT-602).
+
+    Questions (all must be yes to pass):
+    1. Market healthy? — regime gate allowed
+    2. Structure strong? — defined-risk 1-lot put vertical with positive credit
+    3. Clean technical setup? — short delta + DTE in profile band
+    4. Predefined risk? — stop, take-profit, time exit, and size written before entry
+
+    Intentionally does NOT screen equity earnings growth or multi-name watchlists.
+    """
+
+    answers: dict[str, Any] = {}
+    fails: list[str] = []
+
+    market_ok = bool(regime_gate.get("allowed"))
+    answers["market_healthy"] = {
+        "yes": market_ok,
+        "detail": {
+            "blockers": list(regime_gate.get("blockers") or []),
+            "soft_flags": list(regime_gate.get("soft_flags") or []),
+        },
+    }
+    if not market_ok:
+        fails.append("market_healthy=no")
+
+    structure_ok = False
+    structure_detail: dict[str, Any] = {"reason": "no_opportunity"}
+    if isinstance(opportunity, dict):
+        credit = opportunity.get("est_credit") or opportunity.get("natural_credit")
+        qty = int(opportunity.get("quantity") or 0)
+        short_put = opportunity.get("short_put")
+        long_put = opportunity.get("long_put")
+        wing = opportunity.get("put_wing")
+        try:
+            credit_f = float(credit) if credit is not None else 0.0
+        except (TypeError, ValueError):
+            credit_f = 0.0
+        structure_ok = (
+            credit_f > 0
+            and qty == 1
+            and short_put is not None
+            and long_put is not None
+            and float(short_put) > float(long_put)
+        )
+        structure_detail = {
+            "credit": credit_f,
+            "quantity": qty,
+            "short_put": short_put,
+            "long_put": long_put,
+            "put_wing": wing,
+            "defined_risk_put_vertical": structure_ok,
+        }
+    answers["structure_strong"] = {"yes": structure_ok, "detail": structure_detail}
+    if not structure_ok:
+        fails.append("structure_strong=no")
+
+    technical_ok = False
+    technical_detail: dict[str, Any] = {"reason": "no_opportunity"}
+    if isinstance(opportunity, dict):
+        delta = opportunity.get("put_delta")
+        expiry = opportunity.get("expiry")
+        dte = opportunity.get("dte")
+        if dte is None and expiry:
+            try:
+                exp = datetime.strptime(str(expiry)[:10], "%Y-%m-%d").replace(tzinfo=UTC)
+                dte = (exp.date() - datetime.now(UTC).date()).days
+            except ValueError:
+                dte = None
+        try:
+            delta_f = abs(float(delta)) if delta is not None else None
+        except (TypeError, ValueError):
+            delta_f = None
+        delta_ok = delta_f is not None and min_short_delta <= delta_f <= max_short_delta
+        dte_ok = dte is not None and min_dte <= int(dte) <= max_dte
+        technical_ok = bool(delta_ok and dte_ok)
+        technical_detail = {
+            "put_delta": delta_f,
+            "dte": dte,
+            "delta_band": [min_short_delta, max_short_delta],
+            "dte_band": [min_dte, max_dte],
+            "delta_ok": delta_ok,
+            "dte_ok": dte_ok,
+        }
+    answers["clean_technical_setup"] = {"yes": technical_ok, "detail": technical_detail}
+    if not technical_ok:
+        fails.append("clean_technical_setup=no")
+
+    risk_ok = False
+    risk_detail: dict[str, Any] = {"reason": "missing_risk_plan"}
+    if isinstance(risk_plan, dict):
+        required = ("entry", "quantity", "stop_loss", "take_profit", "time_exit")
+        present = {k: risk_plan.get(k) for k in required}
+        risk_ok = all(present[k] is not None and present[k] != "" for k in required)
+        try:
+            qty = int(present.get("quantity") or 0)
+        except (TypeError, ValueError):
+            qty = 0
+        if qty != 1:
+            risk_ok = False
+        risk_detail = {"fields": present, "quantity_is_one_lot": qty == 1}
+    answers["predefined_risk"] = {"yes": risk_ok, "detail": risk_detail}
+    if not risk_ok:
+        fails.append("predefined_risk=no")
+
+    return {
+        "pass": not fails,
+        "rule": "Market healthy? Structure strong? Clean technical setup? Predefined risk?",
+        "source": "fahmy_os_format_steal_AGENT-602",
+        "answers": answers,
+        "fails": fails,
+        "note": (
+            "FORMAT steal only — not a growth-stock earnings screen. "
+            "Live capital stays blocked until put-credit EDGE_CANDIDATE."
+        ),
     }
 
 

--- a/tests/test_active_strategy.py
+++ b/tests/test_active_strategy.py
@@ -287,12 +287,17 @@ def test_repo_kill_switch_file_present():
 
 
 def _put_credit_opp() -> dict:
+    # Keep expiry ~35–45 DTE from "today" so entry OS technical check stays valid.
+    from datetime import UTC, datetime, timedelta
+
+    expiry = (datetime.now(UTC).date() + timedelta(days=40)).isoformat()
     return {
-        "expiry": "2026-08-21",
+        "expiry": expiry,
         "short_put": 700.0,
         "long_put": 695.0,
         "est_credit": 1.0,
         "put_delta": 0.15,
+        "dte": 40,
         "method": "live_delta",
         "quantity": 1,
     }
@@ -304,13 +309,15 @@ def test_put_credit_journal_uses_unique_order_identity(tmp_path, monkeypatch):
     entries_path = tmp_path / "put_credit_entries.json"
     monkeypatch.setattr(pcs, "ENTRIES_FILE", entries_path)
 
-    pcs._record_entry(_put_credit_opp(), "order-1")
-    pcs._record_entry(_put_credit_opp(), "order-2")
+    opp = _put_credit_opp()
+    pcs._record_entry(opp, "order-1")
+    pcs._record_entry(opp, "order-2")
 
     entries = json.loads(entries_path.read_text(encoding="utf-8"))
-    assert set(entries) == {"PCS_260821_order1", "PCS_260821_order2"}
-    assert entries["PCS_260821_order1"]["credit_source"] == "limit_estimate_unconfirmed"
-    assert entries["PCS_260821_order2"]["expiry"] == "2026-08-21"
+    yymmdd = opp["expiry"].replace("-", "")[2:]
+    assert set(entries) == {f"PCS_{yymmdd}_order1", f"PCS_{yymmdd}_order2"}
+    assert entries[f"PCS_{yymmdd}_order1"]["credit_source"] == "limit_estimate_unconfirmed"
+    assert entries[f"PCS_{yymmdd}_order2"]["expiry"] == opp["expiry"]
 
 
 def test_reconcile_put_credit_entries_recovers_exact_filled_structure(tmp_path, monkeypatch):

--- a/tests/test_put_credit_regime.py
+++ b/tests/test_put_credit_regime.py
@@ -185,6 +185,22 @@ def test_entry_os_fails_when_market_unhealthy():
     assert "market_healthy=no" in os_result["fails"]
 
 
+def test_ignore_regime_gate_only_bypasses_market_healthy_failure():
+    """CodeRabbit #4579: --ignore-regime-gate must not waive structure/risk OS fails."""
+    fails = ["market_healthy=no", "predefined_risk=no"]
+    ignore_regime_gate = True
+    blocking = [
+        failure for failure in fails if failure != "market_healthy=no" or not ignore_regime_gate
+    ]
+    assert blocking == ["predefined_risk=no"]
+
+    ignore_regime_gate = False
+    blocking = [
+        failure for failure in fails if failure != "market_healthy=no" or not ignore_regime_gate
+    ]
+    assert blocking == ["market_healthy=no", "predefined_risk=no"]
+
+
 def test_counterfactuals_tp50_and_21dte():
     base = {
         "should_exit": False,

--- a/tests/test_put_credit_regime.py
+++ b/tests/test_put_credit_regime.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from src.risk.put_credit_regime import (
     RegimeSnapshot,
     attach_counterfactuals,
+    evaluate_entry_operating_system,
     evaluate_regime_gate,
 )
 
@@ -18,6 +19,8 @@ def _snap(**kwargs) -> RegimeSnapshot:
         iv_rank_method="test",
         spy_sma_200=700.0,
         spy_above_200dma=True,
+        spy_sma_50=720.0,
+        spy_above_50dma=True,
         source_errors=(),
     )
     base.update(kwargs)
@@ -101,6 +104,85 @@ def test_trend_soft_flag_by_default():
 def test_trend_hard_when_required():
     gate = evaluate_regime_gate(_snap(spy_above_200dma=False), require_above_200dma=True)
     assert gate["allowed"] is False
+
+
+def test_50dma_soft_flag_by_default():
+    gate = evaluate_regime_gate(_snap(spy_above_50dma=False), require_above_50dma=False)
+    assert gate["allowed"] is True
+    assert any("50-day" in f for f in gate["soft_flags"])
+    assert gate["thresholds"]["require_above_50dma"] is False
+
+
+def test_50dma_hard_when_required():
+    gate = evaluate_regime_gate(_snap(spy_above_50dma=False), require_above_50dma=True)
+    assert gate["allowed"] is False
+    assert any("50-day" in b for b in gate["blockers"])
+
+
+def test_entry_os_passes_when_all_four_yes():
+    gate = evaluate_regime_gate(_snap())
+    opp = {
+        "expiry": "2026-10-23",
+        "short_put": 725.0,
+        "long_put": 720.0,
+        "est_credit": 0.67,
+        "quantity": 1,
+        "put_delta": 0.18,
+        "dte": 40,
+    }
+    risk = {
+        "entry": {"expiry": "2026-10-23"},
+        "quantity": 1,
+        "stop_loss": 2.0,
+        "take_profit": 0.25,
+        "time_exit": 7,
+    }
+    os_result = evaluate_entry_operating_system(regime_gate=gate, opportunity=opp, risk_plan=risk)
+    assert os_result["pass"] is True
+    assert os_result["fails"] == []
+    assert os_result["answers"]["market_healthy"]["yes"] is True
+    assert os_result["answers"]["structure_strong"]["yes"] is True
+    assert os_result["answers"]["clean_technical_setup"]["yes"] is True
+    assert os_result["answers"]["predefined_risk"]["yes"] is True
+
+
+def test_entry_os_fails_without_predefined_risk():
+    gate = evaluate_regime_gate(_snap())
+    opp = {
+        "expiry": "2026-10-23",
+        "short_put": 725.0,
+        "long_put": 720.0,
+        "est_credit": 0.67,
+        "quantity": 1,
+        "put_delta": 0.18,
+        "dte": 40,
+    }
+    os_result = evaluate_entry_operating_system(regime_gate=gate, opportunity=opp, risk_plan=None)
+    assert os_result["pass"] is False
+    assert "predefined_risk=no" in os_result["fails"]
+
+
+def test_entry_os_fails_when_market_unhealthy():
+    gate = evaluate_regime_gate(_snap(vix=40.0))
+    opp = {
+        "expiry": "2026-10-23",
+        "short_put": 725.0,
+        "long_put": 720.0,
+        "est_credit": 0.67,
+        "quantity": 1,
+        "put_delta": 0.18,
+        "dte": 40,
+    }
+    risk = {
+        "entry": {"expiry": "2026-10-23"},
+        "quantity": 1,
+        "stop_loss": 2.0,
+        "take_profit": 0.25,
+        "time_exit": 7,
+    }
+    os_result = evaluate_entry_operating_system(regime_gate=gate, opportunity=opp, risk_plan=risk)
+    assert os_result["pass"] is False
+    assert "market_healthy=no" in os_result["fails"]
 
 
 def test_counterfactuals_tp50_and_21dte():


### PR DESCRIPTION
# Pull request

## Work item

- Linear issue: AGENT-602
- Agent: grok
- Base SHA: 5b678569661e6b705e13e7995ac7760ea5f2312b
- Branch/worktree: fix/AGENT-602-fahmy-entry-os / .worktrees/AGENT-601-fahmy-entry-os
- Files or systems claimed: src/risk/put_credit_regime.py, scripts/spy_put_credit.py, tests/test_put_credit_regime.py, tests/test_active_strategy.py, rag_knowledge/lessons_learned/ll_592_fahmy_entry_os_put_credit_2026-09-10.md
- Coordination legacy reason:

## Change

- Scope: FORMAT steal from Fahmy / Investing with IBD onto spy_put_credit rails only (50-DMA soft-flag + four-question entry OS). Follow-up: `--ignore-regime-gate` only bypasses `market_healthy=no` (CodeRabbit P1).
- Deleted surfaces and recovery impact: none.
- Out of scope: equity growth screens, multi-name watchlists, breakout stock entries.

## Verification

- [x] Targeted tests
- [ ] `make skill-check coordination-check` (lint/audit subset via hygiene --check)
- [ ] RAG read/write round trip when RAG changes
- [ ] Orchestration smoke test when orchestration changes
- [ ] `TRADING_ENV=paper make dry-run` when operational paths change
- [ ] CI green on this exact head SHA

## Evidence boundaries

- Test result: `pytest tests/test_put_credit_regime.py` → 20 passed
- CI run: re-queued after CodeRabbit fix push
- Broker/order/fill impact: none unless entry OS blocks a would-be submit

## Coordination

- [x] Linear issue and vault claim updated
- [x] No overlapping active claim or worktree
- [ ] Claim will be marked done or released after merge

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a pre-trade checklist for SPY put-credit opportunities covering market health, trade structure, technical setup, and predefined risk.
  * Added 50-day moving-average monitoring alongside existing 200-day indicators.
  * Dry-run results now display the entry assessment.

* **Bug Fixes**
  * Regime-gate bypass now only overrides unhealthy-market failures; structural, technical, and risk failures remain blocking.

* **Documentation**
  * Added guidance describing the entry checklist and supported SPY put-credit validation process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->