### PR TITLE
feat(AGENT-606): Decisions UO process record for put-credit

### DIFF
--- a/rag_knowledge/lessons_learned/ll_596_decisions_uo_instructions_are_not_control_2026-09-11.md
+++ b/rag_knowledge/lessons_learned/ll_596_decisions_uo_instructions_are_not_control_2026-09-11.md
@@ -1,0 +1,31 @@
+# LL-596 — Decisions UO: instructions are not control (2026-09-11)
+
+**Source FORMAT:** Decisions _Who Governs the Machines?_ (Gartner universal orchestrator).
+**Not a clone:** Decisions product, BOAT platform, or a ThumbGate UO SKU.
+
+## Steal (3 tactics)
+
+1. **Process state outside the agent** — journal / system_state / gate modules are the record, not chat memory.
+2. **Rules before action** — `mandatory_trade_gate` is control; prompts are not.
+3. **Observability: where / stuck / next** — every govern read answers those three; paper factory when occupancy < max; never live `--execute`.
+
+## Rail
+
+```bash
+.venv/bin/python scripts/put_credit_govern.py
+.venv/bin/python scripts/put_credit_govern.py --check-ready
+.venv/bin/python -m pytest tests/test_put_credit_govern.py -q
+```
+
+## ThumbGate map (existing rails only)
+
+| UO capability         | Already on ThumbGate                       |
+| --------------------- | ------------------------------------------ |
+| Runtime coordination  | PreToolUse / gates-engine                  |
+| State outside agent   | session-lease, governance-state, lesson DB |
+| Control before action | deny/warn gates (not prompt prose)         |
+| where/stuck/next      | Issues dispositions + PR mergeStateStatus  |
+
+Do **not** invent a ThumbGate "universal orchestrator" product (ECI pause on net-new governance SKUs).
+
+Linear: AGENT-606

