### PR TITLE
feat(AGENT-605): Parallel Basis receipt for put-credit SEARCH (not FindAll stocks)

### DIFF
--- a/rag_knowledge/lessons_learned/ll_595_parallel_basis_not_findall_stocks_2026-09-11.md
+++ b/rag_knowledge/lessons_learned/ll_595_parallel_basis_not_findall_stocks_2026-09-11.md
@@ -1,0 +1,31 @@
+# LL-595: Parallel Basis FORMAT, not FindAll stocks
+
+**Date**: 2026-09-11
+**Severity**: 3
+**Category**: evidence / discovery loop
+**Source**: [Parallel.ai](https://parallel.ai/?shem=dsdf,sharefoc,agadiscoversdl,,sh/x/discover/m1/4)
+
+## What transferred
+
+Parallel public pitch: Search / Extract / Monitor / Discover / Enrich, with
+**Basis** (citation + calibrated confidence) on every claim. Discovery returns
+**entities**, not links.
+
+Mapped onto **local** `spy_put_credit` ledgers:
+
+- SEARCH cites `strategy_kill_switch.json` (family, paper_only, live_blocked)
+- EVALUATE cites journal open count + paired `trades.json` n toward 30
+- TRADE is receipt-only (`submitted: 0`); no Parallel API call
+- Confidence is high/medium/low from file presence, not a fake model score
+
+CLI: `python scripts/put_credit_basis.py --json`
+
+## What did NOT transfer
+
+- Parallel Task / Search / FindAll / Monitor APIs in the hot path (cost + SPY-only)
+- "Find all tickers" (controlled experiment is SPY put-credit)
+- Untracked primary-checkout theater (`parallel_ai_features.py`,
+  `integrated_parallel_trading.py`, simulated prices)
+- Claiming AUM/Sharpe from n=3
+
+Monetize path remains n≥30 paired put-credit with expectancy>0.

--- a/scripts/put_credit_basis.py
+++ b/scripts/put_credit_basis.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+"""CLI: Parallel Basis FORMAT receipt from local put-credit ledgers (no Parallel API)."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from src.ops.put_credit_basis import build_basis, readiness_ok  # noqa: E402
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="SEARCH/EVALUATE/TRADE receipt with cited local ledgers (Parallel Basis FORMAT)"
+    )
+    parser.add_argument("--json", action="store_true", help="Emit JSON (default)")
+    parser.add_argument(
+        "--check-ready", action="store_true", help="Exit 0 if paper-only spy_put_credit"
+    )
+    parser.add_argument("--project-root", default=".", help="Repo root")
+    args = parser.parse_args(argv)
+
+    receipt = build_basis(Path(args.project_root))
+    if args.check_ready:
+        ok = readiness_ok(receipt)
+        print(json.dumps({"ok": ok, "ticker": receipt["ticker"]}, ensure_ascii=True))
+        return 0 if ok else 2
+    print(json.dumps(receipt, ensure_ascii=True, indent=2, default=str))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/ops/put_credit_basis.py
+++ b/src/ops/put_credit_basis.py
@@ -1,0 +1,161 @@
+"""Parallel Basis FORMAT steal for spy_put_credit SEARCH.
+
+Parallel.ai (https://parallel.ai/) attaches provenance + calibrated confidence
+to every claim ("Basis"). We do **not** vendor Parallel APIs, FindAll, Monitor
+webhooks, or copy untracked `parallel_ai_features.py` theater.
+
+This module cites **local ledgers** for SEARCH → EVALUATE → TRADE. Discover
+does not mean "find all tickers": the controlled experiment is SPY put-credit.
+TRADE is receipt-only (submitted=0). Live stays blocked.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+@dataclass(frozen=True)
+class BasisClaim:
+    """One cited claim. confidence is high|medium|low, never a fake 0-1 model score."""
+
+    claim: str
+    value: Any
+    source: str
+    confidence: str  # high | medium | low
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+def _load_json(path: Path) -> tuple[Any | None, str]:
+    if not path.is_file():
+        return None, "missing"
+    try:
+        return json.loads(path.read_text(encoding="utf-8")), "ok"
+    except (OSError, json.JSONDecodeError):
+        return None, "unreadable"
+
+
+def _conf(ok: bool) -> str:
+    return "high" if ok else "low"
+
+
+def build_basis(project_root: Path | None = None) -> dict[str, Any]:
+    """Return SEARCH/EVALUATE/TRADE receipt with Basis citations."""
+    root = Path(project_root or _REPO_ROOT).resolve()
+    kill_path = root / "data" / "runtime" / "strategy_kill_switch.json"
+    entries_path = root / "data" / "put_credit_entries.json"
+    trades_path = root / "data" / "trades.json"
+    state_path = root / "data" / "system_state.json"
+
+    kill, kill_st = _load_json(kill_path)
+    entries, ent_st = _load_json(entries_path)
+    trades, tr_st = _load_json(trades_path)
+    state, st_st = _load_json(state_path)
+
+    kill = kill if isinstance(kill, dict) else {}
+    entries = entries if isinstance(entries, dict) else {}
+    trades = trades if isinstance(trades, dict) else {}
+    state = state if isinstance(state, dict) else {}
+
+    open_n = sum(
+        1
+        for v in entries.values()
+        if isinstance(v, dict) and str(v.get("status") or "").lower() == "open"
+    )
+    pc_stats = ((trades.get("stats") or {}).get("by_strategy") or {}).get("spy_put_credit") or {}
+    closed_n = pc_stats.get("closed")
+    paper = (
+        (state.get("paper_account") or {}) if isinstance(state.get("paper_account"), dict) else {}
+    )
+
+    claims = [
+        BasisClaim(
+            "active_family",
+            kill.get("active_family"),
+            "data/runtime/strategy_kill_switch.json",
+            _conf(kill_st == "ok" and bool(kill.get("active_family"))),
+        ),
+        BasisClaim(
+            "live_blocked",
+            kill.get("live_blocked"),
+            "data/runtime/strategy_kill_switch.json",
+            _conf(kill_st == "ok" and "live_blocked" in kill),
+        ),
+        BasisClaim(
+            "paper_only",
+            kill.get("paper_only"),
+            "data/runtime/strategy_kill_switch.json",
+            _conf(kill_st == "ok" and "paper_only" in kill),
+        ),
+        BasisClaim(
+            "open_put_credit_journal",
+            open_n,
+            "data/put_credit_entries.json",
+            "medium" if ent_st == "ok" else "low",
+        ),
+        BasisClaim(
+            "paired_put_credit_closed",
+            closed_n,
+            "data/trades.json.stats.by_strategy.spy_put_credit",
+            _conf(tr_st == "ok" and closed_n is not None),
+        ),
+        BasisClaim(
+            "paper_equity",
+            paper.get("equity"),
+            "data/system_state.json.paper_account.equity",
+            _conf(st_st == "ok" and paper.get("equity") is not None),
+        ),
+    ]
+
+    search = {
+        "active_family": kill.get("active_family"),
+        "live_blocked": kill.get("live_blocked"),
+        "paper_only": kill.get("paper_only"),
+    }
+    evaluate = {
+        "open_journal": open_n,
+        "paired_closed": closed_n,
+        "n30_remaining": None if closed_n is None else max(0, 30 - int(closed_n)),
+    }
+    trade = {
+        "submitted": 0,
+        "action": "receipt_only",
+        "live_execute": False,
+        "findall_other_tickers": False,
+        "parallel_api_called": False,
+    }
+
+    return {
+        "generated_at": datetime.now(UTC).isoformat(),
+        "format": "parallel_basis_local_ledgers",
+        "ticker": "SPY",
+        "search": search,
+        "evaluate": evaluate,
+        "trade": trade,
+        "basis": [c.to_dict() for c in claims],
+        "forbid": (
+            "Parallel FindAll of other tickers",
+            "paid Parallel Task/Monitor in the hot path",
+            "copy untracked parallel_ai_features.py theater",
+            "live --execute",
+            "claim green cron as a fill",
+        ),
+    }
+
+
+def readiness_ok(receipt: dict[str, Any]) -> bool:
+    """Ready when kill switch cites spy_put_credit paper-only live-blocked."""
+    search = receipt.get("search") or {}
+    return (
+        search.get("active_family") == "spy_put_credit"
+        and search.get("paper_only") is True
+        and search.get("live_blocked") is True
+        and receipt.get("trade", {}).get("submitted") == 0
+    )

--- a/tests/test_put_credit_basis.py
+++ b/tests/test_put_credit_basis.py
@@ -1,0 +1,88 @@
+"""Tests for Parallel Basis FORMAT steal (local ledgers only)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from src.ops.put_credit_basis import build_basis, readiness_ok
+
+
+def _write(root: Path, rel: str, payload: dict) -> None:
+    path = root / rel
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+
+def test_missing_ledgers_are_low_confidence_not_crash(tmp_path: Path) -> None:
+    receipt = build_basis(tmp_path)
+    assert receipt["ticker"] == "SPY"
+    assert receipt["trade"]["submitted"] == 0
+    assert receipt["trade"]["parallel_api_called"] is False
+    assert receipt["trade"]["findall_other_tickers"] is False
+    assert all(c["confidence"] in {"high", "medium", "low"} for c in receipt["basis"])
+    assert readiness_ok(receipt) is False
+
+
+def test_kill_switch_and_paired_stats_are_cited(tmp_path: Path) -> None:
+    _write(
+        tmp_path,
+        "data/runtime/strategy_kill_switch.json",
+        {
+            "active_family": "spy_put_credit",
+            "paper_only": True,
+            "live_blocked": True,
+        },
+    )
+    _write(
+        tmp_path,
+        "data/put_credit_entries.json",
+        {"a": {"status": "open"}, "b": {"status": "closed"}},
+    )
+    _write(
+        tmp_path,
+        "data/trades.json",
+        {"stats": {"by_strategy": {"spy_put_credit": {"closed": 3}}}},
+    )
+    _write(
+        tmp_path,
+        "data/system_state.json",
+        {"paper_account": {"equity": 94136.95}},
+    )
+    receipt = build_basis(tmp_path)
+    assert receipt["search"]["active_family"] == "spy_put_credit"
+    assert receipt["evaluate"]["open_journal"] == 1
+    assert receipt["evaluate"]["paired_closed"] == 3
+    assert receipt["evaluate"]["n30_remaining"] == 27
+    assert receipt["trade"]["submitted"] == 0
+    by_claim = {c["claim"]: c for c in receipt["basis"]}
+    assert by_claim["live_blocked"]["confidence"] == "high"
+    assert by_claim["paired_put_credit_closed"]["source"].startswith("data/trades.json")
+    assert readiness_ok(receipt) is True
+    assert "FindAll" in " ".join(receipt["forbid"])
+
+
+def test_cli_check_ready_via_module(tmp_path: Path) -> None:
+    _write(
+        tmp_path,
+        "data/runtime/strategy_kill_switch.json",
+        {"active_family": "spy_put_credit", "paper_only": True, "live_blocked": True},
+    )
+    import runpy
+    import sys
+
+    argv = sys.argv
+    sys.argv = [
+        "put_credit_basis.py",
+        "--check-ready",
+        "--project-root",
+        str(tmp_path),
+    ]
+    try:
+        ns = runpy.run_path(
+            str(Path(__file__).resolve().parents[1] / "scripts" / "put_credit_basis.py"),
+            run_name="not_main",
+        )
+        assert ns["main"](["--check-ready", "--project-root", str(tmp_path)]) == 0
+    finally:
+        sys.argv = argv


### PR DESCRIPTION
# Pull request

## Work item

- Linear issue: AGENT-605
- Agent: grok
- Base SHA: ecfb12bf488046e6f7b71d29bfa0fd25cb40c6e8
- Branch/worktree: fix/AGENT-605-parallel-basis / .worktrees/AGENT-605-parallel-basis
- Files or systems claimed: src/ops/put_credit_basis.py, scripts/put_credit_basis.py, tests/test_put_credit_basis.py, rag_knowledge/lessons_learned/ll_595_parallel_basis_not_findall_stocks_2026-09-11.md
- Coordination legacy reason:

## Change

- Scope: Parallel.ai Basis FORMAT steal — SEARCH/EVALUATE/TRADE receipt cites local kill switch, journal, trades.json, system_state with high/medium/low confidence. SPY only. TRADE submitted=0. No Parallel API.
- Deleted surfaces and recovery impact: none.
- Out of scope: Parallel Search/Task/FindAll/Monitor APIs, multi-name discovery, copying untracked parallel_ai_features.py.

## Verification

- [x] Targeted tests
- [ ] make check
- [ ] RAG read/write round trip when RAG changes
- [ ] Orchestration smoke test when orchestration changes
- [ ] TRADING_ENV=paper make dry-run when operational paths change
- [ ] CI green on this exact head SHA

## Evidence boundaries

- Test result: pytest tests/test_put_credit_basis.py → 3 passed; ruff clean; CLI --check-ready ok=true ticker SPY
- CI run: pending after open
- Broker/order/fill impact: none (receipt_only)

## Coordination

- [x] Linear issue and vault claim updated
- [x] No overlapping active claim or worktree
- [ ] Claim will be marked done or released after merge