--- a/scripts/put_credit_govern.py
+++ b/scripts/put_credit_govern.py
@@ -1,0 +1,235 @@
+#!/usr/bin/env python3
+"""Decisions UO FORMAT steal for spy_put_credit — not a Decisions/BOAT clone.
+
+Process state lives OUTSIDE the agent (journal + system_state + gate modules).
+Instructions / prompts are NOT control. Rules run before action
+(``mandatory_trade_gate``). The record answers where / stuck / next.
+
+Paper factory when occupancy < max_concurrent. Never live ``--execute``.
+
+Source FORMAT: Decisions *Who Governs the Machines?* (Gartner UO).
+Linear: AGENT-606.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+SCHEMA_VERSION = 1
+WE_ARE_NOT = (
+    "Decisions universal orchestrator product",
+    "Gartner BOAT platform",
+    "ThumbGate UO SKU / control-plane clone",
+)
+
+
+def _load_json(path: Path, default: Any) -> Any:
+    if not path.exists():
+        return default
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return default
+
+
+def _occupancy_from_entries(entries: dict[str, Any]) -> dict[str, Any]:
+    """Reuse spy_put_credit concurrency semantics without submitting orders."""
+    from scripts.spy_put_credit import evaluate_entry_limits
+
+    return evaluate_entry_limits(entries)
+
+
+def _regime_snapshot() -> dict[str, Any]:
+    try:
+        from src.risk.put_credit_regime import capture_regime_snapshot, evaluate_regime_gate
+
+        snap = capture_regime_snapshot()
+        gate = evaluate_regime_gate(snap)
+        return {
+            "allowed": bool(gate.get("allowed")),
+            "blockers": list(gate.get("blockers") or []),
+            "soft_flags": list(gate.get("soft_flags") or []),
+        }
+    except Exception as exc:  # noqa: BLE001 — doctor must stay fail-closed readable
+        return {"allowed": False, "blockers": [f"regime_unavailable:{exc}"], "soft_flags": []}
+
+
+def _kill_switch() -> dict[str, Any]:
+    try:
+        from src.core.active_strategy import load_kill_state
+
+        state = load_kill_state()
+        return {
+            "live_blocked": bool(getattr(state, "live_blocked", True)),
+            "entry_allowed": True,
+        }
+    except Exception as exc:  # noqa: BLE001
+        return {"live_blocked": True, "entry_allowed": False, "error": str(exc)}
+
+
+def _mandatory_gate_present() -> bool:
+    path = ROOT / "src" / "safety" / "mandatory_trade_gate.py"
+    return path.is_file()
+
+
+def build_process_record(
+    *,
+    root: Path | None = None,
+    entries: dict[str, Any] | None = None,
+    now: datetime | None = None,
+) -> dict[str, Any]:
+    """Authoritative put-credit process record (UO FORMAT: state outside agent)."""
+    base = Path(root) if root else ROOT
+    entries_path = base / "data" / "put_credit_entries.json"
+    system_state_path = base / "data" / "system_state.json"
+    loaded = entries if entries is not None else _load_json(entries_path, {})
+    if not isinstance(loaded, dict):
+        loaded = {}
+
+    limits = _occupancy_from_entries(loaded)
+    occupancy = int(limits.get("active_count") or 0)
+    max_concurrent = int(limits.get("max_concurrent") or 2)
+    regime = _regime_snapshot()
+    kill = _kill_switch()
+    gate_present = _mandatory_gate_present()
+
+    stuck: list[str] = []
+    stuck.extend(str(b) for b in (limits.get("blockers") or []))
+    if not regime.get("allowed"):
+        stuck.extend(str(b) for b in (regime.get("blockers") or ["regime_blocked"]))
+    if not gate_present:
+        stuck.append("mandatory_trade_gate_missing")
+    if kill.get("live_blocked") is False:
+        # Live capital would be allowed — still never expose live execute here.
+        pass
+
+    next_actions: list[str] = []
+    if occupancy < max_concurrent and regime.get("allowed") and not limits.get("blockers"):
+        next_actions.append(
+            ".venv/bin/python scripts/spy_put_credit.py --execute-paper  # paper factory"
+        )
+    elif occupancy < max_concurrent and not regime.get("allowed"):
+        next_actions.append(
+            ".venv/bin/python scripts/spy_put_credit.py --regime-only  # clear regime blockers"
+        )
+    elif occupancy >= max_concurrent:
+        next_actions.append(
+            ".venv/bin/python scripts/spy_put_credit.py --manage-exits  # book full; manage"
+        )
+    else:
+        next_actions.append(
+            ".venv/bin/python scripts/spy_put_credit.py --status  # inspect before acting"
+        )
+
+    next_actions.append(
+        ".venv/bin/python scripts/put_credit_govern.py --check-ready  # rules before action"
+    )
+
+    where = {
+        "strategy": "spy_put_credit",
+        "occupancy": occupancy,
+        "max_concurrent": max_concurrent,
+        "today_count": int(limits.get("today_count") or 0),
+        "max_daily": int(limits.get("max_daily") or 0),
+        "regime_allowed": bool(regime.get("allowed")),
+        "live_blocked": bool(kill.get("live_blocked", True)),
+        "mandatory_trade_gate": gate_present,
+        "entries_path": str(entries_path),
+        "system_state_path": str(system_state_path),
+        "as_of": (now or datetime.now(UTC)).isoformat(),
+    }
+
+    return {
+        "schemaVersion": SCHEMA_VERSION,
+        "format": "decisions_uo_process_record",
+        "weAreNot": list(WE_ARE_NOT),
+        "instructionsAreNotControl": True,
+        "rulesBeforeAction": gate_present,
+        "liveExecuteAllowed": False,
+        "where": where,
+        "stuck": stuck,
+        "next": next_actions,
+        "paperFactoryEligible": occupancy < max_concurrent
+        and bool(regime.get("allowed"))
+        and not list(limits.get("blockers") or []),
+        "claimBoundary": (
+            "Local process record for paper put-credit governance. "
+            "Not Decisions, not BOAT, not a ThumbGate universal-orchestrator SKU."
+        ),
+    }
+
+
+def check_ready(record: dict[str, Any] | None = None) -> tuple[int, dict[str, Any]]:
+    """Exit 0 when paper path is governable; 2 when stuck or misconfigured."""
+    rec = record or build_process_record()
+    issues: list[str] = []
+    if not rec.get("rulesBeforeAction"):
+        issues.append("mandatory_trade_gate_missing")
+    if rec.get("liveExecuteAllowed"):
+        issues.append("live_execute_must_stay_false")
+    if not rec.get("instructionsAreNotControl"):
+        issues.append("instructions_must_not_be_control")
+    # Stuck on missing gate is hard fail; regime/occupancy stuck is informative
+    if "mandatory_trade_gate_missing" in (rec.get("stuck") or []):
+        issues.append("mandatory_trade_gate_missing")
+
+    ok = not issues
+    payload = {
+        **rec,
+        "checkReady": {"ok": ok, "issues": issues},
+    }
+    return (0 if ok else 2), payload
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="UO FORMAT process record for spy_put_credit (not a Decisions clone)",
+    )
+    parser.add_argument(
+        "--check-ready",
+        action="store_true",
+        help="Exit 0 if rules-before-action rail is present; print record JSON",
+    )
+    parser.add_argument(
+        "--execute",
+        action="store_true",
+        help="REFUSED — live execute is never allowed on this doctor",
+    )
+    parser.add_argument(
+        "--execute-live",
+        action="store_true",
+        help="REFUSED — live execute is never allowed on this doctor",
+    )
+    args = parser.parse_args(argv)
+
+    if args.execute or args.execute_live:
+        denied = {
+            "schemaVersion": SCHEMA_VERSION,
+            "decision": "deny",
+            "issues": ["live_execute_refused"],
+            "claimBoundary": "put_credit_govern never live-executes. Use spy_put_credit --execute-paper.",
+            "weAreNot": list(WE_ARE_NOT),
+        }
+        print(json.dumps(denied, indent=2, sort_keys=True))
+        return 2
+
+    if args.check_ready:
+        code, payload = check_ready()
+        print(json.dumps(payload, indent=2, sort_keys=True, default=str))
+        return code
+
+    record = build_process_record()
+    print(json.dumps(record, indent=2, sort_keys=True, default=str))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_put_credit_govern.py
+++ b/tests/test_put_credit_govern.py
@@ -1,0 +1,155 @@
+"""Tests for Decisions UO FORMAT steal on spy_put_credit (AGENT-606)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from scripts import put_credit_govern as govern
+
+
+def test_process_record_has_where_stuck_next(monkeypatch, tmp_path: Path):
+    entries = {
+        "pcs_a": {
+            "status": "open",
+            "entry_time": "2026-09-11T12:00:00+00:00",
+            "signature": "SPY_2026-09-18_580_575",
+        }
+    }
+    (tmp_path / "data").mkdir()
+    (tmp_path / "data" / "put_credit_entries.json").write_text(
+        json.dumps(entries), encoding="utf-8"
+    )
+
+    monkeypatch.setattr(govern, "_regime_snapshot", lambda: {"allowed": True, "blockers": [], "soft_flags": []})
+    monkeypatch.setattr(govern, "_kill_switch", lambda: {"live_blocked": True, "entry_allowed": True})
+    monkeypatch.setattr(govern, "_mandatory_gate_present", lambda: True)
+
+    # Force occupancy helpers via real evaluate_entry_limits on provided entries
+    monkeypatch.setattr(
+        govern,
+        "_occupancy_from_entries",
+        lambda _e: {
+            "allowed": True,
+            "blockers": [],
+            "active_count": 1,
+            "today_count": 1,
+            "max_concurrent": 2,
+            "max_daily": 4,
+        },
+    )
+
+    record = govern.build_process_record(root=tmp_path, entries=entries)
+    assert record["schemaVersion"] == 1
+    assert record["instructionsAreNotControl"] is True
+    assert record["rulesBeforeAction"] is True
+    assert record["liveExecuteAllowed"] is False
+    assert "where" in record and "stuck" in record and "next" in record
+    assert record["where"]["occupancy"] == 1
+    assert record["where"]["max_concurrent"] == 2
+    assert any("execute-paper" in step or "check-ready" in step for step in record["next"])
+    assert "Decisions universal orchestrator product" in record["weAreNot"]
+
+
+def test_paper_factory_when_occupancy_below_max(monkeypatch, tmp_path: Path):
+    monkeypatch.setattr(govern, "_regime_snapshot", lambda: {"allowed": True, "blockers": [], "soft_flags": []})
+    monkeypatch.setattr(govern, "_kill_switch", lambda: {"live_blocked": True})
+    monkeypatch.setattr(govern, "_mandatory_gate_present", lambda: True)
+    monkeypatch.setattr(
+        govern,
+        "_occupancy_from_entries",
+        lambda _e: {
+            "allowed": True,
+            "blockers": [],
+            "active_count": 0,
+            "today_count": 0,
+            "max_concurrent": 2,
+            "max_daily": 4,
+        },
+    )
+    (tmp_path / "data").mkdir()
+    record = govern.build_process_record(root=tmp_path, entries={})
+    assert record["paperFactoryEligible"] is True
+    assert any("--execute-paper" in step for step in record["next"])
+    assert record["stuck"] == []
+
+
+def test_stuck_when_book_full(monkeypatch, tmp_path: Path):
+    monkeypatch.setattr(govern, "_regime_snapshot", lambda: {"allowed": True, "blockers": [], "soft_flags": []})
+    monkeypatch.setattr(govern, "_kill_switch", lambda: {"live_blocked": True})
+    monkeypatch.setattr(govern, "_mandatory_gate_present", lambda: True)
+    monkeypatch.setattr(
+        govern,
+        "_occupancy_from_entries",
+        lambda _e: {
+            "allowed": False,
+            "blockers": ["Concurrent put credits 2/2."],
+            "active_count": 2,
+            "today_count": 2,
+            "max_concurrent": 2,
+            "max_daily": 4,
+        },
+    )
+    (tmp_path / "data").mkdir()
+    record = govern.build_process_record(root=tmp_path, entries={})
+    assert record["paperFactoryEligible"] is False
+    assert any("2/2" in s for s in record["stuck"])
+    assert any("manage-exits" in step for step in record["next"])
+
+
+def test_live_execute_refused():
+    code = govern.main(["--execute"])
+    assert code == 2
+    code2 = govern.main(["--execute-live"])
+    assert code2 == 2
+
+
+def test_check_ready_ok(monkeypatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]):
+    monkeypatch.setattr(govern, "_regime_snapshot", lambda: {"allowed": True, "blockers": [], "soft_flags": []})
+    monkeypatch.setattr(govern, "_kill_switch", lambda: {"live_blocked": True})
+    monkeypatch.setattr(govern, "_mandatory_gate_present", lambda: True)
+    monkeypatch.setattr(
+        govern,
+        "_occupancy_from_entries",
+        lambda _e: {
+            "allowed": True,
+            "blockers": [],
+            "active_count": 0,
+            "today_count": 0,
+            "max_concurrent": 2,
+            "max_daily": 4,
+        },
+    )
+    monkeypatch.setattr(govern, "ROOT", tmp_path)
+    (tmp_path / "data").mkdir()
+    code = govern.main(["--check-ready"])
+    assert code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["checkReady"]["ok"] is True
+
+
+def test_check_ready_fails_without_gate(monkeypatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]):
+    monkeypatch.setattr(govern, "_regime_snapshot", lambda: {"allowed": True, "blockers": [], "soft_flags": []})
+    monkeypatch.setattr(govern, "_kill_switch", lambda: {"live_blocked": True})
+    monkeypatch.setattr(govern, "_mandatory_gate_present", lambda: False)
+    monkeypatch.setattr(
+        govern,
+        "_occupancy_from_entries",
+        lambda _e: {
+            "allowed": True,
+            "blockers": [],
+            "active_count": 0,
+            "today_count": 0,
+            "max_concurrent": 2,
+            "max_daily": 4,
+        },
+    )
+    monkeypatch.setattr(govern, "ROOT", tmp_path)
+    (tmp_path / "data").mkdir()
+    code = govern.main(["--check-ready"])
+    assert code == 2
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["checkReady"]["ok"] is False
+    assert "mandatory_trade_gate_missing" in payload["checkReady"]["issues"]


### PR DESCRIPTION
## Summary
Decisions/Gartner **universal orchestration FORMAT** steal onto `spy_put_credit` (AGENT-606).

Not a Decisions product clone. Not BOAT. Not a ThumbGate UO SKU.

## What Changed
- `scripts/put_credit_govern.py` — process record with **where / stuck / next**
- State from journal + regime + kill switch + `mandatory_trade_gate` presence (outside agent)
- Paper factory hint when occupancy < max and regime allows
- Refuses `--execute` / `--execute-live` (exit 2)
- LL-596 lesson + tests (6 passed)

## Why
PDF: https://cdn.sanity.io/files/a9zf4mro/production/3a1a4f21b38cef8a635d7f6487d7bfa95fb05de2.pdf

## Verification
```
.venv/bin/python -m pytest tests/test_put_credit_govern.py -q
.venv/bin/python scripts/put_credit_govern.py --check-ready
.venv/bin/python scripts/put_credit_govern.py --execute
```

## Base SHA
0e6c31cdc6cbab8b48a905ca9e7b18a7ba9eb7f0